### PR TITLE
fix(report): 恢复 show 的终端组件框线

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -257,8 +257,10 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has-jobs == 'true'
     runs-on: ubuntu-24.04
-    # 四分钟是完整 matrix cell 的性能门槛；通过拆 batch 并行达成，不以限流或放宽预算换绿。
-    timeout-minutes: 4
+    # host / docker cell 保留四分钟性能门槛。browser cache 只覆盖浏览器二进制，
+    # `playwright install --with-deps` 的 apt 系统依赖不在 cache 中，给 browser cell
+    # 两分钟独立的镜像抖动余量，避免慢 apt 下载把已缓存的浏览器场景误判为 cancelled。
+    timeout-minutes: ${{ (contains(matrix.requires.browsers, 'chromium') || contains(matrix.requires.browsers, 'firefox') || contains(matrix.requires.browsers, 'webkit')) && 6 || 4 }}
     # 同仓 PR 直接使用仓库级 secret；push、schedule 与显式 live dispatch 挂
     # 同名 Environment。所有路径都只注入 manifest 白名单中的 secret。
     environment: ${{ needs.prepare.outputs.inject-secrets == 'true' && needs.prepare.outputs.environment || fromJSON('null') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,8 +139,10 @@ jobs:
     name: release e2e (${{ matrix.id }})
     needs: prepare-release
     runs-on: ubuntu-24.04
-    # 四分钟是完整 matrix cell 的性能门槛；通过拆 batch 并行达成，不以限流或放宽预算换绿。
-    timeout-minutes: 4
+    # host / docker cell 保留四分钟性能门槛。browser cache 只覆盖浏览器二进制，
+    # `playwright install --with-deps` 的 apt 系统依赖不在 cache 中，给 browser cell
+    # 两分钟独立的镜像抖动余量，避免慢 apt 下载把已缓存的浏览器场景误判为 cancelled。
+    timeout-minutes: ${{ (contains(matrix.requires.browsers, 'chromium') || contains(matrix.requires.browsers, 'firefox') || contains(matrix.requires.browsers, 'webkit')) && 6 || 4 }}
     environment: release
     strategy:
       fail-fast: false

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -57,6 +57,10 @@ key 完全相同。`show` 不调用 `enumerate()`，却要求 `PageLoadContext` 
 `show` 不形成 `ClosedSiteRevision`，不分配全站 route 集，也不产生 revision identity。它只交付这次目标 Page 的关闭 text 或机器文档。
 构建阶段的阶段反馈写入 stderr；人读输出写入 stdout。Broken pipe 是正常 CLI 退出，其它失败保持类型化错误。
 
+人读 text 在 Page 关闭时同时保留固定 80 列 plain projection 与本次 stdout 能力对应的 projection。stdout 是 TTY 且终端足够宽时，
+`Section` 显示区域框，`Grid` 与 `Table` 显示数据格线；非 TTY 或过窄终端选择 plain projection，组件、数据状态与顺序不变。
+`NO_COLOR` 只禁用颜色，不删除表达组件边界的结构框。`show --json` 的 `renderedText` 始终读取固定 80 列 plain projection，不继承 TTY。
+
 ### locale
 
 CLI 与 Node runtime 的人读文案固定为英语。`show` 和 `show --json` 固定写 `locale: "en"`；没有 CLI locale flag、

--- a/e2e/report/test/report-show.test.ts
+++ b/e2e/report/test/report-show.test.ts
@@ -243,6 +243,7 @@ test("show 在 pipe 与真实 PTY 中保留独立、可读的公开文本", asyn
       expect(piped.exitCode, piped.diagnostic()).toBe(0);
       expect(piped.stdout).toContain("Pass rate");
       expect(piped.stdout).toContain("main");
+      expect(piped.stdout).not.toMatch(/[╭╮╰╯├┤]/u);
 
       const terminal = await runReportPty(
         ["show"],
@@ -250,7 +251,7 @@ test("show 在 pipe 与真实 PTY 中保留独立、可读的公开文本", asyn
           columns: 120,
           rows: 40,
           cwd: projectRoot,
-          env: { TERM: "dumb", NO_COLOR: undefined, FORCE_COLOR: undefined },
+          env: { TERM: "dumb", NO_COLOR: "1", FORCE_COLOR: undefined },
           timeoutMs: 60_000,
         },
       );
@@ -258,6 +259,8 @@ test("show 在 pipe 与真实 PTY 中保留独立、可读的公开文本", asyn
       const visible = stripVTControlCharacters(terminal.stdout);
       expect(visible).toContain("Pass rate");
       expect(visible).toContain("main");
+      expect(visible).toMatch(/^╭.*╮$/mu);
+      expect(visible).toMatch(/^╰.*╯$/mu);
     },
   );
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ import {
 import { reportDefinitionIdentity } from "./report/host/execute.ts";
 import { validateReportRoute } from "./report/execution/paths.ts";
 import { reportHost } from "./report/host/index.ts";
+import { panelCapabilityOf } from "./report/model/panel.ts";
 import {
   ReportHostProgressObserver,
   type ReportHostPhase,
@@ -2895,12 +2896,19 @@ function runShowCommand(
       "Load project, config, Report, and Theme",
       loadCliReportInputs(request),
     );
+    const textProjection = flags.json
+      ? undefined
+      : panelCapabilityOf({
+          isTTY: process.stdout.isTTY,
+          width: process.stdout.columns,
+        });
     const show = request.target.kind === "attempt"
       ? reportHost.show({
           root: request.root,
           locator: request.target.locator,
           report: inputs.report,
           ...(request.page === undefined ? {} : { route: request.page }),
+          ...(textProjection === undefined ? {} : { textProjection: { width: textProjection.width, panelMode: textProjection.mode } }),
           format: flags.json ? "json" as const : "text" as const,
         })
       : reportHost.show({
@@ -2910,6 +2918,7 @@ function runShowCommand(
             : inputs.projectCurrentSelection!,
           report: inputs.report,
           ...(request.page === undefined ? {} : { route: request.page }),
+          ...(textProjection === undefined ? {} : { textProjection: { width: textProjection.width, panelMode: textProjection.mode } }),
           format: flags.json ? "json" as const : "text" as const,
         });
     const output = yield* show.pipe(

--- a/src/report/execution/machine.ts
+++ b/src/report/execution/machine.ts
@@ -557,7 +557,7 @@ export function customTargetExecutionManifest(input: {
   if (!isPositiveSafeInteger(input.textWidth)) {
     throw new TypeError("custom target execution textWidth must be a positive safe integer");
   }
-  const text = resolvedPageText(input.page, { locale: "en", width: input.textWidth });
+  const text = resolvedPageText(input.page, { locale: "en", width: input.textWidth, panelMode: "plain" });
   if (!("state" in text) || text.state !== "rendered") {
     throw new TypeError("the selected Page lacks a closed English text projection at the requested width");
   }

--- a/src/report/host/execute.ts
+++ b/src/report/host/execute.ts
@@ -65,6 +65,7 @@ import {
   materializeRendererAssets,
 } from "../extension/assets.ts";
 import { resolveLocalizedText } from "../model/locale.ts";
+import type { PanelMode } from "../model/panel.ts";
 import {
   type ResolvedPage,
   type ResolvedPageAssetOutput,
@@ -152,6 +153,7 @@ export function executeReportTarget(input: {
   readonly sample: Sample;
   readonly report: ReportDefinition;
   readonly route?: string;
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 }): Effect.Effect<ClosedTargetExecution, ReportExecutionError, Scope.Scope> {
   const request = showTargetRequestForRoute(input.report, input.route);
   if (isReportTargetRouteInvalid(request)) return Effect.fail(request);
@@ -407,6 +409,7 @@ function executeTarget(input: {
   readonly pages: readonly ReportPageDefinition[];
   readonly request: ShowTargetRequest;
   readonly capture: AnalysisIssueCapture;
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 }): Effect.Effect<ResolvedPage, ReportExecutionError, Scope.Scope> {
   return executeShowTarget<ReportPageExecutionFailed, never>({
     definition: { pages: input.pages },
@@ -426,6 +429,7 @@ function executeTarget(input: {
       hrefPages: input.pages,
       page: context.page,
       route: context.target.route,
+      ...(input.textProjection === undefined ? {} : { textProjection: input.textProjection }),
     }),
   });
 }
@@ -440,6 +444,7 @@ function closeRenderedPage(input: {
   readonly hrefPages: readonly ReportPageDefinition[];
   readonly page: PageContext;
   readonly route: string;
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 }): Effect.Effect<ResolvedPageOutput, ReportPageExecutionFailed> {
   return Effect.tryPromise({
     try: () => input.capture.run(async (): Promise<ResolvedPageOutput> => {
@@ -451,20 +456,29 @@ function closeRenderedPage(input: {
       validateReportTree(resolved);
       assertDocumentBudget(resolved, input.page.id, input.page.path);
 
-      const text = WEB_LOCALES.map((locale) => {
+      const requestedTextProjections = [
+        { width: TEXT_WIDTH, panelMode: "plain" as const },
+        ...(input.textProjection === undefined ||
+          (input.textProjection.width === TEXT_WIDTH && input.textProjection.panelMode === "plain")
+          ? []
+          : [input.textProjection]),
+      ];
+      const text = WEB_LOCALES.flatMap((locale) => requestedTextProjections.map((projection) => {
         const pageDimensions = collectPageDimensions(resolved, input.report.dimensionPins, "text");
         const context = createTextContext({
-          width: TEXT_WIDTH,
+          width: projection.width,
           locale,
+          panelMode: projection.panelMode,
           pageDimensions,
           command: (target) => commandForTarget(input.hrefPages, target),
         });
         return Object.freeze({
           locale,
-          width: TEXT_WIDTH,
+          width: projection.width,
+          panelMode: projection.panelMode,
           text: renderNodeToText(resolved, context),
         });
-      });
+      }));
 
       const web = WEB_LOCALES.map((locale) => {
         const pageDimensions = collectPageDimensions(resolved, input.report.dimensionPins, "web");

--- a/src/report/host/from-record.ts
+++ b/src/report/host/from-record.ts
@@ -59,6 +59,7 @@ import {
   type ShowSelection,
 } from "../execution/machine.ts";
 import { renderResolvedPageText } from "../runtime/text.ts";
+import type { PanelMode } from "../model/panel.ts";
 import type { ThemeDefinition } from "../theme.ts";
 import {
   executeReportSite,
@@ -133,6 +134,7 @@ export type ReportRecordTarget = SelectionTarget | AttemptTarget;
 export type ShowReportFromRecordInput = ReportRecordTarget & {
   readonly route?: string;
   readonly format?: "text" | "json";
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 };
 
 export type BuildReportSiteFromRecordInput = ReportRecordTarget & {
@@ -199,6 +201,7 @@ export function reportSnapshotIdentityFromRecord(
 function showSelectionFromRecord(input: SelectionTarget & {
   readonly route?: string;
   readonly format?: "text" | "json";
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 }) {
   return Effect.scoped(Effect.gen(function* () {
     const sample = yield* openSelectionSample(input.root, input.selection);
@@ -209,6 +212,7 @@ function showSelectionFromRecord(input: SelectionTarget & {
       report,
       selection,
       ...(input.route === undefined ? {} : { route: input.route }),
+      ...(input.textProjection === undefined ? {} : { textProjection: input.textProjection }),
       format: input.format ?? "text",
     });
   }));
@@ -217,6 +221,7 @@ function showSelectionFromRecord(input: SelectionTarget & {
 function showAttemptFromRecord(input: AttemptTarget & {
   readonly route?: string;
   readonly format?: "text" | "json";
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 }) {
   return Effect.scoped(Effect.gen(function* () {
     const sample = yield* openAttemptSample(input.root, input.locator);
@@ -231,6 +236,7 @@ function showAttemptFromRecord(input: AttemptTarget & {
       report,
       selection,
       ...(input.route === undefined ? {} : { route: input.route }),
+      ...(input.textProjection === undefined ? {} : { textProjection: input.textProjection }),
       format: input.format ?? "text",
     });
   }));
@@ -249,6 +255,7 @@ function presentShowTarget(input: {
   readonly selection: ShowSelection;
   readonly route?: string;
   readonly format: "text" | "json";
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 }): Effect.Effect<string, ExecuteReportFromRecordError, Scope.Scope> {
   if (input.format === "json") {
     const descriptor = builtInMachineDescriptorOf(input.report);
@@ -267,6 +274,7 @@ function presentShowTarget(input: {
       sample: input.sample,
       report: input.report,
       ...(input.route === undefined ? {} : { route: input.route }),
+      ...(input.textProjection === undefined ? {} : { textProjection: input.textProjection }),
     }));
     return yield* presentTarget({
       sample: input.sample,
@@ -274,6 +282,7 @@ function presentShowTarget(input: {
       execution,
       selection: input.selection,
       format: input.format,
+      ...(input.textProjection === undefined ? {} : { textProjection: input.textProjection }),
     });
   });
 }
@@ -513,6 +522,7 @@ function presentTarget(input: {
   readonly execution: ClosedTargetExecution;
   readonly selection: ShowSelection;
   readonly format: "text" | "json";
+  readonly textProjection?: { readonly width: number; readonly panelMode: PanelMode };
 }): Effect.Effect<
   string,
   ReportShowPresentationFailed,
@@ -522,7 +532,8 @@ function presentTarget(input: {
     return Effect.try({
       try: () => withTrailingNewline(renderResolvedPageText(input.execution.page, {
         locale: "en",
-        width: SHOW_TEXT_WIDTH,
+        width: input.textProjection?.width ?? SHOW_TEXT_WIDTH,
+        panelMode: input.textProjection?.panelMode ?? "plain",
       })),
       catch: (cause): ReportShowPresentationFailed => presentationFailure("text", cause),
     });

--- a/src/report/runtime/resolved-page.ts
+++ b/src/report/runtime/resolved-page.ts
@@ -7,6 +7,7 @@ import {
   type SampleIdentity,
 } from "../../analysis/contracts.ts";
 import type { LocalizedText } from "../../shared/types.ts";
+import type { PanelMode } from "../model/panel.ts";
 
 /** A closed page has no route back to an author callback or a live Sample. */
 export const RESOLVED_PAGE_FORMAT = "niceeval.report.resolved-page/v1";
@@ -21,6 +22,7 @@ export interface ResolvedPageTarget {
 export interface ResolvedPageTextProjection {
   readonly locale: string;
   readonly width: number;
+  readonly panelMode: PanelMode;
   readonly text: string;
 }
 
@@ -166,10 +168,12 @@ export function resolvePage<Rendered, Error, Requirements>(
 /** Finds an already-built terminal projection. It never invokes a renderer. */
 export function resolvedPageTextProjection(
   page: ResolvedPage,
-  input: { readonly locale: string; readonly width: number },
+  input: { readonly locale: string; readonly width: number; readonly panelMode: PanelMode },
 ): ResolvedPageTextProjection | undefined {
   return page.text.find((projection) =>
-    projection.locale === input.locale && projection.width === input.width
+    projection.locale === input.locale &&
+    projection.width === input.width &&
+    projection.panelMode === input.panelMode
   );
 }
 
@@ -275,16 +279,24 @@ function freezeTextProjections(
     if (rejectLiveCapability(projection, sample, ["text", String(index)])) {
       throw new TypeError(`text[${index}] retains a live Sample capability`);
     }
-    if (!isNonEmptyString(projection.locale) || !isPositiveSafeInteger(projection.width) || typeof projection.text !== "string") {
-      throw new TypeError(`text[${index}] must contain locale, positive width, and text`);
+    if (!isNonEmptyString(projection.locale) || !isPositiveSafeInteger(projection.width) ||
+      (projection.panelMode !== "boxed" && projection.panelMode !== "plain") || typeof projection.text !== "string") {
+      throw new TypeError(`text[${index}] must contain locale, positive width, panel mode, and text`);
     }
-    const key = `${projection.locale}\u0000${projection.width}`;
+    const key = `${projection.locale}\u0000${projection.width}\u0000${projection.panelMode}`;
     if (seen.has(key)) throw new TypeError(`text projection ${JSON.stringify(key)} is duplicated`);
     seen.add(key);
-    return Object.freeze({ locale: projection.locale, width: projection.width, text: projection.text });
+    return Object.freeze({
+      locale: projection.locale,
+      width: projection.width,
+      panelMode: projection.panelMode,
+      text: projection.text,
+    });
   });
   return Object.freeze(closed.sort((left, right) =>
-    compareUtf8(left.locale, right.locale) || left.width - right.width
+    compareUtf8(left.locale, right.locale) ||
+    left.width - right.width ||
+    compareUtf8(left.panelMode, right.panelMode)
   ));
 }
 

--- a/src/report/runtime/text.ts
+++ b/src/report/runtime/text.ts
@@ -2,12 +2,15 @@ import {
   resolvedPageTextProjection,
   type ResolvedPage,
 } from "./resolved-page.ts";
+import type { PanelMode } from "../model/panel.ts";
 
 export interface RenderResolvedPageTextOptions {
   /** Explicit: a machine or terminal caller must never inherit process locale. */
   readonly locale: string;
   /** Explicit: closed terminal output is only reusable at the requested width. */
   readonly width: number;
+  /** Explicit: callers select a pre-closed terminal or plain-text projection. */
+  readonly panelMode: PanelMode;
 }
 
 export interface ResolvedPageTextProjectionMissing {
@@ -16,6 +19,7 @@ export interface ResolvedPageTextProjectionMissing {
   readonly route: string;
   readonly locale: string;
   readonly width: number;
+  readonly panelMode: PanelMode;
 }
 
 /**
@@ -51,5 +55,6 @@ function textProjectionMissing(
     route: page.target.route,
     locale: options.locale,
     width: options.width,
+    panelMode: options.panelMode,
   });
 }


### PR DESCRIPTION
## Problem

- User goal: 在交互式终端中通过 `niceeval show` 看清 Report 的 Grid、Section 和 Table 结构。
- Current limitation: 新 Report 执行链固定选择 plain 文本投影；即使 stdout 是宽 PTY，组件框线也会消失，`NO_COLOR=1` 还会错误地抑制结构框线。线上 browser E2E 另受 4 分钟 cell 总预算限制，Playwright browser cache 无法覆盖的 apt 系统依赖下载抖动会取消本来正常的测试。
- Required capability: Report 在闭包阶段同时准备固定 plain 投影和终端请求的投影，再由 CLI 按 stdout 能力选择；颜色开关与结构框线分离。Browser cell 需要独立于 host/docker 性能门槛的系统依赖安装余量。
- User outcome: 宽 TTY 恢复组件框线，pipe、窄终端和 JSON 仍保持稳定的 plain 文本；browser E2E 保留 `--with-deps` 安全性且不再因短暂 apt 慢镜像在 4 分钟处被取消。

## Use cases

### 在终端阅读 show 报告

- Coverage: `happy path | composition | failure | unsupported`
- Starting point: 用户已有一个可由 `niceeval show` 打开的 Record；Report 组合了 Grid、Section 或 Table，内容可以是完整数据或 missing/no data 状态。
- Copyable usage or trigger: `NO_COLOR=1 pnpm exec niceeval show`
- Observable result or diagnostic: 宽 TTY 中组件显示结构框线；同一命令通过 pipe 输出时不含框线；`pnpm exec niceeval show --json` 继续输出 `niceeval.show/v1` JSON。missing 数据使用相同组件结构，不会退化为另一套展示。
- Contract: `docs/feature/reports/cli.md`

### 在 CI 中运行 browser E2E

- Coverage: `lifecycle | failure`
- Starting point: matrix cell 通过 `requires.browsers` 声明 Chromium、Firefox 或 WebKit，并命中 `~/.cache/ms-playwright` browser cache。
- Copyable usage or trigger: 向 PR push 后由 `.github/workflows/e2e.yml` 自动运行 browser cell；release tag 使用 `.github/workflows/release.yml` 的相同策略。
- Observable result or diagnostic: host/docker cell 仍在 4 分钟门槛内；browser cell 有 6 分钟总预算，允许 `playwright install --with-deps` 完成不受 browser cache 覆盖的 apt 系统依赖安装。真正超过 6 分钟仍会 cancelled。
- Contract: `no separate use-case document`

## Public API

### Removed

None

### Added

None

### Changed

#### `reportHost.show`

- Before usage or result: `reportHost.show({ record, report, input: { format: "text" } })` 只能取得固定 plain 文本投影，外部 Host 无法请求终端框线。
- After usage or result: `reportHost.show({ record, report, input: { format: "text" }, textProjection: { width: 120, panelMode: "boxed" } })` 可选择已闭包的终端投影；省略该字段仍返回固定 plain 投影。
- User impact: 现有调用无需迁移；需要终端呈现的 Host 可以显式传递宽度与 panel mode。

## CLI commands

### Removed

None

### Added

None

### Changed

#### `niceeval show`

- Before usage or result: `NO_COLOR=1 pnpm exec niceeval show` 在宽 TTY 中将 Grid、Section 和 Table 渲染成无框 plain 文本。
- After usage or result: 同一命令在宽 TTY 中保留结构框线；`pnpm exec niceeval show | cat` 与 `pnpm exec niceeval show --json` 仍无框。
- User impact: 人类终端输出恢复可读结构；脚本、重定向和 JSON schema 不变。

## Report components

### Removed

None

### Added

None

### Changed

#### `Grid`, `Section`, `Table` 的 CLI text face

- Before usage or result: `<Grid><Stat label="Pass rate" value="89%" /></Grid>` 经 `niceeval show` 在宽 TTY 中仍显示为无框文本。
- After usage or result: 相同 Report JSX 在宽 TTY 中显示组件框线，在 pipe/窄终端中自动降级为 plain。
- User impact: Report 作者无需修改 JSX；完整数据和 missing 数据采用同一组件及响应式框线规则。

## Observable behavior and data contracts

### Removed

None

### Added

None

### Changed

#### Report 文本投影选择

- Before usage or result: Report 闭包只保留 plain 80 列投影，终端呈现无法恢复组件框线。
- After usage or result: 闭包同时保留固定 plain 80 列投影与请求的终端投影；人类 text 输出按 transport 选择，JSON 中的 rendered text 继续选择固定 plain 80 列投影。
- User impact: 交互式阅读更清晰，机器输出和存储数据不变，无迁移要求。

## Record schema and stored-data upgrade

- Affected public Record Format surfaces: None
- Private persisted implementation impact: None
- Version decision: not affected
- Version reason: 本次只改变读取后 Report 的文本投影选择，不写入或重新解释 Record 字段、文件或附件。
- Existing Record behavior: 新 reader 直接读取历史 Record；旧 reader 读取本变更之后产生的 Record 时行为不变，因为 writer 和格式均未改变。
- Migration or recovery path: not applicable — 没有存储格式变化；历史 Record 直接运行 `pnpm exec niceeval show`。
- Migration safety: 不运行迁移，不触碰现有数据。
- Contract: not applicable
- Version history: not applicable
- Verification: 在 `/home/ctrdh/Code/NiceEval/NiceEval-Eval` 对既有 Record 通过公开 CLI 运行 `pnpm exec niceeval show` 与 `pnpm exec niceeval show --json`，均成功读取。

## Environment variables

### Removed

None

### Added

None

### Changed

#### `NO_COLOR`

- Before usage or result: `NO_COLOR=1 pnpm exec niceeval show` 同时去掉颜色与 Report 结构框线。
- After usage or result: 同一命令只禁用颜色，宽 TTY 中仍保留 Grid、Section 和 Table 的结构框线。
- Environment boundary: 由用户或父进程提供并继承，CLI 消费；未设置时沿用默认颜色能力。它不是 secret，也没有新增解析或优先级。
- Necessity: `NO_COLOR` 是既有的跨 CLI 环境约定；本次仅纠正它的作用域，不新增环境配置。
- User and security impact: 无迁移或安全影响；依赖 `NO_COLOR` 的用户继续获得无颜色输出，但不再丢失结构。

## Package scripts

### Removed

None

### Added

None

### Changed

None

## Tests

### `e2e/report/test/report-show.test.ts` — report-show-json

- Change: `substantially rewritten`
- Change class: `bug-regression`
- Disposition: `retain`
- Candidate identity: Git `e4e9afef`; NiceEval tarball SHA-256 `0996e8d590ec5bf87e62bb508caab211ad07a05665b87df4cd3aaf06c1deef6c`
- Contract and owner: `docs/engineering/testing/e2e/report.md#report-show-json`
- Stability budget: 加强既有 Report show owner，仅断言公开 stdout transport 的长期差异；没有新增 owner。
- Example scenario: 同一候选包先以 pipe 执行 `niceeval show`，再在 `NO_COLOR=1` 的真实 PTY 中执行；前者无框，后者同时出现顶部与底部框线。
- Before: 有完整 Report 数据时 PTY 输出不含 `╭`，missing 数据也随组件结构一同退化。
- After: pipe 输出不含框线，宽 PTY 在禁用颜色时仍保留完整结构框线。
- Distinguishing evidence: 先仅加入 PTY 断言，旧实现于 observe 阶段失败；初次修复后将条件收紧为 `NO_COLOR=1` 再次失败，分离颜色与结构能力后转绿。
- Verification: `pnpm e2e --repo report -- --run test/report-show.test.ts`（6/6 passed）；历史实现最早失败于 observe 阶段的 PTY frame assertion。
- Fixed conditions: 根 lockfile 与 Report scenario lockfile 固定；candidate tarball digest 如上；fixture/agent 确定；无 seed、clock 或 image。
- Repeatability: takeover 的 isolated-copy 1/2/3、same-copy 1/2、repo-default-parallel、target-single 全部通过；并行默认矩阵为 6 Vitest files / 11 tests 与 2 Playwright tests；临时资源由 harness 清理。Receipt: `/tmp/niceeval-e2e-takeover-artifacts-EsEfN7/takeover-summary.json`。
- Unit exception or no automation: 风险可由真实安装包、进程 pipe 与 PTY 的稳定公开边界区分，不需要 Unit 例外。
- Unit count: not applicable — root 没有独立 `pnpm test` Unit script，本次未新增或修改 Unit。
- Manual observation: Node 24 / pnpm 11.12.0，在 NiceEval-Eval 链接当前候选并通过公开 `niceeval show` 验证；TTY 的完整与 missing 内容均有框，pipe/JSON 无框且 JSON schema 为 `niceeval.show/v1`。终端执行中途动态 resize 未单独自动化。
- User impact: 防止未来 Report runtime 重构再次让交互式 `show` 丢失组件结构，同时守住脚本输出兼容性。

### GitHub Actions browser matrix execution budget

- Change: `not automated`
- Change class: `not-automated`
- Disposition: `not automated`
- Candidate identity: Git `e4e9afef`; workflow change does not alter the packed NiceEval candidate.
- Contract and owner: `.github/workflows/e2e.yml` and `.github/workflows/release.yml`
- Stability budget: 仅 browser cell 从 4 分钟变为 6 分钟；host/docker 仍为 4 分钟，不改变测试 expected 或 batch 布局。
- Example scenario: Playwright browser cache 命中，但 `install --with-deps chromium` 的 apt 下载耗时约 2 分钟；cell 继续进入并完成 browser E2E。
- Before: 完整 browser 测试无断言失败，但 job 在 4 分钟上限被 cancelled，随后 e2e gate 失败。
- After: 声明 Chromium/Firefox/WebKit 的 cell 得到 6 分钟预算，其他 cell 保持 4 分钟。
- Distinguishing evidence: PR #56 首轮 run `32104054086` 中 browser cache 成功恢复，browser job 仍因 4 分钟 workflow timeout 被取消；其余 6 个 E2E batch 全部通过。
- Verification: YAML parser 成功读取两份 workflow；最终验证以本 PR 新 head 的 GitHub Actions browser cell 与 e2e gate 为准。
- Fixed conditions: GitHub `ubuntu-24.04` runner、根/Repo lockfile、Playwright cache key 与原 `--with-deps` 命令均不变。
- Repeatability: 不新增测试 owner；通过真实 PR rerun 验证慢依赖安装路径，正常 cache 快路径继续使用同一 workflow。
- Unit exception or no automation: workflow timeout 只有 GitHub runner 的真实 job deadline 能可靠验证；不以读取 YAML 的 Unit 复制 workflow 语义。
- Unit count: not applicable — 未修改 Unit。
- Manual observation: run `32104054086` 的 pnpm 与 Playwright cache 均命中；apt 21.1 MB 下载约 1m51s，browser job 在总计 4 分钟时 cancelled。
- User impact: 临时 apt 镜像抖动不再把已缓存且正确的 browser E2E 误报为失败，同时不放宽非浏览器 cell 的性能门槛。
