### PR TITLE
fix(report): 让 show --run 显示采用关系与判定

### DIFF
--- a/docs-site/zh/reference/cli.mdx
+++ b/docs-site/zh/reference/cli.mdx
@@ -171,6 +171,8 @@ npx niceeval view @01H...
 
 打开本地记录查看器。它和 `show` 共用默认 Report 与选择规则。不带 locator 或 `--run` 的命令从默认 Record 读取所有身份仍匹配当前项目的结果；精确 `@<AttemptLocator>` 显示该 Attempt 的默认概览；`--run` 读取指定历史 Run。随后内部 host 投影所需事实，并执行一次 Report。
 
+没有显式 `--report` 时，`--run` 使用内建 `run-membership-overview`，精确 locator 使用 `attempt-overview`。`project-current` 才使用配置里的 Report，并在没有配置时回退到通用 `default-overview`。显式 `--report` 始终优先。Config 仍会为 Theme 和 `view` rebuild 加载；这里只说明配置里的 Report 不参与显式 Run 的默认选择。
+
 此前的局部执行可能让部分 slot 以 `reference` 采用已有 Attempt。这些是当时的采用事实，不是补跑状态。同一份 `AnalysisSample` 不会在页面请求时重新选择。`--experiment` 可按完整 ID 收窄当前项目目标；`--record` 只在主动读取其它 Record root 时使用。
 
 ## `show`
@@ -195,6 +197,20 @@ npx niceeval show --run 01H... --report ./reports/summary.ts --page overview
 不带 locator 或 `--run` 的 `show` 规划当前项目身份，并扫描默认 Record 中全部 published Run。只有 Experiment、Eval、Attempt 序号、evaluation kind、input identity 与 config identity 仍匹配的 slot 才进入 Sample；命令不会按时间只留一个 Run。没有匹配结果时显示空 Sample，过期结果仍可用完整 `--run` 读取。
 
 `--run` 可重复，只读取这些显式历史 Run。`--experiment <id>` 可重复，按完整 ExperimentId 收窄当前项目目标，不能与 `--run` 合用。`exp`、不带 `--record` 的 `show` 与 `view` 默认使用同一个 `.niceeval/record`。
+
+单个 `--run` 用于核对这一轮的 expected-slot 分母与 membership；多个 `--run` 用同一表形状比较多个固定历史边界。即使两个 Run 指向同一个 Attempt，它们也可能分别由实际执行、自动沿用或人工采用形成。`exp --json` 最后一条 receipt 的 `runIds` 是机器稳定出口；TTY 完成反馈也显示 Run ID。`accept` 的成功反馈会显示新 Run ID，但这行人读文本不是 JSON receipt 或自动化输入契约。
+
+内建 `run-membership-overview` 固定使用 `reportId: "run-membership-overview"`、`pageId: "run-membership"` 和 route `/`。
+
+`Run membership` 表的稳定 column keys 分成三组：
+
+- row identity：`runId`、`slotId`。
+- Core 与 provenance：`slotState`、`memberRelation`、`sourceAttemptLocator`、`membershipState`、`membershipOutcome`。
+- Attempt 事实：`verdictState`、`verdict`。
+
+单 Run 和多 Run 都按 `runId`、`slotId` 排序；表在排序后最多显示 200 rows，并显示省略数量。
+
+`membershipOutcome` 来自公开 projector，值为 `carried`、`accepted`、`executed`、`not-dispatched` 或 `interrupted`。它不是持久 payload 的 raw `action` 字段。内建表是 bounded summary；已知 Attempt 的身份与证据用 `show @<AttemptLocator>` 下钻，需要其它 Run 字段时显式选择自定义 Report。
 
 选择完成后，`show` 用已选 handle 读取 Report 声明的 Projection，并形成一次 `ReportExecution`。请求的 Attachment 为 unavailable、migration-required、unsupported、partial 或 invalid 时，命令会原样显示状态；未请求的未知或损坏 Attachment 不影响当前页面。完整契约见[查看结果](/zh/tutorials/viewing-results)。
 

--- a/docs-site/zh/tutorials/viewing-results.mdx
+++ b/docs-site/zh/tutorials/viewing-results.mdx
@@ -18,8 +18,16 @@ npx niceeval view  # 在浏览器查看同一批结果
 选择一个明确 Run：
 
 ```sh
-npx niceeval show --run 01J9ZK3M6P4T7V9X2C5N8QW0RY
+npx niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527
 ```
+
+普通运行可从 `exp --json` 最后一条 receipt 的 `runIds` 读取 Run ID。TTY 完成反馈也显示相同 ID：
+
+```json
+{"type":"receipt","receipt":{"invocationId":"11c8fc15-8a9b-49a0-bb93-68205b52ffab","runIds":["7b8d2ea4-b840-4870-9840-f85a436a5527"],"startedAt":"2026-08-14T10:00:00.000Z","completedAt":"2026-08-14T10:01:00.000Z","completion":"completed"}}
+```
+
+`accept` 会在成功反馈中显示它建立的新 Run ID 和保持不变的 Attempt locator。这是供操作者复制的人读反馈，不是 JSON receipt 或稳定正则接口。
 
 要查看所有仍匹配当前项目源码与配置的结果，直接运行 `show`。`--experiment` 可按完整 ID 收窄当前项目目标：
 
@@ -31,7 +39,7 @@ npx niceeval show --experiment checkout
 
 ## 在终端查看
 
-`show` 呈现默认 Report 的文字内容。指定页面或自定义 Report 时，命令仍从同一份 selection 建立一次 execution。
+`show` 呈现默认 Report 的文字内容。显式 `--run` 默认使用内建 `run-membership-overview`；不带 selector 的当前项目结果使用配置里的 Report，没有配置时才使用通用 overview。指定页面或自定义 Report 时，命令仍从同一份 selection 建立一次 execution。
 
 ```sh
 npx niceeval show --run 01J9ZK3M6P4T7V9X2C5N8QW0RY --page /
@@ -39,6 +47,49 @@ npx niceeval show --experiment checkout --json
 ```
 
 `--json` 输出同一份 execution 的页面、计算、投影摘要和问题。它不建立另一条取数路径。
+
+下面是一条人工采用结果的终端输出。`reference` 表示这个 Run 引用源 Attempt，`accepted` 表示这个 Run 的 membership provenance 记录了人工采用：
+
+```text
+Report run-membership-overview
+Sample: 1 run(s), 1 slot(s)
+
+Page /
+  Run membership overview
+  Run membership
+  Run | Slot | Slot state | Member relation | Source Attempt | Membership state | Membership outcome | Verdict state | Verdict
+  7b8d2ea4-b840-4870-9840-f85a436a5527 | slot-00b400bd-ba81-4850-8803-09ba802896e5 | included | reference | @91ddc61b-ae96-4a23-8578-ddc1b83306dc | available | accepted | available | passed
+  [neutral] Omitted rows: 0
+  [neutral] Unmatched membership actions: 0
+
+Problems
+  none
+```
+
+同一次命令加 `--json` 后，相关 row 使用稳定键：
+
+```json
+{
+  "memberRelation": "reference",
+  "membershipOutcome": "accepted",
+  "membershipState": "available",
+  "runId": "7b8d2ea4-b840-4870-9840-f85a436a5527",
+  "slotId": "slot-00b400bd-ba81-4850-8803-09ba802896e5",
+  "slotState": "included",
+  "sourceAttemptLocator": "@91ddc61b-ae96-4a23-8578-ddc1b83306dc",
+  "verdict": "passed",
+  "verdictState": "available"
+}
+```
+
+Run 回答“这一轮怎样纳入结果”，Attempt 回答“这份结果记录了什么”。继续沿 locator 查看同一个 immutable Attempt：
+
+```sh
+npx niceeval show @91ddc61b-ae96-4a23-8578-ddc1b83306dc
+npx niceeval show @91ddc61b-ae96-4a23-8578-ddc1b83306dc --execution
+```
+
+第一个命令显示 Attempt identity、判定、Assertions 与 Score。第二个命令显示 execution evidence。它们不会重写源 Attempt，也不会把采用 Run 的 provenance 冒充 Attempt 事实。
 
 ## 在浏览器查看
 

--- a/docs/engineering/testing/architecture.md
+++ b/docs/engineering/testing/architecture.md
@@ -163,6 +163,8 @@ E2E 文件从上到下保持同一信息顺序：
 - 在断言阶段悄悄修改共享 evidence。
 
 两个 Repo 出现同一稳定机械 parser 后才提取共享实现；领域预期仍留在测试文件。
+Testkit 可以把严格解码后的公开 Eval event 与调用方提供的字面 expected matrix 作逐字段比较；它不得生成矩阵、补默认 Verdict，
+也不得把 CLI 退出码或候选输出转换成 expected。
 项目复制已经被多类会写结果、配置或导出目录的 case 消费，因此 Testkit 接收显式策略 API；调用点仍明确写出复制源、
 排除项和链接策略，不能把 CLI、Runner、Report、Package、Lifecycle 或 Adapter 的领域动作收进 Testkit。
 

--- a/docs/engineering/testing/e2e/adapter/README.md
+++ b/docs/engineering/testing/e2e/adapter/README.md
@@ -45,7 +45,12 @@
    成功的 `t.send()` 至少证明 `eval.run` 与首轮 turn。只有确实声明并执行 setup 的 Adapter 才要求 `agent.setup`。Adapter owner 不再于 timing test 内重跑 `--execution`，也不用 execution 文本反推 Skill 或 tracing。不能用另一个 Adapter 或 Report Repo 的 `--timing` 通过代替本 Adapter。
    trace 只作时间与结构证据，从不参与判分——判分断言永远只读事件流（见[Observability](../../../../observability.md)）。
 
