### PR TITLE
build(package): 发布原生 ESM 与 CJS 运行时

### DIFF
--- a/bin/niceeval.js
+++ b/bin/niceeval.js
@@ -5,12 +5,14 @@
 // CJS,宿主项目是 CJS 形态(npm init -y 默认)时用户文件落进 Node 的 CJS loader,只注册 ESM
 // hook 就没人转译(见 docs/cli.md「装载用户 .ts」)。
 // 这样框架与被测项目都不需要编译步骤,也不挑宿主的模块形态。
-import { fileURLToPath } from "node:url";
-import { register as registerCjs } from "tsx/cjs/api";
-import { register as registerEsm } from "tsx/esm/api";
+// NiceEval 自身始终执行已发布的 canonical CJS runtime；tsx 只负责随后动态装载用户项目的
+// TypeScript，绝不把已安装包回跳到 checkout 的 src/。
+const cliUrl = new URL("../dist/cli.cjs", import.meta.url);
+await import(cliUrl.href);
 
+// 先原生加载 CLI，避免 CJS hook 截获已预编译的 canonical graph 形成 require/import 循环；
+// CLI 随后的 config、eval、experiment 与 report 文件仍由两面 hook 动态装载。
+const { register: registerCjs } = await import("tsx/cjs/api");
+const { register: registerEsm } = await import("tsx/esm/api");
 registerCjs();
 registerEsm();
-
-const cliUrl = new URL("../src/cli.ts", import.meta.url);
-await import(fileURLToPath(cliUrl));

--- a/package.json
+++ b/package.json
@@ -14,84 +14,152 @@
   "bin": {
     "niceeval": "bin/niceeval.js"
   },
-  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./src/index.ts"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./sandbox": {
-      "types": "./src/sandbox/index.ts",
-      "import": "./src/sandbox/index.ts",
-      "require": "./src/sandbox/index.ts"
+      "import": {
+        "types": "./dist/sandbox/index.d.mts",
+        "default": "./dist/sandbox/index.mjs"
+      },
+      "require": {
+        "types": "./dist/sandbox/index.d.cts",
+        "default": "./dist/sandbox/index.cjs"
+      }
     },
     "./sandbox/e2b-template": {
-      "types": "./src/sandbox/e2b-agent-template.ts",
-      "import": "./src/sandbox/e2b-agent-template.ts",
-      "require": "./src/sandbox/e2b-agent-template.ts"
+      "import": {
+        "types": "./dist/sandbox/e2b-agent-template.d.mts",
+        "default": "./dist/sandbox/e2b-agent-template.mjs"
+      },
+      "require": {
+        "types": "./dist/sandbox/e2b-agent-template.d.cts",
+        "default": "./dist/sandbox/e2b-agent-template.cjs"
+      }
     },
     "./adapter": {
-      "types": "./src/agents/index.ts",
-      "import": "./src/agents/index.ts",
-      "require": "./src/agents/index.ts"
+      "import": {
+        "types": "./dist/agents/index.d.mts",
+        "default": "./dist/agents/index.mjs"
+      },
+      "require": {
+        "types": "./dist/agents/index.d.cts",
+        "default": "./dist/agents/index.cjs"
+      }
     },
     "./adapter/otel": {
-      "types": "./src/agents/ai-sdk-otel.ts",
-      "import": "./src/agents/ai-sdk-otel.ts",
-      "require": "./src/agents/ai-sdk-otel.ts"
+      "import": {
+        "types": "./dist/agents/ai-sdk-otel.d.mts",
+        "default": "./dist/agents/ai-sdk-otel.mjs"
+      },
+      "require": {
+        "types": "./dist/agents/ai-sdk-otel.d.cts",
+        "default": "./dist/agents/ai-sdk-otel.cjs"
+      }
     },
     "./expect": {
-      "types": "./src/expect/index.ts",
-      "import": "./src/expect/index.ts",
-      "require": "./src/expect/index.ts"
+      "import": {
+        "types": "./dist/expect/index.d.mts",
+        "default": "./dist/expect/index.mjs"
+      },
+      "require": {
+        "types": "./dist/expect/index.d.cts",
+        "default": "./dist/expect/index.cjs"
+      }
     },
     "./reporters": {
-      "types": "./src/runner/reporters/index.ts",
-      "import": "./src/runner/reporters/index.ts",
-      "require": "./src/runner/reporters/index.ts"
+      "import": {
+        "types": "./dist/runner/reporters/index.d.mts",
+        "default": "./dist/runner/reporters/index.mjs"
+      },
+      "require": {
+        "types": "./dist/runner/reporters/index.d.cts",
+        "default": "./dist/runner/reporters/index.cjs"
+      }
     },
     "./loaders": {
-      "types": "./src/loaders/index.ts",
-      "import": "./src/loaders/index.ts",
-      "require": "./src/loaders/index.ts"
+      "import": {
+        "types": "./dist/loaders/index.d.mts",
+        "default": "./dist/loaders/index.mjs"
+      },
+      "require": {
+        "types": "./dist/loaders/index.d.cts",
+        "default": "./dist/loaders/index.cjs"
+      }
     },
     "./record": {
-      "types": "./src/record/index.ts",
-      "import": "./src/record/index.ts",
-      "require": "./src/record/index.ts"
+      "import": {
+        "types": "./dist/record/index.d.mts",
+        "default": "./dist/record/index.mjs"
+      },
+      "require": {
+        "types": "./dist/record/index.d.cts",
+        "default": "./dist/record/index.cjs"
+      }
     },
     "./sample": {
-      "types": "./src/sample/index.ts",
-      "import": "./src/sample/index.ts",
-      "require": "./src/sample/index.ts"
+      "import": {
+        "types": "./dist/sample/index.d.mts",
+        "default": "./dist/sample/index.mjs"
+      },
+      "require": {
+        "types": "./dist/sample/index.d.cts",
+        "default": "./dist/sample/index.cjs"
+      }
     },
     "./report": {
-      "types": "./dist/report/index.d.ts",
-      "import": "./dist/report/index.js",
-      "require": "./dist/report/index.js"
+      "import": {
+        "types": "./dist/report/index.d.mts",
+        "default": "./dist/report/index.mjs"
+      },
+      "require": {
+        "types": "./dist/report/index.d.cts",
+        "default": "./dist/report/index.cjs"
+      }
     },
     "./report/react": {
-      "types": "./dist/report/react/index.d.ts",
-      "import": "./dist/report/react/index.js",
-      "require": "./dist/report/react/index.js"
+      "import": {
+        "types": "./dist/report/react/index.d.mts",
+        "default": "./dist/report/react/index.mjs"
+      },
+      "require": {
+        "types": "./dist/report/react/index.d.cts",
+        "default": "./dist/report/react/index.cjs"
+      }
     },
     "./report/built-in": {
-      "types": "./dist/report/built-in/index.d.ts",
-      "import": "./dist/report/built-in/index.js",
-      "require": "./dist/report/built-in/index.js"
+      "import": {
+        "types": "./dist/report/built-in/index.d.mts",
+        "default": "./dist/report/built-in/index.mjs"
+      },
+      "require": {
+        "types": "./dist/report/built-in/index.d.cts",
+        "default": "./dist/report/built-in/index.cjs"
+      }
     },
     "./report/extension": {
-      "types": "./dist/report/extension/index.d.ts",
-      "import": "./dist/report/extension/index.js",
-      "require": "./dist/report/extension/index.js"
+      "import": {
+        "types": "./dist/report/extension/index.d.mts",
+        "default": "./dist/report/extension/index.mjs"
+      },
+      "require": {
+        "types": "./dist/report/extension/index.d.cts",
+        "default": "./dist/report/extension/index.cjs"
+      }
     },
