### PR TITLE
test(e2e): 仅重试断言失败的真实 Eval

### DIFF
--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -258,10 +258,21 @@ Docker cgroup 的 `cpu.max`、`memory.max`、`memory.swap.max` 与 `pids.max` �
 
 ## 重试
 
-只有结构化确认的 infrastructure 失败可以在**新副本**重试一次，例如 provider 明确 429 / 5xx、网络断开、GitHub runner 或
-Docker daemon 故障。以下情况不重试：断言失败、测试超时、parse 失败、cleanup 失败、缺 secret / runtime。
+根 runner 只有在结构化确认 infrastructure 失败时，才可以在**新副本**重试一次，例如 provider 明确 429 / 5xx、网络断开、
+GitHub runner 或 Docker daemon 故障。测试超时、parse 失败、cleanup 失败、缺 secret / runtime 不重试。
 
-重试摘要保留第一次失败，不能只展示最终绿色；同一个断言第二次碰巧过仍需标记 flaky regression。
+真实模型兼容性 Repo 另有一条显式的 Eval 级容错：
+
+- 被重试的 Experiment 固定 `attempts: 1`；
+- 首轮 `niceeval exp --json` 完整结束后，测试读取公开 `eval` 事件；
+- 只有 `verdict: "failed"` 才对精确 Experiment/Eval 配对另起一次 `exp --rerun all` Invocation；
+- `passed`、`errored`、`skipped`、中断和不完整 Invocation 都不重试，第二轮也不递归；
+- 两次 Invocation、receipt 与 Attempt 全部保留，并在 CI 日志标出 retry 后通过。
+
+这不是 Vitest / Playwright retry，也不能计入确定性 owner 的可靠性接管。
+验证 Sandbox reuse 等刻意运行多条 Attempt 的生命周期 owner 不使用这项容错。
+
+重试摘要保留第一次失败，不能只展示最终绿色；同一个断言第二次碰巧过仍需标记 flaky。
 Owner 接管运行完全禁用重试。普通 lane retry 后转绿也不能计入可靠性验收。
 
 候选注入失败要再分一层。runner 没把指定 tarball 注入进去，或 digest / 实际 executable 身份不一致，属于 harness failure。

--- a/e2e/adapter/claude-code/test/claude-code.test.ts
+++ b/e2e/adapter/claude-code/test/claude-code.test.ts
@@ -4,7 +4,7 @@
 // 具体 Skill、MCP、Plugin 与配置行为由各自 Eval 断言；owner 只守住发现完整性与全绿结果。
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
-import { command, type ExpEvalEvent, type ExpEvent, type ProcessReceipt } from "@niceeval/testkit";
+import { command, type ExpEvalEvent, type ProcessReceipt } from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { beforeAll, expect, it } from "vitest";
@@ -33,6 +33,7 @@ const EXPECTED_EXPERIMENTS = [
   "locked-down",
 ] as const;
 const EXPECTED_PASSED_ATTEMPTS = 18;
+const RETRY_CONCURRENCY = 4;
 
 const REQUIRED_LIVE_SECRETS = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"] as const;
 
@@ -60,6 +61,30 @@ async function requireDocker(): Promise<void> {
   }
 }
 
