### PR TITLE
fix(package): 保持报告运行时单一实例

### DIFF
--- a/scripts/package-runtime/build.mjs
+++ b/scripts/package-runtime/build.mjs
@@ -217,8 +217,13 @@ async function writeEsmFacade(outputRoot, source, valueNames, extension = ".mjs"
   const facadeFile = runtimePath(source, extension);
   const output = join(outputRoot, facadeFile);
   const cjsSpecifier = `./${basename(cjsFile)}`;
+  // Both ESM facades read the canonical CJS cache so import() and require()
+  // observe one runtime identity. Vite's static CJS default interop can turn
+  // the default export into undefined, so use an explicit createRequire bridge.
   const lines = [
-    `import __niceevalCanonical from ${JSON.stringify(cjsSpecifier)};`,
+    'import { createRequire as __niceevalCreateRequire } from "node:module";',
+    "const __niceevalRequire = __niceevalCreateRequire(import.meta.url);",
+    `const __niceevalCanonical = __niceevalRequire(${JSON.stringify(cjsSpecifier)});`,
   ];
   let index = 0;
   for (const name of valueNames) {

--- a/src/report/runtime/host.ts
+++ b/src/report/runtime/host.ts
@@ -36,6 +36,11 @@ export type {
 export type { ThemeDefinition } from "../theme.ts";
 export type { ResolvedPage } from "./resolved-page.ts";
 
+// Source hosts must enter the precompiled report graph through its public
+// entry point too. The string annotation keeps the first package build from
+// depending on generated self-reference declarations.
+const BUILT_IN_REPORT_ENTRY: string = "niceeval/report/built-in";
+
 /** 可预期的装载用户错误(与 ReportLoadError 同待遇:打一句直说问题与下一步,不抛堆栈)。 */
 export class HostReportError extends Error {}
 
@@ -85,7 +90,7 @@ export async function loadHostReport(
   if (configuredReport !== undefined) {
     return normalizeConfiguredReport(configuredReport);
   }
-  const { standard } = await import("../built-in/index.tsx");
+  const { standard } = (await import(BUILT_IN_REPORT_ENTRY)) as { standard: ReportDefinition };
   return standard as ReportDefinition;
 }
 
@@ -105,7 +110,7 @@ export function describeReportSource(reportPath: string | undefined, configuredR
  * 没声明时仍保留官方 AttemptDetails，避免组合组件的 locator 因换了首页而退化成不可点击文本。
  */
 export async function loadDefaultHostAttemptPage(): Promise<ReportPage> {
-  const { standard } = await import("../built-in/index.tsx");
+  const { standard } = (await import(BUILT_IN_REPORT_ENTRY)) as { standard: ReportDefinition };
   const page = standard.pages.find((candidate) => candidate.id === "attempt");
   if (page === undefined) throw new Error('The built-in report is missing its "attempt" page.');
   return page;


### PR DESCRIPTION
## Public API

None.

## CLI

None.

## Reports

- **Fixed** — built-in reports loaded by source hosts now enter through the public precompiled report entry.
  - Before: source hosts imported the built-in report source module directly.
  - After: they load `niceeval/report/built-in`, the same packaged runtime graph exposed to consumers.
  - User impact: report values keep one runtime identity across source and packaged entry points.

## Observable behavior

- **Fixed** — ESM and CommonJS facades read the same canonical CJS module cache.
  - Before: the ESM facade relied on static default interop, which could yield an undefined default through Vite.
  - After: it explicitly uses `createRequire` for the canonical CJS module.
  - User impact: import and require observe consistent report-runtime exports.

## Environment variables

None.

## Scripts / CI

- **Changed** — package builds emit ESM facades through Node.js `createRequire`.
  - Before: the facade used static CJS default interop.
  - After: it explicitly resolves the canonical CJS artifact.
  - User impact: package build output preserves a single runtime graph.

## Tests

- Automated test change: None; the corresponding consumer scenario remains in the E2E test-system refactor.
- Validation: `pnpm run build:package && pnpm run typecheck` passed.