### PR TITLE
fix(ci): 显式允许 E2E secrets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -281,18 +281,41 @@ jobs:
       - name: Inject secrets for trusted lane
         if: needs.prepare.outputs.inject-secrets == 'true'
         env:
-          ALL_SECRETS_JSON: ${{ toJSON(secrets) }}
           MANIFEST: e2e/${{ matrix.dir }}/e2e.json
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          BUB_API_BASE: ${{ secrets.BUB_API_BASE }}
+          BUB_API_KEY: ${{ secrets.BUB_API_KEY }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
+          NICEEVAL_JUDGE_BASE: ${{ secrets.NICEEVAL_JUDGE_BASE }}
+          NICEEVAL_JUDGE_KEY: ${{ secrets.NICEEVAL_JUDGE_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
         run: |
           set -euo pipefail
           node <<'NODE_EOF'
           const fs = require("fs");
-          const all = JSON.parse(process.env.ALL_SECRETS_JSON || "{}");
+          const allowed = new Set([
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "BUB_API_BASE",
+            "BUB_API_KEY",
+            "CODEX_API_KEY",
+            "CODEX_BASE_URL",
+            "NICEEVAL_JUDGE_BASE",
+            "NICEEVAL_JUDGE_KEY",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+          ]);
           const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST, "utf8"));
           const lines = [];
           let injected = 0;
           for (const name of manifest.secrets) {
-            const value = all[name];
+            if (!allowed.has(name)) {
+              throw new Error(`${process.env.MANIFEST}: secret ${name} is not in the workflow allowlist`);
+            }
+            const value = process.env[name];
             if (typeof value !== "string" || value.length === 0) continue;
             const marker = `E2E_SECRET_${name}_${Math.random().toString(36).slice(2)}`;
             lines.push(`${name}<<${marker}`, value, marker);
@@ -320,8 +343,8 @@ jobs:
       - name: Redact secrets in artifactRoot
         if: always() && needs.prepare.outputs.inject-secrets == 'true'
         env:
-          ALL_SECRETS_JSON: ${{ needs.prepare.outputs.inject-secrets == 'true' && toJSON(secrets) || '{}' }}
           ARTIFACT_ROOT: ${{ steps.safe.outputs.artifact-root }}
+          MANIFEST: e2e/${{ matrix.dir }}/e2e.json
         run: |
           set -euo pipefail
           if [ ! -d "$ARTIFACT_ROOT" ]; then
@@ -332,10 +355,10 @@ jobs:
           const fs = require("fs");
           const path = require("path");
           const root = process.env.ARTIFACT_ROOT;
-          const all = JSON.parse(process.env.ALL_SECRETS_JSON || "{}");
-          const replacements = Object.entries(all)
-            .filter(([, value]) => typeof value === "string" && value.length > 0)
-            .map(([name, value]) => ({ name, value }));
+          const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST, "utf8"));
+          const replacements = manifest.secrets
+            .map((name) => ({ name, value: process.env[name] }))
+            .filter(({ value }) => typeof value === "string" && value.length > 0);
           function walk(dir, files = []) {
             for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
               const abs = path.join(dir, entry.name);

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -112,6 +112,8 @@ backend、container 与 browser 都必须登记 owned handle；`finally` 做有�
 | `workflow_dispatch` | 显式 | 按 environment | 单 Repo / lane 复现 |
 
 Fork 与同仓 PR 使用同一无密钥门禁。禁止用 `pull_request_target` 让 PR 代码接触 secret。
+可信 lane 的 workflow 只能显式引用已登记的 secret 白名单；禁止 `toJSON(secrets)` 或其它全量枚举。
+Repo manifest 声明了白名单外的名称时，在注入前失败，不动态读取其它仓库 secret。
 任何会实际调用付费模型的 live 验收、批量 Adapter 矩阵或整批重跑，都必须先取得用户明确批准；lane 选择与 secret 可用不构成授权。
 
 ## GitHub Actions 形状


### PR DESCRIPTION
## Problem

- User goal: 将现有 E2E 重构按可独立审阅、可顺序合并的层级交付。
- Current limitation: 总览 PR 把彼此依赖的变更混在同一审阅面中。
- Required capability: 此 PR 仅承载 stack 的第 16 层，base 为 `stack/e2e-15-doc-lint`。
- User outcome: reviewer 可只检查本层相对上一层的变化，并在其通过后顺序合并。

## Public API

None

## CLI commands

None

## Report components

None

## Observable behavior and data contracts

### Stack integration

- Classification: `internal-only`
- Before example: changes were reviewed only through the monolithic `e2e` PR.
- After example: this layer is reviewed against `stack/e2e-15-doc-lint`.
- User impact: no public runtime behavior is introduced merely by changing the PR base.

## Environment variables

None

## Package scripts

None

## Tests

- Change: `substantially rewritten`
- Change class: `internal-refactor`
- Disposition: `retain`
- Candidate identity: current stack candidate `stack/e2e-16-e2e-secret-allowlist`
- Contract and owner: see the affected `docs/engineering/testing/` entry in this layer.
- Stability budget: the layer keeps its diff isolated from later stack changes.
- Example scenario: review the layer diff against `stack/e2e-15-doc-lint`.
- Before: later layers obscured this layer's verification boundary.
- After: CI and review run against this layer alone.
- Distinguishing evidence: commits reachable from `stack/e2e-16-e2e-secret-allowlist` and not `stack/e2e-15-doc-lint`.
- Verification: `pnpm lint` passed before these branches were pushed; CI remains the authoritative per-layer check.
- Fixed conditions: lockfiles and fixtures are those committed on this branch.
- Repeatability: CI executes on each PR; no additional local run was performed solely for this metadata split.
- Unit exception or no automation: not applicable.
- Unit count: not measured for this metadata split.
- Manual observation: GitHub PR base is `stack/e2e-15-doc-lint` and head is `stack/e2e-16-e2e-secret-allowlist`.
- User impact: reviewers can merge this layer before dependent work.