+function evalKey(event: Pick<ExpEvalEvent, "experimentId" | "evalId">): string {
+  return `${event.experimentId}\u0000${event.evalId}`;
+}
+
+function assertExactRetrySelector(events: readonly ExpEvalEvent[], failed: ExpEvalEvent): void {
+  const experiments = new Set(
+    events
+      .filter((event) => event.experimentId.startsWith(failed.experimentId))
+      .map((event) => event.experimentId),
+  );
+  expect(experiments, `ambiguous Experiment retry selector ${failed.experimentId}`).toEqual(
+    new Set([failed.experimentId]),
+  );
+  const evals = events
+    .filter(
+      (event) =>
+        event.experimentId === failed.experimentId && event.evalId.startsWith(failed.evalId),
+    )
+    .map((event) => event.evalId);
+  expect(evals, `ambiguous Eval retry selector ${failed.experimentId}/${failed.evalId}`).toEqual([
+    failed.evalId,
+  ]);
+}
+
 function representativeAttempt(): ExpEvalEvent {
   const attempt = evalEvents.find((event) => event.evalId === "coding-task");
   expect(attempt, run.diagnostic()).toBeDefined();
@@ -77,11 +102,56 @@ beforeAll(async () => {
     ["exp", "--rerun", "all", "--json"],
     { timeoutMs: 50 * 60_000 },
   );
-  expect(run.exitCode, run.diagnostic()).toBe(0);
-  evalEvents = run.ndjson<ExpEvent>().filter(
-    (event): event is ExpEvalEvent => "event" in event && event.event === "eval",
+  const inv = run.expReceipt();
+  const firstEvents = run.expEvalEvents();
+  // plugin-reuse 是八条 Attempt 的 Sandbox 复用 owner，不是模型断言重试消费者。
+  const failed = firstEvents.filter(
+    (event) => event.verdict === "failed" && event.experimentId !== "plugin-reuse",
   );
-}, 52 * 60_000);
+  expect(
+    firstEvents.filter((event) => event.verdict === "errored" || event.verdict === "skipped"),
+    run.diagnostic(),
+  ).toHaveLength(0);
+  expect(run.exitCode, run.diagnostic()).toBe(failed.length > 0 ? 1 : 0);
+  expect(inv.completion, run.diagnostic()).toBe("completed");
+  for (const event of failed) assertExactRetrySelector(firstEvents, event);
+
+  const retryRuns: ProcessReceipt[] = [];
+  for (let offset = 0; offset < failed.length; offset += RETRY_CONCURRENCY) {
+    const batch = failed.slice(offset, offset + RETRY_CONCURRENCY);
+    retryRuns.push(
+      ...(await Promise.all(
+        batch.map((event) =>
+          niceeval.run(
+            ["exp", event.experimentId, event.evalId, "--rerun", "all", "--json"],
+            { timeoutMs: 50 * 60_000 },
+          ),
+        ),
+      )),
+    );
+  }
+  const retriedByEval = new Map<string, ExpEvalEvent>();
+  for (let index = 0; index < retryRuns.length; index += 1) {
+    const retry = retryRuns[index]!;
+    const target = failed[index]!;
+    expect(retry.expReceipt(), retry.diagnostic()).toMatchObject({ completion: "completed" });
+    const events = retry.expEvalEvents();
+    expect(events, retry.diagnostic()).toHaveLength(1);
+    expect(events[0], retry.diagnostic()).toMatchObject({
+      experimentId: target.experimentId,
+      evalId: target.evalId,
+    });
+    expect(events[0]?.verdict, retry.diagnostic()).toBe("passed");
+    expect(retry.exitCode, retry.diagnostic()).toBe(0);
+    retriedByEval.set(evalKey(target), events[0]!);
+  }
+  if (failed.length > 0) {
+    process.stderr.write(
+      `[niceeval e2e] retried ${failed.length} assertion-failed Eval(s) once; first Invocation ${inv.invocationId} remains recorded\n`,
+    );
+  }
+  evalEvents = firstEvents.map((event) => retriedByEval.get(evalKey(event)) ?? event);
+}, 104 * 60_000);
 
 it("真实 Claude Code adapter 的全部专用 Eval 通过", () => {
   // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md「结束反馈与

--- a/e2e/adapter/codex-cli/experiments/baseline.ts
+++ b/e2e/adapter/codex-cli/experiments/baseline.ts
@@ -15,7 +15,6 @@ export default defineExperiment({
   model: "gpt-5.6-luna",
   sandbox,
   evals: ["coding-task", "session", "usage"],
-  attempts: 2,
-  earlyExit: true,
+  attempts: 1,
   budget: 3,
 });

--- a/e2e/adapter/codex-cli/experiments/configfile.ts
+++ b/e2e/adapter/codex-cli/experiments/configfile.ts
@@ -14,7 +14,6 @@ export default defineExperiment({
   model: "gpt-5.6-luna",
   sandbox,
   evals: ["configfile"],
-  attempts: 2,
-  earlyExit: true,
+  attempts: 1,
   budget: 3,
 });

--- a/e2e/adapter/codex-cli/experiments/mcp.ts
+++ b/e2e/adapter/codex-cli/experiments/mcp.ts
@@ -17,7 +17,6 @@ export default defineExperiment({
   model: "gpt-5.6-luna",
   sandbox,
   evals: ["mcp"],
-  attempts: 2,
-  earlyExit: true,
+  attempts: 1,
   budget: 3,
 });

--- a/e2e/adapter/codex-cli/experiments/skill.ts
+++ b/e2e/adapter/codex-cli/experiments/skill.ts
@@ -18,7 +18,6 @@ export default defineExperiment({
   model: "gpt-5.6-luna",
   sandbox,
   evals: ["skill", "skill-release-note"],
-  attempts: 2,
-  earlyExit: true,
+  attempts: 1,
   budget: 3,
 });

--- a/e2e/adapter/codex-cli/test/codex-cli.test.ts
+++ b/e2e/adapter/codex-cli/test/codex-cli.test.ts
@@ -4,16 +4,16 @@
 // 再从公开 CLI 读回 Eval、attempt、execution 与 timing。
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
-import { command, type ExpEvalEvent, type ExpEvent } from "@niceeval/testkit";
+import { command, type ExpEvalEvent, type ProcessReceipt } from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { expect, it } from "vitest";
 
-// baseline/configfile/mcp/skill 都在首个通过 attempt 后 early-exit；其余实验才跑完整计划。
+// 每条 Eval 的首轮只有一个 Attempt；只有结构化 verdict=failed 才由本测试另起一次 Invocation。
 const EXPECTED_PASSED_ATTEMPTS = 17;
 // 每个 Experiment 产生一个 Run（docs/feature/experiments/cli.md「结束反馈与 receipt」）；
-// 除 plugin-reuse 外每条 Eval 在首个通过 attempt 后由 earlyExit 省略剩余 attempt。
 const EXPECTED_EXPERIMENTS = 7;
+const RETRY_CONCURRENCY = 4;
 
 const REQUIRED_LIVE_SECRETS = [
   "CODEX_API_KEY",
@@ -42,6 +42,30 @@ async function requireDocker(): Promise<void> {
   }
 }
 
+function evalKey(event: Pick<ExpEvalEvent, "experimentId" | "evalId">): string {
+  return `${event.experimentId}\u0000${event.evalId}`;
+}
+
+function assertExactRetrySelector(events: readonly ExpEvalEvent[], failed: ExpEvalEvent): void {
+  const experiments = new Set(
+    events
+      .filter((event) => event.experimentId.startsWith(failed.experimentId))
+      .map((event) => event.experimentId),
+  );
+  expect(experiments, `ambiguous Experiment retry selector ${failed.experimentId}`).toEqual(
+    new Set([failed.experimentId]),
+  );
+  const evals = events
+    .filter(
+      (event) =>
+        event.experimentId === failed.experimentId && event.evalId.startsWith(failed.evalId),
+    )
+    .map((event) => event.evalId);
+  expect(evals, `ambiguous Eval retry selector ${failed.experimentId}/${failed.evalId}`).toEqual([
+    failed.evalId,
+  ]);
+}
+
 it("真实 Codex CLI adapter 在 Docker sandbox 中的运行结果经过公开 CLI 读回", async () => {
   requireLiveSecrets();
   await requireDocker();
@@ -53,21 +77,60 @@ it("真实 Codex CLI adapter 在 Docker sandbox 中的运行结果经过公开 C
   const run = await niceeval.run(["exp", "--rerun", "all", "--json"], {
     timeoutMs: 44 * 60_000,
   });
-  expect(run.exitCode, run.diagnostic()).toBe(0);
   // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md「结束反馈与
   // receipt」）：completion 与 runIds（每个 Experiment 一个 Run）。成败由下面带身份的
   // eval 事件精确断言，不从 receipt 猜计数。
   const inv = run.expReceipt();
   expect(inv.completion, run.diagnostic()).toBe("completed");
   expect(inv.runIds, run.diagnostic()).toHaveLength(EXPECTED_EXPERIMENTS);
-  // eval 事件是中间的身份事件：identity / verdict / attempts 在此精确断言。early-exit
-  // 触发的 eval 只带 planned/unstarted/reason，不带 passed；跑满的 eval 则 passed ===
-  // attempts。early-exit 的代表 attempt 是首条通过的那一次，每次贡献一个 passed attempt。
-  const evalEvents = run
-    .ndjson<ExpEvent>()
-    .filter(
-      (event): event is ExpEvalEvent => "event" in event && event.event === "eval",
+  // eval 事件是中间的身份事件：identity / verdict / attempts 在此精确断言。
+  const firstEvents = run.expEvalEvents();
+  // plugin-reuse 是八条 Attempt 的 Sandbox 复用 owner，不是模型断言重试消费者。
+  const failed = firstEvents.filter(
+    (event) => event.verdict === "failed" && event.experimentId !== "plugin-reuse",
+  );
+  expect(
+    firstEvents.filter((event) => event.verdict === "errored" || event.verdict === "skipped"),
+    run.diagnostic(),
+  ).toHaveLength(0);
+  expect(run.exitCode, run.diagnostic()).toBe(failed.length > 0 ? 1 : 0);
+  for (const event of failed) assertExactRetrySelector(firstEvents, event);
+
+  const retryRuns: ProcessReceipt[] = [];
+  for (let offset = 0; offset < failed.length; offset += RETRY_CONCURRENCY) {
+    const batch = failed.slice(offset, offset + RETRY_CONCURRENCY);
+    retryRuns.push(
+      ...(await Promise.all(
+        batch.map((event) =>
+          niceeval.run(
+            ["exp", event.experimentId, event.evalId, "--rerun", "all", "--json"],
+            { timeoutMs: 44 * 60_000 },
+          ),
+        ),
+      )),
     );
+  }
+  const retriedByEval = new Map<string, ExpEvalEvent>();
+  for (let index = 0; index < retryRuns.length; index += 1) {
+    const retry = retryRuns[index]!;
+    const target = failed[index]!;
+    expect(retry.expReceipt(), retry.diagnostic()).toMatchObject({ completion: "completed" });
+    const events = retry.expEvalEvents();
+    expect(events, retry.diagnostic()).toHaveLength(1);
+    expect(events[0], retry.diagnostic()).toMatchObject({
+      experimentId: target.experimentId,
+      evalId: target.evalId,
+    });
+    expect(events[0]?.verdict, retry.diagnostic()).toBe("passed");
+    expect(retry.exitCode, retry.diagnostic()).toBe(0);
+    retriedByEval.set(evalKey(target), events[0]!);
+  }
+  if (failed.length > 0) {
+    process.stderr.write(
+      `[niceeval e2e] retried ${failed.length} assertion-failed Eval(s) once; first Invocation ${inv.invocationId} remains recorded\n`,
+    );
+  }
+  const evalEvents = firstEvents.map((event) => retriedByEval.get(evalKey(event)) ?? event);
   const totalPassed = evalEvents.reduce(
     (sum, event) => sum + (event.reason === "early_exit" ? 1 : (event.passed ?? 0)),
     0,
@@ -116,4 +179,4 @@ it("真实 Codex CLI adapter 在 Docker sandbox 中的运行结果经过公开 C
     "execution tree missing remote HTTP MCP call (deepwiki.read_wiki_structure)",
   ).toBe(true);
   expect(mcpExecution.stdout).not.toContain("weather.get_weather");
-}, 46 * 60_000);
+}, 92 * 60_000);

--- a/packages/testkit/src/process.ts
+++ b/packages/testkit/src/process.ts
@@ -313,6 +313,22 @@ export class ProcessReceipt {
     }
     return terminal.receipt;
   }
+
+  /** Strictly decode the public Eval conclusion events from `niceeval exp --json`. */
+  expEvalEvents(): ExpEvalEvent[] {
+    const events = this.ndjson<unknown>();
+    const evalEvents: ExpEvalEvent[] = [];
+    for (const event of events) {
+      if (!isRecord(event) || event.event !== "eval") continue;
+      if (!isExpEvalEvent(event)) {
+        throw new Error(
+          `expEvalEvents(): stdout contains an invalid Eval event\n\n${this.diagnostic()}`,
+        );
+      }
+      evalEvents.push(event);
+    }
+    return evalEvents;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -340,6 +356,23 @@ function isExpStartEvent(value: unknown): value is ExpStartEvent {
     !isNonNegativeIntegerRecord(value.experimentConcurrency)
   ) return false;
   return true;
+}
+
+function isExpEvalEvent(value: unknown): value is ExpEvalEvent {
+  if (!isRecord(value) || value.event !== "eval") return false;
+  if (typeof value.locator !== "string") return false;
+  if (typeof value.evalId !== "string" || typeof value.experimentId !== "string") return false;
+  if (!isNonNegativeInteger(value.attempts)) return false;
+  if (
+    value.verdict !== "passed" &&
+    value.verdict !== "failed" &&
+    value.verdict !== "errored" &&
+    value.verdict !== "skipped"
+  ) return false;
+  if (value.reason === "early_exit") {
+    return isNonNegativeInteger(value.planned) && isNonNegativeInteger(value.unstarted);
+  }
+  return isNonNegativeInteger(value.passed);
 }
 
 function isReceiptEvent(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Problem

- User goal: 真实模型 E2E 正常只运行一次，在 Eval 断言失败时允许一次精确重试。
- Current limitation: `attempts: 2` 与 `earlyExit` 把独立采样误当成重试，并可能并发启动两次；Vitest / Playwright retry 又会重跑整个测试。
- Required capability: 从 `niceeval exp --json` 的公开 Eval 结论识别 `failed`，只对该 Experiment/Eval 另起一次 Invocation。
- User outcome: 首轮通过不浪费调用；断言失败最多再跑一次；errored、skipped、中断和解析失败不会被掩盖。

## Use cases

### `真实模型 Eval 断言失败后精确重试一次`

- Coverage: `happy path | composition | failure | unsupported`
- Starting point: Codex CLI 或 Claude Code live E2E 以 `attempts: 1` 运行，Repo 全局并发为 4。
- Copyable usage or trigger: `pnpm e2e --lane main --repo adapter/codex-cli`
- Observable result or diagnostic: 首轮 `passed` 不再调用；`failed` 对应的 Experiment/Eval 最多另起一次 `exp --rerun all`；两份 receipt 与 Attempt 均保留。第二次仍失败时测试失败。
- Contract: `docs/engineering/testing/e2e/execution.md#重试`

## Public API

### Removed

None

### Added

#### `@niceeval/testkit ProcessReceipt.expEvalEvents()`

- Before usage or result: Testkit consumer 需要自行把 NDJSON 过滤成 Eval 事件，字段不完整也可能进入重试判定。
- After usage or result: `const failed = receipt.expEvalEvents().filter((event) => event.verdict === "failed")`；方法严格校验公开 Eval 事件形状。
- User impact: E2E 作者可从公开机器输出安全选择失败 Eval；`@niceeval/testkit` 仍是 checkout 内 private harness，不发布 npm。

### Changed

None

## CLI commands

### Removed

None

### Added

None

### Changed

None — 产品 CLI 的参数与输出契约未变；E2E 组合已有命令完成一次条件重跑。

## Report components

### Removed

None

### Added

None

### Changed

None

## Observable behavior and data contracts

### Removed

None

### Added

None

### Changed

#### `Codex CLI / Claude Code live E2E 的失败处理`

- Before usage or result: 部分 Codex Experiment 配置 `attempts: 2, earlyExit: true`；首轮通过仍可能已经并发派发第二条 Attempt。
- After usage or result: 重试消费者固定 `attempts: 1`；只有公开 Eval 结论为 `failed` 时，精确配对另起一次 Invocation，最多四个失败 Eval 并发重跑。
- User impact: 减少正常绿色运行的模型调用，同时保留首败证据；`errored`、`skipped`、中断和不完整运行不重试。Sandbox reuse lifecycle owner 不受影响。

## Record schema and stored-data upgrade

- Affected public Record Format surfaces: None
- Private persisted implementation impact: None；重试产生两个现有格式的独立 Invocation/Record，不改写或覆盖首轮。
- Version decision: not affected
- Version reason: 没有新增或改变 Record 字段、判别器、附件或引用语义。
- Existing Record behavior: 新旧 reader 都按现有命令读取每个独立 Record。
- Migration or recovery path: not applicable；没有格式迁移。
- Migration safety: 不运行迁移，两次 Invocation 均永久保留。
- Contract: not applicable
- Version history: not applicable
- Verification: `pnpm e2e --lane pr --repo cli` 使用真实 candidate/Testkit 注入链通过 4/4。

## Environment variables

### Removed

None

### Added

None

### Changed

None

## Package scripts

### Removed

None

### Added

None

### Changed

None

## Tests

### `Codex CLI 与 Claude Code live adapter owner`

- Change: substantially rewritten
- Change class: bug-regression
- Disposition: retain
- Candidate identity: Git `55a01736`；本地 candidate SHA-256 `886159544a8b1a3c1575464a2c3f8935f3a87fa608dfe8bc7ff4f73fc96b7c8c`
- Contract and owner: `docs/engineering/testing/e2e/execution.md#重试`
- Stability budget: 只修改两个真实模型 owner 与四个原本误用 `attempts: 2` 的 Experiment；lifecycle 和 plugin-reuse owner 未修改。
- Example scenario: 首轮一个 Eval 为 `failed`，测试对精确 Experiment/Eval 再调用一次并采用第二轮 Verdict。
- Before: `attempts: 2 + earlyExit` 可能并发运行两条，不能表达“先失败再重试”。
- After: 首轮通过恰好一次；断言失败恰好最多两次；errored/skipped 不重试。
- Distinguishing evidence: 重试只从严格解码的公开 `eval.verdict` 触发；第二轮必须只返回目标配对且 Verdict 为 passed 才转绿。
- Verification: `pnpm typecheck`、`pnpm lint`、`pnpm e2e --lane pr --repo cli`；live owner 留给本 PR 的同仓 main lane 验收。
- Fixed conditions: checkout `55a01736`；签入 lockfile、现有镜像 digest 与 CI secrets。
- Repeatability: 未执行付费 live 接管矩阵；PR CI 将执行一次完整 main lane，不能计入成熟接管。
- Unit exception or no automation: 未新增 Unit；真实 adapter owner 直接穿过安装后的 CLI、Provider 与公开 NDJSON。
- Unit count: 未运行 `pnpm test`；本 PR 不新增或修改 Unit。
- Manual observation: 本地未调用付费 Provider；未保护风险是 CI 前尚未证明真实模型重试路径。
- User impact: live Eval 的断言波动可精确重试一次，不用整个测试重跑，也不会浪费固定八次模型调用。
