### PR TITLE
ci(e2e): 缩短 I/O 密集型 Adapter 验收

### DIFF
--- a/.agents/friction-log/20260813115630-friction/friction.md
+++ b/.agents/friction-log/20260813115630-friction/friction.md
@@ -1,0 +1,33 @@
+---
+title: '测试指南要求 pnpm test 但根 script 不存在'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+测试指南要求统一复用 `pnpm test` 时，根 `package.json` 应提供该 script，并运行仓库约定的代码测试入口；如果重置期明确禁止统一入口，指南应给出当前可执行的替代命令。
+
+## Current Behavior
+
+根 `package.json` 没有 `test` script。运行 `pnpm test` 立即以 exit 1 结束且没有输出，无法区分“脚本缺失”与测试失败；直接运行 `pnpm exec vitest run --reporter=verbose` 才能得到 12 files / 45 tests passed。
+
+## Possible Solution
+
+补上与当前 Vitest projects 对齐的根 `test` script，或在测试重置期文档中明确唯一的临时验证入口与预期退出行为。
+
+## Minimal Reproducible Example
+
+在仓库根运行：
+
+```sh
+pnpm test
+echo $?
+node -e 'console.log(require("./package.json").scripts.test)'
+pnpm exec vitest run --reporter=verbose
+```
+
+前两步分别得到无输出的 exit 1 和 `undefined`；最后一步正常执行并报告测试结果。
+
+## Context
+
+为 Adapter E2E 并发装箱 PR 做统一验收时，按照仓库测试指南执行 `pnpm test`，需要额外排查才确认不是本次改动导致的测试失败。

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,8 @@ name: e2e
 # 只做 checkout / runtime / matrix / artifact；不解释产品 expected，不复制 manifest 选择。
 #
 # prepare → plan matrix、Testkit typecheck、pack 一次 NiceEval tgz + sha256
-# e2e     → 并行 cell 下载并重算 candidate digest；pnpm e2e run --candidate <exact> --repo <id>
+# e2e     → 并行 cell 下载并重算 candidate digest；Adapter 以最多四 Repo 一格进行 I/O 装箱，
+#           其它 Repo 保持 singleton；pnpm e2e run --candidate <exact> --repo <id>...
 #           （runner 在当前 checkout 为声明的 consumer clean-build Testkit 并注入目录依赖）
 #           --artifact-root "$RUNNER_TEMP/niceeval-e2e-artifacts/<safe-id>"
 #
@@ -148,7 +149,7 @@ jobs:
           DISPATCH_REPO: ${{ github.event.inputs.repo }}
         run: |
           set -euo pipefail
-          args=(--lane "$LANE" --no-diff --json)
+          args=(--lane "$LANE" --no-diff --json --adapter-batch-size 4)
           repo="$(printf '%s' "${DISPATCH_REPO:-}" | tr -d '[:space:]')"
           if [ -n "$repo" ]; then
             args+=(--repo "$repo")
@@ -169,7 +170,13 @@ jobs:
               echo "has-jobs=false"
             fi
           } >> "$GITHUB_OUTPUT"
-          echo "[e2e] plan lane=${LANE} selected ${count}: $(jq -r '[.[].id] | join(", ")' "$plan_file")"
+          repo_count="$(jq '[.[].repoIds[]] | length' "$plan_file")"
+          unique_repo_count="$(jq '[.[].repoIds[]] | unique | length' "$plan_file")"
+          if [ "$repo_count" -ne "$unique_repo_count" ]; then
+            echo "::error::batched plan contains duplicate Repo ids"
+            exit 1
+          fi
+          echo "[e2e] plan lane=${LANE} selected ${repo_count} Repo(s) in ${count} cell(s): $(jq -r '[.[].repoIds[]] | join(", ")' "$plan_file")"
 
       - name: Typecheck Testkit
         if: steps.plan.outputs.has-jobs == 'true'
@@ -250,6 +257,23 @@ jobs:
           echo "id=${safe}" >> "$GITHUB_OUTPUT"
           echo "artifact-root=${RUNNER_TEMP}/niceeval-e2e-artifacts/${safe}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve cell manifests
+        id: cell
+        env:
+          REPO_IDS_JSON: ${{ toJSON(matrix.repoIds) }}
+          REPO_DIRS_JSON: ${{ toJSON(matrix.dirs) }}
+        run: |
+          set -euo pipefail
+          manifests_file="${RUNNER_TEMP}/e2e-cell-manifests.json"
+          jq -n \
+            --argjson ids "$REPO_IDS_JSON" \
+            --argjson dirs "$REPO_DIRS_JSON" \
+            'if ($ids | length) != ($dirs | length) or ($ids | length) == 0 then error("invalid cell repo mapping") else [range(0; $ids | length) | {id: $ids[.], manifest: ("e2e/" + $dirs[.] + "/e2e.json")}] end' \
+            > "$manifests_file"
+          jq -e 'all(.[]; (.id | type == "string") and (.manifest | type == "string"))' "$manifests_file" >/dev/null
+          echo "manifests-file=${manifests_file}" >> "$GITHUB_OUTPUT"
+          echo "[e2e] cell ${{ matrix.id }}: $(jq -r '[.[].id] | join(", ")' "$manifests_file")"
+
       - name: Set up Python
         if: contains(toJSON(matrix.requires), 'python')
         uses: actions/setup-python@v5
@@ -298,7 +322,7 @@ jobs:
       - name: Inject secrets for trusted lane
         if: needs.prepare.outputs.inject-secrets == 'true'
         env:
-          MANIFEST: e2e/${{ matrix.dir }}/e2e.json
+          MANIFESTS_FILE: ${{ steps.cell.outputs.manifests-file }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           BUB_API_BASE: ${{ secrets.BUB_API_BASE }}
@@ -325,12 +349,15 @@ jobs:
             "OPENAI_API_KEY",
             "OPENAI_BASE_URL",
           ]);
-          const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST, "utf8"));
+          const cells = JSON.parse(fs.readFileSync(process.env.MANIFESTS_FILE, "utf8"));
+          const declared = [...new Set(cells.flatMap(({ manifest }) =>
+            JSON.parse(fs.readFileSync(manifest, "utf8")).secrets
+          ))];
           const lines = [];
           let injected = 0;