-    "./report/react/styles.css": "./src/report/assets/styles.css",
-    "./report/react/enhance.js": "./src/report/assets/enhance.js"
+    "./report/react/styles.css": "./dist/report/assets/styles.css",
+    "./report/react/enhance.js": "./dist/report/assets/enhance.js"
   },
   "files": [
     "INDEX.md",
-    "src",
     "bin",
     "dist",
     "docs-site/zh",
@@ -106,9 +174,10 @@
     "docs:reference": "tsx scripts/generate-reference.ts",
     "tiers:sync": "node scripts/sync-tiers.mjs sync",
     "view:build": "vite build --config src/view/app/vite.config.ts",
-    "build:report": "node scripts/prune-report-dist.mjs --clean && tsc -p tsconfig.report-build.json && node scripts/prune-report-dist.mjs",
+    "build:report": "pnpm run build:package",
+    "build:package": "pnpm run view:build && node scripts/package-runtime/build.mjs",
     "build:index": "tsx scripts/generate-reference.ts --bundled-index",
-    "prepare": "pnpm run view:build && pnpm run build:report && pnpm run build:index",
+    "prepare": "pnpm run build:package && pnpm run build:index",
     "site:dev": "cd site && node scripts/dev.mjs",
     "site:build": "cd site && next build && cd .. && tsx scripts/submit-indexnow.ts",
     "docs:dev": "node scripts/docs-dev.mjs",
@@ -153,6 +222,7 @@
     "clsx": "^2.1.1",
     "dockerode": "^4.0.2",
     "e2b": "^2.31.0",
+    "esbuild": "^0.28.1",
     "lucide-react": "^1.21.0",
     "mixpanel-browser": "^2.80.0",
     "motion": "^12.42.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       e2b:
         specifier: ^2.31.0
         version: 2.31.0
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)