-一次 live 运行可在 `beforeAll` 中生产冻结 evidence，再由 verdict、execution 与 timing 三个独立 test 只读共用；按标题单项运行时 `beforeAll` 仍必须现场产生本轮 evidence。第 2 步是唯一的 Eval 判分断言：第 3、4 步只验收公开投影与 telemetry 机制，绝不反过来给事件流评分。
+一次 live 运行可在 `beforeAll` 中生产冻结 evidence，再由 verdict、execution 与 timing 三个独立 test 只读共用。
+按标题单项运行时，`beforeAll` 仍必须现场产生本轮 evidence。
+
+第 2 步是唯一的 Eval 判分断言。第 3、4 步只验收公开投影与 telemetry 机制，绝不反过来给事件流评分。
+Verdict test 在 owner 文件中逐条声明 `(experimentId, evalId, verdict, attempts)` expected matrix。
+它用 Testkit 的 `assertExpEvalOutcomes()` 严格拒绝缺失、额外、重复或终局不符；Testkit 不替 Adapter 选择 expected。
 测试正文遵守 [E2E 总纲](../README.md#单边界-e2e)与[测试 Architecture](../../architecture.md#单文件可读性契约)。
 
 ## Live 官方 Adapter 兼容性

--- a/docs/engineering/testing/testkit.md
+++ b/docs/engineering/testing/testkit.md
@@ -80,6 +80,33 @@ export interface ExpReceiptEvent {
   readonly receipt: InvocationReceipt;
 }
 
+export type ExpEvalEvent = {
+  readonly event: "eval";
+  readonly locator: string;
+  readonly evalId: string;
+  readonly experimentId: string;
+  readonly verdict: "passed" | "failed" | "errored" | "skipped";
+  readonly attempts: number;
+} & (
+  | { readonly passed: number }
+  | {
+      readonly planned: number;
+      readonly unstarted: number;
+      readonly reason: "early_exit";
+    }
+);
+
+export interface ExpEvalOutcomeExpectation {
+  readonly experimentId: string;
+  readonly evalId: string;
+  readonly verdict: "passed" | "failed" | "errored" | "skipped";
+  readonly attempts: number;
+  readonly passed?: number;
+  readonly reason?: "early_exit";
+  readonly planned?: number;
+  readonly unstarted?: number;
+}
+
 export interface ProcessReceipt {
   argv: Argv;
   cwd: string;
@@ -94,7 +121,14 @@ export interface ProcessReceipt {
   json<T = unknown>(): T;
   ndjson<T = unknown>(): T[];
   expReceipt(): InvocationReceipt;
+  expEvalEvents(): ExpEvalEvent[];
 }
+
+export function assertExpEvalOutcomes(
+  actual: readonly ExpEvalEvent[],
+  expected: readonly ExpEvalOutcomeExpectation[],
+  diagnostic?: string | (() => string),
+): ExpEvalEvent[];
 
 export function runProcess(
   argv: Argv,
@@ -123,10 +157,40 @@ Testkit 直接导出公开原始 `ExpEvent`、`ExpReceiptEvent` 与精确的 `In
 - `completedAt` 未提供时不存在，否则为字符串；
 - `completion` 是 `"completed" | "interrupted" | "failed"`。
 
-`expReceipt()` 返回末行的内层 `InvocationReceipt`。它不检查退出码、不折叠 Verdict 或 Attempt，也不提供 expected 辅助断言。
+`expReceipt()` 返回末行的内层 `InvocationReceipt`。它不检查退出码，也不折叠 Verdict 或 Attempt。
 
 业务 Verdict 和 Attempt 只能从中间的 `event: "eval"` 读取，或按 `receipt.runIds` 读取 Record；receipt 本身不复制这些
-业务事实。需要检查逐 Eval 身份的场景仍直接用 `ndjson<ExpEvent>()` 并在读取 `.event` 前排除末行 `type: "receipt"`。
+业务事实。`expEvalEvents()` 严格解码所有公开 Eval 终局事件，并拒绝字段非法的 Eval event。
+
+`assertExpEvalOutcomes()` 要求调用方在测试文件中逐条提供 `experimentId`、`evalId`、Verdict 与 Attempt 数。
+它严格拒绝缺失、额外、重复身份和字段不符，并可选核对 `passed` 或 `early_exit` 字段。
+Testkit 不生成 expected、不按 exit code 推断 Verdict，也不把 `failed`、`errored` 或 `skipped` 折叠成另一状态。
+
+```ts
+const evalEvents = assertExpEvalOutcomes(
+  run.expEvalEvents(),
+  [
+    {
+      experimentId: "transport",
+      evalId: "transport-ok",
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    },
+    {
+      experimentId: "timeout",
+      evalId: "timeout",
+      verdict: "errored",
+      attempts: 1,
+      passed: 0,
+    },
+  ],
+  () => run.diagnostic(),
+);
+```
+
+expected 数组属于调用方 owner；Testkit 只比较公开原始字段。
+CLI 退出码、`InvocationReceipt.completion`、Run 数与后续 `show` 读回仍在测试正文分别断言。
 
 非零 exit 与 signal 会返回收据，`timedOut` 区分 Testkit timeout 与被测进程自行退出。spawn 本身失败时抛
 `ProcessStartError`，错误携带完整 argv、cwd 与原始 cause；调用方不用猜是产品 exit 还是命令没有启动。

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -30,12 +30,33 @@ niceeval view [selection] [report options] --out <directory>
 
 `exp` 与不带 `--record` 的 `show` / `view` 默认使用同一个 `<cwd>/.niceeval/record`。只有主动读取其它 Record root 时才传该选项。旧 Record major 在执行选择或装载 Report 前以 `record-migration-required` 停止，并提示用户运行 `niceeval migrate`。
 
+### selector 与默认 Report
+
+selector 先决定 Sample，默认 Report 再决定要从这个 Sample 读取哪些事实。三条命令使用同一份决议：
+
+| selector | 没有显式 `--report` | 有显式 `--report` |
+|---|---|---|
+| 不带 selector 的 `project-current` | `niceeval.config.ts` 的 `report`；没有配置时使用 `default-overview` | 显式 Report |
+| 一个或多个 `--run` | 内建 `run-membership-overview` | 显式 Report |
+| 精确 `@<AttemptId>` | 内建 `attempt-overview` | 显式 Report |
+
+`--report overview` 是显式选择通用 `default-overview`，不会改成 `run-membership-overview`。`niceeval.config.ts` 仍是 Theme、source snapshot 与 `view` rebuild 的输入；表中的“内建 Run Report 优先”只表示配置里的 Report 不参与这次默认 Report 决议，不表示命令完全不加载 Config。
+
+`--run` 不是“取最后一次结果”，也不是因为同一命令预计会产生不同答案。Run 是一次固定的 expected-slot 分母与 membership 决定边界；两个 Run 即使引用同一个 immutable Attempt，也可能分别是 `origin`、自动沿用的 `carried`，或人工采用的 `accepted`。因此单个 `--run` 用来回答“这一轮纳入了什么、怎样纳入”，多个 `--run` 用同一表形状比较这些历史边界；已知 Attempt 的业务事实则用 `show @<AttemptId>` 下钻。
+
+Run ID 有两个公开取得方式：
+
+- `exp --json` 最后一条 `InvocationReceipt.runIds` 是机器稳定出口；TTY 完成反馈也显示同一批 Run ID。
+- `accept` 当前在成功反馈中显示新 Run ID，供操作者复制；它不是 JSON receipt，也不承诺把人读句子作为自动化输入契约。
+
 ## `niceeval show`
 
 ```sh
-niceeval show --run 01H... --report ./reports/summary.ts
-niceeval show --run 01H... --run 01J... --page /comparison
+niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527
+niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527 --run 91b07bde-e00a-441b-a4c0-cf78c374204a
+niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527 --report ./reports/summary.ts
 niceeval show --experiment checkout --page /overview
+niceeval show @91ddc61b-ae96-4a23-8578-ddc1b83306dc
 niceeval show --json
 ```
 
@@ -51,6 +72,78 @@ Host 只显示每个 input 的 complete/partial 与 problem IDs，不替作者�
 没有 `--page` 时 JSON 按 route 输出全部 pages；有 `--page` 时只输出 exact 选中页，但 sample / projection coverage、calculations、families、download metadata 与 problems 仍保留。arrays 与 keys 使用 canonical order，stdout 为 UTF-8 canonical JSON。Broken pipe 是正常 CLI 退出，其它 console failure 是 typed error，interruption 保持 Cause。
 
 `show` 完成后退出，不 watch。
+
+### 内建 Run membership 概览
+
+一个或多个 `--run` 在没有显式 `--report` 时使用 `run-membership-overview`。它的固定页面是 `pageId: "run-membership"`、route `/`。页面以 bounded table 对齐 Sample Core、Run-owned membership provenance 与 Attempt Verdict；它不会读取 persisted raw action，也不会把一种事实修正成另一种。
+
+稳定表的 column keys 是：
+
+| key | 值域与含义 |
+|---|---|
+| `runId` / `slotId` | row identity。单 Run 与多 Run 都按 canonical `runId`、`slotId` 排序。 |
+| `slotState` | `included \| not-recorded \| core-invalid \| excluded`。 |
+| `memberRelation` | 只有 `included` 才是 `origin \| reference`；否则为 `null`。 |
+| `sourceAttemptLocator` | 只有 `included` 才是 `@<AttemptId>`；否则为 `null`。 |
+| `membershipState` | `available \| action-missing \| unavailable \| migration-required \| migration-unavailable \| unsupported \| invalid`。 |
+| `membershipOutcome` | `carried \| accepted \| executed \| not-dispatched \| interrupted`；没有可读或匹配 action 时为 `null`。这是公开 projector 的 outcome，不是 persisted payload 的 raw `action` 字段。 |
+| `verdictState` | `available \| not-read \| unavailable \| migration-required \| migration-unavailable \| unsupported \| invalid`。非 `included` slot 是 `not-read`。 |
+| `verdict` | `passed \| failed \| errored \| skipped`；没有可读 Verdict 时为 `null`。 |
+
+Membership Attachment 可读、但没有匹配这个 `slotId` 的 action 时显示 `action-missing`。不对应任何 Sample slot 的额外 action 计入确定性的 unmatched count。Attachment 的非 available 状态保持原值，schema、migration 或 issue 详情继续出现在页面与 host problem table；Report 不从 Core 猜 provenance，也不从 provenance 猜 Verdict。
+
+表在 canonical 排序后最多显示 200 rows，并明确显示 omitted count。它是快速检查 Run membership 的 bounded summary，不承诺任意规模 Run 的穷尽查询；需要不同字段或更大切片时显式选择自定义 Report，并仍受 Report host limits 约束。自定义 Report 只继承 selection 与 `niceeval.report-show/v1` envelope，不继承上面的内建表契约。
+
+人读输出示例：
+
+```text
+Report run-membership-overview
+Sample: 1 run(s), 1 slot(s)
+
+Page /
+  Run membership overview
+  Run membership
+  Run | Slot | Slot state | Member relation | Source Attempt | Membership state | Membership outcome | Verdict state | Verdict
+  7b8d2ea4-b840-4870-9840-f85a436a5527 | slot-00b400bd-ba81-4850-8803-09ba802896e5 | included | reference | @91ddc61b-ae96-4a23-8578-ddc1b83306dc | available | accepted | available | passed
+  [neutral] Omitted rows: 0
+  [neutral] Unmatched membership actions: 0
+
+Problems
+  none
+```
+
+同一次 execution 的 `--json` 外层仍是 `niceeval.report-show/v1`。下列是 `pages[0].document` 中稳定审计表的相关子树；文案、section 顺序和其它节点可以增加或调整：
+
+```json
+{
+  "caption": "Run membership",
+  "columns": [
+    { "key": "runId", "label": "Run" },
+    { "key": "slotId", "label": "Slot" },
+    { "key": "slotState", "label": "Slot state" },
+    { "key": "memberRelation", "label": "Member relation" },
+    { "key": "sourceAttemptLocator", "label": "Source Attempt" },
+    { "key": "membershipState", "label": "Membership state" },
+    { "key": "membershipOutcome", "label": "Membership outcome" },
+    { "key": "verdictState", "label": "Verdict state" },
+    { "key": "verdict", "label": "Verdict" }
+  ],
+  "rows": [
+    {
+      "memberRelation": "reference",
+      "membershipOutcome": "accepted",
+      "membershipState": "available",
+      "runId": "7b8d2ea4-b840-4870-9840-f85a436a5527",
+      "slotId": "slot-00b400bd-ba81-4850-8803-09ba802896e5",
+      "slotState": "included",
+      "sourceAttemptLocator": "@91ddc61b-ae96-4a23-8578-ddc1b83306dc",
+      "verdict": "passed",
+      "verdictState": "available"
+    }
+  ],
+  "type": "table"
+}
+```
 
 ## `niceeval view`
 

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -594,6 +594,17 @@ Execution 不含 reader、root、path、Scope、Stream、callback 或 projector 
 
 ## Built-in Reports
 
+`niceeval/report/built-in` 导出 `defaultRunMembershipOverviewReport` 与 factory
+`runMembershipOverviewReport()`。这份普通 Report 供一个或多个 explicit Run 形成 bounded
+membership 概览。它声明
+`selectedRunProjection(membershipProvenanceProjector)` 与
+`attemptSlotProjection(verdictProjector)`。CLI 在显式 `--run` 且没有 `--report` 时使用它；其它
+selection 不会因此扩大 Attachment 读取范围。
+
+它的稳定表契约、row 值域与截断边界见 [CLI](cli.md#内建-run-membership-概览)。Report 只读取公开
+projector 的 `MembershipAction.outcome`，不读取 persisted raw action。Core Member、provenance 与
+Verdict 作为三组独立事实并列显示。
+
 `niceeval/report/built-in` 的 `defaultSandboxHistoryReport` 是一份普通、无额外 reader capability 的
 history Report。调用点先用公开的 all-runs Analysis selection 形成 Sample；Report 只声明并消费
 evaluation plan、Verdict 与 Sandbox 三条 public projection。

--- a/docs/feature/reports/use-case/README.md
+++ b/docs/feature/reports/use-case/README.md
@@ -3,6 +3,7 @@
 本目录按用户目标说明如何组合 bound analysis selection、`RecordProjection`、Calculation 和页面。类型与字段的唯一出处在 [Library](../library.md)，命令选项的唯一出处在 [CLI](../cli.md)。
 
 - [比较质量与成本](比较质量与成本.md)：在固定分母上比较多个 Run。
+- [审阅一次 Run 怎样采用结果](审阅一次Run怎样采用结果.md)：从 Run ID 核对 membership provenance，再沿 locator 下钻 immutable Attempt。
 - [核对 RecordAttachment 完整度](核对RecordAttachment完整度.md)：让 unavailable、unsupported、invalid 等数据问题与不完整输入保持可见。
 - [分享静态报告站](分享静态报告站.md)：导出断网可读的自包含目录。
 - [制作可访问页面](制作可访问页面.md)：让文字、表格和网页具有相同事实与状态。

--- a/docs/feature/reports/use-case/审阅一次Run怎样采用结果.md
+++ b/docs/feature/reports/use-case/审阅一次Run怎样采用结果.md
@@ -1,0 +1,47 @@
+# 审阅一次 Run 怎样采用结果
+
+这个用例回答两个不同的问题：一个 Run 为什么包含某个结果，以及这个 immutable Attempt 有哪些业务事实。前者属于 Run membership，后者属于 Attempt；不能只看 locator 或只看最近一次运行来代替。
+
+## 1. 取得 Run ID
+
+普通 `exp` 的机器调用从最后一条 receipt 读取 `runIds`：
+
+```json
+{"type":"receipt","receipt":{"invocationId":"11c8fc15-8a9b-49a0-bb93-68205b52ffab","runIds":["7b8d2ea4-b840-4870-9840-f85a436a5527"],"startedAt":"2026-08-14T10:00:00.000Z","completedAt":"2026-08-14T10:01:00.000Z","completion":"completed"}}
+```
+
+TTY 完成反馈也显示 Run ID。`niceeval accept @<AttemptId>` 会建立一个新的 Run，并在成功反馈中显示新 Run ID 与保持不变的结果 locator：
+
+```text
+Accepted source Attempt @91ddc61b-ae96-4a23-8578-ddc1b83306dc into new Run 7b8d2ea4-b840-4870-9840-f85a436a5527. Result locator remains @91ddc61b-ae96-4a23-8578-ddc1b83306dc.
+```
+
+`accept` 的这行反馈供操作者复制，不是 JSON receipt 或稳定正则协议。
+
+## 2. 审阅 Run membership
+
+```sh
+niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527
+niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527 --json
+```
+
+没有显式 `--report` 时，`show --run` 使用内建 `run-membership-overview`。在目标 row 中核对：
+
+- `slotState: included`：这个 Run 的分母中有可读 Member。
+- `memberRelation: reference`：Member 指向别的 origin Run 中的 Attempt。
+- `sourceAttemptLocator`：继续下钻时使用的同一个 immutable Attempt locator。
+- `membershipOutcome: accepted`：这个 Run 的 provenance 说明本轮是人工采用；它不持续证明该 Attempt 适合未来 Run。
+- `verdict: passed`：Verdict 从源 Attempt 读取，没有复制进采用 Run。
+
+多次执行可能得到相同 Verdict，但 Run 仍不等价。每个 Run 有自己的 expected-slot 分母、Core Member 与 membership provenance；`executed`、`carried`、`accepted` 回答的是本轮怎样形成，而不是 Attempt 内容是否变化。
+
+## 3. 下钻 immutable Attempt
+
+```sh
+niceeval show @91ddc61b-ae96-4a23-8578-ddc1b83306dc
+niceeval show @91ddc61b-ae96-4a23-8578-ddc1b83306dc --execution
+```
+
+第一个命令读取 Attempt identity、四态 Verdict、Assertions 与适用的 Score；第二个命令读取 execution evidence。两个命令都不会回答另一个 Run 为什么采用它，因为 adoption 属于目标 Run 的 membership provenance。
+
+内建 Run 表是 bounded summary。已知 locator 时用 `show @locator` 精确下钻；需要超过内建表界限的其它 Run 字段时，使用显式自定义 Report。

--- a/e2e/adapter/ai-sdk-direct/test/ai-sdk-direct.test.ts
+++ b/e2e/adapter/ai-sdk-direct/test/ai-sdk-direct.test.ts
@@ -74,13 +74,16 @@ it("真实 aiSdkAgent 的 Eval 以通过 verdict 完成", () => {
   expect(inv.runIds, runReceipt.diagnostic()).toHaveLength(1);
   assertExpEvalOutcomes(
     runReceipt.expEvalEvents(),
-    [{
-      evalId: EVAL_ID,
-      experimentId: "ci",
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // direct-agent：真实 generateText 须执行 remember_marker 工具并保留会话 marker；期望 passed/1。
+      {
+        evalId: EVAL_ID,
+        experimentId: "ci",
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => runReceipt.diagnostic(),
   );
 });

--- a/e2e/adapter/ai-sdk-direct/test/ai-sdk-direct.test.ts
+++ b/e2e/adapter/ai-sdk-direct/test/ai-sdk-direct.test.ts
@@ -4,9 +4,9 @@
 // generateText call, then every observation is read back through public CLI commands.
 
 import {
+  assertExpEvalOutcomes,
   command,
-  type ExpEvalEvent,
-  type ExpEvent,
+  only,
   type ProcessReceipt,
   withProcess,
   withTempDir,
@@ -34,13 +34,12 @@ function requireLiveSecrets(): void {
 }
 
 function latestAttemptLocator(): string {
-  const evalEvent = runReceipt.ndjson<ExpEvent>().find(
-    (event): event is ExpEvalEvent =>
-      "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+  const evalEvent = only(
+    runReceipt.expEvalEvents(),
+    (event) => event.evalId === EVAL_ID,
+    () => runReceipt.diagnostic(),
   );
-  expect(evalEvent, runReceipt.diagnostic()).toMatchObject({ verdict: "passed" });
-  expect(evalEvent?.locator, runReceipt.diagnostic()).toMatch(/^@/);
-  return evalEvent!.locator!;
+  return evalEvent.locator;
 }
 
 beforeAll(async () => {
@@ -67,24 +66,23 @@ beforeAll(async () => {
 }, 14 * 60_000);
 
 it("真实 aiSdkAgent 的 Eval 以通过 verdict 完成", () => {
-  const events = runReceipt.ndjson<ExpEvent>();
   // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md）：
   // completion 与 runIds；成败由带身份的 eval 事件精确断言，不让 live provider
   // 故障冒充通过，也不在 receipt 上断言计数。
   const inv = runReceipt.expReceipt();
   expect(inv.completion, runReceipt.diagnostic()).toBe("completed");
   expect(inv.runIds, runReceipt.diagnostic()).toHaveLength(1);
-  const evalEvent = events.find(
-    (event): event is ExpEvalEvent =>
-      "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+  assertExpEvalOutcomes(
+    runReceipt.expEvalEvents(),
+    [{
+      evalId: EVAL_ID,
+      experimentId: "ci",
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => runReceipt.diagnostic(),
   );
-  expect(evalEvent, runReceipt.diagnostic()).toBeDefined();
-  expect(evalEvent).toMatchObject({
-    event: "eval",
-    evalId: EVAL_ID,
-    verdict: "passed",
-    attempts: 1,
-  });
 });
 
 it("show --execution 读回 aiSdkAgent 的代表性工具证据", async () => {

--- a/e2e/adapter/ai-sdk/test/ai-sdk.test.ts
+++ b/e2e/adapter/ai-sdk/test/ai-sdk.test.ts
@@ -7,9 +7,8 @@
 
 import "dotenv/config";
 import {
+  assertExpEvalOutcomes,
   command,
-  type ExpEvalEvent,
-  type ExpEvent,
   type ProcessReceipt,
   waitForOutput,
   withProcess,
@@ -20,6 +19,13 @@ import { expect, it } from "vitest";
 import { AI_SDK_BASE_URL } from "../src/topology.ts";
 
 const EXPECTED_EVALS = ["tool-call", "hitl-approval", "session-replay"] as const;
+const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
+  experimentId: "ci",
+  evalId,
+  verdict: "passed" as const,
+  attempts: 1,
+  passed: 1,
+}));
 const REQUIRED_LIVE_SECRETS = ["OPENAI_API_KEY", "OPENAI_BASE_URL"] as const;
 
 const niceevalBin = join(process.cwd(), "node_modules", ".bin", "niceeval");
@@ -79,36 +85,21 @@ it("真实 AI SDK adapter 运行结果经过公开 CLI 读回", async () => {
         },
       );
       expect(run.exitCode, run.diagnostic()).toBe(0);
-      const events = run.ndjson<ExpEvent>();
+      const evalEvents = assertExpEvalOutcomes(
+        run.expEvalEvents(),
+        EXPECTED_OUTCOMES,
+        () => run.diagnostic(),
+      );
       // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md）：
       // completion 与 runIds；每个 Eval 的 identity/verdict/attempts 由中间 eval
       // 事件逐一断言，live provider 故障不会冒充通过。
       const inv = run.expReceipt();
       expect(inv.completion, run.diagnostic()).toBe("completed");
       expect(inv.runIds, run.diagnostic()).toHaveLength(1);
-      for (const evalId of EXPECTED_EVALS) {
-        const evalEvent = events.find(
-          (event): event is ExpEvalEvent =>
-            "event" in event && event.event === "eval" && event.evalId === evalId,
-        );
-        expect(evalEvent, run.diagnostic()).toBeDefined();
-        expect(evalEvent).toMatchObject({
-          event: "eval",
-          evalId,
-          verdict: "passed",
-          attempts: 1,
-        });
-      }
-
       const locators = new Map<string, string>();
       for (const evalId of EXPECTED_EVALS) {
-        const evalEvent = events.find(
-          (event): event is ExpEvalEvent =>
-            "event" in event && event.event === "eval" && event.evalId === evalId,
-        );
-        expect(evalEvent, run.diagnostic()).toMatchObject({ verdict: "passed" });
-        expect(evalEvent?.locator, run.diagnostic()).toMatch(/^@/);
-        locators.set(evalId, evalEvent!.locator!);
+        const evalEvent = evalEvents.find((event) => event.evalId === evalId)!;
+        locators.set(evalId, evalEvent.locator);
       }
 
       // outcome：execution 是适配器收到的公开投影；工具名、入参和 OTel 节点

--- a/e2e/adapter/ai-sdk/test/ai-sdk.test.ts
+++ b/e2e/adapter/ai-sdk/test/ai-sdk.test.ts
@@ -9,6 +9,7 @@ import "dotenv/config";
 import {
   assertExpEvalOutcomes,
   command,
+  type ExpEvalOutcomeExpectation,
   type ProcessReceipt,
   waitForOutput,
   withProcess,
@@ -18,14 +19,15 @@ import { join } from "node:path";
 import { expect, it } from "vitest";
 import { AI_SDK_BASE_URL } from "../src/topology.ts";
 
-const EXPECTED_EVALS = ["tool-call", "hitl-approval", "session-replay"] as const;
-const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
-  experimentId: "ci",
-  evalId,
-  verdict: "passed" as const,
-  attempts: 1,
-  passed: 1,
-}));
+const EXPECTED_OUTCOMES = [
+  // tool-call：天气请求须以裸名调用 get_weather，并按 call ID 配对输出；单次请求期望 passed/1。
+  { experimentId: "ci", evalId: "tool-call", verdict: "passed", attempts: 1, passed: 1 },
+  // hitl-approval：approve 须恢复 completed，独立 deny 分支须 rejected 且无工具结果；期望 passed/1。
+  { experimentId: "ci", evalId: "hitl-approval", verdict: "passed", attempts: 1, passed: 1 },
+  // session-replay：同一会话须回忆首轮事实，新会话须隔离历史；两个分支成立时为 passed/1。
+  { experimentId: "ci", evalId: "session-replay", verdict: "passed", attempts: 1, passed: 1 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
+const EXPECTED_EVALS = EXPECTED_OUTCOMES.map((outcome) => outcome.evalId);
 const REQUIRED_LIVE_SECRETS = ["OPENAI_API_KEY", "OPENAI_BASE_URL"] as const;
 
 const niceevalBin = join(process.cwd(), "node_modules", ".bin", "niceeval");

--- a/e2e/adapter/bub/test/bub.test.ts
+++ b/e2e/adapter/bub/test/bub.test.ts
@@ -5,10 +5,10 @@
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
 import {
+  assertExpEvalOutcomes,
   command,
   only,
   type ExpEvalEvent,
-  type ExpEvent,
   type ProcessReceipt,
 } from "@niceeval/testkit";
 import { rmSync } from "node:fs";
@@ -21,6 +21,13 @@ const EXPECTED_EVALS = [
   "extensions/plugin-postsetup",
   "session/recall",
 ] as const;
+const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
+  experimentId: "ci",
+  evalId,
+  verdict: "passed" as const,
+  attempts: 1,
+  passed: 1,
+}));
 
 const REQUIRED_LIVE_SECRETS = ["BUB_API_KEY", "BUB_API_BASE"] as const;
 
@@ -62,9 +69,7 @@ beforeAll(async () => {
     { timeoutMs: 32 * 60_000 },
   );
   expect(run.exitCode, run.diagnostic()).toBe(0);
-  evalEvents = run
-    .ndjson<ExpEvent>()
-    .filter((event): event is ExpEvalEvent => "event" in event && event.event === "eval");
+  evalEvents = run.expEvalEvents();
 
   // legacy 版本线同时证明 version/otelPlugin pin 的 telemetry 契约。
   legacy = await niceeval.run(
@@ -72,9 +77,7 @@ beforeAll(async () => {
     { timeoutMs: 20 * 60_000 },
   );
   expect(legacy.exitCode, legacy.diagnostic()).toBe(0);
-  legacyEvalEvents = legacy
-    .ndjson<ExpEvent>()
-    .filter((event): event is ExpEvalEvent => "event" in event && event.event === "eval");
+  legacyEvalEvents = legacy.expEvalEvents();
 }, 36 * 60_000);
 
 it("真实 Bub adapter 的 Eval 通过数正确且没有未通过项", () => {
@@ -84,22 +87,26 @@ it("真实 Bub adapter 的 Eval 通过数正确且没有未通过项", () => {
   const inv = run.expReceipt();
   expect(inv.completion, run.diagnostic()).toBe("completed");
   expect(inv.runIds, run.diagnostic()).toHaveLength(1);
-  expect(evalEvents.filter((event) => event.verdict === "passed"), run.diagnostic()).toHaveLength(
-    EXPECTED_EVALS.length,
+  assertExpEvalOutcomes(
+    evalEvents,
+    EXPECTED_OUTCOMES,
+    () => run.diagnostic(),
   );
-  expect(evalEvents.filter((event) => event.verdict !== "passed"), run.diagnostic()).toHaveLength(0);
 
   const legacyInv = legacy.expReceipt();
   expect(legacyInv.completion, legacy.diagnostic()).toBe("completed");
   expect(legacyInv.runIds, legacy.diagnostic()).toHaveLength(1);
-  expect(
-    legacyEvalEvents.filter((event) => event.verdict === "passed"),
-    legacy.diagnostic(),
-  ).toHaveLength(1);
-  expect(
-    legacyEvalEvents.filter((event) => event.verdict !== "passed"),
-    legacy.diagnostic(),
-  ).toHaveLength(0);
+  assertExpEvalOutcomes(
+    legacyEvalEvents,
+    [{
+      experimentId: "legacy",
+      evalId: "coding-task/write-and-verify",
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => legacy.diagnostic(),
+  );
 });
 
 it("show --execution 读回 Bub 的代表性工具证据", async () => {

--- a/e2e/adapter/bub/test/bub.test.ts
+++ b/e2e/adapter/bub/test/bub.test.ts
@@ -9,25 +9,23 @@ import {
   command,
   only,
   type ExpEvalEvent,
+  type ExpEvalOutcomeExpectation,
   type ProcessReceipt,
 } from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { beforeAll, expect, it } from "vitest";
 
-const EXPECTED_EVALS = [
-  "coding-task/write-and-verify",
-  "skills/discovery",
-  "extensions/plugin-postsetup",
-  "session/recall",
-] as const;
-const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
-  experimentId: "ci",
-  evalId,
-  verdict: "passed" as const,
-  attempts: 1,
-  passed: 1,
-}));
+const EXPECTED_OUTCOMES = [
+  // coding task：agent 须写文件，再用 shell 串行读回并满足 usage/cost 约束；期望 passed/1。
+  { experimentId: "ci", evalId: "coding-task/write-and-verify", verdict: "passed", attempts: 1, passed: 1 },
+  // Skill discovery：挂载的 review Skill 须被真实读取并以独有魔法词影响回答；期望 passed/1。
+  { experimentId: "ci", evalId: "skills/discovery", verdict: "passed", attempts: 1, passed: 1 },
+  // Plugin setup：Python 包须进入 Bub tool venv，postSetup 须按声明顺序留下证据；期望 passed/1。
+  { experimentId: "ci", evalId: "extensions/plugin-postsetup", verdict: "passed", attempts: 1, passed: 1 },
+  // session recall：Adapter 管理的同一 session_id 须让第二轮回忆首轮事实；期望 passed/1。
+  { experimentId: "ci", evalId: "session/recall", verdict: "passed", attempts: 1, passed: 1 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
 
 const REQUIRED_LIVE_SECRETS = ["BUB_API_KEY", "BUB_API_BASE"] as const;
 
@@ -98,13 +96,16 @@ it("真实 Bub adapter 的 Eval 通过数正确且没有未通过项", () => {
   expect(legacyInv.runIds, legacy.diagnostic()).toHaveLength(1);
   assertExpEvalOutcomes(
     legacyEvalEvents,
-    [{
-      experimentId: "legacy",
-      evalId: "coding-task/write-and-verify",
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // legacy：旧版/otelPlugin pin 仍须完成同一写文件与 shell 读回闭环，因此期望 passed/1。
+      {
+        experimentId: "legacy",
+        evalId: "coding-task/write-and-verify",
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => legacy.diagnostic(),
   );
 });

--- a/e2e/adapter/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/e2e/adapter/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -7,9 +7,9 @@ import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import {
+  assertExpEvalOutcomes,
   command,
-  type ExpEvalEvent,
-  type ExpEvent,
+  only,
   type ProcessReceipt,
   withProcess,
   withTempDir,
@@ -36,13 +36,12 @@ function requireLiveSecrets(): void {
 }
 
 function latestAttemptLocator(): string {
-  const evalEvent = runReceipt.ndjson<ExpEvent>().find(
-    (event): event is ExpEvalEvent =>
-      "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+  const evalEvent = only(
+    runReceipt.expEvalEvents(),
+    (event) => event.evalId === EVAL_ID,
+    () => runReceipt.diagnostic(),
   );
-  expect(evalEvent, runReceipt.diagnostic()).toMatchObject({ verdict: "passed" });
-  expect(evalEvent?.locator, runReceipt.diagnostic()).toMatch(/^@/);
-  return evalEvent!.locator!;
+  return evalEvent.locator;
 }
 
 beforeAll(async () => {
@@ -79,24 +78,23 @@ beforeAll(async () => {
 }, 14 * 60_000);
 
 it("真实 Claude Agent SDK converter 的 Eval 以通过 verdict 完成", () => {
-  const events = runReceipt.ndjson<ExpEvent>();
   // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md）：
   // completion 与 runIds；成败由带身份的 eval 事件精确断言，live provider
   // 故障不会冒充通过。
   const inv = runReceipt.expReceipt();
   expect(inv.completion, runReceipt.diagnostic()).toBe("completed");
   expect(inv.runIds, runReceipt.diagnostic()).toHaveLength(1);
-  const evalEvent = events.find(
-    (event): event is ExpEvalEvent =>
-      "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+  assertExpEvalOutcomes(
+    runReceipt.expEvalEvents(),
+    [{
+      evalId: EVAL_ID,
+      experimentId: "ci",
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => runReceipt.diagnostic(),
   );
-  expect(evalEvent, runReceipt.diagnostic()).toBeDefined();
-  expect(evalEvent).toMatchObject({
-    event: "eval",
-    evalId: EVAL_ID,
-    verdict: "passed",
-    attempts: 1,
-  });
 });
 
 it("show --execution 读回 Claude Agent SDK converter 的代表性证据", async () => {

--- a/e2e/adapter/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/e2e/adapter/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -86,13 +86,16 @@ it("真实 Claude Agent SDK converter 的 Eval 以通过 verdict 完成", () => 
   expect(inv.runIds, runReceipt.diagnostic()).toHaveLength(1);
   assertExpEvalOutcomes(
     runReceipt.expEvalEvents(),
-    [{
-      evalId: EVAL_ID,
-      experimentId: "ci",
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // bash-session：真实 SDK stream 须归一 Bash 调用并在续接轮保留 sentinel；期望 passed/1。
+      {
+        evalId: EVAL_ID,
+        experimentId: "ci",
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => runReceipt.diagnostic(),
   );
 });

--- a/e2e/adapter/claude-code/test/claude-code.test.ts
+++ b/e2e/adapter/claude-code/test/claude-code.test.ts
@@ -4,36 +4,36 @@
 // 具体 Skill、MCP、Plugin 与配置行为由各自 Eval 断言；owner 只守住发现完整性与全绿结果。
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
-import { command, type ExpEvalEvent, type ProcessReceipt } from "@niceeval/testkit";
+import {
+  assertExpEvalOutcomes,
+  command,
+  only,
+  type ExpEvalEvent,
+  type ExpEvalOutcomeExpectation,
+  type ProcessReceipt,
+} from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { beforeAll, expect, it } from "vitest";
 
-const EXPECTED_EVALS = [
-  "coding-task",
-  "session-resume",
-  "skill-used",
-  "skill-checklist",
-  "skill-unused",
-  "repo-skill",
-  "mcp-tools",
-  "plugin-mcp",
-  "remote-plugin",
-  "websearch-denied",
-] as const;
+const EXPECTED_OUTCOMES = [
+  { experimentId: "coding", evalId: "coding-task", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "coding", evalId: "session-resume", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "coding", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "skill", evalId: "skill-used", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "skill", evalId: "skill-checklist", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "skill", evalId: "skill-unused", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "repo-skill", evalId: "repo-skill", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "mcp", evalId: "mcp-tools", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "plugin", evalId: "plugin-mcp", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "plugin-reuse", evalId: "plugin-mcp", verdict: "passed", attempts: 8, passed: 8 },
+  { experimentId: "remote-plugin", evalId: "remote-plugin", verdict: "passed", attempts: 1, passed: 1 },
+  { experimentId: "locked-down", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
 
-const EXPECTED_EXPERIMENTS = [
-  "coding",
-  "skill",
-  "repo-skill",
-  "mcp",
-  "plugin",
-  "plugin-reuse",
-  "remote-plugin",
-  "locked-down",
-] as const;
-// websearch-denied 同时跑在 coding 正例与 locked-down deny 反例上。
-const EXPECTED_PASSED_ATTEMPTS = 19;
+const EXPECTED_EXPERIMENT_COUNT = new Set(
+  EXPECTED_OUTCOMES.map((outcome) => outcome.experimentId),
+).size;
 
 const REQUIRED_LIVE_SECRETS = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"] as const;
 
@@ -81,10 +81,11 @@ function assertExactRetryEvalSelector(events: readonly ExpEvalEvent[], failed: E
 }
 
 function representativeAttempt(): ExpEvalEvent {
-  const attempt = evalEvents.find((event) => event.evalId === "coding-task");
-  expect(attempt, run.diagnostic()).toBeDefined();
-  expect(attempt?.locator, run.diagnostic()).toBeTruthy();
-  return attempt!;
+  return only(
+    evalEvents,
+    (event) => event.evalId === "coding-task",
+    () => run.diagnostic(),
+  );
 }
 
 beforeAll(async () => {
@@ -155,16 +156,8 @@ it("真实 Claude Code adapter 的全部专用 Eval 通过", () => {
   // eval 事件精确断言，不从 receipt 猜计数。
   const inv = run.expReceipt();
   expect(inv.completion, run.diagnostic()).toBe("completed");
-  expect(inv.runIds, run.diagnostic()).toHaveLength(EXPECTED_EXPERIMENTS.length);
-
-  expect(new Set(evalEvents.map((event) => event.evalId))).toEqual(new Set(EXPECTED_EVALS));
-  expect(new Set(evalEvents.map((event) => event.experimentId))).toEqual(new Set(EXPECTED_EXPERIMENTS));
-  for (const event of evalEvents) {
-    expect(event.verdict, `${event.experimentId}/${event.evalId} did not pass`).toBe("passed");
-    expect(event.passed, `${event.experimentId}/${event.evalId} lost an attempt`).toBe(event.attempts);
-  }
-  const totalPassed = evalEvents.reduce((sum, event) => sum + (event.passed ?? 0), 0);
-  expect(totalPassed, run.diagnostic()).toBe(EXPECTED_PASSED_ATTEMPTS);
+  expect(inv.runIds, run.diagnostic()).toHaveLength(EXPECTED_EXPERIMENT_COUNT);
+  assertExpEvalOutcomes(evalEvents, EXPECTED_OUTCOMES, () => run.diagnostic());
 });
 
 it("show --execution 读回 Claude Code 的代表性工具证据", async () => {

--- a/e2e/adapter/claude-code/test/claude-code.test.ts
+++ b/e2e/adapter/claude-code/test/claude-code.test.ts
@@ -17,17 +17,29 @@ import { join } from "node:path";
 import { beforeAll, expect, it } from "vitest";
 
 const EXPECTED_OUTCOMES = [
+  // coding-task：文件写入、编辑与 shell 调用都须完成；单次基线 Attempt 全部断言成立才是 passed/1。
   { experimentId: "coding", evalId: "coding-task", verdict: "passed", attempts: 1, passed: 1 },
+  // session-resume：原生 --resume 须带回首轮事实且两轮 usage 可用；一次会话链完成即为 passed/1。
   { experimentId: "coding", evalId: "session-resume", verdict: "passed", attempts: 1, passed: 1 },
+  // WebSearch 正例：coding 开启 webResearch，必须调用 web_search 且不调用 web_fetch，因此期望 passed/1。
   { experimentId: "coding", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
+  // skill-used：只加载目标本地 Skill，并在回答中采用其独有 marker；单次正调应为 passed/1。
   { experimentId: "skill", evalId: "skill-used", verdict: "passed", attempts: 1, passed: 1 },
+  // skill-checklist：只加载 checklist Skill、不误载 marker/decoy；反选断言同时成立才是 passed/1。
   { experimentId: "skill", evalId: "skill-checklist", verdict: "passed", attempts: 1, passed: 1 },
+  // skill-unused：普通对话不得加载任何已安装 Skill 或调用工具；这个反例成立时仍是 passed/1。
   { experimentId: "skill", evalId: "skill-unused", verdict: "passed", attempts: 1, passed: 1 },
+  // repo-skill：钉定 Git 来源的 Skill 必须安装、原生加载并影响输出；一次完整验证期望 passed/1。
   { experimentId: "repo-skill", evalId: "repo-skill", verdict: "passed", attempts: 1, passed: 1 },
+  // mcp-tools：stdio 与 Streamable HTTP 两个 MCP 工具都须以正确入参完成；因此期望 passed/1。
   { experimentId: "mcp", evalId: "mcp-tools", verdict: "passed", attempts: 1, passed: 1 },
+  // plugin-mcp：官方 Context7 Plugin 的远程 MCP 必须接线并成功调用；单次安装路径期望 passed/1。
   { experimentId: "plugin", evalId: "plugin-mcp", verdict: "passed", attempts: 1, passed: 1 },
+  // plugin-reuse：四个 Sandbox 承接两波共八次复用，八次都须调用 Context7 成功，所以是 passed/8。
   { experimentId: "plugin-reuse", evalId: "plugin-mcp", verdict: "passed", attempts: 8, passed: 8 },
+  // remote-plugin：远程 marketplace 文件须安装，随 Plugin 的 Skill 须被加载并完成请求；期望 passed/1。
   { experimentId: "remote-plugin", evalId: "remote-plugin", verdict: "passed", attempts: 1, passed: 1 },
+  // WebSearch 反例：locked-down settings 禁止 WebSearch/WebFetch，零调用才通过，因此期望 passed/1。
   { experimentId: "locked-down", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
 ] as const satisfies readonly ExpEvalOutcomeExpectation[];
 

--- a/e2e/adapter/codex-cli/test/codex-cli.test.ts
+++ b/e2e/adapter/codex-cli/test/codex-cli.test.ts
@@ -18,16 +18,27 @@ import { expect, it } from "vitest";
 
 // 每条 Eval 的首轮只有一个 Attempt；只有结构化 verdict=failed 才由本测试另起一次 Invocation。
 const EXPECTED_OUTCOMES = [
+  // coding-task：既有文件修改与 shell 调用都须归一并配对完成；最终单次 Attempt 期望 passed/1。
   { experimentId: "baseline", evalId: "coding-task", verdict: "passed", attempts: 1 },
+  // configfile 正例：shell-enabled 配置下同一 prompt 必须调用 shell；分支成立时为 passed/1。
   { experimentId: "baseline", evalId: "configfile", verdict: "passed", attempts: 1 },
+  // session：首轮 thread ID 须捕获，第二轮 exec resume 须回忆事实；一条会话链期望 passed/1。
   { experimentId: "baseline", evalId: "session", verdict: "passed", attempts: 1 },
+  // usage：每轮 token usage 非空，且 session 侧写中的实际模型正确；一次验证期望 passed/1。
   { experimentId: "baseline", evalId: "usage", verdict: "passed", attempts: 1 },
+  // configfile 反例：shell-disabled 配置下同一 prompt 不得调用 shell；零调用成立时为 passed/1。
   { experimentId: "configfile", evalId: "configfile", verdict: "passed", attempts: 1 },
+  // mcp：stdio 求和与远程 DeepWiki 两种 MCP 调用都须出现且入参正确；期望 passed/1。
   { experimentId: "mcp", evalId: "mcp", verdict: "passed", attempts: 1 },
+  // skill：目标 status-report Skill 须被读取并影响文件内容，且不能伪造 skill.loaded；期望 passed/1。
   { experimentId: "skill", evalId: "skill", verdict: "passed", attempts: 1 },
+  // skill-release-note：只读取 release-note Skill、不误读 status/decoy，并采用其约定；期望 passed/1。
   { experimentId: "skill", evalId: "skill-release-note", verdict: "passed", attempts: 1 },
+  // repo-skill：钉定 Git 来源的 Skill 须安装、读取并影响产出；一次完整验证期望 passed/1。
   { experimentId: "repo-skill", evalId: "repo-skill", verdict: "passed", attempts: 1 },
+  // plugin-hook：Plugin 安装痕迹与 SessionStart hook 侧写证据都须存在；单次安装路径期望 passed/1。
   { experimentId: "plugin", evalId: "plugin-hook", verdict: "passed", attempts: 1 },
+  // plugin-reuse：四个 Sandbox 的两波共八次复用都须清理冲突残留并重装成功，所以期望 passed/8。
   { experimentId: "plugin-reuse", evalId: "plugin-hook", verdict: "passed", attempts: 8 },
 ] as const satisfies readonly ExpEvalOutcomeExpectation[];
 

--- a/e2e/adapter/codex-cli/test/codex-cli.test.ts
+++ b/e2e/adapter/codex-cli/test/codex-cli.test.ts
@@ -4,15 +4,40 @@
 // 再从公开 CLI 读回 Eval、attempt、execution 与 timing。
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
-import { command, type ExpEvalEvent, type ProcessReceipt } from "@niceeval/testkit";
+import {
+  assertExpEvalOutcomes,
+  command,
+  only,
+  type ExpEvalEvent,
+  type ExpEvalOutcomeExpectation,
+  type ProcessReceipt,
+} from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { expect, it } from "vitest";
 
 // 每条 Eval 的首轮只有一个 Attempt；只有结构化 verdict=failed 才由本测试另起一次 Invocation。
-const EXPECTED_PASSED_ATTEMPTS = 18;
-// 每个 Experiment 产生一个 Run（docs/feature/experiments/cli.md「结束反馈与 receipt」）；
-const EXPECTED_EXPERIMENTS = 7;
+const EXPECTED_OUTCOMES = [
+  { experimentId: "baseline", evalId: "coding-task", verdict: "passed", attempts: 1 },
+  { experimentId: "baseline", evalId: "configfile", verdict: "passed", attempts: 1 },
+  { experimentId: "baseline", evalId: "session", verdict: "passed", attempts: 1 },
+  { experimentId: "baseline", evalId: "usage", verdict: "passed", attempts: 1 },
+  { experimentId: "configfile", evalId: "configfile", verdict: "passed", attempts: 1 },
+  { experimentId: "mcp", evalId: "mcp", verdict: "passed", attempts: 1 },
+  { experimentId: "skill", evalId: "skill", verdict: "passed", attempts: 1 },
+  { experimentId: "skill", evalId: "skill-release-note", verdict: "passed", attempts: 1 },
+  { experimentId: "repo-skill", evalId: "repo-skill", verdict: "passed", attempts: 1 },
+  { experimentId: "plugin", evalId: "plugin-hook", verdict: "passed", attempts: 1 },
+  { experimentId: "plugin-reuse", evalId: "plugin-hook", verdict: "passed", attempts: 8 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
+
+const EXPECTED_EXPERIMENT_COUNT = new Set(
+  EXPECTED_OUTCOMES.map((outcome) => outcome.experimentId),
+).size;
+const EXPECTED_PASSED_ATTEMPTS = EXPECTED_OUTCOMES.reduce(
+  (sum, outcome) => sum + outcome.attempts,
+  0,
+);
 
 const REQUIRED_LIVE_SECRETS = [
   "CODEX_API_KEY",
@@ -76,7 +101,7 @@ it("真实 Codex CLI adapter 在 Docker sandbox 中的运行结果经过公开 C
   // eval 事件精确断言，不从 receipt 猜计数。
   const inv = run.expReceipt();
   expect(inv.completion, run.diagnostic()).toBe("completed");
-  expect(inv.runIds, run.diagnostic()).toHaveLength(EXPECTED_EXPERIMENTS);
+  expect(inv.runIds, run.diagnostic()).toHaveLength(EXPECTED_EXPERIMENT_COUNT);
   // eval 事件是中间的身份事件：identity / verdict / attempts 在此精确断言。
   const firstEvents = run.expEvalEvents();
   // plugin-reuse 是八条 Attempt 的 Sandbox 复用 owner，不是模型断言重试消费者。
@@ -122,18 +147,19 @@ it("真实 Codex CLI adapter 在 Docker sandbox 中的运行结果经过公开 C
     );
   }
   const evalEvents = firstEvents.map((event) => retriedByEval.get(evalKey(event)) ?? event);
+  assertExpEvalOutcomes(evalEvents, EXPECTED_OUTCOMES, () => run.diagnostic());
   const totalPassed = evalEvents.reduce(
     (sum, event) => sum + (event.reason === "early_exit" ? 1 : (event.passed ?? 0)),
     0,
   );
   expect(totalPassed, run.diagnostic()).toBe(EXPECTED_PASSED_ATTEMPTS);
-  expect(evalEvents.filter((event) => event.verdict !== "passed"), run.diagnostic()).toHaveLength(0);
 
   const locatorFor = (evalId: string): string => {
-    const event = evalEvents.find((candidate) => candidate.evalId === evalId);
-    expect(event, run.diagnostic()).toMatchObject({ verdict: "passed" });
-    expect(event?.locator, run.diagnostic()).toMatch(/^@/);
-    return event!.locator!;
+    return only(
+      evalEvents,
+      (event) => event.evalId === evalId,
+      () => run.diagnostic(),
+    ).locator;
   };
   const codingTaskLocator = locatorFor("coding-task");
 

--- a/e2e/adapter/codex-sdk/test/codex-sdk.test.ts
+++ b/e2e/adapter/codex-sdk/test/codex-sdk.test.ts
@@ -5,9 +5,9 @@
 // show commands only; it never reads the private .niceeval layout.
 
 import {
+  assertExpEvalOutcomes,
   command,
-  type ExpEvalEvent,
-  type ExpEvent,
+  only,
   type ProcessReceipt,
   withProcess,
   withTempDir,
@@ -74,34 +74,32 @@ beforeAll(async () => {
   });
 
   expect(runReceipt.exitCode, runReceipt.diagnostic()).toBe(0);
-  const evalEvent = runReceipt.ndjson<ExpEvent>().find(
-    (event): event is ExpEvalEvent =>
-      "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+  const evalEvent = only(
+    runReceipt.expEvalEvents(),
+    (event) => event.evalId === EVAL_ID,
+    () => runReceipt.diagnostic(),
   );
-  expect(evalEvent, runReceipt.diagnostic()).toMatchObject({ verdict: "passed" });
-  expect(evalEvent?.locator, runReceipt.diagnostic()).toMatch(/^@/);
-  locator = evalEvent!.locator!;
+  locator = evalEvent.locator;
 }, 14 * 60_000);
 
 it("真实 Codex SDK converter 的 Eval 以通过 verdict 完成", () => {
-  const events = runReceipt.ndjson<ExpEvent>();
   // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md）：
   // completion 与 runIds；成败由带身份的 eval 事件精确断言，live provider
   // 故障不会冒充通过。
   const inv = runReceipt.expReceipt();
   expect(inv.completion, runReceipt.diagnostic()).toBe("completed");
   expect(inv.runIds, runReceipt.diagnostic()).toHaveLength(1);
-  const evalEvent = events.find(
-    (event): event is ExpEvalEvent =>
-      "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+  assertExpEvalOutcomes(
+    runReceipt.expEvalEvents(),
+    [{
+      evalId: EVAL_ID,
+      experimentId: "live",
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => runReceipt.diagnostic(),
   );
-  expect(evalEvent, runReceipt.diagnostic()).toBeDefined();
-  expect(evalEvent).toMatchObject({
-    event: "eval",
-    evalId: EVAL_ID,
-    verdict: "passed",
-    attempts: 1,
-  });
 });
 
 it("show --execution 读回 Codex SDK converter 的代表性证据", async () => {

--- a/e2e/adapter/codex-sdk/test/codex-sdk.test.ts
+++ b/e2e/adapter/codex-sdk/test/codex-sdk.test.ts
@@ -91,13 +91,16 @@ it("真实 Codex SDK converter 的 Eval 以通过 verdict 完成", () => {
   expect(inv.runIds, runReceipt.diagnostic()).toHaveLength(1);
   assertExpEvalOutcomes(
     runReceipt.expEvalEvents(),
-    [{
-      evalId: EVAL_ID,
-      experimentId: "live",
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // live compatibility：真实 Thread stream 须保留命令结果并续接 sentinel；单次运行期望 passed/1。
+      {
+        evalId: EVAL_ID,
+        experimentId: "live",
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => runReceipt.diagnostic(),
   );
 });

--- a/e2e/adapter/hermes/test/hermes.test.ts
+++ b/e2e/adapter/hermes/test/hermes.test.ts
@@ -5,10 +5,9 @@
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
 import {
+  assertExpEvalOutcomes,
   createE2EContext,
   only,
-  type ExpEvalEvent,
-  type ExpEvent,
 } from "@niceeval/testkit";
 import { join, resolve } from "node:path";
 import { expect, it } from "vitest";
@@ -19,6 +18,13 @@ const EXPECTED_EVALS = [
   "session/recall",
   "usage/tokens",
 ] as const;
+const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
+  experimentId: "ci",
+  evalId,
+  verdict: "passed" as const,
+  attempts: 1,
+  passed: 1,
+}));
 
 const REQUIRED_LIVE_SECRETS = [
   "BUB_API_KEY",
@@ -60,9 +66,11 @@ it("真实 Hermes CLI adapter 完成运行并公开读回工具与 timing 证据
         timeoutMs: 36 * 60_000,
       });
       expect(run.exitCode, run.diagnostic()).toBe(0);
-      const evalEvents = run
-        .ndjson<ExpEvent>()
-        .filter((event): event is ExpEvalEvent => "event" in event && event.event === "eval");
+      const evalEvents = assertExpEvalOutcomes(
+        run.expEvalEvents(),
+        EXPECTED_OUTCOMES,
+        () => run.diagnostic(),
+      );
 
       // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md「结束反馈与
       // receipt」）：completion 与 runIds（每个 Experiment 一个 Run）。成败由下面带身份的
@@ -70,15 +78,6 @@ it("真实 Hermes CLI adapter 完成运行并公开读回工具与 timing 证据
       const inv = run.expReceipt();
       expect(inv.completion, run.diagnostic()).toBe("completed");
       expect(inv.runIds, run.diagnostic()).toHaveLength(1);
-      expect(
-        evalEvents.filter((event) => event.verdict === "passed"),
-        run.diagnostic(),
-      ).toHaveLength(EXPECTED_EVALS.length);
-      expect(
-        evalEvents.filter((event) => event.verdict !== "passed"),
-        run.diagnostic(),
-      ).toHaveLength(0);
-
       const event = only(
         evalEvents,
         (candidate) => candidate.evalId === "coding-task/write-and-verify",

--- a/e2e/adapter/hermes/test/hermes.test.ts
+++ b/e2e/adapter/hermes/test/hermes.test.ts
@@ -8,23 +8,21 @@ import {
   assertExpEvalOutcomes,
   createE2EContext,
   only,
+  type ExpEvalOutcomeExpectation,
 } from "@niceeval/testkit";
 import { join, resolve } from "node:path";
 import { expect, it } from "vitest";
 
-const EXPECTED_EVALS = [
-  "coding-task/write-and-verify",
-  "skills/selected",
-  "session/recall",
-  "usage/tokens",
-] as const;
-const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
-  experimentId: "ci",
-  evalId,
-  verdict: "passed" as const,
-  attempts: 1,
-  passed: 1,
-}));
+const EXPECTED_OUTCOMES = [
+  // coding task：带可区分入参的文件写入与 shell 读回都须归一完成；单次执行期望 passed/1。
+  { experimentId: "ci", evalId: "coding-task/write-and-verify", verdict: "passed", attempts: 1, passed: 1 },
+  // Skill selection：只加载 incident-report Skill、不加载 decoy，并采用目标约定；期望 passed/1。
+  { experimentId: "ci", evalId: "skills/selected", verdict: "passed", attempts: 1, passed: 1 },
+  // session recall：同一会话的第二轮须引用首轮事实；一条会话链完成即为 passed/1。
+  { experimentId: "ci", evalId: "session/recall", verdict: "passed", attempts: 1, passed: 1 },
+  // usage：两个独立 turn 都须读到正的 input/output token；全部断言成立时为 passed/1。
+  { experimentId: "ci", evalId: "usage/tokens", verdict: "passed", attempts: 1, passed: 1 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
 
 const REQUIRED_LIVE_SECRETS = [
   "BUB_API_KEY",

--- a/e2e/adapter/local-protocol/test/support.ts
+++ b/e2e/adapter/local-protocol/test/support.ts
@@ -1,9 +1,8 @@
 import { createServer } from "node:http";
 import { join, resolve } from "node:path";
 import {
+  assertExpEvalOutcomes,
   createE2EContext,
-  type ExpEvalEvent,
-  type ExpEvent,
   waitForOutput,
 } from "@niceeval/testkit";
 import { expect } from "vitest";
@@ -93,7 +92,6 @@ export async function proveLocalProtocolOwner(kind: OwnerKind): Promise<void> {
             timeoutMs: kind === "timeout" ? 30_000 : 60_000,
           },
         );
-        const events = receipt.ndjson<ExpEvent>();
         // receipt 只承载 Invocation 级完成事实(见 docs/feature/experiments/cli.md「结束反馈与
         // receipt」)：completion 与 runIds。pass/fail 由下面带身份的 eval 事件精确断言，不从
         // receipt 猜成败，也不在 receipt 上断言计数。
@@ -103,18 +101,12 @@ export async function proveLocalProtocolOwner(kind: OwnerKind): Promise<void> {
         // 每个 kind 恰好一个 Experiment / 一个 Eval；eval 事件是中间的身份事件，严格断言
         // evalId / experimentId / verdict / attempts——成功与故障的确定性路径都由此判定。
         const { evalId, verdict } = KIND_EXPECTATIONS[kind];
-        const evalEvent = events.find(
-          (event): event is ExpEvalEvent =>
-            "event" in event && event.event === "eval" && event.evalId === evalId,
+        const evalEvents = assertExpEvalOutcomes(
+          receipt.expEvalEvents(),
+          [{ evalId, experimentId: kind, verdict, attempts: 1 }],
+          () => receipt.diagnostic(),
         );
-        expect(evalEvent, receipt.diagnostic()).toMatchObject({
-          event: "eval",
-          evalId,
-          experimentId: kind,
-          verdict,
-          attempts: 1,
-        });
-        expect(evalEvent?.locator, receipt.diagnostic()).toBeTruthy();
+        const evalEvent = evalEvents[0]!;
         if (verdict === "passed") {
           expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
         } else {
@@ -138,7 +130,7 @@ export async function proveLocalProtocolOwner(kind: OwnerKind): Promise<void> {
         // 必须可从公开 timing 页面读出 Eval 与首轮 Turn。此 direct Agent 没有
         // 声明 setup，runner 不应凭空补一个 agent.setup 阶段。
         const timing = await niceeval.run(
-          ["show", evalEvent!.locator!, "--timing"],
+          ["show", evalEvent!.locator, "--timing"],
         );
         expect(timing.exitCode, timing.diagnostic()).toBe(0);
         expect(timing.stdout, timing.diagnostic()).toContain("eval.run");

--- a/e2e/adapter/local-protocol/test/support.ts
+++ b/e2e/adapter/local-protocol/test/support.ts
@@ -46,10 +46,15 @@ async function assertPortReusable(port: number): Promise<void> {
 
 /** 每个 kind 的 (experiment, eval) 身份与期望终局；五个 owner 文件各取一行。 */
 const KIND_EXPECTATIONS: Readonly<Record<OwnerKind, { evalId: string; verdict: "passed" | "errored" }>> = {
+  // transport：本地协议须完成一次正常 send 并返回匹配内容，所以产品终局应为 passed。
   transport: { evalId: "transport-ok", verdict: "passed" },
+  // approval：pending 工具须经 approve/deny 生命周期正确收束；所有正反断言成立时应为 passed。
   approval: { evalId: "approval-lifecycle", verdict: "passed" },
+  // disconnect：服务端在响应前断开是 Adapter 传输故障，Eval test 无法继续，因此应为 errored。
   disconnect: { evalId: "disconnect", verdict: "errored" },
+  // timeout：服务端故意悬挂直到 send 超时，这是运行错误而非断言失败，因此应为 errored。
   timeout: { evalId: "timeout", verdict: "errored" },
+  // http-error：服务端返回 HTTP 500 会让 send 抛错，属于 Adapter 运行错误，因此应为 errored。
   "http-error": { evalId: "http-error", verdict: "errored" },
 };
 

--- a/e2e/adapter/openai-compat/test/chat-completion-live.test.ts
+++ b/e2e/adapter/openai-compat/test/chat-completion-live.test.ts
@@ -1,6 +1,7 @@
 // owner: docs/engineering/testing/e2e/adapter/openai-compat.md#chat-completion-live
 
 import { beforeAll, expect, test } from "vitest";
+import { assertExpEvalOutcomes } from "@niceeval/testkit";
 import {
   runOpenAiLiveEvidence,
   showOpenAiLiveEvidence,
@@ -22,12 +23,17 @@ test("真实 OpenAI Chat Completion 一次请求以通过 verdict 完成", () =>
   const receipt = evidence.receipt.expReceipt();
   expect(receipt.completion).toBe("completed");
   expect(receipt.runIds, evidence.receipt.diagnostic()).not.toHaveLength(0);
-  expect(evidence.evalEvent).toMatchObject({
-    evalId: evidence.evalId,
-    experimentId: evidence.experimentId,
-    verdict: "passed",
-    attempts: 1,
-  });
+  assertExpEvalOutcomes(
+    evidence.evalEvents,
+    [{
+      evalId: "chat-completion-live",
+      experimentId: "chat-completion-live",
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => evidence.receipt.diagnostic(),
+  );
 });
 
 test("show --execution 读回 OpenAI Chat Completion 的代表性证据", async () => {

--- a/e2e/adapter/openai-compat/test/chat-completion-live.test.ts
+++ b/e2e/adapter/openai-compat/test/chat-completion-live.test.ts
@@ -25,13 +25,16 @@ test("真实 OpenAI Chat Completion 一次请求以通过 verdict 完成", () =>
   expect(receipt.runIds, evidence.receipt.diagnostic()).not.toHaveLength(0);
   assertExpEvalOutcomes(
     evidence.evalEvents,
-    [{
-      evalId: "chat-completion-live",
-      experimentId: "chat-completion-live",
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // Chat Completion：真实一次请求须调用 fixture 工具并公开读回 marker；因此期望 passed/1。
+      {
+        evalId: "chat-completion-live",
+        experimentId: "chat-completion-live",
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => evidence.receipt.diagnostic(),
   );
 });

--- a/e2e/adapter/openai-compat/test/responses-live.test.ts
+++ b/e2e/adapter/openai-compat/test/responses-live.test.ts
@@ -25,13 +25,16 @@ test("真实 OpenAI Responses 一次请求以通过 verdict 完成", () => {
   expect(receipt.runIds, evidence.receipt.diagnostic()).not.toHaveLength(0);
   assertExpEvalOutcomes(
     evidence.evalEvents,
-    [{
-      evalId: "responses-live",
-      experimentId: "responses-live",
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // Responses：真实一次请求须调用 fixture 工具并公开读回 marker；因此期望 passed/1。
+      {
+        evalId: "responses-live",
+        experimentId: "responses-live",
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => evidence.receipt.diagnostic(),
   );
 });

--- a/e2e/adapter/openai-compat/test/responses-live.test.ts
+++ b/e2e/adapter/openai-compat/test/responses-live.test.ts
@@ -1,6 +1,7 @@
 // owner: docs/engineering/testing/e2e/adapter/openai-compat.md#responses-live
 
 import { beforeAll, expect, test } from "vitest";
+import { assertExpEvalOutcomes } from "@niceeval/testkit";
 import {
   runOpenAiLiveEvidence,
   showOpenAiLiveEvidence,
@@ -22,12 +23,17 @@ test("真实 OpenAI Responses 一次请求以通过 verdict 完成", () => {
   const receipt = evidence.receipt.expReceipt();
   expect(receipt.completion).toBe("completed");
   expect(receipt.runIds, evidence.receipt.diagnostic()).not.toHaveLength(0);
-  expect(evidence.evalEvent).toMatchObject({
-    evalId: evidence.evalId,
-    experimentId: evidence.experimentId,
-    verdict: "passed",
-    attempts: 1,
-  });
+  assertExpEvalOutcomes(
+    evidence.evalEvents,
+    [{
+      evalId: "responses-live",
+      experimentId: "responses-live",
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => evidence.receipt.diagnostic(),
+  );
 });
 
 test("show --execution 读回 OpenAI Responses 的代表性证据", async () => {

--- a/e2e/adapter/openai-compat/test/support.ts
+++ b/e2e/adapter/openai-compat/test/support.ts
@@ -3,8 +3,8 @@ import {
   command,
   createE2EContext,
   type ExpEvalEvent,
-  type ExpEvent,
   type ProcessReceipt,
+  only,
 } from "@niceeval/testkit";
 import { expect } from "vitest";
 
@@ -31,6 +31,7 @@ const niceevalShow = command(niceevalBin);
 export interface OpenAiLiveEvidence {
   readonly receipt: ProcessReceipt;
   readonly evalEvent: ExpEvalEvent;
+  readonly evalEvents: readonly ExpEvalEvent[];
   readonly experimentId: string;
   readonly evalId: string;
   readonly executionMarkers: readonly string[];
@@ -62,17 +63,16 @@ export async function runOpenAiLiveEvidence(options: {
         { timeoutMs: 4 * 60_000 },
       );
       expect(run.exitCode, run.diagnostic()).toBe(0);
-      const events = run.ndjson<ExpEvent>();
-      const evalEvent = events.find(
-        (event): event is ExpEvalEvent =>
-          "event" in event && event.event === "eval" && event.evalId === options.evalId,
+      const evalEvents = run.expEvalEvents();
+      const evalEvent = only(
+        evalEvents,
+        (event) => event.evalId === options.evalId,
+        () => run.diagnostic(),
       );
-      if (evalEvent === undefined || evalEvent.locator === undefined) {
-        throw new Error(`live ${options.evalId} eval has no public locator: ${run.diagnostic()}`);
-      }
       evidence = {
         receipt: run,
         evalEvent,
+        evalEvents,
         experimentId: options.experimentId,
         evalId: options.evalId,
         executionMarkers: options.executionMarkers,

--- a/e2e/adapter/openclaw/test/openclaw.test.ts
+++ b/e2e/adapter/openclaw/test/openclaw.test.ts
@@ -5,10 +5,10 @@
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
 import {
+  assertExpEvalOutcomes,
   command,
   only,
   type ExpEvalEvent,
-  type ExpEvent,
   type ProcessReceipt,
 } from "@niceeval/testkit";
 import { rmSync } from "node:fs";
@@ -21,6 +21,13 @@ const EXPECTED_EVALS = [
   "session/recall",
   "usage/tokens",
 ] as const;
+const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
+  experimentId: "ci",
+  evalId,
+  verdict: "passed" as const,
+  attempts: 1,
+  passed: 1,
+}));
 
 const REQUIRED_LIVE_SECRETS = ["BUB_API_KEY", "BUB_API_BASE"] as const;
 
@@ -58,9 +65,7 @@ beforeAll(async () => {
     timeoutMs: 46 * 60_000,
   });
   expect(run.exitCode, run.diagnostic()).toBe(0);
-  evalEvents = run
-    .ndjson<ExpEvent>()
-    .filter((event): event is ExpEvalEvent => "event" in event && event.event === "eval");
+  evalEvents = run.expEvalEvents();
 }, 48 * 60_000);
 
 it("真实 OpenClaw adapter 的 Eval 通过数正确且没有未通过项", () => {
@@ -70,10 +75,11 @@ it("真实 OpenClaw adapter 的 Eval 通过数正确且没有未通过项", () =
   const inv = run.expReceipt();
   expect(inv.completion, run.diagnostic()).toBe("completed");
   expect(inv.runIds, run.diagnostic()).toHaveLength(1);
-  expect(evalEvents.filter((event) => event.verdict === "passed"), run.diagnostic()).toHaveLength(
-    EXPECTED_EVALS.length,
+  assertExpEvalOutcomes(
+    evalEvents,
+    EXPECTED_OUTCOMES,
+    () => run.diagnostic(),
   );
-  expect(evalEvents.filter((event) => event.verdict !== "passed"), run.diagnostic()).toHaveLength(0);
 });
 
 it("show --execution 读回 OpenClaw 的代表性工具证据", async () => {

--- a/e2e/adapter/openclaw/test/openclaw.test.ts
+++ b/e2e/adapter/openclaw/test/openclaw.test.ts
@@ -9,25 +9,23 @@ import {
   command,
   only,
   type ExpEvalEvent,
+  type ExpEvalOutcomeExpectation,
   type ProcessReceipt,
 } from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { beforeAll, expect, it } from "vitest";
 
-const EXPECTED_EVALS = [
-  "coding-task/write-and-verify",
-  "skills/status-report",
-  "session/recall",
-  "usage/tokens",
-] as const;
-const EXPECTED_OUTCOMES = EXPECTED_EVALS.map((evalId) => ({
-  experimentId: "ci",
-  evalId,
-  verdict: "passed" as const,
-  attempts: 1,
-  passed: 1,
-}));
+const EXPECTED_OUTCOMES = [
+  // coding task：文件写入与 shell 读回都须以正确参数完成并进入标准事件流；期望 passed/1。
+  { experimentId: "ci", evalId: "coding-task/write-and-verify", verdict: "passed", attempts: 1, passed: 1 },
+  // Skill status：只读取目标 status-report Skill、不误用 decoy，并采用目标约定；期望 passed/1。
+  { experimentId: "ci", evalId: "skills/status-report", verdict: "passed", attempts: 1, passed: 1 },
+  // session recall：同一会话的第二轮须引用首轮事实；一条会话链完成即为 passed/1。
+  { experimentId: "ci", evalId: "session/recall", verdict: "passed", attempts: 1, passed: 1 },
+  // usage：两个 turn 都须产生正的 input/output token；全部断言成立时为 passed/1。
+  { experimentId: "ci", evalId: "usage/tokens", verdict: "passed", attempts: 1, passed: 1 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
 
 const REQUIRED_LIVE_SECRETS = ["BUB_API_KEY", "BUB_API_BASE"] as const;
 

--- a/e2e/adapter/opencode/test/opencode.test.ts
+++ b/e2e/adapter/opencode/test/opencode.test.ts
@@ -4,7 +4,7 @@
 // 再从公开 CLI 读回 Eval、attempt、execution 与 timing。
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
-import { command, type ExpEvalEvent, type ExpEvent } from "@niceeval/testkit";
+import { assertExpEvalOutcomes, command } from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { expect, it } from "vitest";
@@ -14,6 +14,13 @@ const BASELINE_EVALS = [
   "session/recall",
   "usage/tokens",
 ] as const;
+const BASELINE_OUTCOMES = BASELINE_EVALS.map((evalId) => ({
+  experimentId: "ci",
+  evalId,
+  verdict: "passed" as const,
+  attempts: 1,
+  passed: 1,
+}));
 const SKILL_EVAL = "skills/status-report";
 const GO_EVAL = "provider/go-routing";
 
@@ -84,22 +91,16 @@ it("真实 OpenCode CLI adapter 在 Docker sandbox 中的运行结果经过公�
   const inv = run.expReceipt();
   expect(inv.completion, run.diagnostic()).toBe("completed");
   expect(inv.runIds, run.diagnostic()).toHaveLength(1);
-  const evalEvents = run
-    .ndjson<ExpEvent>()
-    .filter(
-      (event): event is ExpEvalEvent => "event" in event && event.event === "eval",
-    );
-  expect(evalEvents.filter((event) => event.verdict === "passed"), run.diagnostic()).toHaveLength(
-    BASELINE_EVALS.length,
+  const evalEvents = assertExpEvalOutcomes(
+    run.expEvalEvents(),
+    BASELINE_OUTCOMES,
+    () => run.diagnostic(),
   );
-  expect(evalEvents.filter((event) => event.verdict !== "passed"), run.diagnostic()).toHaveLength(0);
 
   const locators: Record<string, string> = {};
   for (const evalId of BASELINE_EVALS) {
     const event = evalEvents.find((candidate) => candidate.evalId === evalId);
-    expect(event, run.diagnostic()).toMatchObject({ verdict: "passed" });
-    expect(event?.locator, run.diagnostic()).toMatch(/^@/);
-    locators[evalId] = event!.locator!;
+    locators[evalId] = event!.locator;
   }
 
   // outcome：execution 是适配器收到的公开投影。TOOL 卡片头是原始未归一化名
@@ -147,11 +148,17 @@ it("真实 OpenCode CLI adapter 在 Docker sandbox 中的运行结果经过公�
   const skillInv = skillRun.expReceipt();
   expect(skillInv.completion, skillRun.diagnostic()).toBe("completed");
   expect(skillInv.runIds, skillRun.diagnostic()).toHaveLength(1);
-  const skillEvents = skillRun.ndjson<ExpEvent>().filter(
-    (event): event is ExpEvalEvent => "event" in event && event.event === "eval",
+  assertExpEvalOutcomes(
+    skillRun.expEvalEvents(),
+    [{
+      experimentId: "skill",
+      evalId: SKILL_EVAL,
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => skillRun.diagnostic(),
   );
-  expect(skillEvents.filter((event) => event.verdict === "passed"), skillRun.diagnostic()).toHaveLength(1);
-  expect(skillEvents.filter((event) => event.verdict !== "passed"), skillRun.diagnostic()).toHaveLength(0);
 
   // Go 配置独立成线：专用 Eval 用显式 OPENCODE_API_KEY、无自定义 base URL 完成
   // 真实 provider 调用，再从官方 session export 核对 provider 与 API model。
@@ -170,16 +177,20 @@ it("真实 OpenCode CLI adapter 在 Docker sandbox 中的运行结果经过公�
   const goInv = goRun.expReceipt();
   expect(goInv.completion, goRun.diagnostic()).toBe("completed");
   expect(goInv.runIds, goRun.diagnostic()).toHaveLength(1);
-  const goEvents = goRun.ndjson<ExpEvent>().filter(
-    (event): event is ExpEvalEvent => "event" in event && event.event === "eval",
+  const goEvents = assertExpEvalOutcomes(
+    goRun.expEvalEvents(),
+    [{
+      experimentId: "go",
+      evalId: GO_EVAL,
+      verdict: "passed",
+      attempts: 1,
+      passed: 1,
+    }],
+    () => goRun.diagnostic(),
   );
-  expect(goEvents.filter((event) => event.verdict === "passed"), goRun.diagnostic()).toHaveLength(1);
-  expect(goEvents.filter((event) => event.verdict !== "passed"), goRun.diagnostic()).toHaveLength(0);
 
   const goEvent = goEvents.find((event) => event.evalId === GO_EVAL);
-  expect(goEvent, goRun.diagnostic()).toMatchObject({ verdict: "passed" });
-  expect(goEvent?.locator, goRun.diagnostic()).toMatch(/^@/);
-  const goLocator = goEvent!.locator!;
+  const goLocator = goEvent!.locator;
   const goExecution = await niceeval.run(["show", goLocator, "--execution"]);
   expect(goExecution.exitCode, goExecution.diagnostic()).toBe(0);
   expect(goExecution.stdout).toContain("opencode export");

--- a/e2e/adapter/opencode/test/opencode.test.ts
+++ b/e2e/adapter/opencode/test/opencode.test.ts
@@ -4,23 +4,24 @@
 // 再从公开 CLI 读回 Eval、attempt、execution 与 timing。
 // 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。
 
-import { assertExpEvalOutcomes, command } from "@niceeval/testkit";
+import {
+  assertExpEvalOutcomes,
+  command,
+  type ExpEvalOutcomeExpectation,
+} from "@niceeval/testkit";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { expect, it } from "vitest";
 
-const BASELINE_EVALS = [
-  "coding-task/write-and-verify",
-  "session/recall",
-  "usage/tokens",
-] as const;
-const BASELINE_OUTCOMES = BASELINE_EVALS.map((evalId) => ({
-  experimentId: "ci",
-  evalId,
-  verdict: "passed" as const,
-  attempts: 1,
-  passed: 1,
-}));
+const BASELINE_OUTCOMES = [
+  // coding task：写文件与 shell 读回都须携带可区分参数并归一完成；单次执行期望 passed/1。
+  { experimentId: "ci", evalId: "coding-task/write-and-verify", verdict: "passed", attempts: 1, passed: 1 },
+  // session recall：OpenCode 同一 session 的第二轮须引用首轮事实；一条会话链期望 passed/1。
+  { experimentId: "ci", evalId: "session/recall", verdict: "passed", attempts: 1, passed: 1 },
+  // usage：两个 send 都须产生正的 input/output token；全部断言成立时为 passed/1。
+  { experimentId: "ci", evalId: "usage/tokens", verdict: "passed", attempts: 1, passed: 1 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
+const BASELINE_EVALS = BASELINE_OUTCOMES.map((outcome) => outcome.evalId);
 const SKILL_EVAL = "skills/status-report";
 const GO_EVAL = "provider/go-routing";
 
@@ -150,13 +151,16 @@ it("真实 OpenCode CLI adapter 在 Docker sandbox 中的运行结果经过公�
   expect(skillInv.runIds, skillRun.diagnostic()).toHaveLength(1);
   assertExpEvalOutcomes(
     skillRun.expEvalEvents(),
-    [{
-      experimentId: "skill",
-      evalId: SKILL_EVAL,
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // Skill：目标 status-report Skill 须安装、被选择且不误用 decoy；单次专用运行期望 passed/1。
+      {
+        experimentId: "skill",
+        evalId: SKILL_EVAL,
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => skillRun.diagnostic(),
   );
 
@@ -179,13 +183,16 @@ it("真实 OpenCode CLI adapter 在 Docker sandbox 中的运行结果经过公�
   expect(goInv.runIds, goRun.diagnostic()).toHaveLength(1);
   const goEvents = assertExpEvalOutcomes(
     goRun.expEvalEvents(),
-    [{
-      experimentId: "go",
-      evalId: GO_EVAL,
-      verdict: "passed",
-      attempts: 1,
-      passed: 1,
-    }],
+    [
+      // Go routing：真实请求须落到 deepseek-v4-flash 并从官方 export 读回；期望 passed/1。
+      {
+        experimentId: "go",
+        evalId: GO_EVAL,
+        verdict: "passed",
+        attempts: 1,
+        passed: 1,
+      },
+    ],
     () => goRun.diagnostic(),
   );
 

--- a/e2e/adapter/sdk-converters/test/claude-sdk-stream.test.ts
+++ b/e2e/adapter/sdk-converters/test/claude-sdk-stream.test.ts
@@ -23,13 +23,16 @@ test("createClaudeSdkEventStream 的锁定上游帧经 Experiment 和公开 CLI 
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
       const evalEvents = assertExpEvalOutcomes(
         run.expEvalEvents(),
-        [{
-          evalId: EVAL_ID,
-          experimentId: EXPERIMENT_ID,
-          verdict: "passed",
-          attempts: 1,
-          passed: 1,
-        }],
+        [
+          // Claude SDK stream：锁定帧须保留 assistant marker 与 Bash 工具轨；一次转换期望 passed/1。
+          {
+            evalId: EVAL_ID,
+            experimentId: EXPERIMENT_ID,
+            verdict: "passed",
+            attempts: 1,
+            passed: 1,
+          },
+        ],
         () => run.diagnostic(),
       );
       const evalEvent = evalEvents[0]!;

--- a/e2e/adapter/sdk-converters/test/claude-sdk-stream.test.ts
+++ b/e2e/adapter/sdk-converters/test/claude-sdk-stream.test.ts
@@ -1,6 +1,6 @@
 // owner: docs/engineering/testing/e2e/adapter/sdk-converters.md#claude-sdk-stream-deterministic
 
-import type { ExpEvalEvent, ExpEvent } from "@niceeval/testkit";
+import { assertExpEvalOutcomes } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 import { sdkConverterE2E, sdkConverterRecordArtifacts } from "./support.ts";
 
@@ -14,7 +14,6 @@ test("createClaudeSdkEventStream 的锁定上游帧经 Experiment 和公开 CLI 
     async ({ commands: { niceeval } }) => {
       const run = await niceeval.run(["exp", EXPERIMENT_ID, "--rerun", "all", "--json"]);
       expect(run.exitCode, run.diagnostic()).toBe(0);
-      const events = run.ndjson<ExpEvent>();
       // The terminal stream event is the Record v1 InvocationReceipt; it carries
       // no verdicts, so business results come from each eval event's identity
       // and verdict below (docs/feature/experiments/cli.md).
@@ -22,17 +21,18 @@ test("createClaudeSdkEventStream 的锁定上游帧经 Experiment 和公开 CLI 
       expect(receipt.completion).toBe("completed");
       expect(receipt.invocationId, run.diagnostic()).toBeTruthy();
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
-      const evalEvent = events.find(
-        (event): event is ExpEvalEvent =>
-          "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+      const evalEvents = assertExpEvalOutcomes(
+        run.expEvalEvents(),
+        [{
+          evalId: EVAL_ID,
+          experimentId: EXPERIMENT_ID,
+          verdict: "passed",
+          attempts: 1,
+          passed: 1,
+        }],
+        () => run.diagnostic(),
       );
-      expect(evalEvent, run.diagnostic()).toBeDefined();
-      expect(evalEvent).toMatchObject({
-        evalId: EVAL_ID,
-        experimentId: EXPERIMENT_ID,
-        verdict: "passed",
-      });
-      expect(evalEvent?.locator, run.diagnostic()).toBeTruthy();
+      const evalEvent = evalEvents[0]!;
 
       // receipt 的 runId 驱动公开读回(adapter/README.md「Live 验收说明」第 3 步)：
       // 运行已发布为完整 Run、slot included，selection 精确指向本轮 receipt。
@@ -46,11 +46,11 @@ test("createClaudeSdkEventStream 的锁定上游帧经 Experiment 和公开 CLI 
 
       // locator 驱动的公开读回：Attempt 的断言评估证据(含 Eval 内的工具/identity
       // 断言)已经随 Run 落盘，并通过 `show @<locator> --source` 可公开读回。
-      const source = await niceeval.run(["show", evalEvent!.locator!, "--source"]);
+      const source = await niceeval.run(["show", evalEvent.locator, "--source"]);
       expect(source.exitCode, source.diagnostic()).toBe(0);
       expect(source.stdout).toContain("Assertions: available");
 
-      const timing = await niceeval.run(["show", evalEvent!.locator!, "--timing"]);
+      const timing = await niceeval.run(["show", evalEvent.locator, "--timing"]);
       expect(timing.exitCode, timing.diagnostic()).toBe(0);
       expect(timing.stdout, timing.diagnostic()).toContain("eval.run");
       expect(timing.stdout, timing.diagnostic()).toMatch(/turn\s+turn1\b/);
@@ -58,7 +58,7 @@ test("createClaudeSdkEventStream 的锁定上游帧经 Experiment 和公开 CLI 
       // locator 驱动的真实执行读回(adapter/README.md「Live 验收说明」第 3 步)：
       // execution 页是「适配器收到了什么」的用户可见投影，逐项断言每个真实
       // marker 与工具身份落在公开读面上。
-      const execution = await niceeval.run(["show", evalEvent!.locator!, "--execution"]);
+      const execution = await niceeval.run(["show", evalEvent.locator, "--execution"]);
       expect(execution.exitCode, execution.diagnostic()).toBe(0);
       expect(execution.stdout).toContain("claude-sdk-assistant-marker");
       expect(execution.stdout).toMatch(/TOOL · (shell|Bash)/);

--- a/e2e/adapter/sdk-converters/test/codex-thread-stream.test.ts
+++ b/e2e/adapter/sdk-converters/test/codex-thread-stream.test.ts
@@ -23,13 +23,16 @@ test("createCodexThreadEventStream 的锁定 ThreadEvent 经 Experiment 和公�
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
       const evalEvents = assertExpEvalOutcomes(
         run.expEvalEvents(),
-        [{
-          evalId: EVAL_ID,
-          experimentId: EXPERIMENT_ID,
-          verdict: "passed",
-          attempts: 1,
-          passed: 1,
-        }],
+        [
+          // Codex Thread stream：锁定事件须保留 command marker 与 file_change；一次转换期望 passed/1。
+          {
+            evalId: EVAL_ID,
+            experimentId: EXPERIMENT_ID,
+            verdict: "passed",
+            attempts: 1,
+            passed: 1,
+          },
+        ],
         () => run.diagnostic(),
       );
       const evalEvent = evalEvents[0]!;

--- a/e2e/adapter/sdk-converters/test/codex-thread-stream.test.ts
+++ b/e2e/adapter/sdk-converters/test/codex-thread-stream.test.ts
@@ -1,6 +1,6 @@
 // owner: docs/engineering/testing/e2e/adapter/sdk-converters.md#codex-thread-stream-deterministic
 
-import type { ExpEvalEvent, ExpEvent } from "@niceeval/testkit";
+import { assertExpEvalOutcomes } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 import { sdkConverterE2E, sdkConverterRecordArtifacts } from "./support.ts";
 
@@ -14,7 +14,6 @@ test("createCodexThreadEventStream 的锁定 ThreadEvent 经 Experiment 和公�
     async ({ commands: { niceeval } }) => {
       const run = await niceeval.run(["exp", EXPERIMENT_ID, "--rerun", "all", "--json"]);
       expect(run.exitCode, run.diagnostic()).toBe(0);
-      const events = run.ndjson<ExpEvent>();
       // The terminal stream event is the Record v1 InvocationReceipt; it carries
       // no verdicts, so business results come from each eval event's identity
       // and verdict below (docs/feature/experiments/cli.md).
@@ -22,17 +21,18 @@ test("createCodexThreadEventStream 的锁定 ThreadEvent 经 Experiment 和公�
       expect(receipt.completion).toBe("completed");
       expect(receipt.invocationId, run.diagnostic()).toBeTruthy();
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
-      const evalEvent = events.find(
-        (event): event is ExpEvalEvent =>
-          "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+      const evalEvents = assertExpEvalOutcomes(
+        run.expEvalEvents(),
+        [{
+          evalId: EVAL_ID,
+          experimentId: EXPERIMENT_ID,
+          verdict: "passed",
+          attempts: 1,
+          passed: 1,
+        }],
+        () => run.diagnostic(),
       );
-      expect(evalEvent, run.diagnostic()).toBeDefined();
-      expect(evalEvent).toMatchObject({
-        evalId: EVAL_ID,
-        experimentId: EXPERIMENT_ID,
-        verdict: "passed",
-      });
-      expect(evalEvent?.locator, run.diagnostic()).toBeTruthy();
+      const evalEvent = evalEvents[0]!;
 
       // receipt 的 runId 驱动公开读回(adapter/README.md「Live 验收说明」第 3 步)：
       // 运行已发布为完整 Run、slot included，selection 精确指向本轮 receipt。
@@ -46,11 +46,11 @@ test("createCodexThreadEventStream 的锁定 ThreadEvent 经 Experiment 和公�
 
       // locator 驱动的公开读回：Attempt 的断言评估证据(含 Eval 内的工具/identity
       // 断言)已经随 Run 落盘，并通过 `show @<locator> --source` 可公开读回。
-      const source = await niceeval.run(["show", evalEvent!.locator!, "--source"]);
+      const source = await niceeval.run(["show", evalEvent.locator, "--source"]);
       expect(source.exitCode, source.diagnostic()).toBe(0);
       expect(source.stdout).toContain("Assertions: available");
 
-      const timing = await niceeval.run(["show", evalEvent!.locator!, "--timing"]);
+      const timing = await niceeval.run(["show", evalEvent.locator, "--timing"]);
       expect(timing.exitCode, timing.diagnostic()).toBe(0);
       expect(timing.stdout, timing.diagnostic()).toContain("eval.run");
       expect(timing.stdout, timing.diagnostic()).toMatch(/turn\s+turn1\b/);
@@ -58,7 +58,7 @@ test("createCodexThreadEventStream 的锁定 ThreadEvent 经 Experiment 和公�
       // locator 驱动的真实执行读回(adapter/README.md「Live 验收说明」第 3 步)：
       // execution 页是「适配器收到了什么」的用户可见投影，逐项断言每个真实
       // marker 与工具身份落在公开读面上。
-      const execution = await niceeval.run(["show", evalEvent!.locator!, "--execution"]);
+      const execution = await niceeval.run(["show", evalEvent.locator, "--execution"]);
       expect(execution.exitCode, execution.diagnostic()).toBe(0);
       expect(execution.stdout).toContain("codex-sdk-command-marker");
       expect(execution.stdout).toContain("file_change");

--- a/e2e/adapter/sdk-converters/test/support.ts
+++ b/e2e/adapter/sdk-converters/test/support.ts
@@ -54,13 +54,16 @@ export async function proveSdkConverterOwner(options: {
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
       const evalEvents = assertExpEvalOutcomes(
         run.expEvalEvents(),
-        [{
-          evalId: options.evalId,
-          experimentId: options.experimentId,
-          verdict: "passed",
-          attempts: 1,
-          passed: 1,
-        }],
+        [
+          // 通用 converter owner：锁定输入的协议断言与公开读回须一次全部成立，因此期望 passed/1。
+          {
+            evalId: options.evalId,
+            experimentId: options.experimentId,
+            verdict: "passed",
+            attempts: 1,
+            passed: 1,
+          },
+        ],
         () => run.diagnostic(),
       );
       const evalEvent = evalEvents[0]!;

--- a/e2e/adapter/sdk-converters/test/support.ts
+++ b/e2e/adapter/sdk-converters/test/support.ts
@@ -1,8 +1,7 @@
 import { join, resolve } from "node:path";
 import {
+  assertExpEvalOutcomes,
   createE2EContext,
-  type ExpEvalEvent,
-  type ExpEvent,
 } from "@niceeval/testkit";
 import { expect } from "vitest";
 
@@ -46,7 +45,6 @@ export async function proveSdkConverterOwner(options: {
     async ({ commands: { niceeval } }) => {
       const run = await niceeval.run(["exp", options.experimentId, "--rerun", "all", "--json"]);
       expect(run.exitCode, run.diagnostic()).toBe(0);
-      const events = run.ndjson<ExpEvent>();
       // The terminal stream event is the Record v1 InvocationReceipt; it carries
       // no verdicts, so business results come from each eval event's identity
       // and verdict below (docs/feature/experiments/cli.md).
@@ -54,17 +52,18 @@ export async function proveSdkConverterOwner(options: {
       expect(receipt.completion).toBe("completed");
       expect(receipt.invocationId, run.diagnostic()).toBeTruthy();
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
-      const evalEvent = events.find(
-        (event): event is ExpEvalEvent =>
-          "event" in event && event.event === "eval" && event.evalId === options.evalId,
+      const evalEvents = assertExpEvalOutcomes(
+        run.expEvalEvents(),
+        [{
+          evalId: options.evalId,
+          experimentId: options.experimentId,
+          verdict: "passed",
+          attempts: 1,
+          passed: 1,
+        }],
+        () => run.diagnostic(),
       );
-      expect(evalEvent, run.diagnostic()).toBeDefined();
-      expect(evalEvent).toMatchObject({
-        evalId: options.evalId,
-        experimentId: options.experimentId,
-        verdict: "passed",
-      });
-      expect(evalEvent?.locator, run.diagnostic()).toBeTruthy();
+      const evalEvent = evalEvents[0]!;
 
       // receipt 的 runId 驱动公开读回(adapter/README.md「Live 验收说明」第 3 步)：
       // 运行已发布为完整 Run、slot included，selection 精确指向本轮 receipt。
@@ -78,14 +77,14 @@ export async function proveSdkConverterOwner(options: {
 
       // locator 驱动的公开读回：Attempt 的断言评估证据(含 Eval 内的工具/identity
       // 断言)已经随 Run 落盘，并通过 `show @<locator> --source` 可公开读回。
-      const source = await niceeval.run(["show", evalEvent!.locator!, "--source"]);
+      const source = await niceeval.run(["show", evalEvent!.locator, "--source"]);
       expect(source.exitCode, source.diagnostic()).toBe(0);
       expect(source.stdout).toContain("Assertions: available");
 
       // 同一 Attempt 仍带 runner 自己记录的实际阶段 timing。只读公开页面，既不
       // 新跑 Experiment，也不把 timing 反过来当作协议事件的判分依据。这些 direct
       // Agent 没有声明 setup，因此不能要求虚构的 agent.setup。
-      const timing = await niceeval.run(["show", evalEvent!.locator!, "--timing"]);
+      const timing = await niceeval.run(["show", evalEvent!.locator, "--timing"]);
       expect(timing.exitCode, timing.diagnostic()).toBe(0);
       expect(timing.stdout, timing.diagnostic()).toContain("eval.run");
       expect(timing.stdout, timing.diagnostic()).toMatch(/turn\s+turn1\b/);
@@ -93,7 +92,7 @@ export async function proveSdkConverterOwner(options: {
       // locator 驱动的真实执行读回(adapter/README.md「Live 验收说明」第 3 步)：
       // execution 页是「适配器收到了什么」的用户可见投影，逐项断言该 converter
       // 的真实 marker 落在公开读面上。
-      const execution = await niceeval.run(["show", evalEvent!.locator!, "--execution"]);
+      const execution = await niceeval.run(["show", evalEvent!.locator, "--execution"]);
       expect(execution.exitCode, execution.diagnostic()).toBe(0);
       for (const marker of options.executionMarkers) {
         expect(execution.stdout, execution.diagnostic()).toContain(marker);

--- a/e2e/adapter/sdk-converters/test/turn-from-ai-sdk.test.ts
+++ b/e2e/adapter/sdk-converters/test/turn-from-ai-sdk.test.ts
@@ -23,13 +23,16 @@ test("turnFromAiSdk 的真实 AI SDK seam 经 Experiment 和公开 CLI 确定性
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
       const evalEvents = assertExpEvalOutcomes(
         run.expEvalEvents(),
-        [{
-          evalId: EVAL_ID,
-          experimentId: EXPERIMENT_ID,
-          verdict: "passed",
-          attempts: 1,
-          passed: 1,
-        }],
+        [
+          // AI SDK seam：inventory tool 与 approval 事件须按锁定输入归一；一次转换期望 passed/1。
+          {
+            evalId: EVAL_ID,
+            experimentId: EXPERIMENT_ID,
+            verdict: "passed",
+            attempts: 1,
+            passed: 1,
+          },
+        ],
         () => run.diagnostic(),
       );
       const evalEvent = evalEvents[0]!;

--- a/e2e/adapter/sdk-converters/test/turn-from-ai-sdk.test.ts
+++ b/e2e/adapter/sdk-converters/test/turn-from-ai-sdk.test.ts
@@ -1,6 +1,6 @@
 // owner: docs/engineering/testing/e2e/adapter/sdk-converters.md#turnfromaisdk-deterministic
 
-import type { ExpEvalEvent, ExpEvent } from "@niceeval/testkit";
+import { assertExpEvalOutcomes } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 import { sdkConverterE2E, sdkConverterRecordArtifacts } from "./support.ts";
 
@@ -14,7 +14,6 @@ test("turnFromAiSdk 的真实 AI SDK seam 经 Experiment 和公开 CLI 确定性
     async ({ commands: { niceeval } }) => {
       const run = await niceeval.run(["exp", EXPERIMENT_ID, "--rerun", "all", "--json"]);
       expect(run.exitCode, run.diagnostic()).toBe(0);
-      const events = run.ndjson<ExpEvent>();
       // The terminal stream event is the Record v1 InvocationReceipt; it carries
       // no verdicts, so business results come from each eval event's identity
       // and verdict below (docs/feature/experiments/cli.md).
@@ -22,17 +21,18 @@ test("turnFromAiSdk 的真实 AI SDK seam 经 Experiment 和公开 CLI 确定性
       expect(receipt.completion).toBe("completed");
       expect(receipt.invocationId, run.diagnostic()).toBeTruthy();
       expect(receipt.runIds, run.diagnostic()).not.toHaveLength(0);
-      const evalEvent = events.find(
-        (event): event is ExpEvalEvent =>
-          "event" in event && event.event === "eval" && event.evalId === EVAL_ID,
+      const evalEvents = assertExpEvalOutcomes(
+        run.expEvalEvents(),
+        [{
+          evalId: EVAL_ID,
+          experimentId: EXPERIMENT_ID,
+          verdict: "passed",
+          attempts: 1,
+          passed: 1,
+        }],
+        () => run.diagnostic(),
       );
-      expect(evalEvent, run.diagnostic()).toBeDefined();
-      expect(evalEvent).toMatchObject({
-        evalId: EVAL_ID,
-        experimentId: EXPERIMENT_ID,
-        verdict: "passed",
-      });
-      expect(evalEvent?.locator, run.diagnostic()).toBeTruthy();
+      const evalEvent = evalEvents[0]!;
 
       // receipt 的 runId 驱动公开读回(adapter/README.md「Live 验收说明」第 3 步)：
       // 运行已发布为完整 Run、slot included，selection 精确指向本轮 receipt。
@@ -46,11 +46,11 @@ test("turnFromAiSdk 的真实 AI SDK seam 经 Experiment 和公开 CLI 确定性
 
       // locator 驱动的公开读回：Attempt 的断言评估证据(含 Eval 内的工具/identity
       // 断言)已经随 Run 落盘，并通过 `show @<locator> --source` 可公开读回。
-      const source = await niceeval.run(["show", evalEvent!.locator!, "--source"]);
+      const source = await niceeval.run(["show", evalEvent.locator, "--source"]);
       expect(source.exitCode, source.diagnostic()).toBe(0);
       expect(source.stdout).toContain("Assertions: available");
 
-      const timing = await niceeval.run(["show", evalEvent!.locator!, "--timing"]);
+      const timing = await niceeval.run(["show", evalEvent.locator, "--timing"]);
       expect(timing.exitCode, timing.diagnostic()).toBe(0);
       expect(timing.stdout, timing.diagnostic()).toContain("eval.run");
       expect(timing.stdout, timing.diagnostic()).toMatch(/turn\s+turn1\b/);
@@ -58,7 +58,7 @@ test("turnFromAiSdk 的真实 AI SDK seam 经 Experiment 和公开 CLI 确定性
       // locator 驱动的真实执行读回(adapter/README.md「Live 验收说明」第 3 步)：
       // execution 页是「适配器收到了什么」的用户可见投影，逐项断言每个真实
       // marker 与工具身份落在公开读面上。
-      const execution = await niceeval.run(["show", evalEvent!.locator!, "--execution"]);
+      const execution = await niceeval.run(["show", evalEvent.locator, "--execution"]);
       expect(execution.exitCode, execution.diagnostic()).toBe(0);
       expect(execution.stdout).toContain("inventory_lookup");
       expect(execution.stdout).toContain("approval_tool");

--- a/e2e/runner/test/accept-reanchor.test.ts
+++ b/e2e/runner/test/accept-reanchor.test.ts
@@ -35,6 +35,74 @@ interface DryPlan {
   matrix: DryTarget[];
 }
 
+type ReportScalar = null | boolean | number | string;
+
+interface ReportTableBlock {
+  type: "table";
+  caption: string;
+  columns: Array<{ key: string; label: string }>;
+  rows: Array<Record<string, ReportScalar>>;
+}
+
+interface ReportBlock {
+  type: string;
+  children?: ReportBlock[];
+  caption?: string;
+  columns?: Array<{ key: string; label: string }>;
+  rows?: Array<Record<string, ReportScalar>>;
+}
+
+interface RunMembershipShow {
+  format: "niceeval.report-show/v1";
+  reportId: string;
+  sample: {
+    selection: { policy: string; runIds?: string[] };
+    runCount: number;
+    slotCount: number;
+    denominator: number;
+  };
+  pages: Array<{
+    state: string;
+    pageId: string;
+    route?: string;
+    document?: { title: string; children: ReportBlock[] };
+  }>;
+}
+
+const RUN_MEMBERSHIP_COLUMN_KEYS = [
+  "runId",
+  "slotId",
+  "slotState",
+  "memberRelation",
+  "sourceAttemptLocator",
+  "membershipState",
+  "membershipOutcome",
+  "verdictState",
+  "verdict",
+] as const;
+
+function reportTables(blocks: ReportBlock[]): ReportTableBlock[] {
+  const tables: ReportTableBlock[] = [];
+  const visit = (block: ReportBlock): void => {
+    if (
+      block.type === "table" &&
+      block.caption !== undefined &&
+      block.columns !== undefined &&
+      block.rows !== undefined
+    ) {
+      tables.push({
+        type: "table",
+        caption: block.caption,
+        columns: block.columns,
+        rows: block.rows,
+      });
+    }
+    for (const child of block.children ?? []) visit(child);
+  };
+  for (const block of blocks) visit(block);
+  return tables;
+}
+
 test("审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 verdict/evidence 与审计 provenance", async () => {
   await runnerE2E.case(
     "accept-reanchor",
@@ -96,9 +164,42 @@ test("审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 ver
 
     const acceptedCurrent = await niceeval.run(["show", "--run", acceptedRunId, "--json"]);
     expect(acceptedCurrent.exitCode, acceptedCurrent.diagnostic()).toBe(0);
-    expect(acceptedCurrent.stdout).toContain(acceptedRunId);
-    expect(acceptedCurrent.stdout).toContain(oldLocator);
-    expect(acceptedCurrent.stdout).toContain('"action":"accepted"');
+    const acceptedShow = acceptedCurrent.json<RunMembershipShow>();
+    expect(acceptedShow).toMatchObject({
+      format: "niceeval.report-show/v1",
+      reportId: "run-membership-overview",
+      sample: {
+        selection: { policy: "explicit-runs", runIds: [acceptedRunId] },
+        runCount: 1,
+        slotCount: 1,
+        denominator: 1,
+      },
+      pages: [{ state: "rendered", pageId: "run-membership", route: "/" }],
+    });
+    const runMembershipPage = acceptedShow.pages.find((page) => page.pageId === "run-membership");
+    expect(runMembershipPage?.document).toBeDefined();
+    const matchingTables = reportTables(runMembershipPage!.document!.children).filter((table) =>
+      table.columns.map((column) => column.key).join("\u0000") === RUN_MEMBERSHIP_COLUMN_KEYS.join("\u0000")
+    );
+    expect(matchingTables).toHaveLength(1);
+    const acceptedRunRows = matchingTables[0]!.rows.filter((row) => row.runId === acceptedRunId);
+    expect(acceptedRunRows).toHaveLength(1);
+    const acceptedSlotId = acceptedRunRows[0]!.slotId;
+    expect(typeof acceptedSlotId).toBe("string");
+    const acceptedRow = matchingTables[0]!.rows.find((row) =>
+      row.runId === acceptedRunId && row.slotId === acceptedSlotId
+    );
+    expect(acceptedRow).toEqual({
+      runId: acceptedRunId,
+      slotId: acceptedSlotId,
+      slotState: "included",
+      memberRelation: "reference",
+      sourceAttemptLocator: oldLocator,
+      membershipState: "available",
+      membershipOutcome: "accepted",
+      verdictState: "available",
+      verdict: "passed",
+    });
 
     const currentEvidence = await niceeval.run(["show", newLocator, "--execution"]);
     expect(currentEvidence.exitCode, currentEvidence.diagnostic()).toBe(0);

--- a/packages/testkit/README.md
+++ b/packages/testkit/README.md
@@ -10,6 +10,10 @@ NiceEval 场景 Repo 共用的机械测试设施。它只负责进程收据、�
 边界，并返回最后唯一一条 `InvocationReceipt`。它不折叠 Verdict 或 Attempt，也不替测试决定 expected；
 这些业务事实必须从中间 `eval` 事件或 receipt 的 Record Runs 读取。
 
+`ProcessReceipt.expEvalEvents()` 严格解码公开的 Eval 结论事件。
+`assertExpEvalOutcomes(actual, expected)` 把这些事件与测试文件显式提供的身份、Verdict 和 Attempt 字面量作精确比较。
+Testkit 不生成 expected，也不把 `failed`、`errored`、`skipped` 互相折叠。
+
 根 E2E runner 会对当前 checkout clean-build 此 private package，并仅在隔离的场景副本中以本地
 directory dependency 安装它。Testkit 不会被打包、上传或作为发布产物消费。
 

--- a/packages/testkit/src/exp-eval-outcomes.ts
+++ b/packages/testkit/src/exp-eval-outcomes.ts
@@ -1,0 +1,138 @@
+import type { ExpEvalEvent } from "./process.js";
+
+export interface ExpEvalOutcomeExpectation {
+  readonly experimentId: string;
+  readonly evalId: string;
+  readonly verdict: ExpEvalEvent["verdict"];
+  readonly attempts: number;
+  readonly passed?: number;
+  readonly reason?: "early_exit";
+  readonly planned?: number;
+  readonly unstarted?: number;
+}
+
+type ComparableField =
+  | "verdict"
+  | "attempts"
+  | "passed"
+  | "reason"
+  | "planned"
+  | "unstarted";
+
+const COMPARABLE_FIELDS = [
+  "verdict",
+  "attempts",
+  "passed",
+  "reason",
+  "planned",
+  "unstarted",
+] as const satisfies readonly ComparableField[];
+
+function identityOf(value: Pick<ExpEvalEvent, "experimentId" | "evalId">): string {
+  return JSON.stringify([value.experimentId, value.evalId]);
+}
+
+function labelOf(value: Pick<ExpEvalEvent, "experimentId" | "evalId">): string {
+  return `${value.experimentId}/${value.evalId}`;
+}
+
+function indexUnique<T extends Pick<ExpEvalEvent, "experimentId" | "evalId">>(
+  values: readonly T[],
+  source: "actual" | "expected",
+): Map<string, T> {
+  const indexed = new Map<string, T>();
+  for (const value of values) {
+    const identity = identityOf(value);
+    if (indexed.has(identity)) {
+      throw new Error(
+        `assertExpEvalOutcomes(): duplicate ${source} Eval identity ${labelOf(value)}`,
+      );
+    }
+    indexed.set(identity, value);
+  }
+  return indexed;
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function actualField(event: ExpEvalEvent, field: ComparableField): unknown {
+  switch (field) {
+    case "verdict":
+      return event.verdict;
+    case "attempts":
+      return event.attempts;
+    case "passed":
+      return event.passed;
+    case "reason":
+      return event.reason;
+    case "planned":
+      return event.planned;
+    case "unstarted":
+      return event.unstarted;
+  }
+}
+
+function expectedField(
+  expectation: ExpEvalOutcomeExpectation,
+  field: ComparableField,
+): unknown {
+  return expectation[field];
+}
+
+function renderDiagnostic(
+  diagnostic: string | (() => string) | undefined,
+): string {
+  if (diagnostic === undefined) return "";
+  const rendered = typeof diagnostic === "function" ? diagnostic() : diagnostic;
+  return `\n\n${rendered}`;
+}
+
+/**
+ * Strictly compare public Eval conclusion events with caller-owned literals.
+ * The helper never derives expectations or interprets one Verdict as another.
+ */
+export function assertExpEvalOutcomes(
+  actual: readonly ExpEvalEvent[],
+  expected: readonly ExpEvalOutcomeExpectation[],
+  diagnostic?: string | (() => string),
+): ExpEvalEvent[] {
+  const actualByIdentity = indexUnique(actual, "actual");
+  const expectedByIdentity = indexUnique(expected, "expected");
+  const problems: string[] = [];
+
+  for (const expectation of expected) {
+    const identity = identityOf(expectation);
+    const event = actualByIdentity.get(identity);
+    if (event === undefined) {
+      problems.push(`missing ${labelOf(expectation)}`);
+      continue;
+    }
+
+    for (const field of COMPARABLE_FIELDS) {
+      if (!hasOwn(expectation, field)) continue;
+      const expectedValue = expectedField(expectation, field);
+      const actualValue = actualField(event, field);
+      if (!Object.is(actualValue, expectedValue)) {
+        problems.push(
+          `${labelOf(expectation)} ${field}: expected ${JSON.stringify(expectedValue)}, got ${JSON.stringify(actualValue)}`,
+        );
+      }
+    }
+  }
+
+  for (const event of actual) {
+    if (!expectedByIdentity.has(identityOf(event))) {
+      problems.push(`unexpected ${labelOf(event)}`);
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `assertExpEvalOutcomes(): Eval conclusions do not match\n${problems.map((problem) => `- ${problem}`).join("\n")}${renderDiagnostic(diagnostic)}`,
+    );
+  }
+
+  return [...actual];
+}

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./process.js";
+export * from "./exp-eval-outcomes.js";
 export * from "./process-lifecycle.js";
 export * from "./primitives.js";
 export * from "./temp.js";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import {
 } from "./analysis/index.ts";
 import { defaultAttemptOverviewReport } from "./report/built-in/attempt-overview.ts";
 import { defaultOverviewReport } from "./report/built-in/overview.ts";
+import { defaultRunMembershipOverviewReport } from "./report/built-in/run-membership-overview.ts";
 import {
   executionEvidenceReport,
   timingEvidenceReport,
@@ -2236,7 +2237,9 @@ function parseReportCliRequest(input: {
     throw usageError("--experiment narrows the default current-project selection; it cannot combine with explicit --run.\n");
   }
 
-  const report = reportSelection(input.cwd, input.flags.report);
+  const report = runs.length > 0 && input.flags.report === undefined
+    ? Object.freeze({ kind: "fixed" as const, report: defaultRunMembershipOverviewReport })
+    : reportSelection(input.cwd, input.flags.report);
   const theme = themeSelection(input.cwd, input.flags.theme);
   const target = runs.length > 0
     ? Object.freeze({ kind: "selection" as const, selection: explicitSelection(runs) })

--- a/src/report/built-in/index.tsx
+++ b/src/report/built-in/index.tsx
@@ -11,6 +11,10 @@ export {
   attemptOverviewReport,
 } from "./attempt-overview.ts";
 export {
+  defaultRunMembershipOverviewReport,
+  runMembershipOverviewReport,
+} from "./run-membership-overview.ts";
+export {
   defaultSourceEvidenceReport,
   sourceEvidenceReport,
 } from "./source.ts";

--- a/src/report/built-in/run-membership-overview.ts
+++ b/src/report/built-in/run-membership-overview.ts
@@ -1,0 +1,299 @@
+import { Either } from "effect";
+import type { AnalysisSlot } from "../../analysis/index.ts";
+import {
+  attemptSlotProjection,
+  membershipProvenanceProjector,
+  selectedRunProjection,
+  verdictProjector,
+  type MembershipAction,
+  type MembershipProvenance,
+  type ProjectedRecordAttachmentResult,
+  type ProjectedSample,
+  type Verdict,
+} from "../../projection/index.ts";
+import { compareCanonicalIdentity } from "../../record/model/identifiers.ts";
+import {
+  definePage,
+  defineReport,
+  reportComponentId,
+  reportId,
+  reportInputs,
+  reportRoute,
+  type Report,
+} from "../author/index.ts";
+import {
+  reportDocument,
+  reportSection,
+  reportStatus,
+  reportTable,
+  reportText,
+  type ReportBlock,
+  type ReportScalar,
+} from "../semantic/index.ts";
+
+const MEMBERSHIP_ROWS_MAX = 200;
+const PROBLEM_DETAILS_MAX = 200;
+
+const runMembershipInputs = reportInputs({
+  membership: selectedRunProjection(membershipProvenanceProjector),
+  verdict: attemptSlotProjection(verdictProjector),
+});
+
+type MembershipEntry = ProjectedSample<
+  "selected-run",
+  MembershipProvenance
+>["entries"][number];
+type VerdictEntry = ProjectedSample<
+  "attempt-slot",
+  Verdict
+>["entries"][number];
+
+interface RunMembershipInputs {
+  readonly membership: ProjectedSample<"selected-run", MembershipProvenance>;
+  readonly verdict: ProjectedSample<"attempt-slot", Verdict>;
+}
+
+interface RunMembershipRow extends Readonly<Record<string, ReportScalar>> {
+  readonly runId: string;
+  readonly slotId: string;
+  readonly slotState: AnalysisSlot["state"];
+  readonly memberRelation: "origin" | "reference" | null;
+  readonly sourceAttemptLocator: string | null;
+  readonly membershipState:
+    | ProjectedRecordAttachmentResult<MembershipProvenance>["state"]
+    | "action-missing";
+  readonly membershipOutcome: MembershipAction["outcome"] | null;
+  readonly verdictState:
+    | ProjectedRecordAttachmentResult<Verdict>["state"]
+    | "not-read";
+  readonly verdict: Verdict | null;
+}
+
+/** The bounded built-in summary for one or more explicit historical Runs. */
+export function runMembershipOverviewReport(): Report {
+  const page = definePage({
+    id: Either.getOrThrow(reportComponentId("run-membership")),
+    route: Either.getOrThrow(reportRoute("/")),
+    inputs: runMembershipInputs,
+    completeness: "allow-partial",
+    render: ({ sample, inputs }) => runMembershipOverviewDocument(sample.slots, inputs),
+  });
+  return defineReport({
+    id: Either.getOrThrow(reportId("run-membership-overview")),
+    pages: [page],
+  });
+}
+
+/** The CLI default Report for an explicit `--run` selection. */
+export const defaultRunMembershipOverviewReport = runMembershipOverviewReport();
+
+export default defaultRunMembershipOverviewReport;
+
+function runMembershipOverviewDocument(
+  slots: readonly AnalysisSlot[],
+  inputs: RunMembershipInputs,
+) {
+  const rows = assembleRows(slots, inputs);
+  const visibleRows = rows.slice(0, MEMBERSHIP_ROWS_MAX);
+  const omittedRows = rows.length - visibleRows.length;
+  const problemBlocks = attachmentProblemBlocks(inputs);
+
+  return reportDocument({
+    title: "Run membership overview",
+    children: [
+      reportTable({
+        caption: "Run membership",
+        columns: [
+          { key: "runId", label: "Run" },
+          { key: "slotId", label: "Slot" },
+          { key: "slotState", label: "Slot state" },
+          { key: "memberRelation", label: "Member relation" },
+          { key: "sourceAttemptLocator", label: "Source Attempt" },
+          { key: "membershipState", label: "Membership state" },
+          { key: "membershipOutcome", label: "Membership outcome" },
+          { key: "verdictState", label: "Verdict state" },
+          { key: "verdict", label: "Verdict" },
+        ],
+        rows: visibleRows,
+      }),
+      reportStatus({
+        tone: omittedRows === 0 ? "neutral" : "warning",
+        label: `Omitted rows: ${omittedRows}`,
+      }),
+      reportStatus({
+        tone: "neutral",
+        label: `Unmatched membership actions: ${countUnmatchedMembershipActions(slots, inputs.membership)}`,
+      }),
+      ...(problemBlocks.length === 0
+        ? []
+        : [reportSection({ heading: "Attachment details", children: problemBlocks })]),
+    ],
+  });
+}
+
+function assembleRows(
+  slots: readonly AnalysisSlot[],
+  inputs: RunMembershipInputs,
+): readonly RunMembershipRow[] {
+  const membershipByRun = new Map<string, MembershipEntry>();
+  for (const entry of inputs.membership.entries) {
+    membershipByRun.set(entry.run.runId, entry);
+  }
+  const verdictBySlot = new Map<string, VerdictEntry>();
+  for (const entry of inputs.verdict.entries) {
+    verdictBySlot.set(slotKey(entry.slot), entry);
+  }
+
+  return Object.freeze(
+    [...slots]
+      .sort(compareSlots)
+      .map((slot) => rowForSlot(
+        slot,
+        membershipByRun.get(slot.runId),
+        verdictBySlot.get(slotKey(slot)),
+      )),
+  );
+}
+
+function rowForSlot(
+  slot: AnalysisSlot,
+  membership: MembershipEntry | undefined,
+  verdict: VerdictEntry | undefined,
+): RunMembershipRow {
+  const action = membershipAction(membership, slot.slotId);
+  const membershipState = membership === undefined
+    ? "unavailable"
+    : membership.attachment.state === "available"
+      ? action === undefined ? "action-missing" : "available"
+      : membership.attachment.state;
+  const verdictValue = verdictForSlot(slot, verdict);
+
+  return Object.freeze({
+    runId: slot.runId,
+    slotId: slot.slotId,
+    slotState: slot.state,
+    memberRelation: slot.state === "included" ? slot.relation : null,
+    sourceAttemptLocator: slot.state === "included" ? `@${slot.attempt.attemptId}` : null,
+    membershipState,
+    membershipOutcome: action?.outcome ?? null,
+    verdictState: verdictValue.state,
+    verdict: verdictValue.value,
+  });
+}
+
+function membershipAction(
+  membership: MembershipEntry | undefined,
+  slotId: string,
+): MembershipAction | undefined {
+  if (membership?.attachment.state !== "available") return undefined;
+  return membership.attachment.value.actions.find((action) => action.slotId === slotId);
+}
+
+function verdictForSlot(
+  slot: AnalysisSlot,
+  entry: VerdictEntry | undefined,
+): {
+  readonly state: RunMembershipRow["verdictState"];
+  readonly value: Verdict | null;
+} {
+  if (slot.state !== "included" || entry?.state !== "attachment-result") {
+    return Object.freeze({ state: "not-read", value: null });
+  }
+  return entry.attachment.state === "available"
+    ? Object.freeze({ state: "available", value: entry.attachment.value })
+    : Object.freeze({ state: entry.attachment.state, value: null });
+}
+
+function countUnmatchedMembershipActions(
+  slots: readonly AnalysisSlot[],
+  membership: ProjectedSample<"selected-run", MembershipProvenance>,
+): number {
+  const selectedSlotsByRun = new Map<string, Set<string>>();
+  for (const slot of slots) {
+    const selected = selectedSlotsByRun.get(slot.runId) ?? new Set<string>();
+    selected.add(slot.slotId);
+    selectedSlotsByRun.set(slot.runId, selected);
+  }
+
+  let unmatched = 0;
+  for (const entry of membership.entries) {
+    if (entry.attachment.state !== "available") continue;
+    const selected = selectedSlotsByRun.get(entry.run.runId) ?? new Set<string>();
+    unmatched += entry.attachment.value.actions.filter((action) => !selected.has(action.slotId)).length;
+  }
+  return unmatched;
+}
+
+function attachmentProblemBlocks(inputs: RunMembershipInputs): readonly ReportBlock[] {
+  const blocks: ReportBlock[] = [];
+  for (const entry of inputs.membership.entries) {
+    if (entry.attachment.state !== "available") {
+      blocks.push(attachmentProblemBlock(`Membership for Run ${entry.run.runId}`, entry.attachment));
+    }
+  }
+  for (const entry of inputs.verdict.entries) {
+    if (entry.state === "attachment-result" && entry.attachment.state !== "available") {
+      blocks.push(attachmentProblemBlock(
+        `Verdict for ${entry.slot.runId}/${entry.slot.slotId}`,
+        entry.attachment,
+      ));
+    }
+  }
+
+  const visible = blocks.slice(0, PROBLEM_DETAILS_MAX);
+  const omitted = blocks.length - visible.length;
+  return Object.freeze([
+    ...visible,
+    ...(omitted === 0
+      ? []
+      : [reportStatus({
+        tone: "warning",
+        label: `${omitted} additional Attachment detail(s) omitted`,
+      })]),
+  ]);
+}
+
+function attachmentProblemBlock<Value>(
+  name: string,
+  attachment: Exclude<ProjectedRecordAttachmentResult<Value>, { readonly state: "available" }>,
+): ReportBlock {
+  switch (attachment.state) {
+    case "unavailable":
+      return reportStatus({ tone: "warning", label: `${name}: unavailable` });
+    case "migration-required":
+      return reportStatus({
+        tone: "warning",
+        label: `${name}: migration-required`,
+        detail: [reportText(`${attachment.from} → ${attachment.to}; ${attachment.command}`)],
+      });
+    case "migration-unavailable":
+      return reportStatus({
+        tone: "warning",
+        label: `${name}: migration-unavailable`,
+        detail: [reportText(`${attachment.from} → ${attachment.to}; ${attachment.reason}`)],
+      });
+    case "unsupported":
+      return reportStatus({
+        tone: "warning",
+        label: `${name}: unsupported`,
+        detail: [reportText(attachment.schemaId)],
+      });
+    case "invalid":
+      return reportStatus({
+        tone: "negative",
+        label: `${name}: invalid`,
+        detail: [reportText(attachment.issues.map((issue) =>
+          `${issue.code} at ${issue.path.length === 0 ? "Attachment" : issue.path.join("/")}`
+        ).join("; "))],
+      });
+  }
+}
+
+function compareSlots(left: AnalysisSlot, right: AnalysisSlot): number {
+  const run = compareCanonicalIdentity(left.runId, right.runId);
+  return run === 0 ? compareCanonicalIdentity(left.slotId, right.slotId) : run;
+}
+
+function slotKey(slot: Pick<AnalysisSlot, "runId" | "slotId">): string {
+  return `${slot.runId}\u0000${slot.slotId}`;
+}


### PR DESCRIPTION
## Problem

- User goal: 既要让 Adapter owner 共享严格的 Eval 终局验收，也要能从公开 CLI 看清一个历史 Run 纳入了哪些 Attempt、为什么纳入，以及这些 Attempt 的 Verdict。
- Current limitation: Adapter 测试各自过滤终局 event；同时 `show --run <RunId>` 默认落到通用 overview，没有 Run membership projection，导致 `accept` 后只能看见 Run ID，看不见 `reference`、`accepted`、源 Attempt locator 与 Verdict 的对应关系。
- Required capability: private Testkit 提供只比较 owner 字面 expected matrix 的机械断言；Report 层提供一个只读取公开 membership 与 Verdict projector 的 bounded 内建 Report，并把显式 Run 的默认选择接到它。
- User outcome: Adapter owner 对缺失、额外、重复或错误终局统一失败；操作者可用 `show --run` 审计一次执行或采用边界，再沿 `show @<AttemptId>` 下钻 immutable Attempt。

## Use cases

### `审阅一次 Run 怎样采用结果`

- Coverage: `happy path | composition | lifecycle`
- Starting point: 用户有 `exp --json` receipt 中的 Run ID，或 `accept` 成功反馈中的新 Run ID。
- Copyable usage or trigger: `niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527 --json`
- Observable result or diagnostic: 默认得到 `run-membership-overview`；稳定 row 同时显示 `slotState`、`memberRelation`、`sourceAttemptLocator`、`membershipOutcome`、`verdictState` 与 `verdict`。多个 `--run` 以同一表形状比较固定历史边界，已知 locator 再用 `niceeval show @<AttemptId> --execution` 下钻。
- Contract: `docs/feature/reports/use-case/审阅一次Run怎样采用结果.md`

### `审阅不完整或超出内建边界的 Run`

- Coverage: `failure | unsupported`
- Starting point: 显式 Run 的 membership 或 Verdict Attachment 不可读，或用户需要超过 200 rows/不同字段。
- Copyable usage or trigger: `niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527 --report ./reports/full.ts`
- Observable result or diagnostic: 内建表保留 `unavailable`、`migration-required`、`unsupported`、`invalid` 等状态并显示 omitted/unmatched count，不从其它事实猜值；任意规模或其它字段不属于内建 summary，显式自定义 Report 仍优先。
- Contract: `docs/feature/reports/cli.md#内建-run-membership-概览`

### `Adapter owner 验收 Eval 终局矩阵`

- Coverage: `happy path | composition | failure | unsupported`
- Starting point: owner 已通过 Testkit 运行 `niceeval exp --json` 并取得 `ProcessReceipt`。
- Copyable usage or trigger: `assertExpEvalOutcomes(run.expEvalEvents(), [{ experimentId: "ci", evalId: "tool-call", verdict: "passed", attempts: 1 }], () => run.diagnostic())`
- Observable result or diagnostic: 完全匹配时返回实际 Eval events；身份缺失、额外、重复或字段不符时抛出逐项诊断。Testkit 不从退出码、receipt 或候选输出推导 expected。
- Contract: `docs/engineering/testing/testkit.md`

## Public API

### Removed

None

### Added

#### `niceeval/report/built-in.runMembershipOverviewReport()` 与 `defaultRunMembershipOverviewReport`

- Before usage or result: `import { defaultRunMembershipOverviewReport } from "niceeval/report/built-in"` 不存在，Report author 需要自行组合 membership 与 Verdict projections。
- After usage or result: `defineEval({ report: defaultRunMembershipOverviewReport, ... })` 或显式 CLI Run selection 可复用同一份 bounded Report，得到固定 `run-membership` 页面。
- User impact: Report author 可显式复用内建 Run audit；新增导出，不移除现有 symbol。

#### `@niceeval/testkit.assertExpEvalOutcomes()` 与 `ExpEvalOutcomeExpectation`

- Before usage or result: owner 需要自行过滤 `ExpEvent`，再用 `find`、计数和零散 matcher 检查终局。
- After usage or result: `assertExpEvalOutcomes(run.expEvalEvents(), [{ experimentId: "ci", evalId: "tool-call", verdict: "passed", attempts: 1 }], () => run.diagnostic())` 对完整身份集合与字段做一一匹配。
- User impact: 场景 Repo 可复用严格机械断言；package 仍是 private workspace harness，不发布 npm，expected 仍由 owner 明确提供。

### Changed

None

## CLI commands

### Removed

None

### Added

None

### Changed

#### `niceeval show/view --run <RunId>` 的默认 Report

- Before usage or result: `niceeval show --run <RunId> --json` 默认返回 `reportId: "default-overview"`，页面可能没有 projection，不能稳定看到源 locator 或 `accepted` provenance。
- After usage or result: 同一命令在没有显式 `--report` 时返回 `reportId: "run-membership-overview"`、page `run-membership` 与稳定审计 row；`--report overview` 或其它显式 Report 始终优先。
- User impact: 显式 Run 默认回答“这一轮怎样纳入结果”；当前项目、精确 Attempt 与显式 Report 的默认行为保持各自边界。JSON automation 应读取新表契约，不再搜索 persisted raw `action`。

## Report components

### Removed

None

### Added

#### `run-membership-overview`

- Before usage or result: 没有一份内建 Report 同时声明 `selectedRunProjection(membershipProvenanceProjector)` 和 `attemptSlotProjection(verdictProjector)`。
- After usage or result: `<Report>` 的固定 `/` 页面渲染最多 200 个 canonical rows，并显示 omitted rows、unmatched membership actions 及非 available Attachment 详情。
- User impact: 人读、JSON、静态导出和 View 共享同一次 Report execution 与同一事实边界；自定义 Report 不继承这张表的字段限制。

### Changed

None

## Observable behavior and data contracts

### Removed

None

### Added

#### `Run membership 审计 row`

- Before usage or result: `show --run` 的通用 overview 只保证包含 selection 概览，不能作为 adoption/membership 审计输入。
- After usage or result: `niceeval.report-show/v1` 中稳定语义子树使用 `reportId: "run-membership-overview"`、`pageId: "run-membership"`、route `/` 及九个 column keys；`membershipOutcome` 来自公开 projector，不读取 persisted raw action。
- User impact: 自动化可区分 `executed`、`carried`、`accepted` 等 Run provenance，同时把 Core Member、provenance 与 Attempt Verdict 当作独立事实。

#### `Adapter verdict owner 的严格身份集合验收`

- Before usage or result: 只查一个 `evalId` 或只比较 passed 数量时，错误 experiment 身份、重复 event 或额外 event 可能逃逸。
- After usage or result: 同一公开事件流必须与 owner 的完整 `(experimentId, evalId)` 集合一一对应，并逐字段匹配 Verdict 与 Attempt。
- User impact: 这是 private test harness 的可观察行为；NiceEval Record、CLI event schema 和 runtime 结果不变。

### Changed

None

## Record schema and stored-data upgrade

- Affected public Record Format surfaces: None
- Private persisted implementation impact: None
- Version decision: not affected
- Version reason: 新 Report 只通过已有公开 projectors 读取既有 Core、membership 与 Verdict Attachments；writer、Attachment schema、文件名、recognition header 和字段语义均不变。
- Existing Record behavior: 新 reader 直接读取旧 Record，旧 reader 也能读取新 writer 产生的 Record；旧 reader 只不会拥有新的内建 Report 默认选择。
- Migration or recovery path: not applicable — 没有格式或 schema 变化；历史数据继续用 `niceeval show --run <RunId>` 或 `niceeval show @<AttemptId>` 直接读取。
- Migration safety: 不运行迁移，不重写、删除或复制已有 Record。
- Contract: not applicable
- Version history: not applicable
- Verification: Runner 既有 owner 先生成 origin Run，再以公开 `accept` 建立 reference Run，最后仅经 `show --run --json` 与 `show @locator --execution` 读取；全部通过。

## Environment variables

### Removed

None

### Added

None

### Changed

None

## Package scripts

### Removed

None

### Added

None

### Changed

None

## Tests

### `e2e/runner/test/accept-reanchor.test.ts`

- Change: `substantially rewritten`
- Change class: `bug-regression`
- Disposition: `retain`
- Candidate identity: Git `088a2e72b703f8e26d7688c495b389c0e6e3eb92`; NiceEval tarball SHA-256 `aab1165360cbb8eb78110c8f9c2432bd06caea3040a342f8c1b97373e818de28`
- Contract and owner: `docs/feature/reports/use-case/审阅一次Run怎样采用结果.md`
- Stability budget: 修复既有 Runner owner，不新增 owner；只把脆弱的 stdout substring/raw action 检查替换为公开 Report envelope、固定页面、column keys 与语义 row，并保留 locator evidence 下钻。
- Example scenario: 旧 Attempt 在源码 digest 改变后被 `accept` 到新 Run；`show --run --json` 必须显示 `reference`、旧 locator、`accepted` 与 `passed`，随后 `show @locator --execution` 仍显示旧 evidence。
- Before: owner 只搜索 Run ID、locator 和 `"action":"accepted"`；实际默认 `default-overview` 没有 projection，线上在 observe/outcome 阶段失败，也无法稳定证明三组事实的对应关系。
- After: owner 精确证明显式 Run 默认 Report、selection、页面、column keys 和 adoption row，并拒绝缺列、错状态、错 locator 或错 Verdict。
- Distinguishing evidence: 在 `dccae9719ed5773c455b5e9a3de7420a0b459ec2` 上先改 owner 后运行同一命令，红灯为 actual `default-overview`/`overview` 对 expected `run-membership-overview`/`run-membership`；实现接线后同一 owner 转绿。
- Verification: `pnpm e2e --repo runner -- --run test/accept-reanchor.test.ts` 通过；`pnpm e2e takeover --candidate /tmp/niceeval-show-run-acceptance.ddvJLZ/candidate.tgz --repo runner --artifact-root /tmp/niceeval-show-run-acceptance.ddvJLZ/takeover-runner -- --run test/accept-reanchor.test.ts -t "审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 verdict/evidence 与审计 provenance"` 全部阶段通过。
- Fixed conditions: checkout `088a2e72b703f8e26d7688c495b389c0e6e3eb92`、固定候选 digest、Runner lockfile/fixture；无随机 seed、fake clock 或容器镜像，host executor。
- Repeatability: isolated-copy-1/2/3、same-copy attempt 1/2、repo-default-parallel、target-single 全部通过，cleanup 全部通过；summary 位于 `/tmp/niceeval-show-run-acceptance.ddvJLZ/takeover-runner/takeover-summary.json`。
- Unit exception or no automation: 没有新增 Unit；公开 CLI/Record 边界已由现有 Runner E2E owner 区分该回归。
- Unit count: not applicable — 未新增或修改 Unit。
- Manual observation: not applicable for automation。
- User impact: `show --run` 不再隐藏人工采用 provenance，且可继续沿源 locator 审阅 immutable Attempt。

### `Report 场景 Repo 全量`

- Change: `not automated`
- Change class: `not-automated`
- Disposition: `not automated`
- Candidate identity: Git `088a2e72b703f8e26d7688c495b389c0e6e3eb92`; NiceEval tarball SHA-256 `aab1165360cbb8eb78110c8f9c2432bd06caea3040a342f8c1b97373e818de28`
- Contract and owner: `docs/feature/reports/README.md`
- Stability budget: 没有新增 Report owner；使用既有 6 个 Vitest files、7 tests 与 1 个浏览器 Journey 做相邻面回归。
- Example scenario: 相同候选通过 Report authoring/host/static output 及浏览器 View Journey。
- Before: Run 默认切换可能破坏 Report 装载、host 或 View build，而单一 Runner owner 不覆盖全部相邻面。
- After: 既有 Report suite 全量通过。
- Distinguishing evidence: 首次浏览器 preflight 因下载 Chromium 缺少 host `libglib-2.0.so.0` 停止；指定真实系统 Chromium 后，同一候选从公开入口全绿，证明是环境配置而非产品失败。
- Verification: `CHROMIUM_EXECUTABLE_PATH=/run/current-system/sw/bin/chromium pnpm e2e run --candidate /tmp/niceeval-show-run-acceptance.ddvJLZ/candidate.tgz --repo report --artifact-root /tmp/niceeval-show-run-acceptance.ddvJLZ/report-with-system-chromium`；6 files/7 tests 与浏览器 Journey 1/1 通过，cleanup 通过。
- Fixed conditions: 同一候选 digest、Report lockfile/fixtures、系统 Chromium `/run/current-system/sw/bin/chromium`；无随机 seed 或 fake clock。
- Repeatability: 本项是相邻面全量回归，不是确定性 owner takeover；单次公开 suite clean pass。
- Unit exception or no automation: 没有新增自动化命题，只运行既有 owner；未守护风险是 200-row 截断与每一种 Attachment 非 available 状态没有独立长期 owner。
- Unit count: not applicable — 未新增或修改 Unit。
- Manual observation: Node.js 与系统 Chromium 经 E2E runner 公开入口执行；结果为 Vitest 与 Playwright 全绿。
- User impact: Run Report 接线未破坏现有 Report host、静态输出或浏览器查看路径。

### `adapter/local-protocol、adapter/sdk-converters 与 live Adapter owners`

- Change: `substantially rewritten`
- Change class: `internal-refactor`
- Disposition: `retain`
- Candidate identity: Git `dccae9719ed5773c455b5e9a3de7420a0b459ec2`; NiceEval tarball SHA-256 `a44c816811e7fa2962bc00ff60f2fa4b7429cb0764d10bee68af39093d8eca10`
- Contract and owner: `docs/engineering/testing/e2e/adapter/README.md`
- Stability budget: 只替换既有 owners 中重复的 Eval 过滤和 Verdict matcher；fixture、输入、动作、expected 与公开 readback 均保留，没有新增 owner。
- Example scenario: local protocol 的正常 transport 产生 `passed`，timeout/disconnect/HTTP fault 产生 `errored`；live owners 保留各自明确的 expected matrix 与 evidence/timing 下钻。
- Before: 零散 `find`/计数断言可能允许额外、重复或 experiment 身份错误的 Eval event 逃逸。
- After: owner 的完整字面矩阵与严格解码后的公开 Eval events 一一匹配；原有 CLI 与 readback 断言继续执行。
- Distinguishing evidence: 构建后的 Testkit 手测让 passed/failed/errored/skipped 精确矩阵通过，并把 `passed` 期望成 `failed` 时确认字段诊断；确定性 local fault owners 继续证明真实 `errored` 路径。
- Verification: `pnpm e2e --lane pr --repo adapter/local-protocol --repo adapter/sdk-converters` 通过；两个 Repo 的 `pnpm e2e takeover` 全矩阵通过。live provider E2E 未执行，因为需要密钥并会产生付费调用。
- Fixed conditions: 固定 checkout/digest、各 Repo lockfile 与既有 fixture；无随机 seed、fake clock 或容器镜像，host executor。
- Repeatability: 两个确定性 Repo 的 isolated-copy-1/2/3、same-copy 1/2、repo-default-parallel、target-single 和 cleanup 全部通过；live owners 未运行付费 repeatability。
- Unit exception or no automation: Testkit 不设独立 Unit suite，由安装当前 Testkit snapshot 的真实场景 Repo验收；不新增 fake provider 复制协议真相。
- Unit count: not applicable — 未新增或修改 Unit，Testkit 没有独立 Unit suite。
- Manual observation: 额外用 Node.js `v24.18.0` 从构建后的 Testkit ESM 入口验证四种 Verdict 与 mismatch 诊断；live 密钥路径未手测。
- User impact: 确定性与 live Adapter owner 的终局断言格式统一且更严格；产品运行行为不变。未守护风险是 live expected matrix 只会在后续已授权付费 lane 暴露上游漂移。
