### PR TITLE
refactor(runtime): 统一 Node 22 运行时基线

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/NiceEval/NiceEval.git"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "bin": {
     "niceeval": "bin/niceeval.js"

--- a/scripts/package-runtime/build.mjs
+++ b/scripts/package-runtime/build.mjs
@@ -255,7 +255,7 @@ async function buildRemarkVendor(outputRoot) {
     bundle: true,
     format: "cjs",
     platform: "node",
-    target: ["node18"],
+    target: ["node22"],
     sourcemap: true,
     outExtension: { ".js": ".cjs" },
     logLevel: "silent",


### PR DESCRIPTION
## Public API

- **Changed** — package installs now require Node.js 22 or later.
  - Before: Node.js 18 or later was accepted.
  - After: Node.js 22 or later is required.
  - User impact: users on Node.js 18–21 must upgrade before installing or running NiceEval.

## CLI

None.

## Reports

None.

## Observable behavior

- **Changed** — generated CommonJS runtime code targets Node.js 22.
  - Before: runtime build output targeted Node.js 18.
  - After: runtime build output targets Node.js 22.
  - User impact: published CJS artifacts may use the Node.js 22 baseline consistently with the package requirement.

## Environment variables

None.

## Scripts / CI

- **Changed** — the package runtime build targets Node.js 22.
  - Before: bundled CJS dependencies were compiled for Node.js 18.
  - After: they are compiled for Node.js 22.
  - User impact: local and CI package builds match the supported runtime baseline.

## Tests

- Automated test change: None; this is a runtime-support declaration and build-target change.
- Validation: `pnpm run build:package && pnpm run typecheck` passed.