--- a/scripts/package-runtime/build.mjs
+++ b/scripts/package-runtime/build.mjs
@@ -1,0 +1,345 @@
+import { cp, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+const esbuild = require("esbuild");
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const SRC = join(ROOT, "src");
+const DIST = join(ROOT, "dist");
+const TYPES_CONFIG = join(ROOT, "tsconfig.package-types.json");
+
+// 每个公开入口的 .mjs 只从对应的 canonical .cjs 取值。它们不参与源码编译，因而无论
+// import 还是 require 都观察同一份 NiceEval 模块状态。
+const PUBLIC_ENTRIES = [
+  [".", "index.ts"],
+  ["./sandbox", "sandbox/index.ts"],
+  ["./sandbox/e2b-template", "sandbox/e2b-agent-template.ts"],
+  ["./adapter", "agents/index.ts"],
+  ["./adapter/otel", "agents/ai-sdk-otel.ts"],
+  ["./expect", "expect/index.ts"],
+  ["./reporters", "runner/reporters/index.ts"],
+  ["./loaders", "loaders/index.ts"],
+  ["./record", "record/index.ts"],
+  ["./sample", "sample/index.ts"],
+  ["./report", "report/index.ts"],
+  ["./report/react", "report/react/index.tsx"],
+  ["./report/built-in", "report/built-in/index.tsx"],
+  ["./report/extension", "report/extension/index.ts"],
+];
+
+function isRuntimeSource(file) {
+  return (file.endsWith(".ts") || file.endsWith(".tsx")) &&
+    !file.endsWith(".test.ts") &&
+    !file.endsWith(".test.tsx") &&
+    !file.endsWith(".harness.ts");
+}
+
+function isExcludedSource(relativePath) {
+  return relativePath === "view/app" || relativePath.startsWith("view/app/");
+}
+
+function isRuntimeAsset(relativePath) {
+  return [".css", ".html", ".js", ".json"].includes(extname(relativePath));
+}
+
+async function walk(dir, files = []) {
+  for (const name of await readdir(dir)) {
+    const absolute = join(dir, name);
+    const info = await stat(absolute);
+    if (info.isDirectory()) await walk(absolute, files);
+    else files.push(absolute);
+  }
+  return files;
+}
+
+function runtimePath(relativeSource, extension) {
+  return relativeSource.replace(/\.(?:tsx?|jsx?)$/, extension);
+}
+
+function relativeRuntimeSpecifier(specifier, extension) {
+  if (!specifier.startsWith(".")) return specifier;
+  return specifier.replace(/\.(?:tsx?|jsx?)$/, extension);
+}
+
+function transformForCjs(source, fileName) {
+  let usesImportMeta = false;
+  let usesImportMetaDirname = false;
+  let usesDynamicImport = false;
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.ES2022,
+    true,
+    fileName.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const transformed = ts.transform(sourceFile, [
+    (context) => {
+      const visit = (node) => {
+        if (
+          ts.isPropertyAccessExpression(node) &&
+          ts.isMetaProperty(node.expression) &&
+          node.expression.keywordToken === ts.SyntaxKind.ImportKeyword &&
+          node.expression.name.text === "meta"
+        ) {
+          if (node.name.text === "url") {
+            usesImportMeta = true;
+            return ts.factory.createIdentifier("__niceevalImportMetaUrl");
+          }
+          if (node.name.text === "dirname") {
+            usesImportMetaDirname = true;
+            return ts.factory.createIdentifier("__niceevalImportMetaDirname");
+          }
+        }
+        if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+          usesDynamicImport = true;
+          const args = [...node.arguments];
+          if (args[0] && ts.isStringLiteral(args[0])) {
+            args[0] = ts.factory.createStringLiteral(relativeRuntimeSpecifier(args[0].text, ".cjs"));
+          }
+          return ts.factory.updateCallExpression(
+            node,
+            ts.factory.createIdentifier("__niceevalDynamicImport"),
+            node.typeArguments,
+            args,
+          );
+        }
+        return ts.visitEachChild(node, visit, context);
+      };
+      return (node) => ts.visitNode(node, visit);
+    },
+  ]);
+  const text = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }).printFile(transformed.transformed[0]);
+  transformed.dispose();
+  return { text, usesImportMeta, usesImportMetaDirname, usesDynamicImport };
+}
+
+function injectPrelude(code, lines) {
+  if (lines.length === 0) return code;
+  const strict = '"use strict";\n';
+  return code.startsWith(strict) ? `${strict}${lines.join("\n")}\n${code.slice(strict.length)}` : `${lines.join("\n")}\n${code}`;
+}
+
+function rewriteCjsRelativeRequires(code) {
+  return code.replace(/require\((['"])(\.\.?\/[^'"]+)\.(?:js|jsx|ts|tsx)\1\)/g, (_all, quote, stem) => {
+    return `require(${quote}${stem}.cjs${quote})`;
+  });
+}
+
+function rewriteRemarkRequires(code, outputFile, outputRoot) {
+  const vendor = (name) => {
+    const target = join(outputRoot, "vendor", "remark", `${name}.cjs`);
+    const specifier = relative(dirname(outputFile), target).replaceAll("\\", "/");
+    return specifier.startsWith(".") ? specifier : `./${specifier}`;
+  };
+  for (const name of ["remark", "remark-gfm", "remark-parse"]) {
+    const escaped = name.replace(/[-/]/g, "\\$&");
+    code = code.replace(new RegExp(`require\\((['"])${escaped}\\1\\)`, "g"), `require("${vendor(name)}")`);
+  }
+  return code;
+}
+
+function withoutSourceMapComment(code) {
+  return code.replace(/\n\/\/# sourceMappingURL=.*?(?:\r?\n)?$/, "\n");
+}
+
+async function writeRuntimeModule(outputFile, code, mapText) {
+  await mkdir(dirname(outputFile), { recursive: true });
+  const mapName = `${basename(outputFile)}.map`;
+  await writeFile(outputFile, `${withoutSourceMapComment(code)}//# sourceMappingURL=${mapName}\n`);
+  await writeFile(`${outputFile}.map`, mapText);
+}
+
+async function emitDeclarations(tempRoot) {
+  const config = ts.getParsedCommandLineOfConfigFile(TYPES_CONFIG, {}, ts.sys);
+  if (!config) throw new Error(`Unable to read ${TYPES_CONFIG}`);
+  const options = {
+    ...config.options,
+    noEmit: false,
+    emitDeclarationOnly: true,
+    declaration: true,
+    declarationMap: false,
+    outDir: tempRoot,
+  };
+  const program = ts.createProgram({ rootNames: config.fileNames, options, projectReferences: config.projectReferences });
+  const diagnostics = [...ts.getPreEmitDiagnostics(program), ...program.emit(undefined, undefined, undefined, true).diagnostics]
+    .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
+  if (diagnostics.length > 0) {
+    throw new Error(ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (name) => name,
+      getCurrentDirectory: () => ROOT,
+      getNewLine: () => "\n",
+    }));
+  }
+  return program;
+}
+
+function rewriteDeclarationSpecifiers(text, extension) {
+  return text.replace(/(['"])(\.\.?\/[^'"]+)\.(?:js|jsx|ts|tsx)\1/g, (_all, quote, stem) => `${quote}${stem}.${extension}${quote}`);
+}
+
+async function writeDualDeclarations(rawTypes, outputRoot) {
+  for (const file of await walk(rawTypes)) {
+    if (!file.endsWith(".d.ts")) continue;
+    const rel = relative(rawTypes, file);
+    const base = rel.slice(0, -".d.ts".length);
+    const text = await readFile(file, "utf8");
+    for (const [suffix, extension] of [[".d.cts", "cjs"], [".d.mts", "mjs"], [".d.ts", "js"]]) {
+      const target = join(outputRoot, `${base}${suffix}`);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, rewriteDeclarationSpecifiers(text, extension));
+    }
+  }
+}
+
+function publicValueExports(program, relativeSource) {
+  const sourceFile = program.getSourceFile(join(SRC, relativeSource));
+  if (!sourceFile) throw new Error(`Missing public source ${relativeSource}`);
+  const checker = program.getTypeChecker();
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) throw new Error(`Missing module symbol for ${relativeSource}`);
+  return checker
+    .getExportsOfModule(moduleSymbol)
+    .filter((symbol) => {
+      const target = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+      return (target.flags & ts.SymbolFlags.Value) !== 0;
+    })
+    .map((symbol) => symbol.name)
+    .sort();
+}
+
+async function writeEsmFacade(outputRoot, source, valueNames, extension = ".mjs") {
+  const cjsFile = runtimePath(source, ".cjs");
+  const facadeFile = runtimePath(source, extension);
+  const output = join(outputRoot, facadeFile);
+  const cjsSpecifier = `./${basename(cjsFile)}`;
+  const lines = [
+    `import __niceevalCanonical from ${JSON.stringify(cjsSpecifier)};`,
+  ];
+  let index = 0;
+  for (const name of valueNames) {
+    if (name === "default") {
+      lines.push("export default __niceevalCanonical.default;");
+      continue;
+    }
+    const local = `__niceevalExport${index++}`;
+    lines.push(`const ${local} = __niceevalCanonical[${JSON.stringify(name)}];`);
+    lines.push(`export { ${local} as ${name} };`);
+  }
+  const map = JSON.stringify({ version: 3, file: basename(output), sources: [], names: [], mappings: "" });
+  await writeRuntimeModule(output, `${lines.join("\n")}\n`, map);
+}
+
+async function copyRuntimeAssets(outputRoot) {
+  for (const file of await walk(SRC)) {
+    const rel = relative(SRC, file);
+    if (isExcludedSource(rel) || !isRuntimeAsset(rel)) continue;
+    const target = join(outputRoot, rel);
+    await mkdir(dirname(target), { recursive: true });
+    await cp(file, target);
+  }
+}
+
+async function buildRemarkVendor(outputRoot) {
+  await esbuild.build({
+    entryPoints: {
+      remark: require.resolve("remark"),
+      "remark-gfm": require.resolve("remark-gfm"),
+      "remark-parse": require.resolve("remark-parse"),
+    },
+    outdir: join(outputRoot, "vendor", "remark"),
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    target: ["node18"],
+    sourcemap: true,
+    outExtension: { ".js": ".cjs" },
+    logLevel: "silent",
+  });
+}
+
+async function build() {
+  const temp = await mkdtemp(join(tmpdir(), "niceeval-package-runtime-"));
+  const outputRoot = join(temp, "dist");
+  const rawTypes = join(temp, "types");
+  try {
+    const program = await emitDeclarations(rawTypes);
+    await mkdir(outputRoot, { recursive: true });
+    await buildRemarkVendor(outputRoot);
+
+    const runtimeSources = (await walk(SRC))
+      .map((file) => relative(SRC, file))
+      .filter((rel) => !isExcludedSource(rel) && isRuntimeSource(rel));
+    for (const rel of runtimeSources) {
+      const file = join(SRC, rel);
+      const output = join(outputRoot, runtimePath(rel, ".cjs"));
+      const input = await readFile(file, "utf8");
+      const transformed = transformForCjs(input, file);
+      const compiled = ts.transpileModule(transformed.text, {
+        compilerOptions: {
+          target: ts.ScriptTarget.ES2022,
+          module: ts.ModuleKind.CommonJS,
+          moduleResolution: ts.ModuleResolutionKind.Node10,
+          ignoreDeprecations: "6.0",
+          jsx: ts.JsxEmit.ReactJSX,
+          esModuleInterop: true,
+          sourceMap: true,
+          inlineSourceMap: false,
+          inlineSources: true,
+          rewriteRelativeImportExtensions: true,
+          allowImportingTsExtensions: true,
+          verbatimModuleSyntax: false,
+        },
+        fileName: file,
+        reportDiagnostics: true,
+      });
+      const errors = (compiled.diagnostics ?? []).filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
+      if (errors.length > 0) {
+        throw new Error(ts.formatDiagnosticsWithColorAndContext(errors, {
+          getCanonicalFileName: (name) => name,
+          getCurrentDirectory: () => ROOT,
+          getNewLine: () => "\n",
+        }));
+      }
+      const prelude = [];
+      if (transformed.usesImportMeta) {
+        prelude.push('const { pathToFileURL: __niceevalPathToFileURL } = require("node:url");');
+        prelude.push("const __niceevalImportMetaUrl = __niceevalPathToFileURL(__filename).href;");
+      }
+      if (transformed.usesImportMetaDirname) {
+        prelude.push('const { dirname: __niceevalDirname } = require("node:path");');
+        prelude.push("const __niceevalImportMetaDirname = __niceevalDirname(__filename);");
+      }
+      if (transformed.usesDynamicImport) {
+        prelude.push("const __niceevalDynamicImport = (specifier) => import(specifier);");
+      }
+      let code = injectPrelude(compiled.outputText, prelude);
+      code = rewriteCjsRelativeRequires(code);
+      code = rewriteRemarkRequires(code, output, outputRoot);
+      await writeRuntimeModule(output, code, compiled.sourceMapText ?? "{}");
+    }
+
+    await copyRuntimeAssets(outputRoot);
+    await writeDualDeclarations(rawTypes, outputRoot);
+    // 旧的仓库内测试和工具会直接读 dist/report/*.js；这些兼容文件仍只是 CJS 主图的
+    // ESM façade，绝不重新编译出第二份 report runtime。
+    for (const source of runtimeSources) {
+      await writeEsmFacade(outputRoot, source, publicValueExports(program, source), ".js");
+    }
+    for (const [, source] of PUBLIC_ENTRIES) {
+      await writeEsmFacade(outputRoot, source, publicValueExports(program, source));
+    }
+
+    await rm(DIST, { recursive: true, force: true });
+    await rename(outputRoot, DIST);
+    process.stdout.write(`build:package: wrote ${relative(ROOT, DIST)} canonical CJS graph and ESM facades\n`);
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+}
+
+await build();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,10 +78,9 @@ import {
   ViewInputError,
 } from "./view/index.ts";
 // load.ts 本身没有 JSX,但它的 ReportDefinition/ReportLoadError 要和 view 报告槽实际装载
-// --report 用的那份(dist/report/**,见 tsconfig.report-build.json)是同一个模块实例——
-// `unique symbol` 品牌与 class 的 instanceof 都按声明处的模块身份判定,raw src 和编译产物
-// 是两份不同源码位置,即使运行时同名同形,TS 类型与 instanceof 都不认。
-import { ReportLoadError } from "../dist/report/runtime/load.js";
+// --report 与 CLI 同属一个 canonical runtime graph。`unique symbol` 品牌与 class 的
+// instanceof 必须从同一份模块实例读取，不能再混用源码与另一份预编译图。
+import { ReportLoadError } from "./report/runtime/load.ts";
 import { runShow } from "./show/index.ts";
 import { setConfiguredLocale, t } from "./i18n/index.ts";
 import type { MessageKey } from "./i18n/zh-CN.ts";
@@ -2011,7 +2010,10 @@ async function main(): Promise<void> {
 // 解析与格式化)时不能让 main() 运行——单元层不起 CLI 进程,进程行为归 E2E。入口判断基于
 // argv,不读环境变量:src/ 的环境变量白名单守护不允许新增测试专用变量
 // (见 test/unit/config-env-boundary.test.ts),而 vitest 的 argv[1] 永远不会是 bin/niceeval.js。
-if (process.argv[1]?.endsWith(`${sep}bin${sep}niceeval.js`)) {
+if (
+  process.argv[1]?.endsWith(`${sep}bin${sep}niceeval.js`) ||
+  process.argv[1]?.endsWith(`${sep}.bin${sep}niceeval`)
+) {
   main().catch(async (e) => {
     process.stderr.write(
       e instanceof SandboxLayerLinkError

--- a/src/report/runtime/host.ts
+++ b/src/report/runtime/host.ts
@@ -1,33 +1,26 @@
 // 报告装载与逐页渲染的中性宿主 facade:show 与 view 共用(docs/feature/reports/architecture.md
 // 「共享内核与两个宿主的代码边界」「单一 report runtime 身份」)。ReportDefinition / ReportPage /
 // ReportMeta 的类型体系,以及装载规范化、resolve、text/web render 全部住在 niceeval/report 的
-// 构建单元(src/report/**,经 `pnpm run build:report` 编译进 dist/report/**);这里只做两个
-// 宿主都需要、但只属于宿主编排的一件事——文件 vs 内建报告的装载分流、逐页渲染——不重复声明
-// 任何报告类型或规范化逻辑。终端专属的可复制命令拼装(`showCommand`)不在这里,只有 show 需要,
-// 住在 src/show/command.ts。
-//
-// 本文件物理上住在 src/report/runtime/(host facade 的架构归属),但**不**参与
-// tsconfig.report-build.json 的编译单元(见该文件的 exclude 注释):它是调用方经 tsx 直接执行的
-// raw TypeScript,内部一律动态 import 兄弟 dist/report/** 产物——不是所有 show / view 命令都
-// 渲染报告,静态 import 会让不需要报告的命令也背上 react / react-dom 依赖(web.ts 静态 import
-// react-dom/server);同一进程也不能混用 raw src/report/** 与 dist/report/** 的同一状态模块,
-// 所以值和类型都从同一批 dist 模块拿,不从本文件的兄弟源码拿。
+// 本文件与报告定义、show、view 一起编进同一个 canonical runtime graph。它只做两个宿主都需要、
+// 但属于宿主编排的一件事——文件 vs 内建报告的装载分流、逐页渲染——不重复声明任何报告类型或
+// 规范化逻辑。终端专属的可复制命令拼装(`showCommand`)不在这里,只有 show 需要,住在
+// src/show/command.ts。动态装载仍保留可选 web 依赖的按需边界，但绝不跳入第二份 report 图。
 
 import type { Record, Sample } from "../../record/index.ts";
 import { resolveLocator, loadAttemptEvidence } from "../../record/index.ts";
 import type { LocalizedText } from "../../types.ts";
-import type { PageContext } from "../../../dist/report/definition/tree.js";
+import type { PageContext } from "../definition/tree.ts";
 import type {
   PageLoadContext,
   ReportDefinition,
   ReportMeta,
   ReportPage,
   ReportTarget,
-} from "../../../dist/report/definition/report.js";
-import type { ThemeDefinition } from "../../../dist/report/theme.js";
-import type { DimensionPins } from "../../../dist/report/presentation.js";
+} from "../definition/report.ts";
+import type { ThemeDefinition } from "../theme.ts";
+import type { DimensionPins } from "../presentation.ts";
 
-export type { PageContext } from "../../../dist/report/definition/tree.js";
+export type { PageContext } from "../definition/tree.ts";
 export type {
   HeadTag,
   ReportAsset,
@@ -39,9 +32,9 @@ export type {
   PageDefinition,
   PageParams,
   PageLoadContext,
-} from "../../../dist/report/definition/report.js";
-export type { ThemeDefinition } from "../../../dist/report/theme.js";
-export type { ResolvedPage } from "../../../dist/report/runtime/resolved-page.js";
+} from "../definition/report.ts";
+export type { ThemeDefinition } from "../theme.ts";
+export type { ResolvedPage } from "./resolved-page.ts";
 
 /** 可预期的装载用户错误(与 ReportLoadError 同待遇:打一句直说问题与下一步,不抛堆栈)。 */
 export class HostReportError extends Error {}
@@ -49,10 +42,10 @@ export class HostReportError extends Error {}
 /**
  * 项目 config 是动态模块；它的 `report` 字段不能因为 `loadConfigFile()` 的静态返回注解而
  * 被当成已经验证过的 ReportDefinition。这里是 source → dist 的唯一收口点：只把同一份
- * dist factory 打过品牌的值交给宿主后续长期持有的 report 槽。
+ * 同一 canonical factory 打过品牌的值交给宿主后续长期持有的 report 槽。
  */
 async function normalizeConfiguredReport(value: unknown): Promise<ReportDefinition> {
-  const { isReportDefinition } = await import("../../../dist/report/definition/report.js");
+  const { isReportDefinition } = await import("../definition/report.ts");
   if (!isReportDefinition(value)) {
     throw new HostReportError(
       'The project default report (the "report" field in niceeval.config.ts) must be the result of defineReport(...) from "niceeval/report".',
@@ -61,9 +54,9 @@ async function normalizeConfiguredReport(value: unknown): Promise<ReportDefiniti
   return value;
 }
 
-/** 与 report 同理：动态 config 值只有通过 dist factory 品牌后才成为 ThemeDefinition。 */
+/** 与 report 同理：动态 config 值只有通过 canonical factory 品牌后才成为 ThemeDefinition。 */
 async function normalizeConfiguredTheme(value: unknown): Promise<ThemeDefinition> {
-  const { isThemeDefinition } = await import("../../../dist/report/theme.js");
+  const { isThemeDefinition } = await import("../theme.ts");
   if (!isThemeDefinition(value)) {
     throw new HostReportError(
       'The project default theme (the "theme" field in niceeval.config.ts) must be the result of defineTheme(...) from "niceeval/report".',
@@ -86,13 +79,13 @@ export async function loadHostReport(
   options?: { freshImport?: boolean },
 ): Promise<ReportDefinition> {
   if (reportPath !== undefined) {
-    const { isExplicitModulePath, loadBuiltInReport, loadReportFile } = await import("../../../dist/report/runtime/load.js");
+    const { isExplicitModulePath, loadBuiltInReport, loadReportFile } = await import("./load.ts");
     return (isExplicitModulePath(reportPath) ? loadReportFile(cwd, reportPath, options) : loadBuiltInReport(reportPath)) as Promise<ReportDefinition>;
   }
   if (configuredReport !== undefined) {
     return normalizeConfiguredReport(configuredReport);
   }
-  const { standard } = await import("../../../dist/report/built-in/index.js");
+  const { standard } = await import("../built-in/index.tsx");
   return standard as ReportDefinition;
 }
 
@@ -112,7 +105,7 @@ export function describeReportSource(reportPath: string | undefined, configuredR
  * 没声明时仍保留官方 AttemptDetails，避免组合组件的 locator 因换了首页而退化成不可点击文本。
  */
 export async function loadDefaultHostAttemptPage(): Promise<ReportPage> {
-  const { standard } = await import("../../../dist/report/built-in/index.js");
+  const { standard } = await import("../built-in/index.tsx");
   const page = standard.pages.find((candidate) => candidate.id === "attempt");
   if (page === undefined) throw new Error('The built-in report is missing its "attempt" page.');
   return page;
@@ -123,13 +116,13 @@ export async function loadDefaultHostAttemptPage(): Promise<ReportPage> {
  * 其余是内建名。view 的 watch 闭集按同一条判别决定盯不盯文件,不另写一套字符串规则。
  */
 export async function isHostModulePath(value: string): Promise<boolean> {
-  const { isExplicitModulePath } = await import("../../../dist/report/runtime/load.js");
+  const { isExplicitModulePath } = await import("./load.ts");
   return isExplicitModulePath(value);
 }
 
 /** ctx.report 的构建(不携带当前页——那是 HostRenderContext.page 的事)。 */
 export async function buildHostReportMeta(definition: ReportDefinition, scope: Sample): Promise<ReportMeta> {
-  const { buildReportMeta } = await import("../../../dist/report/definition/report.js");
+  const { buildReportMeta } = await import("../definition/report.ts");
   return buildReportMeta(definition, scope);
 }
 
@@ -140,7 +133,7 @@ export async function resolveHostTheme(
   configTheme: unknown,
   options?: { freshImport?: boolean },
 ): Promise<ThemeDefinition> {
-  const { isExplicitModulePath, loadBuiltInTheme, loadThemeFile } = await import("../../../dist/report/runtime/load.js");
+  const { isExplicitModulePath, loadBuiltInTheme, loadThemeFile } = await import("./load.ts");
   if (cliTheme !== undefined) return (isExplicitModulePath(cliTheme) ? loadThemeFile(cwd, cliTheme, options) : loadBuiltInTheme(cliTheme)) as Promise<ThemeDefinition>;
   if (reportTheme !== undefined) return reportTheme;
   if (configTheme !== undefined) return normalizeConfiguredTheme(configTheme);
@@ -148,7 +141,7 @@ export async function resolveHostTheme(
 }
 
 export async function hostThemeStylesheet(theme: ThemeDefinition): Promise<string> {
-  const { themeStylesheet } = await import("../../../dist/report/theme.js");
+  const { themeStylesheet } = await import("../theme.ts");
   return themeStylesheet(theme);
 }
 
@@ -214,24 +207,20 @@ export async function renderHostPageText(
   ctx: HostRenderContext,
   options: HostTextRenderOptions,
 ): Promise<string> {
-  const { renderReportTreeToText } = await import("../../../dist/report/runtime/text.js");
-  const { resolveDefinitionPage } = await import("../../../dist/report/runtime/page-render.js");
+  const { renderReportTreeToText } = await import("./text.ts");
+  const { resolveDefinitionPage } = await import("./page-render.ts");
   const resolved = await resolveDefinitionPage(page, ctx);
-  const { renderResolvedPageText } = await import("../../../dist/report/runtime/resolved-page.js");
+  const { renderResolvedPageText } = await import("./resolved-page.ts");
   return renderResolvedPageText(resolved, options);
 }
 
 /**
  * 宿主专属懒加载来源的唯一装配点:按 locator 装配 AttemptEvidence(经 `loadAttemptEvidence`
  * 管线),供 `renderHostTarget` 的 `page.load` 调用。**不**委托给
- * `dist/report/runtime/page-render.js` 的同名 helper——那份编译产物按 tsconfig
- * report-build.json 的编译单元静态 import 了它自己的 `dist/record/open.js`,与本文件(raw
- * src,经 tsx 直接执行)以及 show/view 用来构造 `results` 的 `../../record/index.ts` 是两个
- * 完全不同的模块实例:`resolveLocator` 的 locator 索引挂在 `openRecord()` 内部按 `results`
- * 对象身份建的 WeakMap 上,只有构造 `results` 的那份模块实例的索引里才查得到它,换一份编译产物
- * 的 `resolveLocator` 一律查不到、报 LocatorNotFoundError(真 bug,由 `standardExperimentPage`
- * 落地后的真机冒烟——`show @<locator> --report standard` 暴露)。这里直接用与 show/view 同一份
- * raw src record 模块实现 `PageLoadContext`,保证索引同源。
+ * `page-render.ts` 的同名 helper：它和 show/view 都在同一份 canonical record 模块图中运行。
+ * `resolveLocator` 的 locator 索引按 `results` 对象身份建 WeakMap，必须由构造 `results` 的同一
+ * 模块实例读取；共享图保证 `show @<locator> --report standard` 不会因双份 runtime 而误报
+ * LocatorNotFoundError。这里直接用这份 record 模块实现 `PageLoadContext`，保证索引同源。
  */
 export async function createHostPageLoadContext(results: Record): Promise<PageLoadContext> {
   return {
@@ -261,9 +250,9 @@ export async function renderHostTarget(
   host: HostTargetContext,
   options: HostTextRenderOptions,
 ): Promise<string> {
-  const { renderTarget } = await import("../../../dist/report/runtime/page-render.js");
+  const { renderTarget } = await import("./page-render.ts");
   const resolved = await renderTarget(definition, target, base, ctx, host);
-  const { renderResolvedPageText } = await import("../../../dist/report/runtime/resolved-page.js");
+  const { renderResolvedPageText } = await import("./resolved-page.ts");
   return renderResolvedPageText(resolved, options);
 }
 
@@ -271,18 +260,18 @@ export async function renderHostTarget(
 export async function resolveHostPage(
   page: ReportPage,
   ctx: HostRenderContext,
-  options?: { renderCache?: Map<string, Promise<import("../../../dist/report/definition/tree.js").ReportNode>> },
-): Promise<import("../../../dist/report/runtime/resolved-page.js").ResolvedPage> {
-  const { resolveDefinitionPage } = await import("../../../dist/report/runtime/page-render.js");
+  options?: { renderCache?: Map<string, Promise<import("../definition/tree.ts").ReportNode>> },
+): Promise<import("./resolved-page.ts").ResolvedPage> {
+  const { resolveDefinitionPage } = await import("./page-render.ts");
   return resolveDefinitionPage(page, ctx, options);
 }
 
 /** 从 ResolvedPage 同步渲染 web 面(静态 HTML);动态 import dist 产物,render 本身无 await。 */
 export async function renderHostPageFromResolved(
-  resolved: import("../../../dist/report/runtime/resolved-page.js").ResolvedPage,
+  resolved: import("./resolved-page.ts").ResolvedPage,
   options: { locale: string; href?: (target: ReportTarget) => string | undefined },
 ): Promise<string> {
-  const { renderResolvedPageWeb } = await import("../../../dist/report/runtime/resolved-page.js");
+  const { renderResolvedPageWeb } = await import("./resolved-page.ts");
   return renderResolvedPageWeb(resolved, options);
 }
 
@@ -292,11 +281,11 @@ export async function renderHostPageFromResolved(
  * 条件分支里没有出现的 renderer 也不应进入产物。
  */
 export async function materializeHostPageRendererAssets(
-  resolved: import("../../../dist/report/runtime/resolved-page.js").ResolvedPage,
-): Promise<import("../../../dist/report/extension/types.js").PageRendererAssets> {
+  resolved: import("./resolved-page.ts").ResolvedPage,
+): Promise<import("../extension/types.ts").PageRendererAssets> {
   const { readFile } = await import("node:fs/promises");
   const { collectRendererAssetDeclarations, materializeRendererAssets } =
-    await import("../../../dist/report/extension/index.js");
+    await import("../extension/index.ts");
   const declarations = collectRendererAssetDeclarations(resolved.tree);
   return materializeRendererAssets(declarations, readFile);
 }

--- a/src/show/index.ts
+++ b/src/show/index.ts
@@ -30,10 +30,10 @@ import {
 } from "../record/index.ts";
 // ReportLoadError must come from the SAME module instance the report runtime is built
 // against — `instanceof` is keyed by declaration site, so a raw src copy and the compiled
-// dist copy of "the same" class are two different types. The package-owned report runtime
-// ships as precompiled ESM (dist/report/**, built by `pnpm run build:report`); all report
-// loading/rendering goes through ../report/runtime/host.ts (the shared contact surface).
-import { ReportLoadError } from "../../dist/report/runtime/load.js";
+// The package-owned report runtime and this host share one canonical module graph; a second
+// source-vs-dist copy would make otherwise identical classes different types. All report
+// loading/rendering therefore goes through ../report/runtime/host.ts (the shared contact surface).
+import { ReportLoadError } from "../report/runtime/load.ts";
 import { detectLocale, t } from "../i18n/index.ts";
 import { currentSample, filterExperiments } from "../sample/index.ts";
 import { matchExperimentSelector } from "../shared/aggregate.ts";
@@ -385,7 +385,7 @@ async function renderCompareSlice(
   io: { width: number; locale: string; panelMode: "boxed" | "plain" },
 ): Promise<string> {
   const [{ Table }, { deltaTableContent }] = await Promise.all([
-    import("../../dist/report/definition/primitives.js"),
+    import("../report/definition/primitives.tsx"),
     import("../report/slices/content.ts"),
   ]);
   const report = await loadHostReport(cwd, undefined);
@@ -422,7 +422,7 @@ async function renderStatsSlice(
   io: { width: number; locale: string; panelMode: "boxed" | "plain" },
 ): Promise<string> {
   const [{ Table }, { stabilityMatrixContent }] = await Promise.all([
-    import("../../dist/report/definition/primitives.js"),
+    import("../report/definition/primitives.tsx"),
     import("../report/slices/content.ts"),
   ]);
   // 只给渲染管线占位用的 Sample——Table 走 data 形态,不重新消费它;单独调用

--- a/src/view/data.ts
+++ b/src/view/data.ts
@@ -666,12 +666,12 @@ async function renderReportSlot(
     assets: import("../report/extension/types.ts").PageRendererAssets;
   }>;
 }> {
-  // 报告 runtime 走预编译产物(dist/report/**,`pnpm run build:report` 产出),不受 view
-  // 消费方 cwd/tsconfig 影响;装载与渲染统一经 ../report/runtime/host.ts(两个宿主共用的中性联系面)。
+  // 报告 runtime 与 view 同属一个预编译 canonical graph，不受消费方 cwd/tsconfig 影响；
+  // 装载与渲染统一经 ../report/runtime/host.ts(两个宿主共用的中性联系面)。
   // config 每次重建 fresh 装载——不能吃启动时那份已求值的 report 对象,否则改 reports/*.tsx
   // 只会触发 watch/SSE,内容仍是旧定义。
   const loadDefinitions = async (): Promise<LoadedDefinitions> => {
-    // 配置模块由 raw src 执行，host 则消费 dist/report；私有品牌必须在 host 边界重新证明。
+    // 配置模块与 host 都落到同一 canonical graph；私有品牌不再跨源码/构建图重新证明。
     let configReport: ReportDefinition | undefined;
     let configTheme: ThemeDefinition | undefined;
     if (config !== undefined) {
@@ -698,13 +698,13 @@ async function renderReportSlot(
 
   // 参数化页的唯一 href 派生(target.ts 的 `targetHref`),两个宿主(scope pages 与参数化页
   // 自己的内容)共用同一份纯函数,不各自重新拼字符串。
-  const { targetHref } = await import("../../dist/report/runtime/target.js");
+  const { targetHref } = await import("../report/runtime/target.ts");
 
   // 自定义报告替换的是可见页面，不该顺手切断官方组件的下钻目标。核心不区分实体种类
   // (docs/feature/reports/library.md「参数化页:attempt 与 experiment 详情」)：内建 `standard`
   // 的每一张参数化页(attempt、experiment……)按 id 补位，报告显式声明同 id 页时覆盖它，
   // 且不把补位页塞进导航或报告元数据。
-  const { standard } = await import("../../dist/report/built-in/index.js");
+  const { standard } = await import("../report/built-in/index.tsx");
   const paramPageDefs = new Map<string, ReportPage>();
   for (const p of (standard as ReportDefinition).pages) {
     if (p.params !== undefined) paramPageDefs.set(p.id, p as ReportPage);

--- a/tsconfig.package-types.json
+++ b/tsconfig.package-types.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": false,
+    "rootDir": "./src",
+    "outDir": "./dist/.package-types",
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.harness.ts",
+    "src/view/app/**"
+  ]
+}


### PR DESCRIPTION
## Problem

- User goal: 安装后的 NiceEval 包在真实 ESM 与 CJS 消费者中原生加载。
- Current limitation: public exports 指向 checkout TypeScript，运行时依赖 tsx 和消费者 cwd。
- Required capability: 构建阶段必须产出 canonical runtime graph、双模块入口和声明文件。
- User outcome: npm 包不依赖 checkout 或 tsx，CLI、report、show 与 view 共享已发布运行时。

## Public API

### Package exports

- Classification: behavior-change
- Before usage: import { defineAgent } from niceeval loads src TypeScript.
- After usage: import { defineAgent } from niceeval loads dist ESM or CJS plus matching declarations.
- User impact: consumers receive native package artifacts rather than source-tree execution.

## CLI commands

### niceeval

- Classification: behavior-change
- Before usage: installed bin dynamically loaded src/cli.ts through tsx.
- After usage: installed bin loads dist/cli.cjs before registering tsx for user project files.
- User impact: CLI package runtime is independent of the consumer checkout.

## Report components

### Report runtime host

- Classification: internal-only
- Before usage: report host could resolve source runtime through consumer loading paths.
- After usage: report host resolves the canonical built runtime.
- User impact: report authors keep the same API with reliable installed execution.

## Observable behavior and data contracts

### Installed package loading

- Classification: behavior-change
- Before example: a CJS consumer requires a NiceEval subpath that points to TypeScript source.
- After example: the same consumer loads its declared dist CJS entry; ESM loads the corresponding dist ESM entry.
- User impact: package imports are portable across normal Node consumers.

## Environment variables

None

## Package scripts

### pnpm run build:package

- Change: added
- Before usage: pnpm run build:report
- After usage: pnpm run build:package
- User impact: one build produces runtime graph, declarations, report assets, view assets and bundled index.

## Tests

### Package build verification

- Change: not automated
- Example scenario: build the package and typecheck its canonical ESM/CJS graph.
- Before: consumers relied on source execution.
- After: pnpm run build:package and pnpm run typecheck completed successfully.
- User impact: protects package installation behavior; independent E2E package-consumer Journeys remain in #30.