### PR TITLE
fix(sandbox): 隔离 Compose 项目身份

### DIFF
--- a/.agents/friction-log/20260807120930-opencode-interactive-worker/friction.md
+++ b/.agents/friction-log/20260807120930-opencode-interactive-worker/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'OpenCode interactive worker 的 READY 与 idle 状态无法可靠续传 prompt'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Herdr 按 flash-max-worker 预设启动 OpenCode run --interactive 后，可以先收到 READY，再通过 herdr agent prompt 下发完整任务；idle 状态与 prompt 的停止指令应准确生效。
+
+## Current Behavior
+
+初始消息只要求回复 READY 时，OpenCode 回复后立即退出，下一条 herdr agent prompt 返回 agent_not_found。改为把完整任务放进初始消息后，Herdr 长期显示 idle，但 worker 仍在连续执行；父 agent 连续两次要求停止写入并只交接，worker 仍继续创建和修改临时校验文件，最终只能发送 Ctrl-C。
+
+## Possible Solution
+
+让 run --interactive 在完成首轮后保持可提示会话；Herdr 的 OpenCode 检测应区分模型采样、等待输入与退出，并让 prompt/中断在消息边界可靠生效。
+
+## Minimal Reproducible Example
+
+1. herdr agent start audit --kind opencode --pane PANE -- run --interactive --model opencode-go/deepseek-v4-flash --variant max --auto 只回复READY
+2. herdr agent prompt audit 完整任务
+3. 观察 agent_not_found；若首条消息直接给完整任务，则观察 agent_status=idle 与实际持续执行不一致。
+
+## Context
+
+本轮为了取得交接，父 agent 需要重启会话；worker 无视停止指令后又必须用 herdr agent send-keys C-c 强制中止，并手工删除它创建的临时配置与空目录。

