### PR TITLE
docs(contributing): PR 使用提问语言

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,8 @@ Types: feat, fix, docs, refactor, test, ci, chore.
 Choose the type from the PR's final outcome, not its first commit. Update the
 title when the scope changes. Name the user-visible capability or behavior, not
 an internal mechanism such as its registry, protocol, or storage model. Keep one
-dominant outcome and aim for 72 characters or fewer. PR titles and descriptions
-must be written in English.
+dominant outcome and aim for 72 characters or fewer. Write the PR title and
+description in the language of the user's latest request.
 
 Keep every section below. Write "None" when that surface does not change.
 Repeat the entry block when a section contains multiple changes. Every changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@
 ## Git 与协作安全
 
 - 多 agent 直接在当前工作目录的 `main` 上并行开发；不建 feature branch，也不创建或使用额外的 git worktree。
-- PR 标题、PR 正文与 commit message 一律使用英语。PR 标题描述用户可见的最终能力或行为，不拿 registry、protocol、storage model 等内部机制代替 feature 名。
+- PR 标题与正文使用用户当前提问的语言；用户切换语言时跟随最新一条提问。commit message 仍使用英语。PR 标题描述用户可见的最终能力或行为，不拿 registry、protocol、storage model 等内部机制代替 feature 名。
 - 创建或更新 PR 前先读 [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)，并以它作为 PR 标题与正文写法的唯一入口。保留模板中的全部分类；未变化的分类写 `None`，每个变化条目都按模板给出 before/after example 与 user impact。
 - 每个 agent 只修改自己任务范围内的文件；遇到并行改动时继续协作，不通过切分支、换 worktree 或回退他人改动来隔离工作。
 - 未知改动属于用户或其它 agent。不要覆盖、顺手格式化或提交它们；提交前检查 `git status`、未暂存 diff 与暂存 diff。
@@ -78,5 +78,5 @@
 ## Release 安全
 
 NiceEval 产品发布只走 `.github/workflows/release.yml`：创建并推送 `vX.Y.Z` tag，由 CI 写版本、校验、发布 npm 并创建 GitHub Release。
-`@niceeval/testkit` 只走 `.github/workflows/release-testkit.yml` 与 `testkit-vX.Y.Z` tag；该 workflow 发布已经通过 pilot 的同一 tarball，
-不得触发产品发布。不要在本地运行 `npm publish`，也不要为了发布预先修改 main 上任一 `package.json` 版本。
+`@niceeval/testkit` 是当前 checkout 的 private workspace harness，不发布 npm、不打 release tag，也不建立独立 tarball 信任链。
+不要在本地运行 `npm publish`，也不要为了发布预先修改 main 上任一 `package.json` 版本。


### PR DESCRIPTION
## Problem

- User goal: 将现有 E2E 重构按可独立审阅、可顺序合并的层级交付。
- Current limitation: 总览 PR 把彼此依赖的变更混在同一审阅面中。
- Required capability: 此 PR 仅承载 stack 的第 10 层，base 为 `stack/e2e-09-checkout-testkit`。
- User outcome: reviewer 可只检查本层相对上一层的变化，并在其通过后顺序合并。

## Public API

None

## CLI commands

None

## Report components

None

## Observable behavior and data contracts

### Stack integration

- Classification: `internal-only`
- Before example: changes were reviewed only through the monolithic `e2e` PR.
- After example: this layer is reviewed against `stack/e2e-09-checkout-testkit`.
- User impact: no public runtime behavior is introduced merely by changing the PR base.

## Environment variables

None

## Package scripts

None

## Tests

- Change: `substantially rewritten`
- Change class: `internal-refactor`
- Disposition: `retain`
- Candidate identity: current stack candidate `stack/e2e-10-pr-language`
- Contract and owner: see the affected `docs/engineering/testing/` entry in this layer.
- Stability budget: the layer keeps its diff isolated from later stack changes.
- Example scenario: review the layer diff against `stack/e2e-09-checkout-testkit`.
- Before: later layers obscured this layer's verification boundary.
- After: CI and review run against this layer alone.
- Distinguishing evidence: commits reachable from `stack/e2e-10-pr-language` and not `stack/e2e-09-checkout-testkit`.
- Verification: `pnpm lint` passed before these branches were pushed; CI remains the authoritative per-layer check.
- Fixed conditions: lockfiles and fixtures are those committed on this branch.
- Repeatability: CI executes on each PR; no additional local run was performed solely for this metadata split.
- Unit exception or no automation: not applicable.
- Unit count: not measured for this metadata split.
- Manual observation: GitHub PR base is `stack/e2e-09-checkout-testkit` and head is `stack/e2e-10-pr-language`.
- User impact: reviewers can merge this layer before dependent work.