-          for (const name of manifest.secrets) {
+          for (const name of declared) {
             if (!allowed.has(name)) {
-              throw new Error(`${process.env.MANIFEST}: secret ${name} is not in the workflow allowlist`);
+              throw new Error(`cell secret ${name} is not in the workflow allowlist`);
             }
             const value = process.env[name];
             if (typeof value !== "string" || value.length === 0) continue;
@@ -341,27 +368,34 @@ jobs:
           if (lines.length > 0) {
             fs.appendFileSync(process.env.GITHUB_ENV, lines.join("\n") + "\n");
           }
-          console.log(`[e2e] injected ${injected}/${manifest.secrets.length} declared secret(s)`);
+          console.log(`[e2e] injected ${injected}/${declared.length} declared secret(s)`);
           NODE_EOF
 
       - name: Run e2e for ${{ matrix.id }}
         env:
           CANDIDATE: ${{ steps.candidate.outputs.candidate }}
-          REPO_ID: ${{ matrix.id }}
+          REPO_IDS_JSON: ${{ toJSON(matrix.repoIds) }}
+          REPO_CONCURRENCY: ${{ matrix.repoConcurrency }}
           ARTIFACT_ROOT: ${{ steps.safe.outputs.artifact-root }}
         run: |
           set -euo pipefail
           mkdir -p "$ARTIFACT_ROOT"
+          mapfile -t repo_ids < <(jq -r '.[]' <<< "$REPO_IDS_JSON")
+          repo_args=()
+          for repo_id in "${repo_ids[@]}"; do
+            repo_args+=(--repo "$repo_id")
+          done
           pnpm e2e run \
             --candidate "$CANDIDATE" \
-            --repo "$REPO_ID" \
+            "${repo_args[@]}" \
+            --repo-concurrency "$REPO_CONCURRENCY" \
             --artifact-root "$ARTIFACT_ROOT"
 
       - name: Redact secrets in artifactRoot
         if: always() && needs.prepare.outputs.inject-secrets == 'true'
         env:
           ARTIFACT_ROOT: ${{ steps.safe.outputs.artifact-root }}
-          MANIFEST: e2e/${{ matrix.dir }}/e2e.json
+          MANIFESTS_FILE: ${{ steps.cell.outputs.manifests-file }}
         run: |
           set -euo pipefail
           if [ ! -d "$ARTIFACT_ROOT" ]; then
@@ -372,8 +406,11 @@ jobs:
           const fs = require("fs");
           const path = require("path");
           const root = process.env.ARTIFACT_ROOT;
-          const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST, "utf8"));
-          const replacements = manifest.secrets
+          const cells = JSON.parse(fs.readFileSync(process.env.MANIFESTS_FILE, "utf8"));
+          const declared = [...new Set(cells.flatMap(({ manifest }) =>
+            JSON.parse(fs.readFileSync(manifest, "utf8")).secrets
+          ))];
+          const replacements = declared
             .map((name) => ({ name, value: process.env[name] }))
             .filter(({ value }) => typeof value === "string" && value.length > 0);
           function walk(dir, files = []) {

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -109,9 +109,9 @@ checkout 的 Testkit 源码编译到新的 scratch staging package，并在同�
 - runner 在 install 前后及副本 cleanup 后核对 snapshot digest；任何 mutation 都是 infra。receipt 只保存 version、checkout 相对 source path、snapshot digest 与副本内 installed realpath，全部仅供诊断。durable artifact 与 exact replay
   只属于 NiceEval candidate；重跑时 Testkit 始终来自当时所在 checkout。
 
-功能 Repo 与 Adapter Repo 永远是不同的 matrix cell。`--repo report` 只复制并运行 Report 功能 Repo，不会挑一个
-`adapter/ai-sdk` Repo 来提供“更真实”的模型结果；`--repo adapter/ai-sdk` 也只运行该兼容性项目。`main` / `release` lane
-可以同时选择两组 Repo，但它们仍分别安装、执行、收集 artifact 和 cleanup。
+功能 Repo 与 Adapter Repo 永远不会混进同一个 matrix cell。`--repo report` 只复制并运行 Report 功能 Repo，不会挑一个
+`adapter/ai-sdk` Repo 来提供“更真实”的模型结果；`--repo adapter/ai-sdk` 也只运行该兼容性项目。可信 CI lane 可把多个
+I/O-bound Adapter Repo 装入一个 4 vCPU cell 并发运行；每个 Repo 仍分别安装、执行、收集 artifact 和 cleanup。
 
 ## 一次运行
 
@@ -204,13 +204,14 @@ prepare job
              │
              ▼
 matrix jobs：下载同一 candidate.tgz
-  └─ checkout 中 build Testkit；e2e run --candidate … --repo <matrix.id>
+  ├─ 功能 Repo：checkout 中 build Testkit；e2e run --candidate … --repo <id>
+  └─ Adapter batch：同一 checkout / Testkit 下并发 run 多个独立 --repo <id>
 ```
 
 Workflow 只准备 Node / pnpm / Docker / browser、下发矩阵、缓存 store / image layer、上传 artifact。
 它不自己改 dependency、分类错误、实现重试、决定 expected 或维护另一份 Repo 清单。
-每个 matrix cell 自己上传 receipt、summary、JUnit 与声明附件；GitHub 原生汇总 matrix 成败，不再启动一个 job
-下载并复述所有 cell 的结果。
+每个 matrix cell 自己上传 receipt、summary、JUnit 与声明附件；Adapter batch 的 artifact root 下仍按 Repo ID 分目录并
+保存独立 receipt，batch summary 列全该格 Repo。GitHub 原生汇总 matrix 成败，不再启动一个 job 下载并复述所有 cell 的结果。
 
 Cache key 至少区分 pnpm 版本、OS / 架构和 Docker image digest。包管理器 store 依赖自身内容寻址；PR 不使用会把
 其它候选测试文件带回来的宽泛 restore key。Nightly 定期跑 cold cell，防止日常 cache 掩盖缺失依赖或镜像初始化问题。
@@ -249,9 +250,10 @@ Docker cgroup 的 `cpu.max`、`memory.max`、`memory.swap.max` 与 `pids.max` �
 - 同一 checkout 的独立根 E2E invocation 可以并发启动；只有会触发共享 `prepare` 写入的 candidate `pnpm pack` 生命周期按 canonical checkout 的跨进程 lease 局部串行，计划、Testkit snapshot、隔离 Repo 与 run 阶段继续并发；
 - lease 位于 OS 临时控制目录而不进入待打包文件。正常退出、失败或取消都会释放；进程崩溃留下的 lease fail-closed 并报出精确人工删除路径，绝不靠超时或不安全删除让两个 pack 同时写入；
 - 无密钥 host Repo 可按 CPU 并行，每个 Repo 独立副本；
-- CI E2E matrix 使用 4 vCPU Blacksmith runner，场景的全局 attempt 并发统一为 4，使每个并发 attempt 对应一个 vCPU；
+- CI E2E matrix 使用 4 vCPU Blacksmith runner。功能 Repo 保持 singleton；I/O-bound Adapter 按最多四个 Repo 装箱，
+  格内并发启动且各 Repo 保留自己的 attempt 并发，因此允许约 8–16 条外部等待同时铺开，不把 vCPU 数当作 I/O 并发上限；
 - Repo 内保留 Vitest / Playwright 的默认文件级并行；短命控制文件、结果根、项目副本与资源名按 case 隔离；
-- 使用 Docker backend 的 Repo 按 runner CPU / memory 设置 `max-parallel`；
+- Adapter 装箱先分散 Docker-heavy Repo；出现 OOM、daemon 抖动或显著尾延迟时拆分对应 cell，不以升配 CPU 作为默认修法；
 - live provider 按 provider / account 建 concurrency group，避免同一配额互相制造 429；
 - Lifecycle case 用独立进程组、动态端口和 run ID 核对自己的 orphan，不得因兄弟任务存在就误判；
 - 共享 evidence 只能在冻结后只读并行。无法拥有独立资源的 case 才局部串行，不把整个 Lifecycle 域降为串行。
@@ -322,4 +324,4 @@ Release Repo 使用同一 checkout 的私有 Testkit 作为 harness，但只有 
 - 注入身份核验失败与待测包不可消费使用不同失败分类，并保留各自的原始收据。
 - Adapter 与 Report Repo 按 owner 拆成原生测试文件，再按文件和标题分片；不把多个命题压进线性脚本或同一文件。
 - CLI、Runner、Report、Package 与 live Adapter 共用根 runner 的 pack → plan → run → artifact 链；workflow 不复制选择或注入逻辑。
-- 共用 runner 不等于共用 Repo；功能与 Adapter 始终是不同 matrix cell、依赖安装和结果根。
+- 共用 runner 不等于共用 Repo；功能与 Adapter 不混装，Adapter 同格时仍保留各自的依赖安装、结果根、receipt 与 cleanup。

--- a/e2e/scripts/cli.ts
+++ b/e2e/scripts/cli.ts
@@ -58,6 +58,7 @@ Commands:
 Root run options:
   --repo <id>          Select a repository (repeatable)
   --lane <lane>        Select a manifest lane
+  --repo-concurrency N Run up to N selected repositories concurrently
   --keep-workdir       Retain the isolated scratch tree for local diagnosis
   --help, -h           Print this help without planning, packing, or running
 
@@ -101,7 +102,12 @@ export async function executeDefault(
   const selected = await dependencies.plan(selectionArgs);
   if (selected.length === 0) return false;
   const candidate = await dependencies.pack(dependencies.candidatePath);
-  await dependencies.run(buildDefaultRunArgs(candidate.path, selected.map((entry) => entry.id), nativeArgs, keepWorkdir));
+  await dependencies.run(buildDefaultRunArgs(
+    candidate.path,
+    selected.flatMap((entry) => entry.repoIds),
+    nativeArgs,
+    keepWorkdir,
+  ));
   return true;
 }
 

--- a/e2e/scripts/durable-path.ts
+++ b/e2e/scripts/durable-path.ts
@@ -96,7 +96,14 @@ async function createDeclaredDurableRoot(declaredRoot: string, label: string): P
     const next = join(current, part);
     let stat = await lstatOrUndefined(next);
     if (stat === undefined) {
-      await mkdir(next);
+      try {
+        await mkdir(next);
+      } catch (error) {
+        // Parallel repo runs can converge on a shared canonical parent such
+        // as artifactRoot/adapter. EEXIST is safe only after the lstat below
+        // proves the winner created the real directory we expected.
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
       stat = await lstat(next);
     }
     assertRealDirectoryStat(stat, next, label);
@@ -132,7 +139,11 @@ async function walkBelowPhysicalRoot(
     const next = join(current, part);
     let stat = await lstatOrUndefined(next);
     if (stat === undefined && createMissing) {
-      await mkdir(next);
+      try {
+        await mkdir(next);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
       stat = await lstat(next);
     }
     if (stat === undefined) throw new Error(`${label} directory is missing: ${next}`);

--- a/e2e/scripts/owned-process.ts
+++ b/e2e/scripts/owned-process.ts
@@ -22,6 +22,8 @@ export interface OwnedProcessOptions {
   timeoutMs?: number;
   /** Stops a command that has already started and prevents a new one from starting. */
   abortSignal?: AbortSignal;
+  /** Prefix each streamed line without changing captured stdout/stderr. */
+  streamPrefix?: string;
 }
 
 export interface OwnedProcessResult {
@@ -147,6 +149,8 @@ class ActiveOwnedProcess {
   private groupCleanupDetail: string;
   private readonly groupSignalsSent: NodeJS.Signals[] = [];
   private killAttempted = false;
+  private stdoutAtLineStart = true;
+  private stderrAtLineStart = true;
 
   constructor(
     private readonly child: ChildProcess,
@@ -155,6 +159,7 @@ class ActiveOwnedProcess {
     private readonly stream: boolean,
     private readonly graceMs: number,
     private readonly processGroupOwned: boolean,
+    private readonly streamPrefix?: string,
   ) {
     const pid = child.pid;
     // `detached: true` creates a new POSIX session/process group whose id is
@@ -175,12 +180,12 @@ class ActiveOwnedProcess {
       child.stdout?.on("data", (chunk: Buffer | string) => {
         const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
         this.stdout += text;
-        if (stream) process.stdout.write(text);
+        if (stream) process.stdout.write(this.prefixedChunk(text, "stdout"));
       });
       child.stderr?.on("data", (chunk: Buffer | string) => {
         const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
         this.stderr += text;
-        if (stream) process.stderr.write(text);
+        if (stream) process.stderr.write(this.prefixedChunk(text, "stderr"));
       });
     }
 
@@ -194,6 +199,16 @@ class ActiveOwnedProcess {
       // finish only after the owned-group postcondition below.
       void this.finishAfterLeaderClose(exitCode, signal);
     });
+  }
+
+  private prefixedChunk(text: string, channel: "stdout" | "stderr"): string {
+    if (this.streamPrefix === undefined || text.length === 0) return text;
+    const atLineStart = channel === "stdout" ? this.stdoutAtLineStart : this.stderrAtLineStart;
+    const prefix = `[${this.streamPrefix}] `;
+    const transformed = `${atLineStart ? prefix : ""}${text.replace(/\n(?!$)/g, `\n${prefix}`)}`;
+    if (channel === "stdout") this.stdoutAtLineStart = text.endsWith("\n");
+    else this.stderrAtLineStart = text.endsWith("\n");
+    return transformed;
   }
 
   requestTermination(signal: NodeJS.Signals, cause: OwnedTermination): void {
@@ -450,6 +465,7 @@ export class OwnedProcessSupervisor {
       options.stream ?? true,
       this.graceMs,
       processGroupOwned,
+      options.streamPrefix,
     );
     this.active.add(active);
 

--- a/e2e/scripts/plan.ts
+++ b/e2e/scripts/plan.ts
@@ -24,14 +24,21 @@ export interface SelectionOptions {
 }
 
 export interface PlanEntry {
+  /** Stable matrix-cell identity. Singleton cells retain the repo id. */
   id: string;
-  /** Path relative to e2e/, suitable for a matrix job's checkout. */
-  dir: string;
+  /** Exact scenario repos executed by this cell. */
+  repoIds: readonly string[];
+  /** Backward-compatible singleton directory; absent for a multi-repo cell. */
+  dir?: string;
+  /** Paths relative to e2e/, in the same order as repoIds. */
+  dirs: readonly string[];
   executor: Executor;
-  /** Manifest areas are the stable capability vocabulary. */
+  /** Union of the cell's manifest areas; manifests remain the source of truth. */
   capabilities: readonly Area[];
-  /** One discovered repo is one executable matrix shard. */
+  /** Stable diagnostic shard identity. */
   shard: string;
+  /** Number of isolated repos the root runner may execute concurrently. */
+  repoConcurrency: number;
   requires?: RepoRequires;
 }
 
@@ -42,6 +49,8 @@ export interface PlanCli {
   /** Explicitly disable both supplied and implicit working-tree path filtering. */
   noDiff: boolean;
   capability?: string;
+  /** Pack adapter repos into cells of at most this size; omitted means singleton cells. */
+  adapterBatchSize?: number;
   json: boolean;
 }
 
@@ -226,6 +235,18 @@ function valueAsStrings(value: unknown): string[] {
   return typeof value === "string" ? [value] : [];
 }
 
+function parsePositiveInteger(value: unknown, option: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw new Error(`${option} must be a positive integer, got ${JSON.stringify(value)}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${option} must be a positive integer, got ${JSON.stringify(value)}`);
+  }
+  return parsed;
+}
+
 function parseLane(value: unknown): Lane {
   if (value === undefined) return "pr";
   if (typeof value !== "string" || !(LANES as readonly string[]).includes(value)) {
@@ -244,6 +265,7 @@ export function parsePlanCli(argv: readonly string[]): PlanCli {
       diff: { type: "string", multiple: true },
       "no-diff": { type: "boolean", default: false },
       capability: { type: "string" },
+      "adapter-batch-size": { type: "string" },
       json: { type: "boolean", default: false },
     },
     allowPositionals: false,
@@ -264,21 +286,114 @@ export function parsePlanCli(argv: readonly string[]): PlanCli {
     diffPaths: diffPaths.length > 0 ? diffPaths : undefined,
     noDiff,
     capability,
+    adapterBatchSize: parsePositiveInteger(values["adapter-batch-size"], "--adapter-batch-size"),
     json: values.json === true,
   };
 }
 
-export function makePlan(repos: readonly DiscoveredRepo[], root: string, options: SelectionOptions): PlanEntry[] {
-  return selectRepos(repos, options)
-    .map((repo) => ({
-      id: repo.manifest.id,
-      dir: relative(root, repo.dir),
-      executor: repo.manifest.executor,
-      capabilities: repo.manifest.areas,
-      shard: repo.manifest.id,
-      ...(repo.manifest.requires === undefined ? {} : { requires: repo.manifest.requires }),
-    }))
+function singletonEntry(repo: DiscoveredRepo, root: string): PlanEntry {
+  const dir = relative(root, repo.dir);
+  return {
+    id: repo.manifest.id,
+    repoIds: [repo.manifest.id],
+    dir,
+    dirs: [dir],
+    executor: repo.manifest.executor,
+    capabilities: repo.manifest.areas,
+    shard: repo.manifest.id,
+    repoConcurrency: 1,
+    ...(repo.manifest.requires === undefined ? {} : { requires: repo.manifest.requires }),
+  };
+}
+
+function mergedRequires(entries: readonly PlanEntry[]): RepoRequires | undefined {
+  const requirements = entries.flatMap((entry) => entry.requires === undefined ? [] : [entry.requires]);
+  if (requirements.length === 0) return undefined;
+  const runtimes = [...new Set(requirements.flatMap((requirement) => requirement.runtimes ?? []))];
+  const browsers = [...new Set(requirements.flatMap((requirement) => requirement.browsers ?? []))];
+  const platforms = [...new Set(requirements.flatMap((requirement) => requirement.platforms ?? []))];
+  return {
+    ...(requirements.some((requirement) => requirement.docker === true) ? { docker: true } : {}),
+    ...(requirements.some((requirement) => requirement.externalNetwork === true) ? { externalNetwork: true } : {}),
+    ...(platforms.length === 0 ? {} : { platforms }),
+    ...(runtimes.length === 0 ? {} : { runtimes }),
+    ...(browsers.length === 0 ? {} : { browsers }),
+  };
+}
+
+function adapterBatch(entries: readonly PlanEntry[], index: number): PlanEntry {
+  const executors = new Set(entries.map((entry) => JSON.stringify(entry.executor)));
+  if (executors.size !== 1 || entries[0] === undefined) {
+    throw new Error(`adapter batch ${index + 1} requires one shared executor`);
+  }
+  const id = `adapter-batch-${index + 1}`;
+  const requires = mergedRequires(entries);
+  return {
+    id,
+    repoIds: entries.flatMap((entry) => entry.repoIds),
+    dirs: entries.flatMap((entry) => entry.dirs),
+    executor: entries[0].executor,
+    capabilities: [...new Set(entries.flatMap((entry) => entry.capabilities))],
+    shard: id,
+    repoConcurrency: entries.length,
+    ...(requires === undefined ? {} : { requires }),
+  };
+}
+
+/**
+ * Pack I/O-bound adapter repos onto fewer runners while spreading Docker-heavy
+ * repos across cells. The original plan remains authoritative and is checked
+ * after packing so batching cannot add, omit, or duplicate a repo.
+ */
+export function batchAdapterEntries(entries: readonly PlanEntry[], maxBatchSize: number): PlanEntry[] {
+  if (!Number.isSafeInteger(maxBatchSize) || maxBatchSize < 1) {
+    throw new Error(`adapter batch size must be a positive integer, got ${maxBatchSize}`);
+  }
+  const adapters = entries.filter((entry) => entry.capabilities.includes("adapter"));
+  if (adapters.length <= 1) return [...entries];
+
+  const nonAdapters = entries.filter((entry) => !entry.capabilities.includes("adapter"));
+  const batchCount = Math.ceil(adapters.length / maxBatchSize);
+  const groups = Array.from({ length: batchCount }, () => [] as PlanEntry[]);
+  const dockerFirst = [
+    ...adapters.filter((entry) => entry.requires?.docker === true),
+    ...adapters.filter((entry) => entry.requires?.docker !== true),
+  ];
+  for (const entry of dockerFirst) {
+    const eligible = groups
+      .map((group, index) => ({ group, index }))
+      .filter(({ group }) => group.length < maxBatchSize)
+      .sort((left, right) => left.group.length - right.group.length || left.index - right.index);
+    const target = eligible[0];
+    if (target === undefined) throw new Error(`could not place adapter repo ${entry.id} into a batch`);
+    target.group.push(entry);
+  }
+
+  const packed = [
+    ...nonAdapters,
+    ...groups.map((group, index) => adapterBatch(group, index)),
+  ].sort((left, right) => left.id.localeCompare(right.id));
+  const before = entries.flatMap((entry) => entry.repoIds).sort();
+  const after = packed.flatMap((entry) => entry.repoIds).sort();
+  if (before.length !== new Set(before).size || after.length !== new Set(after).size) {
+    throw new Error("E2E plan contains duplicate repo ids before or after adapter batching");
+  }
+  if (JSON.stringify(before) !== JSON.stringify(after)) {
+    throw new Error("adapter batching changed the selected E2E repo-id set");
+  }
+  return packed;
+}
+
+export function makePlan(
+  repos: readonly DiscoveredRepo[],
+  root: string,
+  options: SelectionOptions,
+  adapterBatchSize?: number,
+): PlanEntry[] {
+  const entries = selectRepos(repos, options)
+    .map((repo) => singletonEntry(repo, root))
     .sort((left, right) => left.id.localeCompare(right.id));
+  return adapterBatchSize === undefined ? entries : batchAdapterEntries(entries, adapterBatchSize);
 }
 
 function printHumanPlan(entries: readonly PlanEntry[], lane: Lane): void {
@@ -289,7 +404,8 @@ function printHumanPlan(entries: readonly PlanEntry[], lane: Lane): void {
   console.log(`${entries.length} e2e shard(s) selected for lane ${lane}:\n`);
   for (const entry of entries) {
     console.log(`- ${entry.id}  [${entry.capabilities.join(", ")}]  executor=host`);
-    console.log(`    dir: ${entry.dir}  shard: ${entry.shard}`);
+    console.log(`    repos: ${entry.repoIds.join(", ")}  concurrency: ${entry.repoConcurrency}`);
+    console.log(`    dirs: ${entry.dirs.join(", ")}  shard: ${entry.shard}`);
   }
 }
 
@@ -309,12 +425,17 @@ export function resolvePlan(argv: readonly string[]): ResolvedPlan {
   const diffPaths = cli.noDiff ? undefined : cli.diffPaths ?? tryReadDiffPaths(resolve(e2eRoot, ".."));
   return {
     cli,
-    entries: makePlan(repos, e2eRoot, {
-      lane: cli.lane,
-      repoIds: cli.repoIds,
-      diffPaths,
-      capability: cli.capability,
-    }),
+    entries: makePlan(
+      repos,
+      e2eRoot,
+      {
+        lane: cli.lane,
+        repoIds: cli.repoIds,
+        diffPaths,
+        capability: cli.capability,
+      },
+      cli.adapterBatchSize,
+    ),
   };
 }
 

--- a/e2e/scripts/run-repo.ts
+++ b/e2e/scripts/run-repo.ts
@@ -194,6 +194,7 @@ export async function runCommand(
   env: NodeJS.ProcessEnv,
   timeoutMs: number,
   execution: E2EExecutionControl,
+  streamPrefix?: string,
 ): Promise<CommandCapture> {
   const result = await execution.supervisor.run(command, {
     cwd,
@@ -202,6 +203,7 @@ export async function runCommand(
     stream: true,
     timeoutMs,
     abortSignal: execution.abortSignal,
+    streamPrefix,
   });
   return commandCapture(result);
 }
@@ -223,6 +225,8 @@ export interface RunRepoOptions {
   sourceSnapshotDigest?: string;
   /** Retain this isolated repo copy for explicit local diagnosis. */
   keepWorkdir?: boolean;
+  /** Prefix streamed install/test output when multiple repos share one runner. */
+  logPrefix?: string;
 }
 
 function withInvocationContext(
@@ -379,7 +383,14 @@ export async function runRepo(
                 setupInvocationId,
                 copyDir,
               );
-              const installCapture = await runCommand(installCmd, copyDir, installEnv, 30 * 60_000, execution);
+              const installCapture = await runCommand(
+                installCmd,
+                copyDir,
+                installEnv,
+                30 * 60_000,
+                execution,
+                options.logPrefix,
+              );
               const installOk =
                 installCapture.exitCode === 0 &&
                 !installCapture.timedOut &&
@@ -484,7 +495,14 @@ export async function runRepo(
                           invocationId,
                           copyDir,
                         );
-                        const testCapture = await runCommand(testCmd, copyDir, childEnv, timeoutMs, execution);
+                        const testCapture = await runCommand(
+                          testCmd,
+                          copyDir,
+                          childEnv,
+                          timeoutMs,
+                          execution,
+                          options.logPrefix,
+                        );
                         testExitCode = testCapture.exitCode;
                         const testOk =
                           testCapture.exitCode === 0 &&

--- a/e2e/scripts/run.ts
+++ b/e2e/scripts/run.ts
@@ -30,7 +30,7 @@ import { parseArgs } from "node:util";
 
 import { discoverAllRepos, e2eRootDir, repoRootDir } from "./discovery.ts";
 import { readCandidateTarball } from "./injection.ts";
-import { buildTestkitPackage } from "./testkit.ts";
+import { buildTestkitPackage, verifyTestkitSnapshot } from "./testkit.ts";
 import { selectRepos } from "./plan.ts";
 import { LANES, type Lane } from "./manifest.ts";
 import { appendNativeArgs, materializeCandidateArtifact, runRepo, type RepoRunResult } from "./run-repo.ts";
@@ -58,6 +58,7 @@ interface Cli {
   artifactRoot: string | undefined;
   nativeArgs: string[];
   keepWorkdir: boolean;
+  repoConcurrency: number;
 }
 
 function splitNativeArgs(argv: readonly string[]): { optionArgs: readonly string[]; nativeArgs: string[] } {
@@ -78,6 +79,7 @@ export function parseRunCli(argv: readonly string[]): Cli {
       "artifact-root": { type: "string" },
       "diff-path": { type: "string", multiple: true },
       "keep-workdir": { type: "boolean", default: false },
+      "repo-concurrency": { type: "string", default: "1" },
     },
     allowPositionals: false,
     strict: true,
@@ -96,6 +98,14 @@ export function parseRunCli(argv: readonly string[]): Cli {
   const diffPaths = Array.isArray(values["diff-path"])
     ? values["diff-path"].filter((value): value is string => typeof value === "string")
     : [];
+  const concurrencyValue = values["repo-concurrency"];
+  if (typeof concurrencyValue !== "string" || !/^\d+$/.test(concurrencyValue)) {
+    throw new Error(`--repo-concurrency must be a positive integer, got ${JSON.stringify(concurrencyValue)}`);
+  }
+  const repoConcurrency = Number(concurrencyValue);
+  if (!Number.isSafeInteger(repoConcurrency) || repoConcurrency < 1) {
+    throw new Error(`--repo-concurrency must be a positive integer, got ${JSON.stringify(concurrencyValue)}`);
+  }
   return {
     repoIds,
     lane: typeof laneValue === "string" ? (laneValue as Lane) : undefined,
@@ -107,7 +117,41 @@ export function parseRunCli(argv: readonly string[]): Cli {
       : undefined,
     nativeArgs,
     keepWorkdir: values["keep-workdir"] === true,
+    repoConcurrency,
   };
+}
+
+async function runRepoPool<T>(
+  items: readonly T[],
+  concurrency: number,
+  execution: E2EExecutionControl,
+  run: (item: T, index: number) => Promise<RepoRunResult>,
+): Promise<RepoRunResult[]> {
+  const ordered: Array<RepoRunResult | undefined> = Array.from({ length: items.length });
+  const unexpectedFailures: Array<{ index: number; error: unknown }> = [];
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (!isExecutionCancelled(execution)) {
+      const index = nextIndex;
+      if (index >= items.length) return;
+      nextIndex += 1;
+      const item = items[index];
+      if (item === undefined) return;
+      try {
+        ordered[index] = await run(item, index);
+      } catch (error) {
+        unexpectedFailures.push({ index, error });
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  if (unexpectedFailures.length > 0) {
+    throw new AggregateError(
+      unexpectedFailures.map(({ error }) => error),
+      `${unexpectedFailures.length} repo worker(s) failed unexpectedly after all started repos settled`,
+    );
+  }
+  return ordered.filter((result): result is RepoRunResult => result !== undefined);
 }
 
 // ---------------------------------------------------------------------------
@@ -282,24 +326,29 @@ export async function main(
 
       const allSecretNames = new Set<string>();
       for (const r of repos) for (const s of r.manifest.secrets) allSecretNames.add(s);
+      const activeScratchRoot = scratchRoot;
+      const activeArtifactRoot = artifactRoot;
 
-      for (const repo of selected) {
-        if (isExecutionCancelled(execution)) break;
+      console.log(`[e2e] repo concurrency: ${Math.min(cli.repoConcurrency, selected.length)}`);
+      results.push(...await runRepoPool(selected, cli.repoConcurrency, execution, async (repo) => {
         console.log(`\n[e2e] === ${repo.manifest.id} ===`);
         const result = await runRepo(
           repo,
           candidate,
-          scratchRoot,
-          artifactRoot,
+          activeScratchRoot,
+          activeArtifactRoot,
           allSecretNames,
           cli.nativeArgs,
           testkit,
-          { execution, keepWorkdir: cli.keepWorkdir },
+          { execution, keepWorkdir: cli.keepWorkdir, logPrefix: `e2e:${repo.manifest.id}` },
         );
         console.log(`[e2e] ${repo.manifest.id}: artifactDir=${result.artifactDir}`);
         console.log(`[e2e] ${repo.manifest.id}: receiptPath=${result.receiptPath}`);
-        results.push(result);
-        if (result.category === "cancelled") break;
+        return result;
+      }));
+      if (testkit !== undefined) {
+        await verifyTestkitSnapshot(testkit);
+        console.log(`[e2e] Testkit snapshot sha256:${testkit.digest} unchanged after all repos settled`);
       }
     }
   } catch (err) {


### PR DESCRIPTION
## Problem

- User goal: 在不增加 Blacksmith CPU 规格的前提下，缩短所有 Adapter E2E 的等待时间和 runner 用量。
- Current limitation: 13 个 Adapter Repo 各占一个 `blacksmith-4vcpu` matrix cell，但大部分时间都在等待外部 AI、CLI 或网络 I/O；每格只跑一个 Repo，重复 checkout、runtime、下载 candidate 和构建 Testkit。
- Required capability: 计划器需要把多个 Adapter Repo 动态装箱，根 runner 需要在同一 cell 内隔离并发运行多个 Repo，workflow 需要按整格能力与密钥并集准备环境。
- User outcome: main E2E 把 13 个 Adapter Repo 装为 4 个并行 cell（4/3/3/3），每格在 4 vCPU 上并发 3–4 个 Repo，并保留各 Repo 自己的 attempt 并发、artifact、receipt 和 cleanup。

## 实测性能

对比使用同一天、同一 workflow 的 singleton run `31660667181` 与本 PR run `31664150678` 的最终成功 job durations：

| 指标 | 之前：13 个 singleton | 本 PR：4 个 batch | 变化 |
| --- | ---: | ---: | ---: |
| Adapter Blacksmith jobs | 13 | 4 | -69.2% |
| Adapter runner 总占用 | 931s | 386s | -58.5% |
| 正常样本的 Adapter 关键路径 | 114s | 110s | -3.5% |
| Runner 规格 | `blacksmith-4vcpu` | `blacksmith-4vcpu` | 不升配 |

这里的主要收益是 runner 数量、重复 setup 与付费 runner-minutes，不宣称 AI 响应本身变快。batch-2 的成功重跑日志显示 `claude-code`、`codex-sdk`、`opencode` 在同一毫秒被领取，分别用 70.11s、13.12s、45.99s 完成；batch wall time由最慢 Repo 决定，而不是三者相加。

首轮 batch-2 有一次 Claude Code `locked-down/websearch-denied` 在其余 17/18 attempts 已通过后单独等满 600s；这是异常样本，不纳入正常关键路径。相同 batch 的 CI 重跑 110s 全绿；本地 Claude singleton 98.51s 全绿；本地完全相同三 Repo batch 中 Claude 101.21s、OpenCode 46.71s、Codex SDK 14.24s，3/3 Repo 全绿。旧 singleton run `31661305229` 的 Claude Code 单独占 runner 时也曾跑 10m44s 后失败，因此当前证据不支持装箱导致该长尾。

## Use cases

### `在 4 vCPU runner 上并发运行所有 Adapter Repo`

- Coverage: `happy path | composition | lifecycle | failure | unsupported`
- Starting point: 仓库已有由 manifest 发现的 Adapter Repo、Blacksmith 4 vCPU matrix 与精确 candidate tarball。
- Copyable usage or trigger: `pnpm e2e plan --lane main --no-diff --adapter-batch-size 4 --json` 生成不重不漏的装箱计划；每格执行 `pnpm e2e run --candidate <candidate.tgz> --repo <id> ... --repo-concurrency <N>`。
- Observable result or diagnostic: 13 个 Adapter 变为 4 个动态 cell；同格日志带 Repo 前缀，结果仍按 Repo ID 分目录；任何 Repo 非 pass 时该格失败。取消后不再领取新 Repo，并等待已启动 Repo 收尾。
- Contract: `docs/engineering/testing/e2e/execution.md`

不支持把功能 Repo 与 Adapter Repo 混装；显式 `--repo adapter/<name>` 仍是 singleton。Docker-heavy Repo 会优先分散到不同 cell，若出现 OOM 或 daemon 抖动则拆分对应 cell，而不是默认升配 CPU。

## Public API

### Removed

None

### Added

None

### Changed

None

## CLI commands

### Removed

None

### Added

#### `pnpm e2e plan --adapter-batch-size <N>`

- Before usage or result: `not available`
- After usage or result: `pnpm e2e plan --lane main --no-diff --adapter-batch-size 4 --json` 输出 Adapter batch，且 `repoIds` 展平后的集合与原始计划完全一致。
- User impact: CI 可按 manifest 选择结果动态装箱，不维护第二份 Repo 清单；省略参数时继续输出 singleton 计划。

#### `pnpm e2e run --repo-concurrency <N>`

- Before usage or result: `not available`
- After usage or result: `pnpm e2e run --candidate ./candidate.tgz --repo adapter/local-protocol --repo adapter/sdk-converters --repo-concurrency 2` 在同一进程中并发执行两个隔离 Repo。
- User impact: 默认仍为 `1`；传入正整数时不按 CPU 数硬限制，并发 Repo 共享只读 candidate/Testkit，但保持安装目录、输出、receipt 和 cleanup 隔离。

### Changed

None

## Report components

### Removed

None

### Added

None

### Changed

None

## Observable behavior and data contracts

### Removed

None

### Added

None

### Changed

#### `Adapter E2E matrix 调度`

- Before usage or result: main lane 的 13 个 Adapter Repo 各占一个 `blacksmith-4vcpu` cell；每格重复完成 workflow setup 和 Testkit build。
- After usage or result: 同样 13 个 Repo 动态装为 4 个并行 cell（4/3/3/3），每格最多四个 Repo；非 Adapter、release workflow 和显式单 Repo 仍保持 singleton。
- User impact: 不增加 CPU 规格即可把 I/O 等待重叠起来，并减少 9 份 runner setup；每个 Adapter 的 manifest、密钥 allowlist、artifact、receipt 和失败分类不变。

## Record schema and stored-data upgrade

- Affected public Record Format surfaces: None
- Private persisted implementation impact: E2E batch 的临时 scratch、artifact 目录和 summary 调度改变；每 Repo receipt 形状不变，失败后仍保留 durable artifact。
- Version decision: not affected
- Version reason: 没有修改 Record format、schemaVersion、producer、文件名、附件或跨文件引用。
- Existing Record behavior: 新旧 reader/writer 互不受影响；本 PR 只改变 E2E harness 调度。
- Migration or recovery path: not applicable，因为没有 Record 迁移。
- Migration safety: 不运行迁移，不接触已有 Record。
- Contract: not applicable
- Version history: not applicable
- Verification: `pnpm run typecheck` 通过；真实双 Repo 并发运行生成各自 receipt 与一个 batch summary，均为 pass。

## Environment variables

### Removed

None

### Added

None

### Changed

None

## Package scripts

### Removed

None

### Added

None

### Changed

None

## Tests

### `真实双 Repo 并发 E2E`

- Change: `not automated`
- Change class: `not-automated`
- Disposition: `not automated`
- Candidate identity: Git SHA `2d11d4f5`; NiceEval tarball SHA-256 `b270b0016714e4fffc3813fa35ae5ae1fa44e65474da94906652cd87f17ca9a6`
- Contract and owner: `docs/engineering/testing/e2e/execution.md`
- Stability budget: 仓库处于自动化测试重置期，不新增 E2E owner；使用现有两个 deterministic Adapter owner 做本次真实验收。
- Example scenario: 同一根 runner 以 `--repo-concurrency 2` 并发安装、运行 `adapter/local-protocol` 与 `adapter/sdk-converters`。
- Before: 并发创建共享 `artifactRoot/adapter` 父目录可能触发 `EEXIST`，且根 runner 只能串行消费 Repo。
- After: 两个 Repo 并发完成，5 + 8 个测试通过，日志有独立前缀，candidate/Testkit digest 不变，各自 receipt 完整，scratch 已删除。
- Distinguishing evidence: 首次真实并发运行复现了 durable-path 的 `EEXIST` 竞态；修正为只在后续 `lstat` 证明真实目录时接受竞争者创建的路径，第二次及最终复跑均通过。
- Verification: `pnpm e2e run --candidate /tmp/niceeval-e2e-batch-candidate.tgz --repo adapter/local-protocol --repo adapter/sdk-converters --repo-concurrency 2 --artifact-root <tmp>`；prepare/install/invoke/observe/outcome/cleanup 全部通过。
- Fixed conditions: Node `v24.18.0`、pnpm `11.18.0`、candidate SHA-256 如上；fixture/seed/clock/image digest 不适用。
- Repeatability: fresh copies 2/2；最终复跑 2 Repo/13 tests 全过；默认并发、日志标题隔离、结果路径隔离、scratch cleanup 均通过。
- Unit exception or no automation: 本 PR 修改既有 E2E harness 与 workflow；按仓库重置期约束不新增 `src/**/*.test.*`、`test/unit/**` 或 `e2e/**` owner。未自动保护的风险是 GitHub runner 上的外部 provider 尾延迟，交由本 PR 的真实 Actions run 验收。
- Unit count: `pnpm test` script 不存在；`pnpm exec vitest run --reporter=verbose` 为 45 tests passed。
- Manual observation: 本机 Linux、Node `v24.18.0`、pnpm `11.18.0`；生产入口 `pnpm e2e run`；真实安装两个隔离 adapter 项目并读取公开 summary/receipt，未调用付费 AI。
- User impact: 证明多个 Adapter Repo 能在一台 4 vCPU runner 上安全并发，而不是靠增加 CPU 规格缩短等待。

### `Claude Code singleton 与同 batch live 复现`

- Change: `not automated`
- Change class: `not-automated`
- Disposition: `not automated`
- Candidate identity: Git SHA `2d11d4f5`; NiceEval tarball SHA-256 `b270b0016714e4fffc3813fa35ae5ae1fa44e65474da94906652cd87f17ca9a6`
- Contract and owner: `docs/engineering/testing/e2e/adapter/claude-code.md#adapter-claude-code-live-compatibility`
- Stability budget: 不新增 owner；用既有 Claude Code Journey 判断 600s 长尾是否由同 batch 触发。
- Example scenario: 先单独运行 `adapter/claude-code`，再以 repo concurrency 3 同时运行 `claude-code`、`opencode`、`codex-sdk`；每个 Repo 内 NiceEval 继续使用 `maxConcurrency: 4`。
- Before: PR 首轮的 `locked-down/websearch-denied` 是第 18 条 attempt，前 17 条已在 90s 内通过，但该条等满 600s 后 errored。
- After: 本地 singleton 98.51s 全绿；本地同 batch 101.21s 全绿；GitHub 相同 failed-job 重跑 70.11s 全绿。
- Distinguishing evidence: 首轮失败日志的 start event 为 `total:18, configs:8, concurrency:4`，30s 与 60s 的 `running` 都是 4，证明 Repo 内 experiment/eval attempt 与 Repo 层并发同时存在。旧 singleton run `31661305229` 也出现同类 600s Claude 长尾。
- Verification: `node --env-file=<existing env> --import tsx e2e/scripts/cli.ts run --candidate /tmp/niceeval-e2e-batch-candidate.tgz --repo adapter/claude-code --repo adapter/opencode --repo adapter/codex-sdk --repo-concurrency 3 --artifact-root <tmp>`；3 passed，0 failure，scratch removed。
- Fixed conditions: Node `v24.18.0`、pnpm `11.18.0`、Docker `29.6.2`、candidate SHA-256 如上；使用同一组 live provider credentials，不输出 secret。
- Repeatability: GitHub 同 batch 1/2（一次单条 provider 长尾，一次全绿）；本地 singleton 1/1；本地同 batch 1/1；所有成功 run 的 digest、receipt 与 cleanup 均通过。
- Unit exception or no automation: 外部模型长尾不是可由 deterministic fake 证明的 Adapter 正确性；继续由既有 live E2E owner 观察，不新增重复测试。
- Unit count: `pnpm exec vitest run --reporter=verbose` 为 45 tests passed。
- Manual observation: 本地真实 Claude Code/OpenCode/Codex SDK，三 Repo 同秒启动；Claude Repo 内仍以 concurrency 4 调度 18 attempts。
- User impact: 当前没有证据表明 batch 降低 Adapter 正确性；偶发 provider 长尾仍可能主导单次 CI 墙钟时间。

补充验证：

- `pnpm run typecheck`：通过。
- `pnpm lint`：45 tests passed，Mint validate 与 broken-links 通过。
- 计划守恒：main lane 为 21 Repo / 12 cell，其中 13 Adapter 为 4 cell；装箱前后 Repo ID 集合相等且唯一。
- workflow YAML 解析、matrix manifest/secret union 模拟、`git diff --check`：通过。