--- a/docs/engineering/testing/unit/adapters.md
+++ b/docs/engineering/testing/unit/adapters.md
@@ -60,6 +60,14 @@ function scriptedInstaller(steps: {
   - `defineAgent` 固定产出 `kind: "direct"`，并保留 Direct Agent 的公开定义字段。
   - `defineDirectAgent` 是指向 `defineAgent` 的 deprecated 兼容 alias，不建立第二套构造逻辑。
   - 动态 JavaScript 输入违反必填契约时，错误统一指向 canonical `defineAgent`。
+- **原始工具名与规范分类**（[标准事件模型](../../../feature/adapters/architecture/events.md)）：
+
+  - 上游提供的工具名在 `StreamEvent.operation.name` 原样保存；归一函数只计算旁边的 `tool: ToolName`，不能改写原名。
+  - 通用复合别名按大小写无关规则映射为 `ToolName`；进入规范化流程后仍不认识时保留原始 `name`，并把 `tool` 分类为 `unknown`。
+    不承诺分类任意应用工具的协议可以省略 `tool`，但仍必须保留原始 `name`。
+  - `search`、`run` 等可能属于被测应用的单字动词不能由通用表猜成系统工具。
+  - Unit 只展开这张 NiceEval 自有的确定性基表。某个 SDK / CLI 是否同时写入正确原始名与规范分类，
+    仍由对应 Adapter E2E 证明，不在这里复制上游 wire fixture。
 - **probe 命中、staged 安装、复检失败**（[Agent Ensure](../../../feature/adapters/architecture/agent-ensure.md)）：
 
   - probe 命中 → 记录命中的安装事实，不调用 install。

--- a/docs/feature/adapters/architecture/events.md
+++ b/docs/feature/adapters/architecture/events.md
@@ -31,7 +31,9 @@ type StreamEvent =
 2. tool 与 subagent 共用 `operation.started` / `operation.finished`，用稳定 operation ID 配对。
    ID 只需在**一次 started→finished 配对内**稳定,不要求跨轮唯一。
    同一个 ID 在 finished 后再次 started 是新操作,core 新建记录而非覆盖。
-3. tool operation 的 `name` 保留原始工具名，`tool` 保存跨 Agent 规范名。
+3. tool operation 的 `name` 保留上游原始工具名；可选的 `tool` 保存跨 Agent 的闭集规范分类。
+   进入规范化流程后仍无法识别时，`tool` 写 `unknown`；不承诺分类任意应用工具的协议也可以省略 `tool`。
+   两种情况都不能丢掉或改写 `name`，读者始终能看到真实协议值。
    `operation.finished.kind` 必须与对应 started 的 `operation.kind` 相同。
 4. 人工拒绝是 `rejected`，执行故障是 `failed`。
 5. Skill 加载只产 `skill.loaded`，不重复计入工具调用。
@@ -70,6 +72,10 @@ interface InputRequest {
 
 `deriveRunFacts(events)` 统一折叠工具调用、subagent 调用、待输入请求、parked、消息数、压缩次数与 `context.injected` 次数（`contextInjections`）。
 Adapter 不预计算断言结果。
+
+折叠后的 `ToolCall.name` 是规范分类，`ToolCall.originalName` 继续保存事件里的原始 `operation.name`；Report 的 conversation
+同样分别交付原始 `name` 与可选 `tool`。因此 `unknown` 只表示分类结果，不会让上游名称从 Record 或公开读回中消失。
+
 折叠按 `operationId` 把 started 与 finished 对成一条操作：配上 finished 的取其状态；只有 started、尚未等到 finished 的操作状态是 **`pending`**——HITL 停在审批上的工具调用就以这个状态被断言，不是容错分支。
 只有 finished、没配上 started 才属于 core 容错，不是正常映射契约。
 

--- a/docs/feature/sandbox/case.md
+++ b/docs/feature/sandbox/case.md
@@ -242,15 +242,16 @@ Compose 自己处理 `depends_on`、healthcheck、网络 DNS、`extra_hosts`、v
 - 让 main 容器脱离受管网络、覆盖受管 workdir,或让任一 service 挂载 Docker socket；
 - 为任一 service 声明固定 `container_name`；
 - 让非 `external` 的 network、volume、config 或 secret 使用不随 Compose project 变化的全局名称；
-- 顶层 `include`,以及引用外部文件的 `services.*.extends.file`。
+- 顶层 `include`,以及任意 `services.*.extends.file`。
 
 命名空间检查以 Compose 合成后的有效模型为准,涵盖同文件 anchor、merge、插值与 service extends。
 Provider 用两个不同的哨兵 project 求值同一份 file 与 env；受管资源的有效名称必须在两份模型中分别按 `<project>_<logical-key>` 变化。
+
 完整模型只驻留规划内存,不落盘、不进入日志或错误正文,避免展开后的 credential env 值泄漏。
 无法取得有效模型或解码其 JSON 时规划失败,不能跳过检查。
 
 `external: true` 明确表示资源不归本 Case 创建和回收,因此保留其外部名称。
-外部 Compose 文件则不属于当前 CaseKey 的输入闭包；`include` 与 `extends.file` 必须拒绝,不能读取后仍用主文件身份携带结果。
+Compose 的第二文件入口不属于当前 CaseKey 的输入闭包；`include` 与任意 `extends.file` 必须拒绝,不能读取后仍用主文件身份携带结果。同文件复用用 anchor、merge 或不带 `file` 的 service extends。
 
 `dns`、`extra_hosts`、自定义 networks 与 sidecar 隔离可以直接构成题目语义,Docker case 不把它们归一化掉。
 Agent 只能进入 main 容器;sidecar 文件系统只经题目网络交互或受控的判分采证接口可见——把 sidecar 合并进主 Sandbox 会改变题目,不属于合法降级。

--- a/docs/feature/sandbox/case.md
+++ b/docs/feature/sandbox/case.md
@@ -165,6 +165,7 @@ CaseKey
 **BuildKey 负责构建产物复用,CaseKey 负责完整 attempt 环境身份与 fingerprint。**
 只挂进 sidecar 的脚本改动不触发 client 镜像重建,但改变 CaseKey、作废旧结果。
 逐 attempt 的容器名、临时目录和随机 project name 由 Provider 生成,不进 CaseKey,只作为本次启动的运行事实记录。
+
 作者不能用 `container_name` 固定任一 service 的容器名；这会绕开受管 project namespace,让并发 Case 争用同一个宿主资源。
 Agent 身份与 Sandbox 实例身份正交进入指纹(见 [Adapters · Agent Ensure](../adapters/architecture/agent-ensure.md)),因此同一份任务构建结果可以被多个 Agent experiment 共用,不要求为每个「题目 × Agent」组合构建 image 或 template。
 

--- a/docs/roadmap/testing/architecture.md
+++ b/docs/roadmap/testing/architecture.md
@@ -78,7 +78,7 @@ E2E 文件从上到下保持同一信息顺序：
 
 | 位置 | 保留的信息 | 不放入这里的内容 |
 |---|---|---|
-| 文件头 | Repo ID、NiceEval 根目录重跑命令、隔离 Repo 内命令 | 依赖安装教程 |
+| 文件头 | 第一行的 `feature:` / `cases:`、Repo ID、NiceEval 根目录重跑命令、隔离 Repo 内命令 | 依赖安装教程 |
 | 局部类型 | 本测试实际读取的公开字段 | 完整生产 DTO、候选导出的 schema 常量 |
 | 局部函数 | process、parse、唯一项查找、资源关闭等机械操作 | scenario 名到用户动作的映射、领域 expected |
 | 测试标题与注释 | 长期用户结果；`feature:` 写契约归属，历史 kill 用 `regression:` 指向 memory | 临时实现函数名、当前 DOM 结构 |
@@ -89,7 +89,8 @@ E2E 文件从上到下保持同一信息顺序：
 抽取后测试标题、argv、sentinel、verdict 和历史回归理由仍留在 owner 文件。
 
 Feature 是每条测试的长期归属，Bug 不是第三种执行层。目录、文件名与标题按功能和可观察结果命名；
-`regression:` 只是已证明能杀死旧实现时附加的历史凭据。Unit 的 `// cases:` / `// bug:` 与 E2E 的
+E2E 的 `// feature:` 与 Unit 的 `// cases:` 放在第一行，让 owner 不依赖 import 排列。一个文件含多个 case 时，
+`regression:` / `bug:` 紧贴真正能杀死旧实现的那个 case，不能把整文件的其它测试也伪装成回归。Unit 的 `// cases:` / `// bug:` 与 E2E 的
 `feature:` / `regression:` 怎样对应，统一见[功能归属与 Bug 回归](portfolio.md#功能归属与-bug-回归)。
 
 ## Oracle 独立性
@@ -127,7 +128,8 @@ Feature 是每条测试的长期归属，Bug 不是第三种执行层。目录�
 - 在断言阶段悄悄修改共享 evidence。
 
 两个 Repo 出现同一稳定机械 parser 后才提取共享实现；领域预期仍留在测试文件。
-项目复制已经由 Runner mutation 与 Report Journey 两个功能 Repo 消费，因此 Testkit 接收显式策略 API。
+项目复制已经被多类会写结果、配置或导出目录的 case 消费，因此 Testkit 接收显式策略 API；调用点仍明确写出复制源、
+排除项和链接策略，不能把 CLI、Runner、Report、Package、Lifecycle 或 Adapter 的领域动作收进 Testkit。
 
 HTTP server lifecycle 暂时只有 Local protocol 一个消费者，只作为 0.x callback API 试用；path、status、body 和错误阶段仍在
 Adapter 测试正文。浏览器和 stdin 不进入 Testkit；Playwright Test 继续拥有 browser / context / page。

--- a/docs/roadmap/testing/example/README.md
+++ b/docs/roadmap/testing/example/README.md
@@ -59,6 +59,9 @@ Playwright 用 `tests/<product-area>/*.spec.ts`。三者都用产品域与行为
 E2E 文件直接链接长期契约，优先使用 `docs/feature/**`；安装后 CLI 等内部边界可以链接其稳定 owner 文档。
 历史缺陷链接 `memory/**`。公开 issue 只有真实存在时才追加，不能单独充当依据。
 
+E2E 的 `// feature:` 与 Unit 的 `// cases:` 放在文件第一行。若一个文件含多个 case，`// regression:` 或 `// bug:`
+紧贴对应的 `test()` / `it()`；只有整文件唯一 case 时，才可与 owner 一起放在文件头。
+
 ```ts
 // feature: docs/feature/reports/show/json.md
 // regression: memory/show-json-pipe-truncated-at-128k.md

--- a/docs/roadmap/testing/example/REVIEW.md
+++ b/docs/roadmap/testing/example/REVIEW.md
@@ -8,7 +8,7 @@
 | 用 `mechanism-unit/` 或 `cli-results.test.ts` 给一组异质测试命名 | 名字只说抽象类别，看不出 owner、用户动作或失败边界；同目录会持续吸入无关 case | 顶层只分 `unit/` 与 E2E `repos/`；Unit 按 Feature、E2E 文件按行为命名，CLI 已拆为 selection、streams-and-exit、show-json-pipe |
 | 多个 adapter 共用一个 package / 结果根 | 不能证明各自真实依赖、安装、secret 与协议 | 每个 adapter 一个叶子 Repo；local protocol 不冒充 live |
 | 通用功能借用 `ai-sdk` / `codex-cli` Repo | 功能回归会被上游凭据、网络和版本漂移污染；Adapter 兼容性检查又会被误算成功能证据 | CLI、Runner、Report、Package、Lifecycle 使用自己的功能 Repo；`adapter/<id>` 只证明对应协议兼容性 |
-| 把相似风险都标成历史 regression | 新测试可能杀不死历史旧实现 | 只有存在旧实现 kill 证据才写 `regression:`，否则写 `risk:` |
+| 把相似风险都标成历史 regression | 新测试可能杀不死历史旧实现 | 只有存在旧实现 kill 证据才写 `regression:`；否则只写 Feature，相关 memory 只作解释 |
 | 把功能测试和 Bug 测试拆成两套目录 | 同一长期行为出现两个 owner；issue 关闭后目录名也失去语义 | 文件始终按 Feature 与结果命名；旧实现 kill 只用 `regression: memory/**` 附在 owner 上 |
 | Experiment 或测试文件只叫 `smoke` / `basic` | 名字只表示作者觉得它便宜或简单，读者看不出输入、结果和失败边界 | 标识符写业务阶段与预期结果，例如 `post-interrupt-consumer`；口袋名只允许出现在研究分类正文 |
 | CommonJS test 在 `/tmp` 临时造未安装项目 | `pnpm exec niceeval` 的实际 binary owner 不确定 | CommonJS 叶子本身就是 consumer，由 runner 注入候选 tarball |

--- a/docs/roadmap/testing/example/repos/adapter/ai-sdk/README.md
+++ b/docs/roadmap/testing/example/repos/adapter/ai-sdk/README.md
@@ -3,8 +3,10 @@
 live 适配器 Repo：`experiments/tool-call.ts` 使用真实官方工厂 `uiMessageStreamAgent`
 （`niceeval/adapter`）。它只经 HTTP 边界接入**本仓库自带的被测应用**（`src/backend/`）。
 该应用是 `useChat` 形状的 UI Message Stream SSE 后端，真实模型经 `@ai-sdk/openai` 接入。
-本 Repo 证明：真实协议下工具调用发生了，并以不带命名空间的工具名出现。公开执行证据
-（`niceeval show --execution --json`）能够读回该工具名。它进入 main / nightly / release lane
+
+本 Repo 证明：真实协议下工具调用发生了，并以不带命名空间的原始工具名出现。公开执行证据
+（`niceeval show --execution --json`）能够读回该 `name`；UI Message Stream 不承诺为任意应用工具补 `tool` 分类。
+它进入 main / nightly / release lane
 （见 `e2e.json.lanes`），需要真实 provider 凭据。
 
 ## 怎么跑
@@ -16,6 +18,9 @@ pnpm e2e --repo adapter/ai-sdk
 # 已安装候选包的独立 ai-sdk Repo 根目录；测试自己启停被测应用
 pnpm test
 ```
+
+根 runner 的临时副本隔离不同 invocation；每条会写 `.niceeval` 的 case 还使用自己的项目副本，
+让同一 Repo 以后增加测试文件时仍可保留 Vitest 默认并行。被测应用继续使用动态端口，不共享固定监听地址。
 
 ## lockfile 规则（正式）
 
@@ -34,4 +39,4 @@ pnpm test
 | `src/backend/` | 被测应用：UI Message Stream SSE 后端（`get_weather` / `calculate` 工具） |
 | `experiments/tool-call.ts` | `uiMessageStreamAgent`，URL 读 `AI_SDK_URL`（测试注入） |
 | `evals/tool-call/weather.eval.ts` | 天气 prompt → `calledTool("get_weather")`，`notCalledTool("calculate")` |
-| `test/tool-identity.test.ts` | 起应用 → `exp` → `show --history` → `show --execution`：工具名与入参保真读回 |
+| `test/tool-identity.test.ts` | 起应用 → 私有项目副本里的 `exp` / `show`：原始工具名与入参保真读回 |

--- a/docs/roadmap/testing/example/repos/adapter/ai-sdk/test/tool-identity.test.ts
+++ b/docs/roadmap/testing/example/repos/adapter/ai-sdk/test/tool-identity.test.ts
@@ -1,9 +1,12 @@
+// feature: docs/feature/adapters/sdk/ai-sdk/README.md
+import { resolve } from "node:path";
 import {
   command,
   defined,
   only,
   startProcess,
   waitForOutput,
+  withProjectCopy,
   type ProcessHandle,
 } from "@niceeval/testkit";
 import { afterAll, beforeAll, expect, test } from "vitest";
@@ -11,7 +14,6 @@ import { afterAll, beforeAll, expect, test } from "vitest";
 // Adapter 兼容性 Repo；exp/show 只是公开证据读回手段，不承担通用功能矩阵。
 // NiceEval 根目录：pnpm e2e --repo adapter/ai-sdk
 // 已安装候选包的独立 ai-sdk Repo 根：pnpm test
-// feature: docs/feature/adapters/sdk/ai-sdk/README.md
 
 interface HistorySection {
   experimentId: string;
@@ -46,6 +48,13 @@ interface ExecutionDocument {
 }
 
 const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
+// 被测应用（pnpm start）留在原 Repo，只把 CLI 产物隔离进每 case 的私有副本。
+const PROJECT_COPY = {
+  from: process.cwd(),
+  prefix: "niceeval-e2e-ai-sdk-identity-",
+  omitTopLevel: [".niceeval", "node_modules", "test"],
+  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
+} as const;
 let backendUrl: string | undefined;
 let backend: ProcessHandle | undefined;
 
@@ -64,41 +73,44 @@ afterAll(async () => {
   await backend?.dispose();
 }, 15_000);
 
-// 契约：UI Message Stream 没有命名空间概念，协议原样的工具名就是规范身份——
+// 契约：UI Message Stream 没有命名空间概念，保留应用声明的原始 `name`——
 // 公开执行证据必须读到 get_weather，且 calculate（反例）不得出现。
+// 这个协议只承诺原始 name，不承诺 `tool` 规范分类，因此这里只断言 name，不虚构 unknown。
 test("AI SDK 真实工具调用从公开执行证据读回为不带命名空间的工具名", async () => {
   const url = defined(backendUrl, "被测应用应已就绪");
   expect(url, "被测应用应已就绪").toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
 
-  const run = await niceeval.run(
-    ["exp", "tool-call", "--rerun", "all", "--json"],
-    { env: { AI_SDK_URL: url } },
-  );
-  expect(run.exitCode, run.diagnostic()).toBe(0);
+  await withProjectCopy(PROJECT_COPY, async ({ root }) => {
+    const run = await niceeval.run(
+      ["exp", "tool-call", "--rerun", "all", "--json"],
+      { cwd: root, env: { AI_SDK_URL: url } },
+    );
+    expect(run.exitCode, run.diagnostic()).toBe(0);
 
-  const history = await niceeval.run(["show", "tool-call/weather", "--history", "--json"]);
-  expect(history.exitCode, history.diagnostic()).toBe(0);
-  const historyDocument = history.json<HistoryDocument>();
-  const section = only(
-    historyDocument.data.sections,
-    (item) => item.evalId === "tool-call/weather",
-    history.diagnostic(),
-  );
-  const attempt = only(section.attempts, (item) => item.verdict === "passed", history.diagnostic());
+    const history = await niceeval.run(["show", "tool-call/weather", "--history", "--json"], { cwd: root });
+    expect(history.exitCode, history.diagnostic()).toBe(0);
+    const historyDocument = history.json<HistoryDocument>();
+    const section = only(
+      historyDocument.data.sections,
+      (item) => item.evalId === "tool-call/weather",
+      history.diagnostic(),
+    );
+    const attempt = only(section.attempts, (item) => item.verdict === "passed", history.diagnostic());
 
-  const shown = await niceeval.run(["show", attempt.locator, "--execution", "--json"]);
-  expect(shown.exitCode, shown.diagnostic()).toBe(0);
-  const document = shown.json<ExecutionDocument>();
-  expect(document.view).toBe("execution");
-  expect(document.data.locator).toBe(attempt.locator);
+    const shown = await niceeval.run(["show", attempt.locator, "--execution", "--json"], { cwd: root });
+    expect(shown.exitCode, shown.diagnostic()).toBe(0);
+    const document = shown.json<ExecutionDocument>();
+    expect(document.view).toBe("execution");
+    expect(document.data.locator).toBe(attempt.locator);
 
-  const toolReplies = (document.data.conversation?.rounds ?? [])
-    .flatMap((round) => round.replies)
-    .filter((reply): reply is ToolReply => reply.kind === "tool");
-  expect(toolReplies.map((reply) => reply.name)).toContain("get_weather");
-  expect(toolReplies.map((reply) => reply.name)).not.toContain("calculate");
+    const toolReplies = (document.data.conversation?.rounds ?? [])
+      .flatMap((round) => round.replies)
+      .filter((reply): reply is ToolReply => reply.kind === "tool");
+    expect(toolReplies.map((reply) => reply.name)).toContain("get_weather");
+    expect(toolReplies.map((reply) => reply.name)).not.toContain("calculate");
 
-  // 入参保真同样穿到展示面：天气城市在公开执行证据里。
-  const weatherCall = only(toolReplies, (reply) => reply.name === "get_weather", shown.diagnostic());
-  expect(weatherCall.input?.city).toMatch(/北京/);
+    // 入参保真同样穿到展示面：天气城市在公开执行证据里。
+    const weatherCall = only(toolReplies, (reply) => reply.name === "get_weather", shown.diagnostic());
+    expect(weatherCall.input?.city).toMatch(/北京/);
+  });
 });

--- a/docs/roadmap/testing/example/repos/adapter/codex-cli/README.md
+++ b/docs/roadmap/testing/example/repos/adapter/codex-cli/README.md
@@ -2,7 +2,7 @@
 
 live 适配器 Repo：`experiments/tool-call.ts` 用真实官方工厂 `codexAgent`
 （`niceeval/adapter`）在 Docker Sandbox 里跑真实 `codex exec --json`。本 Repo 证明：
-真实命令调用被归一为规范 `shell` 工具、调用与结果配对成立、且从公开执行证据读回
+真实命令调用同时保留协议原名 `command_execution` 与规范分类 `shell`、调用与结果配对成立、且从公开执行证据读回
 （`niceeval show --execution --json`）可见。进入 main / nightly / release lane
 （见 `e2e.json.lanes`），需要真实凭据与 Docker。
 
@@ -15,6 +15,9 @@ pnpm e2e --repo adapter/codex-cli
 # 已安装候选包的独立 codex-cli Repo 根目录
 pnpm test            # 需要 CODEX_API_KEY / CODEX_BASE_URL 与 Docker
 ```
+
+根 runner 的临时副本隔离不同 invocation；每条会写 `.niceeval` 的 case 还使用自己的项目副本，
+让同一 Repo 以后增加测试文件时仍可保留 Vitest 默认并行。Docker 资源身份也必须由该 case 独占。
 
 ## lockfile 规则（正式）
 
@@ -32,7 +35,7 @@ pnpm test            # 需要 CODEX_API_KEY / CODEX_BASE_URL 与 Docker
 |---|---|
 | `experiments/tool-call.ts` | `codexAgent`，凭据读 `CODEX_API_KEY` / `CODEX_BASE_URL` |
 | `evals/tool-call/shell.eval.ts` | `echo` 任务 → `calledTool("shell")` + `noFailedActions` |
-| `test/tool-identity.test.ts` | `exp` → `show --history` → `show --execution`：规范 `shell` 与命令入参保真读回 |
+| `test/tool-identity.test.ts` | 私有项目副本里的 `exp` / `show`：原始 `command_execution`、规范 `shell` 与命令入参读回 |
 
 Codex CLI 事件解码路径（`src/o11y/parsers/codex.ts`）自始带规范名。
 identity 丢失的故障家族写在 `memory/sdk-stream-transformers-missing-canonical-tool.md`

--- a/docs/roadmap/testing/example/repos/adapter/codex-cli/test/tool-identity.test.ts
+++ b/docs/roadmap/testing/example/repos/adapter/codex-cli/test/tool-identity.test.ts
@@ -1,10 +1,11 @@
-import { command, only } from "@niceeval/testkit";
+// feature: docs/feature/adapters/sdk/codex-cli/README.md
+import { resolve } from "node:path";
+import { command, only, withProjectCopy } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 
 // Adapter 兼容性 Repo；exp/show 只是公开证据读回手段，不承担通用功能矩阵。
 // NiceEval 根目录：pnpm e2e --repo adapter/codex-cli
 // 已安装候选包的独立 codex-cli Repo 根：pnpm test
-// feature: docs/feature/adapters/sdk/codex-cli/README.md
 
 interface HistorySection {
   experimentId: string;
@@ -40,39 +41,50 @@ interface ExecutionDocument {
 
 const CMD_MARKER = "niceeval-e2e-echo-914";
 const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
+const PROJECT_COPY = {
+  from: process.cwd(),
+  prefix: "niceeval-e2e-codex-identity-",
+  omitTopLevel: [".niceeval", "node_modules", "test"],
+  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
+} as const;
 
 // 规范身份契约：codexAgent 的真实命令调用必须以规范 ToolName "shell" 出现在公开执行
-// 证据里，不能退化成协议原始名（command_execution）或 unknown——identity 一旦丢失，
-// 用户侧 calledTool("shell") 会静默失配（同类故障家族见 memory/sdk-stream-transformers-
-// missing-canonical-tool.md，Codex CLI 解析路径自始带规范名，本测试防止它回归）。
-test("Codex CLI 的真实命令调用能从公开执行证据读回为规范 shell", async () => {
-  const run = await niceeval.run(["exp", "tool-call", "--rerun", "all", "--json"]);
-  expect(run.exitCode, run.diagnostic()).toBe(0);
+// 证据里；同时原始协议名 command_execution 原样保留在 name——unknown/规范分类不能
+// 覆盖原名（identity 一旦丢失，用户侧 calledTool("shell") 会静默失配；同类故障家族见
+// memory/sdk-stream-transformers-missing-canonical-tool.md，Codex CLI 解析路径自始带
+// 规范名，本测试防止它回归）。
+test("Codex CLI 的真实命令调用能从公开执行证据读回为规范 shell 且保留原名", async () => {
+  await withProjectCopy(PROJECT_COPY, async ({ root }) => {
+    const run = await niceeval.run(["exp", "tool-call", "--rerun", "all", "--json"], { cwd: root });
+    expect(run.exitCode, run.diagnostic()).toBe(0);
 
-  const history = await niceeval.run(["show", "tool-call/shell", "--history", "--json"]);
-  expect(history.exitCode, history.diagnostic()).toBe(0);
-  const historyDocument = history.json<HistoryDocument>();
-  const section = only(
-    historyDocument.data.sections,
-    (item) => item.evalId === "tool-call/shell",
-    history.diagnostic(),
-  );
-  const attempt = only(section.attempts, (item) => item.verdict === "passed", history.diagnostic());
+    const history = await niceeval.run(["show", "tool-call/shell", "--history", "--json"], { cwd: root });
+    expect(history.exitCode, history.diagnostic()).toBe(0);
+    const historyDocument = history.json<HistoryDocument>();
+    const section = only(
+      historyDocument.data.sections,
+      (item) => item.evalId === "tool-call/shell",
+      history.diagnostic(),
+    );
+    const attempt = only(section.attempts, (item) => item.verdict === "passed", history.diagnostic());
 
-  const shown = await niceeval.run(["show", attempt.locator, "--execution", "--json"]);
-  expect(shown.exitCode, shown.diagnostic()).toBe(0);
-  const document = shown.json<ExecutionDocument>();
-  expect(document.view).toBe("execution");
-  expect(document.data.locator).toBe(attempt.locator);
+    const shown = await niceeval.run(["show", attempt.locator, "--execution", "--json"], { cwd: root });
+    expect(shown.exitCode, shown.diagnostic()).toBe(0);
+    const document = shown.json<ExecutionDocument>();
+    expect(document.view).toBe("execution");
+    expect(document.data.locator).toBe(attempt.locator);
 
-  const toolReplies = (document.data.conversation?.rounds ?? [])
-    .flatMap((round) => round.replies)
-    .filter((reply): reply is ToolReply => reply.kind === "tool");
-  const canonicalTools = toolReplies.map((reply) => reply.tool);
-  expect(canonicalTools).toContain("shell");
-  expect(canonicalTools).not.toContain("unknown");
+    const toolReplies = (document.data.conversation?.rounds ?? [])
+      .flatMap((round) => round.replies)
+      .filter((reply): reply is ToolReply => reply.kind === "tool");
+    // 原始协议名原样保留：unknown/规范分类是叠加字段，不能覆盖 name。
+    expect(toolReplies.map((reply) => reply.name)).toContain("command_execution");
+    const canonicalTools = toolReplies.map((reply) => reply.tool);
+    expect(canonicalTools).toContain("shell");
+    expect(canonicalTools).not.toContain("unknown");
 
-  // 入参保真同样穿到展示面：命令文本在公开执行证据里。
-  const shellCall = only(toolReplies, (reply) => reply.tool === "shell", shown.diagnostic());
-  expect(shellCall.input?.command).toMatch(new RegExp(CMD_MARKER));
+    // 入参保真同样穿到展示面：命令文本在公开执行证据里。
+    const shellCall = only(toolReplies, (reply) => reply.tool === "shell", shown.diagnostic());
+    expect(shellCall.input?.command).toMatch(new RegExp(CMD_MARKER));
+  });
 });

--- a/docs/roadmap/testing/example/repos/adapter/local-protocol/README.md
+++ b/docs/roadmap/testing/example/repos/adapter/local-protocol/README.md
@@ -20,6 +20,9 @@ pnpm test
 随后从 `niceeval show local/roundtrip --history --json` 读回 errored verdict。
 完整命令都在调用点，不读 `.niceeval/` 私有布局。
 
+根 runner 的临时副本隔离不同 invocation；每条会写 `.niceeval` 的 case 还使用自己的项目副本，
+让同一 Repo 以后增加测试文件时仍可保留 Vitest 默认并行。HTTP fixture 监听动态端口，不共享固定地址。
+
 ## lockfile 规则（正式）
 
 - 本目录是 docs 示例，**不签入、不手写** `pnpm-lock.yaml`：文档里手写的 lockfile 必然

--- a/docs/roadmap/testing/example/repos/adapter/local-protocol/test/local-backend-failure.test.ts
+++ b/docs/roadmap/testing/example/repos/adapter/local-protocol/test/local-backend-failure.test.ts
@@ -1,10 +1,11 @@
-import { command, only, withHttpServer } from "@niceeval/testkit";
+// feature: docs/feature/error-classification/library.md
+import { resolve } from "node:path";
+import { command, only, withHttpServer, withProjectCopy } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 
 // Adapter 兼容性 Repo；exp/show 只是公开证据读回手段，不承担通用功能矩阵。
 // NiceEval 根目录：pnpm e2e --repo adapter/local-protocol
 // 已安装候选包的独立 local-protocol Repo 根：pnpm test
-// feature: docs/feature/error-classification/library.md
 
 interface ErrorEvent {
   event: "error";
@@ -38,45 +39,54 @@ interface HistoryDocument {
 }
 
 const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
+const PROJECT_COPY = {
+  from: process.cwd(),
+  prefix: "niceeval-e2e-local-backend-",
+  omitTopLevel: [".niceeval", "node_modules", "test"],
+  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
+} as const;
 
 // 本地 backend 的 5xx 是 Repo 自己的 fixture：它只证明 NiceEval 经真实 adapter
 // 边界（uiMessageStreamAgent → HTTP）传输并分类错误，不冒充 live 兼容性
 // （89ba8e64 把伪 E2E 与真实边界分开的裁决）。
 test("本地 backend 返回 5xx 时实验 errored 且错误带阶段与原因，公开读回同样可见", async () => {
-  await withHttpServer(
-    async () => new Response("provider exploded", { status: 502 }),
-    async (backend) => {
-      const run = await niceeval.run(["exp", "local", "--rerun", "all", "--json"], {
-        env: { LOCAL_BACKEND_URL: backend.url },
-      });
-      expect(run.exitCode, run.diagnostic()).toBe(1);
+  await withProjectCopy(PROJECT_COPY, async ({ root }) => {
+    await withHttpServer(
+      async () => new Response("provider exploded", { status: 502 }),
+      async (backend) => {
+        const run = await niceeval.run(["exp", "local", "--rerun", "all", "--json"], {
+          cwd: root,
+          env: { LOCAL_BACKEND_URL: backend.url },
+        });
+        expect(run.exitCode, run.diagnostic()).toBe(1);
 
-      const events = run.ndjson<ExpEvent>();
-      const errorEvents = events.filter((item): item is ErrorEvent & ExpEvent =>
-        item.event === "error" &&
-        typeof (item as ErrorEvent).phase === "string" &&
-        typeof (item as ErrorEvent).reason === "string",
-      );
-      const errored = only(errorEvents, (item) => item.evalId === "local/roundtrip", run.diagnostic());
-      // 阶段归因：agent 传输失败在顶层 eval.run 阶段收束（send 在飞时的嵌套 agent.run
-      // 归因只在超时/scope 路径使用，见 runner 的 LifecyclePhase 注释）。
-      expect(errored.phase).toBe("eval.run");
-      expect(errored.reason).toContain("502");
-      expect(events.at(-1)).toMatchObject({ event: "result", status: "failed" });
+        const events = run.ndjson<ExpEvent>();
+        const errorEvents = events.filter((item): item is ErrorEvent & ExpEvent =>
+          item.event === "error" &&
+          typeof (item as ErrorEvent).phase === "string" &&
+          typeof (item as ErrorEvent).reason === "string",
+        );
+        const errored = only(errorEvents, (item) => item.evalId === "local/roundtrip", run.diagnostic());
+        // 阶段归因：agent 传输失败在顶层 eval.run 阶段收束（send 在飞时的嵌套 agent.run
+        // 归因只在超时/scope 路径使用，见 runner 的 LifecyclePhase 注释）。
+        expect(errored.phase).toBe("eval.run");
+        expect(errored.reason).toContain("502");
+        expect(events.at(-1)).toMatchObject({ event: "result", status: "failed" });
 
-      // 公开读回：errored 同样落进 history，verdict 可被 show 读到（不读 .niceeval）。
-      const history = await niceeval.run(["show", "local/roundtrip", "--history", "--json"]);
-      expect(history.exitCode, history.diagnostic()).toBe(0);
-      const historyDocument = history.json<HistoryDocument>();
-      const section = only(
-        historyDocument.data.sections,
-        (item) => item.evalId === "local/roundtrip",
-        history.diagnostic(),
-      );
-      // 最新一条 attempt 就是本次运行产出的那条：verdict 与 locator 都与 exp 事件流同源。
-      const latest = section.attempts.at(-1);
-      expect(latest?.verdict).toBe("errored");
-      expect(latest?.locator).toBe(errored.locator);
-    },
-  );
+        // 公开读回：errored 同样落进 history，verdict 可被 show 读到（不读 .niceeval）。
+        const history = await niceeval.run(["show", "local/roundtrip", "--history", "--json"], { cwd: root });
+        expect(history.exitCode, history.diagnostic()).toBe(0);
+        const historyDocument = history.json<HistoryDocument>();
+        const section = only(
+          historyDocument.data.sections,
+          (item) => item.evalId === "local/roundtrip",
+          history.diagnostic(),
+        );
+        // 最新一条 attempt 就是本次运行产出的那条：verdict 与 locator 都与 exp 事件流同源。
+        const latest = section.attempts.at(-1);
+        expect(latest?.verdict).toBe("errored");
+        expect(latest?.locator).toBe(errored.locator);
+      },
+    );
+  });
 });

--- a/docs/roadmap/testing/example/repos/cli/test/experiment-selection.test.ts
+++ b/docs/roadmap/testing/example/repos/cli/test/experiment-selection.test.ts
@@ -1,10 +1,10 @@
+// feature: docs/feature/experiments/cli.md
 import { resolve } from "node:path";
 import { command, withProjectCopy } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 
 // NiceEval 根目录：pnpm e2e --repo cli -- --run test/experiment-selection.test.ts
 // 已安装候选包的隔离 Repo 根：pnpm test --run test/experiment-selection.test.ts
-// feature: docs/feature/experiments/cli.md
 
 interface PlanDocument {
   format: "niceeval.exp-plan";

--- a/docs/roadmap/testing/example/repos/cli/test/process-streams-and-exit.test.ts
+++ b/docs/roadmap/testing/example/repos/cli/test/process-streams-and-exit.test.ts
@@ -1,10 +1,10 @@
+// feature: docs/feature/experiments/cli.md
 import { resolve } from "node:path";
 import { command, withProjectCopy } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 
 // NiceEval 根目录：pnpm e2e --repo cli -- --run test/process-streams-and-exit.test.ts
 // 已安装候选包的隔离 Repo 根：pnpm test --run test/process-streams-and-exit.test.ts
-// feature: docs/feature/experiments/cli.md
 
 interface ExpEvent {
   event: string;

--- a/docs/roadmap/testing/example/repos/cli/test/show-json-pipe.test.ts
+++ b/docs/roadmap/testing/example/repos/cli/test/show-json-pipe.test.ts
@@ -1,11 +1,11 @@
+// feature: docs/feature/reports/show/json.md
+// regression: memory/show-json-pipe-truncated-at-128k.md
 import { resolve } from "node:path";
 import { command, defined, only, withProjectCopy } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 
 // NiceEval 根目录：pnpm e2e --repo cli -- --run test/show-json-pipe.test.ts
 // 已安装候选包的隔离 Repo 根：pnpm test --run test/show-json-pipe.test.ts
-// feature: docs/feature/reports/show/json.md
-// regression: memory/show-json-pipe-truncated-at-128k.md
 
 interface HistoryDocument {
   format: "niceeval.show";

--- a/docs/roadmap/testing/example/repos/lifecycle/README.md
+++ b/docs/roadmap/testing/example/repos/lifecycle/README.md
@@ -21,12 +21,14 @@
 ```text
 host / Actions runner
 └─ Vitest
-   └─ pnpm exec niceeval exp slow
-      └─ node fixtures/backend.mjs <unique-temp-path>
+   └─ per-case project copy
+      └─ pnpm exec niceeval exp slow
+         └─ node fixtures/backend.mjs <unique-temp-path>
 ```
 
-本 Repo 保留 Vitest 默认的文件级并行，不设全 Repo 串行闸。当前只有一个测试文件，因此没有可并行的兄弟文件。
-以后新增文件时，每条 case 必须拥有控制文件、进程组和资源身份；会改当前结果的 case 再使用独立结果根或项目副本。
+本 Repo 保留 Vitest 默认的文件级并行，不设全 Repo 串行限制。当前只有一个测试文件，因此没有可并行的兄弟文件。
+根 runner 的副本隔离不同 Repo invocation；测试正文的 `withProjectCopy()` 继续隔离同一 Vitest 进程里未来可能并行的 case，
+两层不能互相替代。每条 case 还必须拥有控制文件、进程组和资源身份。
 
 本 Repo 等 owned backend **真启动**（`/health` 返回 200）后再发 SIGINT。
 进程退出码为 130，`result` 折叠成 `interrupted`，实验级 teardown 照常执行

--- a/docs/roadmap/testing/example/repos/lifecycle/test/interrupt-cleanup.test.ts
+++ b/docs/roadmap/testing/example/repos/lifecycle/test/interrupt-cleanup.test.ts
@@ -1,13 +1,22 @@
 // feature: docs/feature/experiments/use-case/生命周期/启动共享服务.md
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { command, defined, only, pollUntil, withProcess, withTempDir } from "@niceeval/testkit";
+import { join, resolve } from "node:path";
+import { command, defined, only, pollUntil, withProcess, withProjectCopy, withTempDir } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 
 // NiceEval 根目录：pnpm e2e --repo lifecycle -- --run test/interrupt-cleanup.test.ts
 // 已安装候选包的隔离 Repo 根：pnpm test
 
 const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
+
+// 外层副本隔离 NiceEval 状态（.niceeval / config / evals），内层临时目录隔离控制收据
+// （backend.json 与端口）；两者不互相污染。
+const PROJECT_COPY = {
+  from: process.cwd(),
+  prefix: "niceeval-e2e-lifecycle-",
+  omitTopLevel: [".niceeval", "node_modules", "test"],
+  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
+} as const;
 
 interface BackendInfo {
   pid: number;
@@ -45,58 +54,64 @@ async function waitForHealth(baseUrl: string): Promise<void> {
 // SIGINT 让 Invocation 折叠成 interrupted，退出码 130，实验级 teardown 照常执行。
 // 无 orphan 必须核对 owned 资源本身（backend 的 pid 与端口），只查父进程 pid 不算。
 test("SIGINT 后返回 130、实验 teardown 完成、owned backend 释放且下一消费者可运行", async () => {
-  await withTempDir("niceeval-lifecycle-", async (controlRoot) => {
-    const backendInfoPath = join(controlRoot, "backend.json");
-    const owned = await withProcess(
-      ["pnpm", "--silent", "exec", "niceeval", "exp", "slow", "--json"],
-      {
-        env: { ...process.env, NICEEVAL_BACKEND_INFO_PATH: backendInfoPath },
-        processGroup: true,
-        dispose: { signal: "SIGINT", graceMs: 5_000 },
-      },
-      async (controlled) => {
-        // 等 owned backend 真启动：先取信息文件，再等 /health 返回 200。
-        const info = await pollUntil(() => readBackendInfoIfReady(backendInfoPath), {
-          timeoutMs: 15_000,
-          intervalMs: 100,
-          label: backendInfoPath,
-        });
-        const baseUrl = `http://127.0.0.1:${info.port}`;
-        await waitForHealth(baseUrl);
-        // 这是给 NiceEval 根进程的产品刺激；processGroup 仅供 dispose/timeout 兜底终止整组。
-        expect(controlled.signal("SIGINT")).toBe(true);
+  await withProjectCopy(PROJECT_COPY, async ({ root }) => {
+    await withTempDir("niceeval-lifecycle-", async (controlRoot) => {
+      const backendInfoPath = join(controlRoot, "backend.json");
+      const owned = await withProcess(
+        ["pnpm", "--silent", "exec", "niceeval", "exp", "slow", "--json"],
+        {
+          cwd: root,
+          env: { ...process.env, NICEEVAL_BACKEND_INFO_PATH: backendInfoPath },
+          processGroup: true,
+          dispose: { signal: "SIGINT", graceMs: 5_000 },
+        },
+        async (controlled) => {
+          // 等 owned backend 真启动：先取信息文件，再等 /health 返回 200。
+          const info = await pollUntil(() => readBackendInfoIfReady(backendInfoPath), {
+            timeoutMs: 15_000,
+            intervalMs: 100,
+            label: backendInfoPath,
+          });
+          const baseUrl = `http://127.0.0.1:${info.port}`;
+          await waitForHealth(baseUrl);
+          // 这是给 NiceEval 根进程的唯一产品刺激；processGroup 仅供 dispose/timeout 异常终结时覆盖整组。
+          expect(controlled.signal("SIGINT")).toBe(true);
 
-        const interrupted = await controlled.done;
-        expect(interrupted.exitCode, interrupted.diagnostic()).toBe(130);
+          const interrupted = await controlled.done;
+          expect(interrupted.exitCode, interrupted.diagnostic()).toBe(130);
 
-        const events = interrupted.ndjson<ExpEvent>();
-        const result = only(events, (item) => item.event === "result", () => interrupted.diagnostic());
-        expect(result).toMatchObject({ event: "result", status: "interrupted" });
+          const events = interrupted.ndjson<ExpEvent>();
+          const result = only(events, (item) => item.event === "result", () => interrupted.diagnostic());
+          expect(result).toMatchObject({ event: "result", status: "interrupted" });
 
-        // 实验级 teardown 在中断路径也要执行（docs/feature/experiments/architecture.md
-        // 「实验级生命周期」：失败、中断也执行）。
-        const teardown = only(
-          events,
-          (item) => item.event === "experiment_teardown" && item.experimentId === "slow",
-          () => interrupted.diagnostic(),
-        );
-        expect(teardown.status).toBe("done");
+          // 实验级 teardown 在中断路径也要执行（docs/feature/experiments/architecture.md
+          // 「实验级生命周期」：失败、中断也执行）。
+          const teardown = only(
+            events,
+            (item) => item.event === "experiment_teardown" && item.experimentId === "slow",
+            () => interrupted.diagnostic(),
+          );
+          expect(teardown.status).toBe("done");
 
-        return {
-          invocationPid: defined(controlled.pid, () => interrupted.diagnostic()),
-          backendPid: info.pid,
-          baseUrl,
-        };
-      },
-    );
+          return {
+            invocationPid: defined(controlled.pid, () => interrupted.diagnostic()),
+            backendPid: info.pid,
+            baseUrl,
+          };
+        },
+      );
 
-    // `withProcess` 返回前已做幂等 dispose；再核对产品拥有的真实资源。
-    expect(() => process.kill(owned.invocationPid, 0)).toThrow();
-    expect(() => process.kill(owned.backendPid, 0)).toThrow();
-    await expect(fetch(`${owned.baseUrl}/health`)).rejects.toThrow();
+      // `withProcess` 返回前已做幂等 dispose；再核对产品拥有的真实资源。
+      expect(() => process.kill(owned.invocationPid, 0)).toThrow();
+      expect(() => process.kill(owned.backendPid, 0)).toThrow();
+      await expect(fetch(`${owned.baseUrl}/health`)).rejects.toThrow();
 
-    // 下一次独立消费者可以正常启动，不受上次中断影响。
-    const next = await niceeval.run(["exp", "post-interrupt-consumer", "--rerun", "all", "--json"]);
-    expect(next.exitCode, next.diagnostic()).toBe(0);
+      // 下一次独立消费者在同一个私有项目副本 cwd 里正常启动，不受上次中断影响。
+      const next = await niceeval.run(
+        ["exp", "post-interrupt-consumer", "--rerun", "all", "--json"],
+        { cwd: root },
+      );
+      expect(next.exitCode, next.diagnostic()).toBe(0);
+    });
   });
 });

--- a/docs/roadmap/testing/example/repos/package/test/commonjs-init-list.test.ts
+++ b/docs/roadmap/testing/example/repos/package/test/commonjs-init-list.test.ts
@@ -1,3 +1,5 @@
+// feature: docs/cli.md
+// regression: memory/tsx-dynamic-import-require-cycle.md
 import { rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { command, withProjectCopy } from "@niceeval/testkit";
@@ -9,8 +11,6 @@ const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
 //   pnpm e2e --repo package -- --run test/commonjs-init-list.test.ts
 // Isolated repo:
 //   pnpm test --run test/commonjs-init-list.test.ts
-// feature: docs/feature/compile-time-contracts/library.md
-// regression: memory/tsx-dynamic-import-require-cycle.md
 // init 会改写共享 config，因此整条 case 在私有副本里执行，不碰 Repo 根现场。
 const PROJECT_COPY = {
   from: process.cwd(),

--- a/docs/roadmap/testing/example/repos/report/test/exported-navigation.spec.ts
+++ b/docs/roadmap/testing/example/repos/report/test/exported-navigation.spec.ts
@@ -1,3 +1,4 @@
+// feature: docs/feature/reports/view.md
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
@@ -9,7 +10,6 @@ import { expect, test } from "@playwright/test";
 //   pnpm e2e --repo report -- --grep "actual href"
 // Isolated repo:
 //   pnpm test -- --grep "actual href"
-// feature: docs/feature/reports/view.md
 
 interface HistoryDocument {
   format: "niceeval.show";

--- a/docs/roadmap/testing/example/repos/report/test/first-eval-to-debug.spec.ts
+++ b/docs/roadmap/testing/example/repos/report/test/first-eval-to-debug.spec.ts
@@ -1,3 +1,4 @@
+// feature: docs/feature/reports/view.md
 import { rmSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { join, resolve } from "node:path";
@@ -7,7 +8,6 @@ import { expect, test } from "@playwright/test";
 // 场景 Repo：e2e/report；Journey 是测试文件体裁，不是另一份 Repo。
 // NiceEval 根目录：pnpm e2e --repo report -- --grep "新项目"
 // 已安装候选包的隔离 Repo 根：pnpm test -- --grep "新项目"
-// feature: docs/feature/experiments/cli.md
 
 interface ListDocument {
   format: "niceeval.experiments";

--- a/docs/roadmap/testing/example/repos/runner/test/carry-reuse.test.ts
+++ b/docs/roadmap/testing/example/repos/runner/test/carry-reuse.test.ts
@@ -1,3 +1,4 @@
+// feature: docs/feature/experiments/cache.md
 import { readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { command, defined, only, withProjectCopy } from "@niceeval/testkit";
@@ -6,8 +7,7 @@ import { expect, test } from "vitest";
 // 场景 Repo：e2e/runner（本设计稿位于 example/repos/runner）。
 // 从 NiceEval 根目录运行：pnpm e2e --repo runner -- --run test/carry-reuse.test.ts
 // 从已安装候选包的隔离 Repo 根运行：pnpm test --run test/carry-reuse.test.ts
-// 固定 launcher 在文件头可见；RUN / RUN_ALL / DRY 保留完整子命令与 flags。
-// feature: docs/feature/experiments/cache.md
+// 固定 launcher 在文件头可见；FULL / PARTIAL 常量保留完整子命令与 flags，不隐藏 argv。
 
 interface ExpPlanDocument {
   format: "niceeval.exp-plan";
@@ -24,9 +24,11 @@ interface ExpEvent {
 }
 
 const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
-const RUN = ["exp", "carry", "--json"] as const;
-const RUN_ALL = ["exp", "carry", "--rerun", "all", "--json"] as const;
-const DRY = ["exp", "carry", "--dry", "--json"] as const;
+const RUN_FULL_ALL = ["exp", "carry", "--rerun", "all", "--json"] as const;
+const RUN_FULL = ["exp", "carry", "--json"] as const;
+const DRY_FULL = ["exp", "carry", "--dry", "--json"] as const;
+const RUN_PARTIAL_ALPHA = ["exp", "carry", "simple/alpha", "--json"] as const;
+const DRY_PARTIAL_ALPHA = ["exp", "carry", "simple/alpha", "--dry", "--json"] as const;
 const PROJECT_COPY = {
   from: process.cwd(),
   prefix: "niceeval-e2e-carry-",
@@ -56,13 +58,13 @@ async function runAndReadReused(args: readonly string[], cwd?: string): Promise<
 // 结果根属于本 case 的私有副本，不与其它测试共享。
 test("dry plan 预测的携入数与真实 run 一致且全部命中", async () => {
   await withProjectCopy(PROJECT_COPY, async (copy) => {
-    expect(await runAndReadReused(RUN_ALL, copy.root)).toBe(0);
+    expect(await runAndReadReused(RUN_FULL_ALL, copy.root)).toBe(0);
 
-    const planned = await readPlan(DRY, copy.root);
+    const planned = await readPlan(DRY_FULL, copy.root);
     expect(planned.reused).toBe(planned.total);
     expect(planned.matrix.every((row) => row.reused)).toBe(true);
 
-    expect(await runAndReadReused(RUN, copy.root)).toBe(planned.reused);
+    expect(await runAndReadReused(RUN_FULL, copy.root)).toBe(planned.reused);
   });
 });
 
@@ -74,7 +76,7 @@ test("修改 config 后 dry plan 不再预测任何携入", async () => {
     ...PROJECT_COPY,
     prefix: "niceeval-e2e-carry-config-",
   }, async (copy) => {
-    expect(await runAndReadReused(RUN_ALL, copy.root)).toBe(0);
+    expect(await runAndReadReused(RUN_FULL_ALL, copy.root)).toBe(0);
 
     const configPath = join(copy.root, "niceeval.config.ts");
     const configV2 = [
@@ -87,42 +89,45 @@ test("修改 config 后 dry plan 不再预测任何携入", async () => {
     ].join("\n");
     writeFileSync(configPath, configV2, "utf8");
 
-    const planned = await readPlan(DRY, copy.root);
+    const planned = await readPlan(DRY_FULL, copy.root);
     expect(planned.matrix.every((row) => !row.reused)).toBe(true);
     expect(planned.reused).toBe(0);
 
-    expect(await runAndReadReused(RUN, copy.root)).toBe(0);
+    expect(await runAndReadReused(RUN_FULL, copy.root)).toBe(0);
   });
 });
 
-// 部分补跑不得抹掉更早 run 的携入结果：完整 run 后只改一条 eval，下一次整组运行
-// 时未变化的 eval 仍从第一次 run 携入（regression: memory/rerun-with-eval-filter-
-// partial-snapshot.md，跨历史每 eval 取最新基线）。全部在隔离副本里
+// 部分补跑不得抹掉更早 run 的携入结果：完整 run 后只改一条 eval，用公开 eval selector
+// 只补跑 simple/alpha（dry 与 run 都是同一个 selector），下一次整组 dry 时 alpha 从部分
+// run 携入、beta 从更早的完整 run 携入（跨历史每 eval 取最新基线）。全部在隔离副本里
 // 完成 full → partial → full，不碰共享现场。
+// regression: memory/rerun-with-eval-filter-partial-snapshot.md
 test("full → partial → full：部分补跑后未变化 eval 仍从更早 run 携入", async () => {
   await withProjectCopy({
     ...PROJECT_COPY,
     prefix: "niceeval-e2e-carry-partial-",
   }, async (copy) => {
-    expect(await runAndReadReused(RUN_ALL, copy.root)).toBe(0);
+    expect(await runAndReadReused(RUN_FULL_ALL, copy.root)).toBe(0);
 
     const alphaPath = join(copy.root, "evals", "simple", "alpha.eval.ts");
     const alphaV2 = readFileSync(alphaPath, "utf8").replace('includes("fixture")', 'includes("固定回复")');
     writeFileSync(alphaPath, alphaV2, "utf8");
 
-    const partialPlan = await readPlan(DRY, copy.root);
+    // eval selector 的 dry plan 只含 simple/alpha：这次计划里没有 beta，不整组断言。
+    const partialPlan = await readPlan(DRY_PARTIAL_ALPHA, copy.root);
+    expect(partialPlan.matrix.map((row) => row.evalId)).toEqual(["simple/alpha"]);
     const alpha = only(partialPlan.matrix, (row) => row.evalId === "simple/alpha", "partial plan");
-    const beta = only(partialPlan.matrix, (row) => row.evalId === "simple/beta", "partial plan");
     expect(alpha.reused).toBe(false);
-    expect(beta.reused).toBe(true);
-    expect(partialPlan.reused).toBe(1);
+    expect(partialPlan.reused).toBe(0);
 
-    expect(await runAndReadReused(RUN, copy.root)).toBe(1);
+    // 同样的 eval selector 实跑：只补跑 alpha，不是把完整 Experiment 再跑一遍。
+    expect(await runAndReadReused(RUN_PARTIAL_ALPHA, copy.root)).toBe(0);
 
-    const fullPlan = await readPlan(DRY, copy.root);
+    // 完整 dry：alpha 从部分 run 携入、beta 从更早的完整 run 携入，两者都 reused。
+    const fullPlan = await readPlan(DRY_FULL, copy.root);
     expect(fullPlan.reused).toBe(fullPlan.total);
     expect(fullPlan.matrix.every((row) => row.reused)).toBe(true);
 
-    expect(await runAndReadReused(RUN, copy.root)).toBe(fullPlan.reused);
+    expect(await runAndReadReused(RUN_FULL, copy.root)).toBe(fullPlan.reused);
   });
 });

--- a/docs/roadmap/testing/example/repos/runner/test/history-dedup.test.ts
+++ b/docs/roadmap/testing/example/repos/runner/test/history-dedup.test.ts
@@ -1,10 +1,10 @@
+// feature: docs/feature/reports/show/history.md
 import { resolve } from "node:path";
 import { command, only, withProjectCopy, type ProcessReceipt } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 
 // NiceEval 根目录：pnpm e2e --repo runner -- --run test/history-dedup.test.ts
 // 已安装候选包的隔离 Repo 根：pnpm test --run test/history-dedup.test.ts
-// feature: docs/feature/reports/show/history.md
 
 interface HistorySection {
   experimentId: string;
@@ -54,7 +54,7 @@ function locators(attempts: HistorySection["attempts"]): string[] {
   return attempts.map((attempt) => attempt.locator);
 }
 
-// risk: history 跨快照去重。身份就是 locator，断言用身份集合而不是行数猜测；
+// 相关风险：history 跨快照去重。身份就是 locator，断言用身份集合而不是行数猜测；
 // 这不是 031ce196 的因果回归，因此不冒充 historical regression。
 // 结果根属于本 case 的私有副本，不与 carry 的副本共享。
 test("--rerun all 追加新 attempt，全携入 run 按身份键去重不重复行", async () => {

--- a/docs/roadmap/testing/example/testkit/README.md
+++ b/docs/roadmap/testing/example/testkit/README.md
@@ -21,27 +21,31 @@
 ## 功能 Repo 的调用点
 
 - [CLI pipe](../repos/cli/test/show-json-pipe.test.ts)：`command()` 与收据的 `json()`；128 KiB、sentinel 和 bug 引用仍可见。
+- [CLI 状态写入](../repos/cli/test/process-streams-and-exit.test.ts)：`withProjectCopy()` 给每个 case 独立结果根；exit、stream 与
+  NDJSON 预期仍留在 CLI owner。
 - [Runner carry](../repos/runner/test/carry-reuse.test.ts)：`withProjectCopy()` 拥有副本生命周期；排除项、链接策略、
   schemaVersion、reused 关系与对应 memory 留在正文。
-- [Lifecycle](../repos/lifecycle/test/interrupt-cleanup.test.ts)：`withTempDir()` 为每条 case 分配控制文件，`withProcess()` 拥有进程；
+- [Lifecycle](../repos/lifecycle/test/interrupt-cleanup.test.ts)：`withProjectCopy()` 隔离结果根，`withTempDir()` 为每条 case 分配控制文件，`withProcess()` 拥有进程；
   signal、teardown、PID、端口和下一消费者仍由测试断言。
 - [Report](../repos/report/test/exported-navigation.spec.ts)：Testkit 只运行 CLI；浏览器仍使用 Playwright Test 的 `page` fixture。
 - [Journey](../repos/report/test/first-eval-to-debug.spec.ts)：与 Report 共用消费现场，`withProjectCopy()` 隔离新项目；
   Playwright 负责 browser、context、trace 与 screenshot。
+- [Package](../repos/package/test/commonjs-init-list.test.ts)：config mutation 只发生在 CommonJS consumer 的私有副本；
+  `init → list` 及宿主模块形态仍由 Package owner 断言。
 
 ## Adapter Repo 的调用点
 
-- [AI SDK](../repos/adapter/ai-sdk/test/tool-identity.test.ts)：跨 hook 共享进程时使用 caller-owned `startProcess()`，
-  原生 `afterAll` 调用 `dispose()`。
-- [Codex CLI](../repos/adapter/codex-cli/test/tool-identity.test.ts)：复用命令收据与唯一项选择；真实 CLI、Docker 与工具身份
+- [AI SDK](../repos/adapter/ai-sdk/test/tool-identity.test.ts)：`withProjectCopy()` 隔离结果，跨 hook 共享进程时使用 caller-owned
+  `startProcess()`，原生 `afterAll` 调用 `dispose()`。
+- [Codex CLI](../repos/adapter/codex-cli/test/tool-identity.test.ts)：项目副本、命令收据与唯一项选择可复用；真实 CLI、Docker 与工具身份
   都留在这个 Adapter Repo。
-- [Local protocol](../repos/adapter/local-protocol/test/local-backend-failure.test.ts)：`withHttpServer()` 只拥有 server 生命周期；
+- [Local protocol](../repos/adapter/local-protocol/test/local-backend-failure.test.ts)：`withProjectCopy()` 隔离结果，`withHttpServer()` 只拥有 server 生命周期；
   502 body、错误阶段和 verdict 留在 Adapter 测试。
 
 两组调用点只共享 API 实现，不共享场景 Repo。功能测试不会从 `adapter/ai-sdk` 借 backend 或运行结果；Adapter 测试也不会
 通过 Testkit 获得 CLI、Report 或 Runner 的领域动作函数。
 
-`ProcessHandle.signal()` 只刺激根进程；`processGroup: true` 只让 `dispose()` 与 timeout 的兜底终止整组。
+`ProcessHandle.signal()` 只刺激根进程；`processGroup: true` 只让 `dispose()` 与 timeout 的异常终结作用于整组。
 Lifecycle 因此能证明 backend 是被产品 teardown 释放的，不会由 Testkit 提前杀掉被测资源。
 
 核心 Unit 不在这里套一层统一 DSL。[`example/unit/`](../unit/) 继续使用 Vitest、最小领域 fixture、fake clock 或 barrier；
@@ -74,5 +78,5 @@ JSON error、timeout 和 cleanup 模板，但不能删除这些业务步骤。�
 
 [`carry-reuse.test.ts`](../repos/runner/test/carry-reuse.test.ts) 把复制起始目录、顶层排除项和 `node_modules` 链接写在文件头。
 `withProjectCopy()` 只执行这些策略并保证删除副本，因此它可以服务不同 Repo 的 mutation 场景，
-却不知道 configHash、Eval 或 carry 是什么。当前两个实际消费者都是功能 Repo：Runner mutation 与 Report Journey；
-这不表示二者共用同一个 Repo，只表示它们复用同一项文件系统生命周期。
+却不知道 configHash、Eval、carry、Report、Package 或 Adapter 是什么。CLI、Runner、Report、Package、Lifecycle 与 Adapter
+可以各自消费它；这不表示它们共用同一个 Repo，只表示它们复用同一项文件系统生命周期。

--- a/docs/roadmap/testing/example/testkit/api.ts
+++ b/docs/roadmap/testing/example/testkit/api.ts
@@ -42,6 +42,10 @@ export interface DisposeOptions {
 }
 
 export interface StartOptions extends RunOptions {
+  /**
+   * 只改变异常终结范围：为 true 时，dispose()/timeout 终结向整个进程组发送信号，
+   * 异常终结时回收命令的派生子进程；它不改变产品刺激——signal() 永远只发根 PID。
+   */
   processGroup?: boolean;
   dispose?: DisposeOptions;
 }
@@ -51,6 +55,11 @@ export interface ProcessHandle {
   readonly pid: number | undefined;
   readonly stdout: NodeJS.ReadableStream | null;
   readonly stderr: NodeJS.ReadableStream | null;
+  /**
+   * 产品刺激：永远只向根 PID 发送信号，不扩散到派生子进程。
+   * 需要连同整个进程组一起异常终结时，用 processGroup + dispose()/timeout，
+   * 不能靠这里补发多次。
+   */
   signal(signal: NodeJS.Signals): boolean;
   dispose(): Promise<void>;
 }

--- a/docs/roadmap/testing/example/unit/record/tool-name-normalization.test.ts
+++ b/docs/roadmap/testing/example/unit/record/tool-name-normalization.test.ts
@@ -1,8 +1,10 @@
+// cases: docs/engineering/testing/unit/adapters.md
 import { describe, expect, it } from "vitest";
 import { normalizeToolName } from "../../../../../../src/o11y/tool-names.ts";
 
-// cases: docs/engineering/testing/unit/adapters.md
-// 本单元只证明 NiceEval 自己拥有的确定性规范名映射；真实 Codex SDK 接线由 adapter E2E 拥有。
+// 本单元只证明 NiceEval 自有的确定性基表：normalizeToolName 只计算旁边的规范
+// `tool: ToolName` 分类，不覆盖也不丢失事件原始 `name`——返回 "unknown" 只表示
+// 这条名称进不了规范分类；原始名由 adapter E2E 在 StreamEvent.operation.name 上证明。
 describe("normalizeToolName 的规范 ToolName 映射", () => {
   it("把确定性复合别名映射为 NiceEval 的规范工具名", () => {
     expect(normalizeToolName("read_file")).toBe("file_read");
@@ -17,6 +19,10 @@ describe("normalizeToolName 的规范 ToolName 映射", () => {
 
   it("不认识的名称返回 unknown，不猜测为另一个规范工具", () => {
     expect(normalizeToolName("application_search")).toBe("unknown");
+  });
+
+  it("search/run 等裸单字动词不猜成系统工具，留给确知 transcript 词汇的 parser 显式 opt-in", () => {
     expect(normalizeToolName("search")).toBe("unknown");
+    expect(normalizeToolName("run")).toBe("unknown");
   });
 });

--- a/docs/roadmap/testing/example/unit/sandbox/e2b-detached-state.test.ts
+++ b/docs/roadmap/testing/example/unit/sandbox/e2b-detached-state.test.ts
@@ -1,3 +1,4 @@
+// cases: docs/engineering/testing/unit/sandbox.md
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Sandbox, SandboxInfo, SandboxPaginator } from "e2b";
 import { inspectDetached } from "../../../../../../src/sandbox/keep.ts";
@@ -13,7 +14,6 @@ vi.mock("e2b", () => ({
   },
 }));
 
-// cases: docs/engineering/testing/unit/sandbox.md
 // 单元层只驱动 inspectDetached 的领域状态分类；live SDK 可用性由真实 E2B E2E 拥有。
 const sandboxInfoDefaults = {
   templateId: "niceeval-test-template",

--- a/docs/roadmap/testing/history-problems.md
+++ b/docs/roadmap/testing/history-problems.md
@@ -168,7 +168,8 @@ Portfolio 只链接 owner，命令、expected 和 bug 引用留在原生测试�
 - HTML target 只沿用户实际拿到的 `href` 走；可访问 selector 必须先是产品契约，缺失就登记产品 gap；
 - mutation 只在私有副本，lifecycle 观察带 run ID 的 owned resource 并由下一消费者闭环；
 - 验证收据保留 producer 的 exit / signal，所有临时服务与进程都进入同一 collect / cleanup 生命周期；
-- 只有实际历史 kill 才写 `regression: memory/<条目>.md`；同形但未验证的补充测试写 `risk:`，不能借 commit 或 issue 增加可信度。
+- 只有实际历史 kill 才写 `regression: memory/<条目>.md`；同形但未验证的补充测试只写 Feature，相关 memory 只作解释，
+  不能借 commit 或 issue 增加可信度。
 
 **验收**：先审 Repo 是否能独立安装和单跑，再审测试数量。把任一 live adapter Repo 删除时，本地 fixture 不能继续声称该 adapter
 兼容。让父进程退出但留下 backend / container 时 Lifecycle 必须红。去掉产品可访问身份时，browser 样例不能靠自造 selector 继续绿。

--- a/docs/roadmap/testing/portfolio.md
+++ b/docs/roadmap/testing/portfolio.md
@@ -70,6 +70,9 @@ HTTP 或浏览器读取。只有“旧 Record 兼容性”本身是契约时，�
 公开 issue 可以追加一行 `issue:`，但不能替代仓库内的 memory。issue 可能改标题、关闭或迁移；memory 必须保存复现条件、
 fix parent 或逆补丁、最早失败阶段，以及为什么这条 oracle 能区分旧实现。
 
+单边界 E2E 指向它唯一跨过的契约。Journey 跨多个产品域时只登记最终用户结果的 owner；中间步骤的次级契约留在步骤旁的
+普通注释。这样 `feature:` 仍能回答“这条长流程归谁维护”，不会变成一串每次流程增减都要同步的标签。
+
 ```ts
 // feature: docs/feature/reports/show/json.md
 // regression: memory/show-json-pipe-truncated-at-128k.md
@@ -80,7 +83,8 @@ test("show --json 经 pipe 仍交付完整文档", async () => {
 ```
 
 没有历史 Bug 的功能测试只写功能归属。发现 Bug 后，先加强原 owner；新断言确实能杀死旧实现时，才追加 `regression:`。
-若只能证明同类风险而没有 kill 收据，则写 `risk:` 或只链接 Feature 契约。
+若只能证明同类风险而没有 kill 收据，仍只链接 Feature 契约。相关 memory 可以在普通解释注释或 Repo README 中写成
+“相关风险”，但不再发明一行看似可机器追踪、实际没有 kill 资格的 `risk:` 元数据。
 
 ## 历史 Bug 回归
 
@@ -95,8 +99,8 @@ Bug escape 后按顺序处理：
 
 无法杀死旧实现的 case 只能叫补充验证，不能宣称“防住了这个历史 bug”。
 按现象类比也不够：HTTP 两页 cursor 不能代替 SDK paginator，普通 5xx 不能代替 pseudo-E2E 的候选包边界，locator 往返也不能
-代替共享 mutation 的顺序 bug。`regression` 指向的 memory 需要同时保存旧实现失败的断言与最早失败阶段；没有 kill 收据时写
-`risk:` 或公开契约链接，不只挂历史 commit 或 issue。
+代替共享 mutation 的顺序 bug。`regression` 指向的 memory 需要同时保存旧实现失败的断言与最早失败阶段；没有 kill 收据时
+只保留公开契约链接，相关历史只能作为解释材料，不能只挂 commit 或 issue 冒充回归证明。
 
 ## 迁移与退役
 

--- a/docs/roadmap/testing/testkit.md
+++ b/docs/roadmap/testing/testkit.md
@@ -17,7 +17,7 @@
 | 严格 NDJSON | 5 | 接收 |
 | `only` / `defined` | 7 | 接收 |
 | 长驻 process + readiness + cleanup | AI SDK、Lifecycle | 接收窄接口 |
-| 项目副本 / 临时目录 | Runner、Report Journey | 接收显式策略 API |
+| 项目副本 / 临时目录 | CLI、Runner、Report、Package、Lifecycle、Adapter | 接收显式策略 API |
 | HTTP server lifecycle | Local protocol | 接收通用 callback API；0.x 暂定 |
 | Browser lifecycle | Report | 继续使用 Playwright Test |
 | stdin / PTY | 尚无两个相同消费者 | 暂不接收 |
@@ -107,7 +107,7 @@ export function withProcess<T>(
 `withProcess()` 是默认入口。readiness 失败、轮询超时、断言异常和正常返回都会进入幂等 cleanup；默认按
 TERM → grace period → KILL 结束 owned process。正文已经让进程退出时，cleanup 是 no-op。
 
-`handle.signal()` 永远只向启动的根进程 PID 发送产品刺激。`processGroup: true` 只改变 `dispose()` 与 timeout 的兜底范围，
+`handle.signal()` 永远只向启动的根进程 PID 发送产品刺激。`processGroup: true` 只改变 `dispose()` 与 timeout 的异常终结范围，
 让它们终止整组后代。两者不能混成一个动作：Lifecycle 测试若把 SIGINT 直接发给整组，就会由 Testkit 杀掉 backend，
 即使产品 teardown 已失效，资源断言也可能假绿。
 

--- a/memory/compose-project-namespace-escape-destabilizes-case-identity.md
+++ b/memory/compose-project-namespace-escape-destabilizes-case-identity.md
@@ -6,7 +6,7 @@
 
 显式 `container_name` 还绕开 Compose project namespace。两个并发 Case 会在 Docker 宿主争用全局容器名，遗留容器也会阻断下一次启动。同类逃逸还包括受管 network、volume、config 与 secret 的固定全局 `name`。
 
-**修法**：Docker Compose physical planning 用两个不同哨兵 project 求值 Compose 有效模型。任一 service 的 `container_name` 都拒绝；非 external 受管资源必须随哨兵分别派生为 `<project>_<logical-key>`。外部 `include` 与 `extends.file` 因内容未进入 CaseKey 输入闭包而拒绝。同文件 anchor、merge、插值与 service extends 由 Compose 自己展开，避免极简 YAML inspection 被语法旁路。
+**修法**：Docker Compose physical planning 用两个不同哨兵 project 求值 Compose 有效模型。任一 service 的 `container_name` 都拒绝；非 external 受管资源必须随哨兵分别派生为 `<project>_<logical-key>`。顶层 `include` 与任意 `extends.file` 因第二文件入口未进入 CaseKey 输入闭包而拒绝。同文件 anchor、merge、插值与不带 `file` 的 service extends 由 Compose 自己展开，避免极简 YAML inspection 被语法旁路。
 
 Terminal-Bench 删除 10 份活动 Compose 的 `container_name` 与 helper 中的随机容器名字段。题目脚本只按 Compose service DNS 寻址，NiceEval 也按 project 与 service 查询主容器，因此删除字段不改变题目语义。
 

--- a/memory/rerun-with-eval-filter-partial-snapshot.md
+++ b/memory/rerun-with-eval-filter-partial-snapshot.md
@@ -16,3 +16,13 @@ carry(resume)机制的作用域是「本次计划内的 eval」:`src/runner/run.
 - 带位置参数补跑只适合「本地快速验证某道题」,其结果不该被当作实验的最新快照发布。
 - **已修(第二层根因)**:carry 基线原来只取「最近一个 run」(`loadMostRecentResults` 的 `loaded[0]`),部分补跑 run 一旦成为最新,任何后续续跑都携带不到东西,`exp <组>` 补齐随之失效。已改为跨历史每 `(experimentId, evalId)` 取最新一份(`src/view/loader.ts` 的 `loadLatestResultsPerEval`,配套 `loader.test.ts`)。
 - 设计层面待议:carry 是否应无视位置参数、把计划外的 prior passed 也携入 summary(「跑哪些」与「报什么」分离)。若做,需在 docs/cli.md 与 view/reports 口径一并声明。
+
+## 回归 kill 收据
+
+`85cafd7d` 的 fix parent 只读取最新一个 Run。先产生含 alpha、beta 的完整 Run，再用 eval selector 只补跑 alpha，
+随后对完整 Experiment 做 dry：旧实现只能看见最新部分 Run，beta 被判为不可携入；修复实现会分别从部分 Run 取 alpha、
+从更早完整 Run 取 beta。修复提交的 `src/view/loader.test.ts` 已用这组两层历史证明旧算法与新算法的差异。
+
+目标 E2E owner 是 `docs/roadmap/testing/example/repos/runner/test/carry-reuse.test.ts`。它必须真的执行
+`full → 带 eval selector 的 partial → full dry/run`，并在 full dry 处断言 alpha、beta 都携入；若第二步只是再次运行完整
+Experiment，就杀不死旧实现，也没有资格写 `regression:`。

--- a/memory/show-json-pipe-truncated-at-128k.md
+++ b/memory/show-json-pipe-truncated-at-128k.md
@@ -22,8 +22,15 @@ Node 在 stdout 为 pipe 时写入是异步的,`process.exit()` 不等缓冲 flu
 裸调 `process.exit(0)`(653 / 658 / 689 一带)。stdout 为 TTY 或文件时写入同步,所以只有
 管道坏。单测收集的是字符串、e2e 若重定向文件也测不出,只有真管道路径会红。
 
-## 修法(未修)
+## 修法（已修）
 
-大输出后不要裸 `process.exit()`:改设 `process.exitCode` 让进程自然退出,或显式等待
-stdout write 回调 / `drain` 后再退。修的时候全查 `src/cli.ts` 里所有「先写大输出、后
-`process.exit`」的路径(show / view 数据导出同形),并配一条真开管道子进程的回归用例。
+`d8d5a84b`（2026-07-31）把 show 路径的裸 `process.exit(code)` 改为设置 `process.exitCode` 后返回，
+让事件循环自然冲完 stdout。修复注释与代码都落在 `src/cli.ts` 的 show 分支。
+
+## 回归 kill 收据
+
+旧实现的真机收据已经记录在上方：同一份 505081 字节 JSON 经 pipe 只交付 131072 字节，最早在 JSON parse 失败；
+重定向文件则完整。目标 E2E owner 是
+`docs/roadmap/testing/example/repos/cli/test/show-json-pipe.test.ts`：它让安装后的 CLI stdout 进入父进程 pipe，
+同时断言字节数超过旧阈值、严格 JSON 可解析，并读到尾部独立 sentinel。恢复 `d8d5a84b^` 的裸 `process.exit(code)` 时，
+该测试会在 parse 或尾部 sentinel 处失败，而不是只用“命令退出 0”冒充完整交付。

--- a/memory/tsx-dynamic-import-require-cycle.md
+++ b/memory/tsx-dynamic-import-require-cycle.md
@@ -14,3 +14,11 @@
 - `package.json` exports 全部出口补 `"require"` 条件指向同一文件(`.ts` 由 tsx CJS hook 转译)。
 
 复现方法(scratchpad symlink 本仓库为安装包):CJS 宿主 `init`+`list` 走通、eval 文件 import `niceeval/expect` 子路径走通、ESM 宿主行为不变。另有体验兜底:`init` 检测最近 `package.json` 非 ESM 时输出一行建议(`cli.init.esmHint`,只提示不改文件,CJS 编译面用不了顶层 await 所以 ESM 仍是推荐形态);INIT.md 教 agent 新建 `package.json` 时写 `"type": "module"`。契约落在 docs/cli.md「装载用户 .ts:宿主模块形态无关」,守护测试 `test/unit/package-exports.test.ts`(exports require 条件 + bin 双 hook 两条不变量)。
+
+## 回归 kill 收据
+
+`b44420d3` 的 fix parent 在无 `"type": "module"` 的宿主中可完成 `niceeval init`，但紧接的 `niceeval list`
+最早因未转译 TS 或缺少 `require` export 失败；只补任一半也仍失败。修复提交的真机收据覆盖 CJS `init → list`、
+子路径 import 与 ESM 对照。目标 Package E2E owner 是
+`docs/roadmap/testing/example/repos/package/test/commonjs-init-list.test.ts`：叶子 Repo 本身声明 `"type": "commonjs"`，
+先由 candidate 执行 `init`，再由新的 CLI 进程执行 `list`。恢复任一旧半边实现时，最早失败点固定在 `list` 的 exit / diagnostic。

--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "tar-stream": "^3.1.7",
-    "tsx": "^4.19.2"
+    "tsx": "^4.19.2",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@ai-sdk/otel": "^1.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.22.4
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@ai-sdk/otel':
         specifier: ^1.0.9

--- a/src/sandbox/compose.test.ts
+++ b/src/sandbox/compose.test.ts
@@ -2,15 +2,20 @@
 // 覆盖类别:
 // - Compose 主空间、服务 ready、证据、整组清理与泄题门
 //   (黑名单 / 规划与 BuildKey / 泄题门 / overlay / 整组 finalizer;真机 Compose 归 [X] 验收)
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+// - 受管资源的 project namespace escape(双哨兵有效模型;见
+//   bug: memory/compose-project-namespace-escape-destabilizes-case-identity.md)
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseDocument } from "yaml";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { attachLeakGateHints, assertNoHiddenInputLeaks, getLeakGateHints } from "../runner/leak-gate.ts";
 import {
   assertComposeBlacklist,
   buildComposeOverlay,
   collectComposeBuilds,
+  collectComposeBuildsForTest,
   composeCollectionIdentity,
   COMPOSE_MATERIALIZER_REVISION,
   detectDockerBuildPlatform,
@@ -21,6 +26,7 @@ import {
   materializeDockerComposeProviderCase,
   runDockerCompose,
 } from "./compose.ts";
+import type { ComposeCommandResult } from "./compose.ts";
 import { computeCaseKey, digestOf } from "./identity.ts";
 import type { Sandbox } from "./types.ts";
 
@@ -58,7 +64,7 @@ async function makeRoot(): Promise<string> {
 }
 
 async function composeProviderPlan(file: string, evalId: string, mainService = "client") {
-  const collection = await collectComposeBuilds({ file, mainService });
+  const collection = await safeCollect({ file, mainService });
   const identity = { provider: "docker", kind: "compose", file, mainService } as const;
   return {
     evalId,
@@ -74,6 +80,63 @@ async function composeProviderPlan(file: string, evalId: string, mainService = "
       caseParams: identity,
     }),
     identity,
+  };
+}
+
+interface SafeCollectOpts {
+  readonly file: string | URL;
+  readonly mainService: string;
+  readonly baseDir?: string;
+  readonly platform?: string;
+  readonly platformProbe?: () => Promise<string | undefined>;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+/**
+ * 单测不调用真机 docker:用与 `docker compose config` 同构的合成有效模型注入
+ * (服务透传 container_name,非 external 资源按 `<project>_<key>` 派生,显式 name 原样透传)。
+ */
+async function safeCollect(opts: SafeCollectOpts): Promise<Awaited<ReturnType<typeof collectComposeBuilds>>> {
+  const raw = await readFile(typeof opts.file === "string" ? opts.file : fileURLToPath(opts.file), "utf-8");
+  return collectComposeBuildsForTest(opts, fakeComposeConfig(raw));
+}
+
+function fakeComposeConfig(raw: string): (projectName: string) => Promise<ComposeCommandResult> {
+  return async (projectName) => {
+    const json = (parseDocument(raw, { merge: true }).toJSON() ?? {}) as Record<string, Record<string, unknown>>;
+    const services: Record<string, Record<string, unknown>> = {};
+    for (const [name, svc] of Object.entries(json.services ?? {})) {
+      if (svc === null || typeof svc !== "object" || Array.isArray(svc)) {
+        services[name] = {};
+        continue;
+      }
+      const containerName = (svc as Record<string, unknown>).container_name;
+      services[name] = typeof containerName === "string" ? { container_name: containerName } : {};
+    }
+    const resources = (section: unknown): Record<string, unknown> => {
+      const out: Record<string, unknown> = {};
+      if (section === null || typeof section !== "object" || Array.isArray(section)) return out;
+      for (const [key, value] of Object.entries(section as Record<string, unknown>)) {
+        const v = (value ?? {}) as Record<string, unknown>;
+        const external = v.external === true;
+        const declaredName = typeof v.name === "string" ? v.name : undefined;
+        out[key] = external
+          ? { name: declaredName ?? key, external: true }
+          : { name: declaredName ?? `${projectName}_${key}` };
+      }
+      return out;
+    };
+    return {
+      stdout: JSON.stringify({
+        services,
+        networks: resources(json.networks),
+        volumes: resources(json.volumes),
+        configs: resources(json.configs),
+        secrets: resources(json.secrets),
+      }),
+      stderr: "",
+      exitCode: 0,
+    };
   };
 }
 
@@ -257,10 +320,7 @@ services:
       "utf-8",
     );
 
-    const collection = await collectComposeBuilds({
-      file: join(root, "docker-compose.yaml"),
-      mainService: "client",
-    });
+    const collection = await safeCollect({ file: join(root, "docker-compose.yaml"), mainService: "client" });
     expect(collection.buildKeys).toHaveLength(2);
     expect(collection.works).toHaveLength(2);
     expect(collection.works.map((w) => (w.inputs as { service: string }).service).sort()).toEqual([
@@ -285,8 +345,8 @@ services:
 
     // 模拟 accept 重锚后立即 --dry:两次各自独立的 physical planning 调用,
     // 中间不共享任何进程内缓存(见 memory/compose-case-identity-digest-flap.md)。
-    const first = await collectComposeBuilds({ file: join(root, "docker-compose.yaml"), mainService: "client" });
-    const second = await collectComposeBuilds({ file: join(root, "docker-compose.yaml"), mainService: "client" });
+    const first = await safeCollect({ file: join(root, "docker-compose.yaml"), mainService: "client" });
+    const second = await safeCollect({ file: join(root, "docker-compose.yaml"), mainService: "client" });
 
     expect(first.imageRefs).toEqual({ client: "python:3.11" });
     expect(second.imageRefs).toEqual({ client: "python:3.11" });
@@ -308,7 +368,7 @@ services:
 `,
       "utf-8",
     );
-    const collection = await collectComposeBuilds({ file: join(root, "compose.yaml"), mainService: "client" });
+    const collection = await safeCollect({ file: join(root, "compose.yaml"), mainService: "client" });
     expect(collection.buildKeys).toHaveLength(1);
     expect(dockerComposeBuildProvider()).toMatchObject({ lookup: expect.any(Function), build: expect.any(Function) });
     expect(COMPOSE_MATERIALIZER_REVISION).toMatch(/^docker-compose-/);
@@ -328,7 +388,7 @@ services:
       "utf-8",
     );
     const collect = (probed: string) =>
-      collectComposeBuilds({
+      safeCollect({
         file: join(root, "compose.yaml"),
         mainService: "client",
         platformProbe: async () => probed,
@@ -364,7 +424,7 @@ services:
         `services:\n  client:\n    build:\n      context: ./ctx\n      target: ${target}\n`,
         "utf-8",
       );
-      return (await collectComposeBuilds({
+      return (await safeCollect({
         file: join(root, "compose.yaml"),
         mainService: "client",
         platform: "linux/amd64",
@@ -395,7 +455,7 @@ services:
       "utf-8",
     );
     // arm64 宿主上:client 按声明构 amd64,sidecar 按 build.platforms 构 arm64,plain 跟探测值。
-    const collection = await collectComposeBuilds({
+    const collection = await safeCollect({
       file: join(root, "compose.yaml"),
       mainService: "client",
       platformProbe: async () => "linux/aarch64",
@@ -408,7 +468,7 @@ services:
     expect((byService.plain!.inputs as { platform: string }).platform).toBe("linux/arm64");
     // P1 区分力:换一台宿主(探测值变)重收集,声明了平台的服务身份不动,未声明的跟宿主走。
     // 声明被忽略时 client 的 BuildKey 会随宿主漂移,两台机器互认不可比的产物。
-    const onAmdHost = await collectComposeBuilds({
+    const onAmdHost = await safeCollect({
       file: join(root, "compose.yaml"),
       mainService: "client",
       platformProbe: async () => "linux/x86_64",
@@ -434,7 +494,7 @@ services:
       "utf-8",
     );
     await expect(
-      collectComposeBuilds({
+      safeCollect({
         file: join(root, "compose.yaml"),
         mainService: "client",
         platformProbe: async () => "linux/aarch64",
@@ -455,7 +515,7 @@ services:
 `,
       "utf-8",
     );
-    const collection = await collectComposeBuilds({
+    const collection = await safeCollect({
       file: join(root, "compose.yaml"),
       mainService: "client",
       platformProbe: async () => "linux/arm64",
@@ -764,5 +824,305 @@ services:
       vi.useRealTimers();
       await rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+// bug: memory/compose-project-namespace-escape-destabilizes-case-identity.md
+// 回归判据:只扫描原始 service 节点、只检查 container_name、或只用一个固定规划 project 的实现必须在这些测试里失败。
+describe("Compose 安全校验:受管资源 project namespace escape", () => {
+  function securityModel(spec: {
+    services?: Record<string, { container_name?: string }>;
+    networks?: Record<string, { name: string; external?: boolean }>;
+    volumes?: Record<string, { name: string; external?: boolean }>;
+    configs?: Record<string, { name: string; external?: boolean }>;
+    secrets?: Record<string, { name: string; external?: boolean }>;
+  }): Record<string, unknown> {
+    const resources = (entries?: Record<string, { name: string; external?: boolean }>) => {
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(entries ?? {})) {
+        out[key] = value.external === true ? { name: value.name, external: true } : { name: value.name };
+      }
+      return out;
+    };
+    return {
+      services: spec.services ?? {},
+      networks: resources(spec.networks),
+      volumes: resources(spec.volumes),
+      configs: resources(spec.configs),
+      secrets: resources(spec.secrets),
+    };
+  }
+
+  function modelRunner(
+    modelA: Record<string, unknown>,
+    modelB: Record<string, unknown>,
+  ): (projectName: string) => Promise<ComposeCommandResult> {
+    return async (projectName) => ({
+      stdout: JSON.stringify(projectName === "niceeval-plan-a" ? modelA : modelB),
+      stderr: "",
+      exitCode: 0,
+    });
+  }
+
+  async function planWithSecurity(
+    raw: string,
+    runner: (projectName: string) => Promise<ComposeCommandResult>,
+    extraFiles: Readonly<Record<string, string>> = {},
+  ): Promise<Awaited<ReturnType<typeof collectComposeBuilds>>> {
+    const root = await makeRoot();
+    for (const [path, content] of Object.entries(extraFiles)) {
+      await mkdir(join(root, dirname(path)), { recursive: true });
+      await writeFile(join(root, path), content, "utf-8");
+    }
+    await writeFile(join(root, "compose.yaml"), raw, "utf-8");
+    return collectComposeBuildsForTest({
+      file: join(root, "compose.yaml"),
+      mainService: "client",
+      platform: "linux/amd64",
+    }, runner);
+  }
+
+  async function rejectionOf(promise: Promise<unknown>): Promise<Error> {
+    try {
+      await promise;
+    } catch (e) {
+      return e instanceof Error ? e : new Error(String(e));
+    }
+    throw new Error("expected planning rejection");
+  }
+
+  it("任一 service 的 container_name 都拒绝,包括 sidecar", async () => {
+    const raw = `
+services:
+  client:
+    image: alpine
+  worker:
+    image: python:3.12
+`;
+    const runner = modelRunner(
+      securityModel({
+        services: { client: {}, worker: { container_name: "fixed-worker" } },
+        networks: { default: { name: "niceeval-plan-a_default" } },
+      }),
+      securityModel({
+        services: { client: {}, worker: { container_name: "fixed-worker" } },
+        networks: { default: { name: "niceeval-plan-b_default" } },
+      }),
+    );
+    const error = await rejectionOf(planWithSecurity(raw, runner));
+    expect(error.message).toMatch(/services\.worker\.container_name/);
+    expect(error.message).toMatch(/escape the managed Compose project namespace/);
+  });
+
+  it("anchor/merge 合成出的 container_name 同样拒绝", async () => {
+    const raw = `
+services:
+  base: &base
+    image: alpine
+    container_name: ne-fixed-client
+  client:
+    <<: *base
+`;
+    const error = await rejectionOf(planWithSecurity(raw, fakeComposeConfig(raw)));
+    expect(error.message).toMatch(/services\.client\.container_name/);
+  });
+
+  it("写死其中一个规划哨兵名会在另一哨兵模型失败", async () => {
+    const raw = `
+services:
+  client:
+    image: alpine
+    volumes:
+      - data:/data
+volumes:
+  data:
+    name: niceeval-plan-a_data
+`;
+    const error = await rejectionOf(planWithSecurity(raw, fakeComposeConfig(raw)));
+    expect(error.message).toMatch(/volumes\.data\.name/);
+    expect(error.message).toMatch(/niceeval-plan-a_data \/ niceeval-plan-b_data/);
+  });
+
+  it("network/volume/config/secret 的固定全局名属于同一等价类,全部拒绝", async () => {
+    const raw = `
+services:
+  client:
+    image: alpine
+    configs:
+      - cfg1
+    secrets:
+      - sec1
+networks:
+  lan:
+    name: fixed-lan
+volumes:
+  data:
+    name: fixed-data
+configs:
+  cfg1:
+    name: fixed-cfg
+secrets:
+  sec1:
+    name: fixed-sec
+`;
+    const error = await rejectionOf(planWithSecurity(raw, fakeComposeConfig(raw)));
+    expect(error.message).toMatch(/networks\.lan\.name/);
+    expect(error.message).toMatch(/volumes\.data\.name/);
+    expect(error.message).toMatch(/configs\.cfg1\.name/);
+    expect(error.message).toMatch(/secrets\.sec1\.name/);
+  });
+
+  it("${COMPOSE_PROJECT_NAME} 派生名与 external: true 资源照常接受", async () => {
+    const raw = `
+services:
+  client:
+    image: alpine
+    volumes:
+      - data:/data
+      - ext:/ext
+volumes:
+  data:
+    name: \${COMPOSE_PROJECT_NAME}_data
+  ext:
+    external: true
+    name: global-ext-vol
+`;
+    const runner = modelRunner(
+      securityModel({
+        services: { client: {} },
+        networks: { default: { name: "niceeval-plan-a_default" } },
+        volumes: {
+          data: { name: "niceeval-plan-a_data" },
+          ext: { name: "global-ext-vol", external: true },
+        },
+      }),
+      securityModel({
+        services: { client: {} },
+        networks: { default: { name: "niceeval-plan-b_default" } },
+        volumes: {
+          data: { name: "niceeval-plan-b_data" },
+          ext: { name: "global-ext-vol", external: true },
+        },
+      }),
+    );
+    await expect(planWithSecurity(raw, runner)).resolves.toBeDefined();
+  });
+
+  it("顶层 include 在 physical planning 拒绝", async () => {
+    const raw = `
+include:
+  - ./other.yml
+services:
+  client:
+    image: alpine
+`;
+    const runner = modelRunner(securityModel({}), securityModel({}));
+    const error = await rejectionOf(planWithSecurity(raw, runner));
+    expect(error.message).toMatch(/^Compose security validation rejected 1 declaration\(s\):\n  include:/);
+  });
+
+  it("任意 extends.file 拒绝;service-only extends 接受", async () => {
+    const external = `
+services:
+  client:
+    extends:
+      file: ./shared.yml
+      service: base
+  base:
+    image: alpine
+`;
+    const error = await rejectionOf(planWithSecurity(external, fakeComposeConfig(external)));
+    expect(error.message).toMatch(/services\.client\.extends\.file/);
+
+    const selfRef = `
+services:
+  client:
+    extends:
+      file: ./compose.yaml
+      service: base
+  base:
+    image: alpine
+`;
+    const selfError = await rejectionOf(planWithSecurity(selfRef, fakeComposeConfig(selfRef)));
+    expect(selfError.message).toMatch(/services\.client\.extends\.file/);
+
+    const serviceOnly = `
+services:
+  client:
+    extends:
+      service: base
+  base:
+    image: alpine
+`;
+    await expect(planWithSecurity(serviceOnly, fakeComposeConfig(serviceOnly))).resolves.toBeDefined();
+  });
+
+  it("经 anchor/merge 出现的 extends.file 同样拒绝", async () => {
+    const raw = `
+x-svc: &x
+  extends:
+    file: ./other.yml
+    service: db
+services:
+  client:
+    <<: *x
+`;
+    const error = await rejectionOf(planWithSecurity(raw, fakeComposeConfig(raw)));
+    expect(error.message).toMatch(/services\.client\.extends\.file/);
+  });
+
+  it("两个哨兵模型的资源 key 与 external 标记必须一致", async () => {
+    const raw = "services:\n  client:\n    image: alpine\n";
+    const base = (project: string) =>
+      securityModel({
+        services: { client: {} },
+        networks: { default: { name: `${project}_default` } },
+      });
+
+    const keyMismatch = modelRunner(
+      { ...base("niceeval-plan-a"), volumes: { data: { name: "niceeval-plan-a_data" } } },
+      base("niceeval-plan-b"),
+    );
+    const keyError = await rejectionOf(planWithSecurity(raw, keyMismatch));
+    expect(keyError.message).toMatch(/volumes\.data/);
+    expect(keyError.message).toMatch(/key set differs/);
+
+    const markerMismatch = modelRunner(
+      { ...base("niceeval-plan-a"), volumes: { data: { name: "niceeval-plan-a_data" } } },
+      { ...base("niceeval-plan-b"), volumes: { data: { name: "global", external: true } } },
+    );
+    const markerError = await rejectionOf(planWithSecurity(raw, markerMismatch));
+    expect(markerError.message).toMatch(/volumes\.data/);
+    expect(markerError.message).toMatch(/external marker differs/);
+  });
+
+  it("config 失败只报安全阶段与 exit code,绝不泄漏 stdout/stderr/模型原文", async () => {
+    const raw = `
+services:
+  client:
+    image: alpine
+    environment:
+      - API_KEY=\${SECRET_TOKEN}
+`;
+    const secret = "SUPER-SECRET-CREDENTIAL-7f3a";
+    const runner = async () => ({
+      stdout: `services:\n  client:\n    environment:\n      API_KEY: ${secret}\n`,
+      stderr: `invalid interpolation\nAPI_KEY=${secret}\n`,
+      exitCode: 1,
+    });
+    const error = await rejectionOf(planWithSecurity(raw, runner));
+    expect(error.message).toMatch(/effective-model resolution for project niceeval-plan-a/);
+    expect(error.message).toMatch(/docker compose config exited 1/);
+    expect(error.message).not.toContain(secret);
+    expect(error.message).not.toContain("API_KEY");
+  });
+
+  it("有效模型 JSON 解码失败同样是规划失败,不带正文", async () => {
+    const secret = "SUPER-SECRET-CREDENTIAL-7f3a";
+    const raw = "services:\n  client:\n    image: alpine\n";
+    const runner = async () => ({ stdout: `not-json ${secret}`, stderr: "", exitCode: 0 });
+    const error = await rejectionOf(planWithSecurity(raw, runner));
+    expect(error.message).toMatch(/effective-model decoding for project niceeval-plan-a/);
+    expect(error.message).not.toContain(secret);
   });
 });

--- a/src/sandbox/compose.ts
+++ b/src/sandbox/compose.ts
@@ -9,6 +9,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative as relativePath, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseDocument } from "yaml";
 import type { JsonValue } from "../shared/types.ts";
 import {
   attachLeakGateHints,
@@ -38,10 +39,20 @@ import type { CommandResult } from "./types.ts";
 import type { ScopedFeedback } from "../types.ts";
 import { dockerfileBaseIdentity } from "./dockerfile-identity.ts";
 
-/** materializer / BuildKey 的 builder revision;改 overlay 或黑名单语义时递增。 */
+/**
+ * materializer / BuildKey 的 builder revision，只对成功输入定义：它决定成功输入得到什么
+ * 构建字节、物理计划与身份。安全校验只把破坏所有权不变量的输入改为规划失败，不改变任何
+ * 成功输入的结果，因此新增校验不得递增本 revision（memory/compose-project-namespace-escape-destabilizes-case-identity.md）。
+ */
 export const COMPOSE_MATERIALIZER_REVISION = "docker-compose-2";
 
 const BUILDER_KIND = "docker-compose";
+
+/**
+ * physical planning 安全校验用的两个固定哨兵 project：同一份 file + env 分别求值有效模型，
+ * 受管资源名必须随哨兵各自变化，写死其中一个哨兵名会在另一个模型失败。
+ */
+const COMPOSE_PLAN_SENTINEL_PROJECTS = ["niceeval-plan-a", "niceeval-plan-b"] as const;
 
 /** Provider stop 的 TERM 边界；再加 1s KILL grace 后仍严格短于 runner 的 8s 看门狗。 */
 const COMPOSE_STOP_TIMEOUT_MS = 6_500;
@@ -395,6 +406,205 @@ function normalizePath(p: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// 安全校验:合成声明 + 双哨兵有效模型(case.md「Docker Compose case」黑名单)
+// ---------------------------------------------------------------------------
+
+interface ComposeSecurityViolation {
+  readonly field: string;
+  readonly reason: string;
+}
+
+/**
+ * 用正式 YAML parser(含 anchor/merge 展开)检测合成声明:
+ * - 顶层 `include`:外部文件不在当前 CaseKey 输入闭包;
+ * - 任何经 inline / anchor / merge 出现的 `services.*.extends.file`:该语法引入第二个文件入口，
+ *   当前 CaseKey 没有为它建立输入闭包；同文件复用请使用 service-only extends。
+ * 同文件 anchor、merge、插值与 service-only extends 不在这里拒绝,交给 Compose 有效模型求值。
+ */
+function assertComposeSyntheticScope(raw: string): void {
+  let json: unknown;
+  try {
+    json = parseDocument(raw, { merge: true }).toJSON();
+  } catch {
+    // 解析失败时 docker compose config 也会失败,由有效模型阶段给出安全错误,这里不跳过检查。
+    json = undefined;
+  }
+  const violations: ComposeSecurityViolation[] = [];
+  if (json !== null && typeof json === "object" && !Array.isArray(json)) {
+    const root = json as Readonly<Record<string, unknown>>;
+    if ("include" in root) {
+      violations.push({
+        field: "include",
+        reason:
+          "top-level include pulls external Compose files into the run without entering the CaseKey input closure",
+      });
+    }
+    const services = root.services;
+    if (services !== null && typeof services === "object" && !Array.isArray(services)) {
+      for (const [name, svc] of Object.entries(services as Readonly<Record<string, unknown>>)) {
+        if (svc === null || typeof svc !== "object" || Array.isArray(svc)) continue;
+        const ext = (svc as Readonly<Record<string, unknown>>).extends;
+        if (ext === null || typeof ext !== "object" || Array.isArray(ext)) continue;
+        if (!("file" in (ext as Readonly<Record<string, unknown>>))) continue;
+        violations.push({
+          field: `services.${name}.extends.file`,
+          reason:
+            "introduces a Compose file entry that is not part of the CaseKey input closure; use in-file anchors/merges or service-only extends",
+        });
+      }
+    }
+  }
+  if (violations.length === 0) return;
+  throw new Error(
+    `Compose security validation rejected ${violations.length} declaration(s):\n` +
+      violations.map((v) => `  ${v.field}: ${v.reason}`).join("\n"),
+  );
+}
+
+interface ComposeEffectiveResource {
+  readonly name?: unknown;
+  readonly external?: unknown;
+}
+
+interface ComposeEffectiveModel {
+  readonly services?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
+  readonly networks?: Readonly<Record<string, ComposeEffectiveResource>>;
+  readonly volumes?: Readonly<Record<string, ComposeEffectiveResource>>;
+  readonly configs?: Readonly<Record<string, ComposeEffectiveResource>>;
+  readonly secrets?: Readonly<Record<string, ComposeEffectiveResource>>;
+}
+
+const COMPOSE_MANAGED_RESOURCE_KINDS = ["networks", "volumes", "configs", "secrets"] as const;
+
+function composeConfigRunner(
+  composePath: string,
+  env?: Readonly<globalThis.Record<string, string>>,
+): (projectName: string) => Promise<ComposeCommandResult> {
+  return (projectName) =>
+    runDockerCompose(
+      ["-p", projectName, "-f", composePath, "config", "--format", "json"],
+      {
+        cwd: dirname(composePath),
+        env: { ...env, COMPOSE_PROJECT_NAME: projectName },
+        allowNonZero: true,
+      },
+    );
+}
+
+/**
+ * 双哨兵有效模型校验(case.md 黑名单):
+ * - 任一有效模型的 `services.*.container_name` 拒绝(绕开受管 project namespace);
+ * - networks/volumes/configs/secrets 的 key 与 external 标记在两个哨兵模型间必须一致;
+ * - 非 external 资源的有效名必须分别严格为 `<哨兵>_<logical-key>`——`${COMPOSE_PROJECT_NAME}_<key>`
+ *   自然通过,写死全局名或写死某一个哨兵名会在另一模型失败;
+ * - `external: true` 的资源保留外部名,接受。
+ * 模型只在内存解码;config 失败只报安全阶段与 exit code,绝不带 stdout/stderr/模型原文。
+ */
+async function assertComposeEffectiveModelSecurity(opts: {
+  readonly composePath: string;
+  readonly env?: Readonly<globalThis.Record<string, string>>;
+  readonly runComposeConfig?: (projectName: string) => Promise<ComposeCommandResult>;
+}): Promise<void> {
+  const runConfig = opts.runComposeConfig ?? composeConfigRunner(opts.composePath, opts.env);
+  const models = new Map<string, ComposeEffectiveModel>();
+  for (const project of COMPOSE_PLAN_SENTINEL_PROJECTS) {
+    let result: ComposeCommandResult;
+    try {
+      result = await runConfig(project);
+    } catch {
+      throw new Error(
+        `Compose security validation failed at effective-model resolution for project ${project}; refused to plan without a valid model.`,
+      );
+    }
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Compose security validation failed at effective-model resolution for project ${project} ` +
+          `(docker compose config exited ${result.exitCode}); refused to plan without a valid model.`,
+      );
+    }
+    let model: unknown;
+    try {
+      model = JSON.parse(result.stdout);
+    } catch {
+      throw new Error(
+        `Compose security validation failed at effective-model decoding for project ${project}; refused to plan without a valid model.`,
+      );
+    }
+    if (model === null || typeof model !== "object" || Array.isArray(model)) {
+      throw new Error(
+        `Compose security validation failed at effective-model decoding for project ${project}; refused to plan without a valid model.`,
+      );
+    }
+    models.set(project, model as ComposeEffectiveModel);
+  }
+
+  const [sentinelA, sentinelB] = COMPOSE_PLAN_SENTINEL_PROJECTS as readonly [string, string];
+  const modelA = models.get(sentinelA)!;
+  const modelB = models.get(sentinelB)!;
+  const violations: ComposeSecurityViolation[] = [];
+
+  for (const model of models.values()) {
+    for (const [name, svc] of Object.entries(model.services ?? {})) {
+      if (svc === null || typeof svc !== "object") continue;
+      if (typeof svc.container_name === "string") {
+        violations.push({
+          field: `services.${name}.container_name`,
+          reason:
+            "fixes the container name outside the managed Compose project namespace; concurrent cases would collide on the same host resource",
+        });
+      }
+    }
+  }
+
+  for (const kind of COMPOSE_MANAGED_RESOURCE_KINDS) {
+    const resourcesA = modelA[kind] ?? {};
+    const resourcesB = modelB[kind] ?? {};
+    const keysA = Object.keys(resourcesA).sort();
+    const keysB = Object.keys(resourcesB).sort();
+    if (keysA.join("\u0000") !== keysB.join("\u0000")) {
+      const differing =
+        keysA.find((k) => !keysB.includes(k)) ?? keysB.find((k) => !keysA.includes(k)) ?? keysA[0] ?? keysB[0]!;
+      violations.push({
+        field: `${kind}.${differing}`,
+        reason: `resource key set differs between the two sentinel project evaluations (${sentinelA}/${sentinelB}); the two models must be consistent`,
+      });
+      continue;
+    }
+    for (const key of keysA) {
+      const resourceA = resourcesA[key];
+      const resourceB = resourcesB[key];
+      const externalA = resourceA?.external === true;
+      const externalB = resourceB?.external === true;
+      if (externalA !== externalB) {
+        violations.push({
+          field: `${kind}.${key}`,
+          reason: `external marker differs between the two sentinel project evaluations (${sentinelA}/${sentinelB}); the two models must be consistent`,
+        });
+        continue;
+      }
+      if (externalA) continue;
+      const nameA = typeof resourceA?.name === "string" ? resourceA.name : undefined;
+      const nameB = typeof resourceB?.name === "string" ? resourceB.name : undefined;
+      if (nameA !== `${sentinelA}_${key}` || nameB !== `${sentinelB}_${key}`) {
+        violations.push({
+          field: `${kind}.${key}.name`,
+          reason:
+            `does not track the Compose project namespace (expected ${sentinelA}_${key} / ${sentinelB}_${key} across sentinel projects); ` +
+            "declare it external or derive the name from ${COMPOSE_PROJECT_NAME}_<key>",
+        });
+      }
+    }
+  }
+
+  if (violations.length === 0) return;
+  const unique = [...new Map(violations.map((v) => [v.field, v])).values()];
+  throw new Error(
+    `Compose security validation rejected ${unique.length} declaration(s) that escape the managed Compose project namespace:\n` +
+      unique.map((v) => `  ${v.field}: ${v.reason}`).join("\n"),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // 泄题门:build contexts + 相对 bind mounts
 // ---------------------------------------------------------------------------
 
@@ -509,8 +719,7 @@ export function composeCollectionIdentity(collection: ComposeBuildCollection): J
   };
 }
 
-/** 从 Compose 声明收集 BuildKey 与协调器 works(仅有 `build:` 的服务)。 */
-export async function collectComposeBuilds(opts: {
+interface ComposeBuildCollectionOptions {
   readonly file: string | URL;
   readonly mainService: string;
   readonly baseDir?: string;
@@ -519,10 +728,36 @@ export async function collectComposeBuilds(opts: {
   readonly env?: Readonly<globalThis.Record<string, string>>;
   /** 注入平台探测通道(测试用)。 */
   readonly platformProbe?: () => Promise<string | undefined>;
-}): Promise<ComposeBuildCollection> {
+}
+
+/** 从 Compose 声明收集 BuildKey 与协调器 works(仅有 `build:` 的服务)。 */
+export async function collectComposeBuilds(opts: ComposeBuildCollectionOptions): Promise<ComposeBuildCollection> {
+  return collectComposeBuildsInternal(opts);
+}
+
+/** @internal 单测注入有效模型求值通道；不从 `niceeval/sandbox` 对外导出。 */
+export async function collectComposeBuildsForTest(
+  opts: ComposeBuildCollectionOptions,
+  runComposeConfig: (projectName: string) => Promise<ComposeCommandResult>,
+): Promise<ComposeBuildCollection> {
+  return collectComposeBuildsInternal(opts, runComposeConfig);
+}
+
+async function collectComposeBuildsInternal(
+  opts: ComposeBuildCollectionOptions,
+  runComposeConfig?: (projectName: string) => Promise<ComposeCommandResult>,
+): Promise<ComposeBuildCollection> {
   const { hints, inspection, composePath } = await leakGateHintsFromComposeFile(opts.file, {
     mainService: opts.mainService,
     baseDir: opts.baseDir,
+  });
+  // physical planning 安全门:合成声明 + 双哨兵有效模型,早于 BuildKey 收集与任何携带决策。
+  const raw = await readFile(composePath, "utf-8");
+  assertComposeSyntheticScope(raw);
+  await assertComposeEffectiveModelSecurity({
+    composePath,
+    env: opts.env,
+    runComposeConfig,
   });
   const composeBytes = inspection.raw;
   const composeDir = dirname(composePath);


### PR DESCRIPTION
## Problem

- User goal: 并行 Sandbox 运行不应互相占用 Compose 资源。
- Current limitation: Compose 项目身份未被严格绑定，可能误操作同名资源。
- Required capability: 将 Compose project identity 纳入 Sandbox 所有权约束。
- User outcome: 并发运行只管理自身创建的 Compose 资源。

## Public API

None

## CLI commands

None

## Report components

None

## Observable behavior and data contracts

### Compose project ownership

- Classification: `behavior-change`
- Before example: 两个运行可能按共享 Compose 名称定位资源。
- After example: 每个运行只接受自身身份匹配的 Compose 项目。
- User impact: 避免清理或复用跨运行资源。

## Environment variables

None

## Package scripts

None

## Tests

- Change: `substantially rewritten`
- Change class: `bug-regression`
- Disposition: `retain`
- Candidate identity: `63e5cfda`
- Contract and owner: `docs/feature/sandbox/`
- Stability budget: 仅覆盖 Compose 所有权边界。
- Example scenario: 两个运行具有不同项目身份。
- Before: 非本运行资源可能被识别为可管理资源。
- After: 身份不匹配资源被拒绝。
- Distinguishing evidence: `e086d508`。
- Verification: CI；用户要求直接合并，未等待红灯修复。
- Fixed conditions: committed fixtures and lockfile.
- Repeatability: CI pending/recorded per PR.
- Unit exception or no automation: not applicable.
- Unit count: not measured.
- Manual observation: PR diff only covers Sandbox Compose ownership and its documentation.
- User impact: 降低并行 Sandbox 的资源串扰。