### PR TITLE
ci(e2e): 并行运行拆分后的 Docker 场景

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -296,7 +296,9 @@ jobs:
           install: false
 
       - name: Install orchestrator dependencies
-        run: pnpm install --frozen-lockfile
+        # prepare 已从同一 checkout 构建并封装 exact candidate；matrix 只需要根 CLI 的
+        # JS 依赖，不能为每个 cell 重跑根 prepare 的 report/index 构建。
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Derive safe artifact id
         id: safe
@@ -331,7 +333,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Set up Playwright browsers
+      - name: Restore Playwright browser cache
+        if: contains(matrix.requires.browsers, 'chromium') || contains(matrix.requires.browsers, 'firefox') || contains(matrix.requires.browsers, 'webkit')
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
         if: contains(matrix.requires.browsers, 'chromium') || contains(matrix.requires.browsers, 'firefox') || contains(matrix.requires.browsers, 'webkit')
         env:
           BROWSERS_JSON: ${{ toJSON(matrix.requires.browsers) }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ name: e2e
 #
 # prepare → plan matrix、Testkit typecheck、pack 一次 NiceEval tgz + sha256
 # e2e     → 并行 cell 下载并重算 candidate digest；所有独立 Repo 按 manifest batch 共机并发；
-#           pnpm e2e run --candidate <exact> --repo <id>...
+#           pnpm e2e run --candidate <exact> --plan <exact-plan> --cell <matrix-id>
 #           （runner 在当前 checkout 为声明的 consumer clean-build Testkit 并注入目录依赖）
 #           --artifact-root "$RUNNER_TEMP/niceeval-e2e-artifacts/<safe-id>"
 #
@@ -233,6 +233,7 @@ jobs:
             exit 1
           fi
           printf '%s\n' "$candidate_sha256" > "${candidate_path}.sha256"
+          cp "${RUNNER_TEMP}/e2e-plan.json" "${out_dir}/e2e-plan.json"
           {
             echo "candidate_sha256=${candidate_sha256}"
             echo "candidate_path=${candidate_path}"
@@ -247,6 +248,7 @@ jobs:
           path: |
             ${{ steps.pack.outputs.candidate_path }}
             ${{ steps.pack.outputs.candidate_path }}.sha256
+            ${{ runner.temp }}/niceeval-e2e-candidate/e2e-plan.json
           if-no-files-found: error
           retention-days: 14
 
@@ -255,8 +257,8 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has-jobs == 'true'
     runs-on: ubuntu-24.04
-    # 覆盖 runner/action 启动、依赖安装及并行 live Repo；单 Repo 的产品预算仍由 manifest 收紧。
-    timeout-minutes: 15
+    # 四分钟是完整 matrix cell 的性能门槛；通过拆 batch 并行达成，不以限流或放宽预算换绿。
+    timeout-minutes: 4
     # 同仓 PR 直接使用仓库级 secret；push、schedule 与显式 live dispatch 挂
     # 同名 Environment。所有路径都只注入 manifest 白名单中的 secret。
     environment: ${{ needs.prepare.outputs.inject-secrets == 'true' && needs.prepare.outputs.environment || fromJSON('null') }}
@@ -423,21 +425,16 @@ jobs:
       - name: Run e2e for ${{ matrix.id }}
         env:
           CANDIDATE: ${{ steps.candidate.outputs.candidate }}
-          REPO_IDS_JSON: ${{ toJSON(matrix.repoIds) }}
-          REPO_CONCURRENCY: ${{ matrix.repoConcurrency }}
+          PLAN: ${{ runner.temp }}/niceeval-e2e-candidate/e2e-plan.json
+          CELL_ID: ${{ matrix.id }}
           ARTIFACT_ROOT: ${{ steps.safe.outputs.artifact-root }}
         run: |
           set -euo pipefail
           mkdir -p "$ARTIFACT_ROOT"
-          mapfile -t repo_ids < <(jq -r '.[]' <<< "$REPO_IDS_JSON")
-          repo_args=()
-          for repo_id in "${repo_ids[@]}"; do
-            repo_args+=(--repo "$repo_id")
-          done
           pnpm e2e run \
             --candidate "$CANDIDATE" \
-            "${repo_args[@]}" \
-            --repo-concurrency "$REPO_CONCURRENCY" \
+            --plan "$PLAN" \
+            --cell "$CELL_ID" \
             --artifact-root "$ARTIFACT_ROOT"
 
       - name: Redact secrets in artifactRoot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,8 @@ jobs:
     name: release e2e (${{ matrix.id }})
     needs: prepare-release
     runs-on: ubuntu-24.04
-    # 与 testing execution 契约一致：覆盖 action/setup、安装与有界 Repo batch；
-    # 单 Repo 的产品预算仍由各自 manifest 收紧。
-    timeout-minutes: 15
+    # 四分钟是完整 matrix cell 的性能门槛；通过拆 batch 并行达成，不以限流或放宽预算换绿。
+    timeout-minutes: 4
     environment: release
     strategy:
       fail-fast: false
@@ -291,20 +290,15 @@ jobs:
         env:
           ARTIFACT_ROOT: ${{ steps.paths.outputs.artifact-root }}
           CANDIDATE: ${{ steps.candidate.outputs.path }}
-          REPO_IDS_JSON: ${{ toJSON(matrix.repoIds) }}
-          REPO_CONCURRENCY: ${{ matrix.repoConcurrency }}
+          PLAN: ${{ runner.temp }}/niceeval-release-candidate/release-plan.json
+          CELL_ID: ${{ matrix.id }}
         run: |
           set -euo pipefail
           mkdir -p "$ARTIFACT_ROOT"
-          mapfile -t repo_ids < <(jq -r '.[]' <<< "$REPO_IDS_JSON")
-          repo_args=()
-          for repo_id in "${repo_ids[@]}"; do
-            repo_args+=(--repo "$repo_id")
-          done
           pnpm e2e run \
             --candidate "$CANDIDATE" \
-            "${repo_args[@]}" \
-            --repo-concurrency "$REPO_CONCURRENCY" \
+            --plan "$PLAN" \
+            --cell "$CELL_ID" \
             --artifact-root "$ARTIFACT_ROOT"
 
       - name: Redact release secrets in receipts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,9 @@ jobs:
           cache-dependency-path: ${{ steps.dependency-cache.outputs.paths }}
 
       - name: Install orchestrator dependencies
-        run: pnpm install --frozen-lockfile
+        # release candidate 已由 prepare-release 从同一 checkout 构建；matrix 只安装
+        # orchestrator 所需依赖，不重复执行根 prepare。
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Resolve cell manifests
         id: cell
@@ -202,7 +204,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Set up Playwright browsers
+      - name: Restore Playwright browser cache
+        if: contains(matrix.requires.browsers, 'chromium') || contains(matrix.requires.browsers, 'firefox') || contains(matrix.requires.browsers, 'webkit')
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
         if: contains(matrix.requires.browsers, 'chromium') || contains(matrix.requires.browsers, 'firefox') || contains(matrix.requires.browsers, 'webkit')
         env:
           BROWSERS_JSON: ${{ toJSON(matrix.requires.browsers) }}

--- a/docs/engineering/testing/e2e/adapter/openclaw.md
+++ b/docs/engineering/testing/e2e/adapter/openclaw.md
@@ -16,7 +16,7 @@ Repo ID 是 `adapter/openclaw`；manifest 声明 `areas: ["adapter", "sandbox"]`
 
 ## 仓库验收
 
-- `ci` Experiment 选中本仓库的 Skill 工具轨、会话与 usage Eval；原生验收脚本列全 OpenClaw 协议 Eval ID，防止少发现/少运行后假绿。三条 live Eval 在同一 Repo 内串行，避免同一 embedded agent / compat provider 的突发并发把原生 120 秒退出误判成 adapter 回归；Repo 仍与 batch 中的其它 Repo 并行。Live Adapter 不用非确定性的通用 coding 任务重复承担产品可靠性。
+- `ci` Experiment 选中本仓库的 Skill 工具轨、会话与 usage Eval；原生验收脚本列全 OpenClaw 协议 Eval ID，防止少发现/少运行后假绿。三条彼此独立的 live Eval 在同一 Repo 内同轮启动，直接验证 adapter / compat provider 的真实并发能力，不把单次 120 秒尾延迟固化成永久串行；Repo 仍与 batch 中的其它 Repo 并行。Live Adapter 不用非确定性的通用 coding 任务重复承担产品可靠性。
 - **Eval 结果**：原生验收只断言通过数与未通过数。Skill 读取与 decoy 反选都留在 Eval 的事件流断言中。
 - **Evidence Page**：独立 `show @locator --execution` test 只读回 Skill Eval 的代表性 shell 工具证据，不用 Page text 再给 Skill 判分。
 - **Timing Page**：独立 target Page test 验收 OpenClaw 的阶段树，不在该 owner 内重复 Evidence Page 断言。

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -34,6 +34,8 @@ pnpm e2e plan --lane pr --json
 pnpm e2e plan --lane main --no-diff --exclude-external-network --json
 pnpm e2e plan --lane release --no-diff --json
 pnpm e2e run --candidate artifacts/niceeval-candidate.tgz --repo report --artifact-root artifacts/e2e/report
+pnpm e2e run --candidate artifacts/niceeval-candidate.tgz \
+  --plan artifacts/e2e-plan.json --cell repo-batch-docker-1 --artifact-root artifacts/e2e/docker-1
 
 # Owner 接管可靠性收据：target 必须在 -- 后给出原生文件/标题参数
 pnpm e2e takeover --candidate artifacts/niceeval-candidate.tgz --repo report \
@@ -50,7 +52,7 @@ pnpm e2e verify-release --plan artifacts/release-plan.json \
 - `run` 在选中 Testkit consumer 时构建当前 workspace Testkit 的 invocation-local scratch snapshot 一次；
 - 无 Repo 被选择或 manifest 非法时不 pack、不 build；
 - CI 的 prepare job 先 plan，只在选中 Repo 后测试 Testkit 并 pack 一次 candidate；
-- matrix run 消费 candidate artifact 与当前 checkout，不再下载第二份 Testkit artifact；
+- matrix run 消费 candidate artifact、同一次生成的 plan 与当前 checkout，通过 `--plan/--cell` 精确执行该格；它不再把 Repo 列表和并发数翻译成 workflow shell，也不下载第二份 Testkit artifact；
 - `plan` 不 pack、不安装、不读 secret、不创建 Repo 副本；显式 `run --candidate` 不重新 pack。
 
 `verify-release` 只接受非空的 `plan --json` 数组、candidate `.tgz`、receipt root 与 tag。
@@ -212,18 +214,18 @@ prepare job
              │
              ▼
 matrix jobs：下载同一 candidate.tgz
-  └─ Repo batch：同一 checkout / Testkit 下最多并发 run 两个独立 --repo <id>
+  └─ run --plan <同一 plan> --cell <id>：同格独立 Repo 全部并发启动
 ```
 
 Workflow 只准备 Node / pnpm / Docker / browser、下发矩阵、缓存 store / image layer、上传 artifact。
 它不自己改 dependency、分类错误、实现重试、决定 expected 或维护另一份 Repo 清单。
 
-batch plan 的 `repoConcurrency` 上限为 2。host cell 使用 2 vCPU，Docker cell 使用 4 vCPU；每个 Repo 还会执行安装、
-typecheck、Docker Sandbox 或 live CLI，因此不能让同一 batch 的全部 Repo 同时占用共享 runner。该上限只约束共机调度，
-不放宽任何 Repo 自己的 `timeoutMinutes`，也不改变 lane 的精确 Repo 集。
+batch 是共机放置单位，不是限流单位；plan 不携带 CI 限流参数，同格所有独立 Repo 立即并发启动。
+资源竞争、OOM 或尾延迟通过把 manifest 显式拆到 `docker-1`、`docker-2`、`docker-3` 等更多 matrix cell 处理，
+不能通过让同格 Repo 排队来换取通过；拆分不改变 lane 的精确 Repo 集。
 
-matrix job 的 15 分钟上限包含 runner/action 启动、依赖安装与同 cell 的并行 live Repo；每个 Repo 的产品执行预算仍由
-manifest 自己收紧，不能用 job 上限放宽 provider timeout。
+matrix cell 的 4 分钟上限包含 runner/action 启动、依赖安装与同 cell 的并行 live Repo；这是 E2E 关键路径的性能门槛。
+每个 Repo 的产品执行预算仍由 manifest 自己收紧，不能用 job 上限放宽 provider timeout。
 
 每个 matrix cell 自己上传 receipt、summary、JUnit 与声明附件；Repo batch 的 artifact root 下仍按 Repo ID 分目录并
 保存独立 receipt，batch summary 列全该格 Repo。GitHub 原生汇总 matrix 成败，不再启动一个 job 下载并复述所有 cell 的结果。

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -33,6 +33,8 @@ pnpm e2e plan --lane pr --json
 pnpm e2e plan --lane release --no-diff --json
 pnpm e2e pack --out /tmp/niceeval-candidate.tgz
 pnpm e2e run --candidate /tmp/niceeval-candidate.tgz --repo cli
+pnpm e2e run --candidate /tmp/niceeval-candidate.tgz \
+  --plan /tmp/e2e-plan.json --cell repo-batch-docker-1
 pnpm e2e takeover --candidate /tmp/niceeval-candidate.tgz --repo report \
   -- --run test/report.browser.spec.ts -t "打开"
 pnpm e2e verify-release --plan /tmp/release-plan.json --candidate /tmp/niceeval-candidate.tgz \

--- a/e2e/adapter/ai-sdk-direct/e2e.json
+++ b/e2e/adapter/ai-sdk-direct/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/ai-sdk-direct",
-  "batch": "host-1",
+  "batch": "host-2",
   "areas": ["adapter"],
   "lanes": ["main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/ai-sdk/e2e.json
+++ b/e2e/adapter/ai-sdk/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/ai-sdk",
-  "batch": "host-1",
+  "batch": "host-3",
   "areas": ["adapter"],
   "lanes": ["main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/claude-agent-sdk/e2e.json
+++ b/e2e/adapter/claude-agent-sdk/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/claude-agent-sdk",
-  "batch": "host-1",
+  "batch": "host-3",
   "areas": ["adapter"],
   "lanes": ["main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/codex-cli/e2e.json
+++ b/e2e/adapter/codex-cli/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/codex-cli",
-  "batch": "docker-1",
+  "batch": "docker-2",
   "areas": ["adapter", "sandbox"],
   "lanes": ["main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/codex-sdk/e2e.json
+++ b/e2e/adapter/codex-sdk/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/codex-sdk",
-  "batch": "host-1",
+  "batch": "host-2",
   "areas": ["adapter"],
   "lanes": ["main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/local-protocol/e2e.json
+++ b/e2e/adapter/local-protocol/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/local-protocol",
-  "batch": "host-1",
+  "batch": "host-2",
   "areas": ["adapter"],
   "lanes": ["pr", "main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/openclaw/e2e.json
+++ b/e2e/adapter/openclaw/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/openclaw",
-  "batch": "docker-1",
+  "batch": "docker-2",
   "areas": ["adapter", "sandbox"],
   "lanes": ["main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/openclaw/niceeval.config.ts
+++ b/e2e/adapter/openclaw/niceeval.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "niceeval";
 export default defineConfig({
   name: { "zh-CN": "openclaw E2E", en: "openclaw E2E" },
   timeoutMs: 900_000,
-  // OpenClaw 的 embedded agent 与同一 compat provider 串行交互；并发 Eval 会让其中一条
-  // live session 在原生 120 秒边界退出，不能把 provider 突发压力误判成 adapter 回归。
-  maxConcurrency: 1,
+  // 这个 owner 恰有三条彼此独立的 live Eval；同轮启动才能验证 adapter / compat
+  // provider 的真实并发能力，不能把单次 120 秒尾延迟固化成永久串行。
+  maxConcurrency: 3,
 });

--- a/e2e/adapter/opencode/e2e.json
+++ b/e2e/adapter/opencode/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/opencode",
-  "batch": "docker-1",
+  "batch": "docker-2",
   "areas": ["adapter", "sandbox"],
   "lanes": ["main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/adapter/sdk-converters/e2e.json
+++ b/e2e/adapter/sdk-converters/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "adapter/sdk-converters",
-  "batch": "host-1",
+  "batch": "host-3",
   "areas": ["adapter"],
   "lanes": ["pr", "main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/cli/e2e.json
+++ b/e2e/cli/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "cli",
-  "batch": "host-1",
+  "batch": "host-2",
   "areas": ["cli"],
   "lanes": ["pr", "main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/eval/e2e.json
+++ b/e2e/eval/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "eval",
-  "batch": "host-1",
+  "batch": "host-3",
   "areas": ["eval"],
   "lanes": ["pr", "main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/lifecycle/e2e.json
+++ b/e2e/lifecycle/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "lifecycle",
-  "batch": "docker-1",
+  "batch": "docker-3",
   "areas": ["lifecycle"],
   "lanes": ["pr", "main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/lifecycle/experiments/interrupts/complete.ts
+++ b/e2e/lifecycle/experiments/interrupts/complete.ts
@@ -1,5 +1,9 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { defineExperiment } from "niceeval";
 import { lifecycleSandbox, quickAgent } from "../../agents/deterministic.ts";
+
+export const siblingCompleteMarker = ".niceeval-lifecycle-sibling-complete";
 
 /** The independently sealed sibling in the SIGINT publication lifecycle case. */
 export default defineExperiment({
@@ -7,4 +11,10 @@ export default defineExperiment({
   agent: quickAgent,
   sandbox: lifecycleSandbox,
   evals: ["probe"],
+  teardown: async () => {
+    // Test-only synchronization seam: teardown starts only after this
+    // Experiment's Attempt and Eval have settled. Invocation progress remains
+    // a sampled heartbeat and is deliberately not used as a barrier.
+    await writeFile(join(process.cwd(), siblingCompleteMarker), "complete\n", "utf8");
+  },
 });

--- a/e2e/lifecycle/test/interrupt-cleanup.test.ts
+++ b/e2e/lifecycle/test/interrupt-cleanup.test.ts
@@ -10,6 +10,7 @@ import {
   withProjectCopy,
 } from "@niceeval/testkit";
 import { expect, test } from "vitest";
+import { siblingCompleteMarker } from "../experiments/interrupts/complete.ts";
 
 interface BackendInfo { pid: number; port: number }
 interface ProcessReceipt { diagnostic(): string }
@@ -37,6 +38,15 @@ async function backendInfo(path: string): Promise<BackendInfo | undefined> {
   try {
     const value = JSON.parse(await readFile(path, "utf8")) as BackendInfo;
     return typeof value.pid === "number" && typeof value.port === "number" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function fileExists(path: string): Promise<true | undefined> {
+  try {
+    await readFile(path);
+    return true;
   } catch {
     return undefined;
   }
@@ -112,6 +122,7 @@ async function waitForSecondReuseAttempt(pid: number, cwd: string): Promise<void
 test("SIGINT 中断复用 Docker Sandbox、执行 teardown、释放 owned 资源，下一消费者仍可运行", async () => {
   await withProjectCopy(projectCopy, async ({ root }) => {
     const infoPath = join(root, ".niceeval-lifecycle-backend.json");
+    const siblingMarkerPath = join(root, siblingCompleteMarker);
     const owned = await withProcess(
       [binary, "exp", "interrupts", "--rerun", "all", "--json"],
       {
@@ -132,11 +143,18 @@ test("SIGINT 中断复用 Docker Sandbox、执行 teardown、释放 owned 资源
         );
         await waitForHealth(info.port, controlled.done);
         const invocationPid = defined(controlled.pid, "niceeval invocation did not expose a pid");
+        await whileRunning(
+          pollUntil(() => fileExists(siblingMarkerPath), {
+            timeoutMs: 60_000,
+            intervalMs: 100,
+            label: "sibling Experiment completion marker",
+          }),
+          controlled.done,
+          "the sibling Experiment completed",
+        );
         // The second-attempt marker proves that attempt 1 settled and released
-        // the reused sandbox. The interrupted public event stream below must
-        // also contain the completed sibling Eval, so the fixture does not rely
-        // on a 30-second progress heartbeat that may occur before cold Docker
-        // provisioning has reached the state being observed.
+        // the reused sandbox. Together the two fixture seams define when to send
+        // SIGINT without depending on a sampled progress heartbeat.
         await waitForSecondReuseAttempt(invocationPid, root);
         expect(controlled.signal("SIGINT")).toBe(true);
 

--- a/e2e/lifecycle/test/interrupt-cleanup.test.ts
+++ b/e2e/lifecycle/test/interrupt-cleanup.test.ts
@@ -21,13 +21,6 @@ interface ExpEvent {
   verdict?: string;
   locator?: string;
 }
-interface ProgressEvent {
-  event: "progress";
-  total: number;
-  running: number;
-  passed: number;
-  queued: number;
-}
 const binary = join(process.cwd(), "node_modules", ".bin", "niceeval");
 const niceeval = command([binary]);
 const docker = command(["docker"]);
@@ -81,26 +74,6 @@ async function waitForHealth(port: number, exited: Promise<ProcessReceipt>): Pro
 
 function outputLines(stdout: string): string[] {
   return stdout.split("\n").map((line) => line.trim()).filter((line) => line !== "");
-}
-
-function isSiblingCompletionProgress(value: unknown): value is ProgressEvent {
-  if (typeof value !== "object" || value === null) return false;
-  const event = value as Partial<ProgressEvent>;
-  return event.event === "progress"
-    && event.total === 3
-    && event.running === 1
-    && event.passed === 2
-    && event.queued === 0;
-}
-
-function siblingCompletionObserved(stdout: string): boolean {
-  return outputLines(stdout).some((line) => {
-    try {
-      return isSiblingCompletionProgress(JSON.parse(line));
-    } catch {
-      return false;
-    }
-  });
 }
 
 async function containersOwnedBy(pid: number, cwd: string): Promise<string[]> {
@@ -159,18 +132,11 @@ test("SIGINT 中断复用 Docker Sandbox、执行 teardown、释放 owned 资源
         );
         await waitForHealth(info.port, controlled.done);
         const invocationPid = defined(controlled.pid, "niceeval invocation did not expose a pid");
-        await whileRunning(
-          pollUntil(
-            () => siblingCompletionObserved(controlled.bufferedStdout) ? true : undefined,
-            { timeoutMs: 60_000, intervalMs: 100, label: "completed sibling Run public progress" },
-          ),
-          controlled.done,
-          "public progress showed the sibling Run complete",
-        );
-        // There are exactly three fresh slots: one sibling slot and two serial
-        // `inflight` slots. `passed: 2, running: 1, queued: 0` proves that the
-        // sibling and first in-flight Attempt have settled; the marker below
-        // then proves the remaining Attempt is the second reused one.
+        // The second-attempt marker proves that attempt 1 settled and released
+        // the reused sandbox. The interrupted public event stream below must
+        // also contain the completed sibling Eval, so the fixture does not rely
+        // on a 30-second progress heartbeat that may occur before cold Docker
+        // provisioning has reached the state being observed.
         await waitForSecondReuseAttempt(invocationPid, root);
         expect(controlled.signal("SIGINT")).toBe(true);
 

--- a/e2e/plugins/e2e.json
+++ b/e2e/plugins/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "plugins",
-  "batch": "docker-1",
+  "batch": "docker-3",
   "areas": ["lifecycle"],
   "lanes": ["pr", "main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/scripts/cli.ts
+++ b/e2e/scripts/cli.ts
@@ -77,6 +77,8 @@ Root run options:
   --exclude-external-network
                        Omit live provider repositories during planning
   --repo-concurrency N Run up to N selected repositories concurrently
+  --plan <path>        Execute a previously emitted batched JSON plan
+  --cell <id>          Run exactly one cell from --plan
   --keep-workdir       Retain the isolated scratch tree for local diagnosis
   --help, -h           Print this help without planning, packing, or running
 

--- a/e2e/scripts/plan.ts
+++ b/e2e/scripts/plan.ts
@@ -41,8 +41,6 @@ export interface PlanEntry {
   capabilities: readonly Area[];
   /** Stable diagnostic shard identity. */
   shard: string;
-  /** Number of isolated repos the root runner may execute concurrently. */
-  repoConcurrency: number;
   requires?: RepoRequires;
 }
 
@@ -308,7 +306,6 @@ function singletonEntry(repo: DiscoveredRepo, root: string): PlanEntry {
     executor: repo.manifest.executor,
     capabilities: repo.manifest.areas,
     shard: repo.manifest.id,
-    repoConcurrency: 1,
     ...(repo.manifest.requires === undefined ? {} : { requires: repo.manifest.requires }),
   };
 }
@@ -345,7 +342,6 @@ function repoBatch(entries: readonly PlanEntry[], index: number): PlanEntry {
   const batch = entries[0].batch;
   const id = `repo-batch-${batch}`;
   const requires = mergedRequires(entries);
-  const repoCount = entries.reduce((sum, entry) => sum + entry.repoIds.length, 0);
   return {
     id,
     repoIds: entries.flatMap((entry) => entry.repoIds),
@@ -354,12 +350,6 @@ function repoBatch(entries: readonly PlanEntry[], index: number): PlanEntry {
     executor: entries[0].executor,
     capabilities: [...new Set(entries.flatMap((entry) => entry.capabilities))],
     shard: id,
-    // CI batch runners provide 2 vCPU for host work and 4 vCPU for Docker work.
-    // Running every Repo at once makes install, typecheck, Docker and live CLI
-    // processes contend until their product-level timeout expires. Two concurrent
-    // Repos keeps the shared machine busy without turning resource pressure into
-    // a false product regression.
-    repoConcurrency: Math.min(repoCount, 2),
     ...(requires === undefined ? {} : { requires }),
   };
 }
@@ -416,7 +406,7 @@ function printHumanPlan(entries: readonly PlanEntry[], lane: Lane): void {
   console.log(`${entries.length} e2e shard(s) selected for lane ${lane}:\n`);
   for (const entry of entries) {
     console.log(`- ${entry.id}  [${entry.capabilities.join(", ")}]  executor=host`);
-    console.log(`    repos: ${entry.repoIds.join(", ")}  concurrency: ${entry.repoConcurrency}`);
+    console.log(`    repos: ${entry.repoIds.join(", ")}  concurrency: all`);
     console.log(`    dirs: ${entry.dirs.join(", ")}  shard: ${entry.shard}`);
   }
 }

--- a/e2e/scripts/run.ts
+++ b/e2e/scripts/run.ts
@@ -23,7 +23,7 @@
 // counts, and must never parse a repo's .niceeval/ for pass/fail.
 
 import { join, resolve } from "node:path";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { parseArgs } from "node:util";
@@ -59,6 +59,41 @@ interface Cli {
   nativeArgs: string[];
   keepWorkdir: boolean;
   repoConcurrency: number;
+  planPath?: string;
+  cellId?: string;
+}
+
+interface RunPlanCell {
+  repoIds: readonly string[];
+}
+
+function readRunPlanCell(planPath: string, cellId: string): RunPlanCell {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(planPath, "utf8"));
+  } catch (error) {
+    throw new Error(`could not parse E2E plan ${planPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error("E2E plan must be a non-empty JSON array emitted by `pnpm e2e plan --batch --json`");
+  }
+  const matches = raw.filter((entry): entry is Record<string, unknown> =>
+    typeof entry === "object" && entry !== null && !Array.isArray(entry) && entry.id === cellId
+  );
+  if (matches.length !== 1) {
+    throw new Error(`E2E plan must contain exactly one cell ${JSON.stringify(cellId)}, found ${matches.length}`);
+  }
+  const entry = matches[0]!;
+  const repoIds = entry.repoIds;
+  if (
+    !Array.isArray(repoIds) ||
+    repoIds.length === 0 ||
+    !repoIds.every((id) => typeof id === "string" && id.length > 0) ||
+    new Set(repoIds).size !== repoIds.length
+  ) {
+    throw new Error(`E2E plan cell ${JSON.stringify(cellId)} must contain unique non-empty string repoIds`);
+  }
+  return { repoIds: repoIds as string[] };
 }
 
 function splitNativeArgs(argv: readonly string[]): { optionArgs: readonly string[]; nativeArgs: string[] } {
@@ -79,7 +114,9 @@ export function parseRunCli(argv: readonly string[]): Cli {
       "artifact-root": { type: "string" },
       "diff-path": { type: "string", multiple: true },
       "keep-workdir": { type: "boolean", default: false },
-      "repo-concurrency": { type: "string", default: "1" },
+      "repo-concurrency": { type: "string" },
+      plan: { type: "string" },
+      cell: { type: "string" },
     },
     allowPositionals: false,
     strict: true,
@@ -94,17 +131,43 @@ export function parseRunCli(argv: readonly string[]): Cli {
     throw new Error(`--lane must be one of ${LANES.join("|")}, got ${JSON.stringify(laneValue)}`);
   }
 
-  const repoIds = Array.isArray(values.repo) ? values.repo.filter((value): value is string => typeof value === "string") : [];
+  let repoIds = Array.isArray(values.repo) ? values.repo.filter((value): value is string => typeof value === "string") : [];
   const diffPaths = Array.isArray(values["diff-path"])
     ? values["diff-path"].filter((value): value is string => typeof value === "string")
     : [];
-  const concurrencyValue = values["repo-concurrency"];
-  if (typeof concurrencyValue !== "string" || !/^\d+$/.test(concurrencyValue)) {
-    throw new Error(`--repo-concurrency must be a positive integer, got ${JSON.stringify(concurrencyValue)}`);
+  const planValue = values.plan;
+  const cellValue = values.cell;
+  if ((planValue === undefined) !== (cellValue === undefined)) {
+    throw new Error("--plan and --cell must be supplied together");
   }
-  const repoConcurrency = Number(concurrencyValue);
-  if (!Number.isSafeInteger(repoConcurrency) || repoConcurrency < 1) {
-    throw new Error(`--repo-concurrency must be a positive integer, got ${JSON.stringify(concurrencyValue)}`);
+  let repoConcurrency = 1;
+  let planPath: string | undefined;
+  let cellId: string | undefined;
+  if (typeof planValue === "string" && typeof cellValue === "string") {
+    if (
+      repoIds.length > 0 ||
+      values.lane !== undefined ||
+      values.capability !== undefined ||
+      values["diff-path"] !== undefined ||
+      values["repo-concurrency"] !== undefined
+    ) {
+      throw new Error("--plan/--cell cannot be combined with selection options or --repo-concurrency");
+    }
+    if (planValue.length === 0 || cellValue.length === 0) throw new Error("--plan and --cell require non-empty values");
+    planPath = resolve(planValue);
+    cellId = cellValue;
+    const planned = readRunPlanCell(planPath, cellId);
+    repoIds = [...planned.repoIds];
+    repoConcurrency = planned.repoIds.length;
+  } else {
+    const concurrencyValue = values["repo-concurrency"] ?? "1";
+    if (!/^\d+$/.test(concurrencyValue)) {
+      throw new Error(`--repo-concurrency must be a positive integer, got ${JSON.stringify(concurrencyValue)}`);
+    }
+    repoConcurrency = Number(concurrencyValue);
+    if (!Number.isSafeInteger(repoConcurrency) || repoConcurrency < 1) {
+      throw new Error(`--repo-concurrency must be a positive integer, got ${JSON.stringify(concurrencyValue)}`);
+    }
   }
   return {
     repoIds,
@@ -118,6 +181,8 @@ export function parseRunCli(argv: readonly string[]): Cli {
     nativeArgs,
     keepWorkdir: values["keep-workdir"] === true,
     repoConcurrency,
+    ...(planPath === undefined ? {} : { planPath }),
+    ...(cellId === undefined ? {} : { cellId }),
   };
 }
 
@@ -329,6 +394,9 @@ export async function main(
       const activeScratchRoot = scratchRoot;
       const activeArtifactRoot = artifactRoot;
 
+      if (cli.cellId !== undefined) {
+        console.log(`[e2e] plan cell: ${cli.cellId} (${cli.planPath})`);
+      }
       console.log(`[e2e] repo concurrency: ${Math.min(cli.repoConcurrency, selected.length)}`);
       results.push(...await runRepoPool(selected, cli.repoConcurrency, execution, async (repo) => {
         console.log(`\n[e2e] === ${repo.manifest.id} ===`);


### PR DESCRIPTION
## Problem

- User goal: 让完整 E2E 通过跨 cell 和 cell 内并发稳定守住四分钟性能门槛，并让 CI 调用保持可读。
- Current limitation: Docker Repo 被放进一个 cell 并以 `repoConcurrency = 2` 排队，12 个 host Repo 也在单机竞争；matrix 重复执行根 `prepare`，browser 每次下载 Chromium，OpenClaw owner 又被永久串行化，关键路径超过四分钟。
- Required capability: plan cell 必须成为 runner 的精确执行输入；batch 只决定共机放置，不能同时承担限流职责。
- User outcome: Docker 场景分到三个并行 matrix cell，同格 Repo 全部立即启动，CI 用一条 `--plan/--cell` 命令执行并继续产出独立 receipt。

## Use cases

### 在 CI 中执行一个已计划的 E2E cell

- Coverage: happy path | composition | lifecycle | failure | unsupported
- Starting point: prepare job 已生成 candidate tarball、SHA-256 与 batched plan；matrix 提供 cell id。
- Copyable usage or trigger: `pnpm e2e run --candidate "$CANDIDATE" --plan "$PLAN" --cell "$CELL_ID" --artifact-root "$ARTIFACT_ROOT"`
- Observable result or diagnostic: runner 精确选择该 cell 的 Repo，同格 Repo 全部并发；未知、重复或空 cell 会在创建 scratch 和启动测试前报错；`--plan/--cell` 不支持与 `--repo` 或 `--repo-concurrency` 混用。
- Contract: `docs/engineering/testing/e2e/execution.md#github-actions-形状`

## Public API

### Removed

None

### Added

None

### Changed

None

## CLI commands

### Removed

None

### Added

#### `pnpm e2e run --plan <path> --cell <id>`

- Before usage or result: not available
- After usage or result: `pnpm e2e run --candidate candidate.tgz --plan e2e-plan.json --cell repo-batch-docker-1` 精确执行 plan 中的一个 cell。
- User impact: CI 和维护者无需把 Repo 列表或并发数展开成 shell 参数；错误 plan/cell 返回非零退出码与明确诊断。

### Changed

None

## Report components

### Removed

None

### Added

None

### Changed

None

## Observable behavior and data contracts

### Removed

#### batched plan 的 `repoConcurrency`

- Before usage or result: plan 输出 `repoConcurrency: 2`，同 cell 其余 Repo 排队。
- After usage or result: removed
- User impact: CI 不再通过降低吞吐规避资源竞争；batch 内所有 Repo 立即启动。

### Added

None

### Changed

#### Docker E2E matrix placement

- Before usage or result: 8 个 Docker Repo 全部属于 `docker-1`。
- After usage or result: `docker-1` 为 bub/claude-code/hermes，`docker-2` 为 codex-cli/openclaw/opencode，`docker-3` 为 lifecycle/plugins。
- User impact: 三个独立 CI cell 并行执行 3/3/2 个 Repo，避免单 cell 排队形成关键路径。

#### Host E2E matrix placement

- Before usage or result: 12 个 host Repo 在 `host-1` 同机并发，runner 资源竞争后整格超过四分钟。
- After usage or result: host Repo 按实测关键路径拆为 `host-1`、`host-2`、`host-3` 三个 4-Repo cell，格内仍全部并发。
- User impact: host cell 实测分别为 2分02秒、1分27秒、2分11秒，不再通过单机过载消耗性能预算。

#### Matrix 安装与 Playwright browser cache

- Before usage or result: 每个 cell 的根安装重复执行 report/index `prepare`；Chromium 在 fresh runner 上重复下载。
- After usage or result: candidate 只在 prepare job 构建一次；matrix 根安装使用 `--ignore-scripts`，并按 OS、架构和根 lockfile 缓存 `~/.cache/ms-playwright`。
- User impact: cell 不再重复构建候选；browser cache 命中时复用精确版本的浏览器二进制。

#### OpenClaw live owner 并发

- Before usage or result: 三条独立 live Eval 由 `maxConcurrency: 1` 永久串行。
- After usage or result: `maxConcurrency: 3`，三条 Eval 同轮启动并直接验证 adapter/provider 并发能力。
- User impact: docker-2 在三路 OpenClaw live Eval 全部通过时以 2分55秒完成。

#### Lifecycle SIGINT 同步断言

- Before usage or result: 测试要求 30 秒采样 heartbeat 恰好出现 `passed=2/running=1/queued=0` 的瞬时快照。
- After usage or result: sibling Experiment completion 与第二次 sandbox reuse 使用确定性 fixture marker；最终结果仍由公开 NDJSON/receipt、teardown 与资源释放断言。
- User impact: 不再把 Docker 冷启动和 heartbeat 采样时机误报为生命周期回归。

#### E2E matrix cell timeout

- Before usage or result: 普通与 release E2E cell 的 job timeout 为 15 分钟。
- After usage or result: 同一 cell 的 job timeout 为 4 分钟。
- User impact: 四分钟继续作为真实性能门槛；超时会失败，不以放宽预算换取通过。

## Record schema and stored-data upgrade

- Affected public Record Format surfaces: None
- Private persisted implementation impact: None；新增上传的 E2E plan 只属于临时 CI candidate artifact，不是 Record。
- Version decision: not affected
- Version reason: 没有修改 Record 文件、字段、引用、reader 或 writer。
- Existing Record behavior: 新旧 reader 与 writer 行为不变。
- Migration or recovery path: not applicable；没有存储格式变化。
- Migration safety: 不运行迁移，也没有数据损失边界变化。
- Contract: not applicable
- Version history: not applicable
- Verification: E2E runner 只消费 plan 并运行既有公开场景；package 场景的真实 candidate 读写通过。

## Environment variables

### Removed

None

### Added

None

### Changed

None

## Package scripts

### Removed

None

### Added

None

### Changed

#### `pnpm e2e run`

- Before usage or result: workflow 展开多个 `--repo <id>` 并另传 `--repo-concurrency 2`。
- After usage or result: workflow 传 `--plan <path> --cell <matrix-id>`，runner 从同一份 plan 取得精确 Repo 集并全部并发启动。
- User impact: CI 命令更短，prepare 与 matrix 不再分别维护选择和并发语义；原有直接 `--repo` 用法继续可用。

## Tests

### E2E plan cell 执行与 Docker matrix 计划

- Change: not automated
- Change class: not-automated
- Disposition: not automated
- Candidate identity: Git `43426ce5`; NiceEval tarball SHA-256 `5bc412c1238690aa0349ee34f940367f513376d5c2ef4f5fe4a50e3835133097`
- Contract and owner: `docs/engineering/testing/e2e/execution.md#github-actions-形状`
- Stability budget: 没有新增或实质修改产品自动化 owner；修改的是根 E2E runner 与 CI 编排。
- Example scenario: main/release plan 生成 docker 3/3/2；runner 以 `--plan/--cell package` 安装候选并运行 package Repo。
- Before: Docker cell 通过并发上限排队，workflow 重复展开 Repo 参数。
- After: plan 不含限流字段；三个 Docker cell 独立并行，同格 Repo 同时启动。
- Distinguishing evidence: 最新 Actions run `32102831598` 的 7 个 matrix cell 与 gate 全部通过；docker-1/2/3 分别为 3分25秒、2分55秒、1分55秒，host-1/2/3 分别为 2分02秒、1分27秒、2分11秒，browser 为 3分31秒；OpenClaw 三路 live Eval 与 marker 驱动的 lifecycle owner 均通过。
- Verification: `pnpm typecheck`; `pnpm lint`; `pnpm e2e plan --lane main --no-diff --batch --json`; `pnpm e2e run --candidate /tmp/niceeval-plan-cell-candidate.tgz --plan /tmp/niceeval-package-plan.json --cell package --artifact-root /tmp/niceeval-plan-cell-artifacts`，结果 1 Repo pass、cleanup removed；workflow YAML parse 通过。
- Fixed conditions: repository lockfile；Node 24；pnpm 11.18.0；本机 package manager store；无 live provider 调用。
- Repeatability: 本次没有变更产品 owner，可靠性 takeover 不适用；真实 package 隔离副本完成一次，docker-3 使用 `--help` 做双 Repo 并发入口 smoke 并完成 cleanup。
- Unit exception or no automation: runner 由真实场景与 CI receipt 验收，测试契约明确不建立 `test/unit/e2e-runner` 模拟套件；完整 live Docker 三组由本 PR CI 验证。未守护风险是 CI provider/runner 的真实四分钟长尾只能在 Actions 环境观察。
- Unit count: not applicable；未新增或修改 Unit，根 package 当前没有 `pnpm test` script。
- Manual observation: Node 24.18.0、pnpm 11.18.0；真实 candidate 经根 E2E production entry 安装到仓库外副本，package 原生 Vitest 1 file/1 test passed，summary category=pass，scratch removed。
- User impact: CI 直接暴露超过四分钟的 E2E 性能回归，同时让失败 cell 与 Repo receipt 保持可定位。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789621438&installation_model_id=431746&pr_number=54&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F54&signature=bd269fbc5d65c4eb3cc55c3baa316d6cb7014cef12abe9a56b47e481bd546779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->