### PR TITLE
ci(e2e): 恢复 Claude 与 Runner 线上验收

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -283,9 +283,7 @@ jobs:
     # cell 的 matrix.container 为 null，仍直接运行在普通 GitHub runner。镜像已经包含 browser
     # 与系统依赖，不在每次 job 中运行 apt / `playwright install --with-deps`。
     container: ${{ matrix.container }}
-    # Repo test budgets are enforced by the root runner. Keep one additional
-    # minute for checkout, dependency installation, collection, and cleanup.
-    timeout-minutes: 5
+    timeout-minutes: ${{ matrix.container && 5 || 4 }}
     # 同仓 PR 直接使用仓库级 secret；push、schedule 与显式 live dispatch 挂
     # 同名 Environment。所有路径都只注入 manifest 白名单中的 secret。
     environment: ${{ needs.prepare.outputs.inject-secrets == 'true' && needs.prepare.outputs.environment || fromJSON('null') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -283,7 +283,9 @@ jobs:
     # cell 的 matrix.container 为 null，仍直接运行在普通 GitHub runner。镜像已经包含 browser
     # 与系统依赖，不在每次 job 中运行 apt / `playwright install --with-deps`。
     container: ${{ matrix.container }}
-    timeout-minutes: ${{ matrix.container && 5 || 4 }}
+    # Repo test budgets are enforced by the root runner. Keep one additional
+    # minute for checkout, dependency installation, collection, and cleanup.
+    timeout-minutes: 5
     # 同仓 PR 直接使用仓库级 secret；push、schedule 与显式 live dispatch 挂
     # 同名 Environment。所有路径都只注入 manifest 白名单中的 secret。
     environment: ${{ needs.prepare.outputs.inject-secrets == 'true' && needs.prepare.outputs.environment || fromJSON('null') }}

--- a/docs/engineering/testing/e2e/adapter/claude-agent-sdk.md
+++ b/docs/engineering/testing/e2e/adapter/claude-agent-sdk.md
@@ -37,8 +37,8 @@ group，确保没有残留子进程。
 唯一 `bash-session` Journey 的首轮要求真实模型用原生 Bash 执行一条带随机 marker 的安全
 `printf`。它断言 canonical `shell`、精确 command input 与 `completed`；这个 completed 状态同时证明
 `tool_use_id` 和 `tool_result` 已配对。首轮和 resume 轮的 input / output usage 都必须为正，
-`t.sessionId` 必须已经由 `system/init` 捕获。第二轮要求模型引用首轮随机哨兵，证明 SDK `resume`
-真正取回首轮会话。
+`t.sessionId` 必须已经由 `system/init` 捕获。第二轮要求模型引用首轮短随机 challenge code，证明 SDK `resume`
+真正取回首轮会话；challenge 保持不可预知，但不把长 UUID 的逐字抄写能力混入 session 兼容性判定。
 
 测试只通过公开 CLI 的 `show`、`show --json` 和代表 Report 的 execution target Page 读回通过结果。
 target Page 使用 `show @locator --report <fixture-module> --page <route>`。

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -229,8 +229,9 @@ batch 是共机放置单位，不是限流单位；plan 不携带 CI 限流参�
 资源竞争、OOM 或尾延迟通过把 manifest 显式拆到 `docker-1`、`docker-2`、`docker-3` 等更多 matrix cell 处理，
 不能通过让同格 Repo 排队来换取通过；拆分不改变 lane 的精确 Repo 集。
 
-matrix cell 的 4 分钟上限包含 runner/action 启动、依赖安装与同 cell 的并行 live Repo；这是 E2E 关键路径的性能门槛。
-每个 Repo 的产品执行预算仍由 manifest 自己收紧，不能用 job 上限放宽 provider timeout。
+matrix cell 的 5 分钟外层上限包含 runner/action 启动、依赖安装、artifact 收集与 cleanup；这是 E2E 关键路径的性能门槛。
+每个 Repo 的产品执行预算仍由 manifest 自己收紧，外层比最长 host Repo 的 4 分钟测试预算多留一分钟编排余量，
+不能用 job 上限放宽 provider timeout。
 
 每个 matrix cell 自己上传 receipt、summary、JUnit 与声明附件；Repo batch 的 artifact root 下仍按 Repo ID 分目录并
 保存独立 receipt，batch summary 列全该格 Repo。GitHub 原生汇总 matrix 成败，不再启动一个 job 下载并复述所有 cell 的结果。

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -229,9 +229,8 @@ batch 是共机放置单位，不是限流单位；plan 不携带 CI 限流参�
 资源竞争、OOM 或尾延迟通过把 manifest 显式拆到 `docker-1`、`docker-2`、`docker-3` 等更多 matrix cell 处理，
 不能通过让同格 Repo 排队来换取通过；拆分不改变 lane 的精确 Repo 集。
 
-matrix cell 的 5 分钟外层上限包含 runner/action 启动、依赖安装、artifact 收集与 cleanup；这是 E2E 关键路径的性能门槛。
-每个 Repo 的产品执行预算仍由 manifest 自己收紧，外层比最长 host Repo 的 4 分钟测试预算多留一分钟编排余量，
-不能用 job 上限放宽 provider timeout。
+matrix cell 的 4 分钟上限包含 runner/action 启动、依赖安装与同 cell 的并行 live Repo；这是 E2E 关键路径的性能门槛。
+每个 Repo 的产品执行预算仍由 manifest 自己收紧，不能用 job 上限放宽 provider timeout。
 
 每个 matrix cell 自己上传 receipt、summary、JUnit 与声明附件；Repo batch 的 artifact root 下仍按 Repo ID 分目录并
 保存独立 receipt，batch summary 列全该格 Repo。GitHub 原生汇总 matrix 成败，不再启动一个 job 下载并复述所有 cell 的结果。

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -229,8 +229,9 @@ batch 是共机放置单位，不是限流单位；plan 不携带 CI 限流参�
 资源竞争、OOM 或尾延迟通过把 manifest 显式拆到 `docker-1`、`docker-2`、`docker-3` 等更多 matrix cell 处理，
 不能通过让同格 Repo 排队来换取通过；拆分不改变 lane 的精确 Repo 集。
 
-matrix cell 的 4 分钟上限包含 runner/action 启动、依赖安装与同 cell 的并行 live Repo；这是 E2E 关键路径的性能门槛。
-每个 Repo 的产品执行预算仍由 manifest 自己收紧，不能用 job 上限放宽 provider timeout。
+matrix cell 的 5 分钟外层上限包含 runner/action 启动、依赖安装、artifact 收集与 cleanup；这是 E2E 关键路径的性能门槛。
+每个 Repo 的产品执行预算仍由 manifest 自己收紧，外层比最长 host Repo 的 4 分钟测试预算多留一分钟编排余量，
+不能用 job 上限放宽 provider timeout。
 
 每个 matrix cell 自己上传 receipt、summary、JUnit 与声明附件；Repo batch 的 artifact root 下仍按 Repo ID 分目录并
 保存独立 receipt，batch summary 列全该格 Repo。GitHub 原生汇总 matrix 成败，不再启动一个 job 下载并复述所有 cell 的结果。
@@ -274,9 +275,10 @@ Docker cgroup 的 `cpu.max`、`memory.max`、`memory.swap.max` 与 `pids.max` �
 - 同一 checkout 的独立根 E2E invocation 可以并发启动；只有会触发共享 `prepare` 写入的 candidate `pnpm pack` 生命周期按 canonical checkout 的跨进程 lease 局部串行，计划、Testkit snapshot、隔离 Repo 与 run 阶段继续并发；
 - lease 位于 OS 临时控制目录而不进入待打包文件。正常退出、失败或取消都会释放；进程崩溃留下的 lease fail-closed 并报出精确人工删除路径，绝不靠超时或不安全删除让两个 pack 同时写入；
 - 无密钥 host Repo 可按 CPU 并行，每个 Repo 独立副本；
-- CI E2E matrix 按 capability 选择 Blacksmith runner：声明 `requires.docker: true` 的 cell 使用 4 vCPU，
-  其它 host / browser cell 使用 2 vCPU。所有独立 Repo 按 manifest `batch` 装箱，格内并发启动且各 Repo 保留
-  自己的 file / experiment / attempt 并发；这些 owner 的主要开销是依赖安装、容器启动、浏览器与外部 I/O 等待，不把 vCPU 数当作 I/O 并发上限；
+- CI E2E matrix 使用标准 GitHub-hosted `ubuntu-24.04` runner；browser cell 只是在同类 runner 上进入精确 Playwright
+  container，不切换 runner 供应商或规格。当前 public repository 的该标签由 GitHub 定义为 4 vCPU，但并发预算仍以 workflow
+  与实测收据为准，不从 runner 名称猜测。所有独立 Repo 按 manifest `batch` 装箱，格内并发启动且各 Repo 保留自己的
+  file / experiment / attempt 并发；这些 owner 的主要开销是依赖安装、容器启动、浏览器与外部 I/O 等待，不把 vCPU 数当作 I/O 并发上限；
 - Repo 内保留 Vitest / Playwright 的默认文件级并行；短命控制文件、结果根、项目副本与资源名按 case 隔离；
 - 出现 OOM、daemon 抖动或显著尾延迟时，把部分 Repo 显式移到 `docker-2`、`host-2` 等新 batch，不以升配 CPU 作为默认修法；
 - live provider 按 provider / account 建 concurrency group，避免同一配额互相制造 429；

--- a/e2e/adapter/claude-agent-sdk/test/claude-agent-sdk.test.ts
+++ b/e2e/adapter/claude-agent-sdk/test/claude-agent-sdk.test.ts
@@ -3,7 +3,7 @@
 // 真实 SDK / provider Journey：候选包公开的 converter 只消费 SDKMessage，测试只经
 // 安装后的 CLI 读回。没有 HTTP server、MCP 或私有 .niceeval 读取。
 
-import { randomUUID } from "node:crypto";
+import { randomInt, randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -42,7 +42,10 @@ beforeAll(async () => {
   requireLiveSecrets();
 
   marker = `niceeval-claude-sdk-bash-${randomUUID()}`;
-  sentinel = `niceeval-claude-sdk-session-${randomUUID()}`;
+  // Resume only needs an unpredictable challenge that was present in the first
+  // turn. A UUID makes the live model's character-perfect transcription, rather
+  // than SDK session continuity, the dominant source of failure.
+  sentinel = `NE-${randomInt(1_000, 10_000)}`;
 
   await withTempDir("niceeval-claude-agent-sdk-", async (tempRoot) => {
     const privateHome = join(tempRoot, "home");

--- a/e2e/runner/e2e.json
+++ b/e2e/runner/e2e.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "id": "runner",
-  "batch": "host-1",
+  "batch": "host-4",
   "areas": ["runner"],
   "lanes": ["pr", "main", "nightly", "release"],
   "executor": { "kind": "host" },

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -4,9 +4,9 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     // Runner cases spend most of their wall time waiting on isolated child
-    // processes. Keep four file workers explicit on the public GitHub-hosted
-    // runner so environment-derived defaults cannot serialize this I/O workload.
-    maxWorkers: 4,
+    // processes. Use two file workers per public-runner vCPU so long lifecycle
+    // files start early instead of sitting behind other I/O-bound owners.
+    maxWorkers: 8,
     testTimeout: 240_000,
     hookTimeout: 120_000,
   },

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -1,12 +1,33 @@
 import { defineConfig } from "vitest/config";
+import { BaseSequencer, type TestSpecification } from "vitest/node";
+
+const criticalPathOwners = [
+  "shared-state-recovery.test.ts",
+  "shared-state-lifecycle.test.ts",
+  "shared-state-startup-authority.test.ts",
+] as const;
+
+class RunnerSequencer extends BaseSequencer {
+  override async sort(files: TestSpecification[]): Promise<TestSpecification[]> {
+    const sorted = await super.sort(files);
+    return sorted.sort((left, right) => {
+      const priority = (moduleId: string) => {
+        const index = criticalPathOwners.findIndex((file) => moduleId.endsWith(`/${file}`));
+        return index === -1 ? criticalPathOwners.length : index;
+      };
+      return priority(left.moduleId) - priority(right.moduleId);
+    });
+  }
+}
 
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
-    // Runner cases spend most of their wall time waiting on isolated child
-    // processes. Ten workers start the long recovery owner after at most one
-    // short wave without overloading four-core CI with every file at once.
-    maxWorkers: 10,
+    // Start long child-process journeys first, then keep concurrency at the
+    // public runner's four-vCPU capacity so individual Agent deadlines remain
+    // meaningful under load.
+    sequence: { sequencer: RunnerSequencer },
+    maxWorkers: 4,
     testTimeout: 240_000,
     hookTimeout: 120_000,
   },

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -4,9 +4,9 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     // Runner cases spend most of their wall time waiting on isolated child
-    // processes. Use two file workers per public-runner vCPU so long lifecycle
-    // files start early instead of sitting behind other I/O-bound owners.
-    maxWorkers: 8,
+    // processes. Ten workers start the long recovery owner after at most one
+    // short wave without overloading four-core CI with every file at once.
+    maxWorkers: 10,
     testTimeout: 240_000,
     hookTimeout: 120_000,
   },

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     // Runner cases spend most of their wall time waiting on isolated child
-    // processes. Keep enough file workers to exercise that intended parallelism
-    // on the two-vCPU CI host instead of serializing I/O behind the CPU count.
+    // processes. Keep four file workers explicit on the public GitHub-hosted
+    // runner so environment-derived defaults cannot serialize this I/O workload.
     maxWorkers: 4,
     testTimeout: 240_000,
     hookTimeout: 120_000,

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
+    // Runner cases spend most of their wall time waiting on isolated child
+    // processes. Keep enough file workers to exercise that intended parallelism
+    // on the two-vCPU CI host instead of serializing I/O behind the CPU count.
+    maxWorkers: 4,
     testTimeout: 240_000,
     hookTimeout: 120_000,
   },


### PR DESCRIPTION
## Problem

- User goal: 让线上 E2E 在 Repo 自身四分钟测试预算与 matrix cell 五分钟外层预算内稳定完成，并只在 Claude Agent SDK 的真实 session/resume 兼容性失效时变红。
- Current limitation: `bash-session` 要求模型逐字复述 36 位 UUID。main 的 run 32331659565 中两次 Invocation 都完整执行 Bash、捕获 session id 并恢复会话，却因模型把 `09cea6a2` 抄成 `09cea2a` 而失败；首次修复后的 PR run 32332241800 证明 Claude owner 已转绿，但 `runner` 与另外三个 Repo 共用 `host-1`，资源竞争让该 cell 在完成前撞上四分钟 job 门。
- Required capability: resume challenge 仍须每次随机且不可预知，但长度应只证明跨轮会话连续性，不额外考验长随机串的字符级抄写；Runner 需要独立 batch，以四个 Vitest workers 对齐 public runner 的四核资源，并让 recovery、lifecycle、startup-authority 三个长 owner 优先启动，避免排队与过量并发同时污染结果。Repo 测试仍须在四分钟内结束，cell 外层另留一分钟给 checkout、安装、汇总与 cleanup。
- User outcome: Claude SDK 的 live E2E 保留 Bash 配对、usage、session id 和 resume 证明，同时不再因长 UUID 少抄字符而假红；Runner 不再被同 cell 的负载挤占资源，并在 Repo 四分钟、cell 五分钟的分层性能门内完成全部 owner。

## Terminology

### Added terms

None

### Removed terms

None

## Tests

### `e2e/adapter/claude-agent-sdk/test/claude-agent-sdk.test.ts`

- Purpose: bug regression
- Protects: 真实 Claude Agent SDK 的 Bash 配对、usage 与 session resume 兼容性；避免长 UUID 转录噪声掩盖协议结果。
- Runs: 安装后 `niceeval exp --rerun all --json`，结构化失败时精确补跑一次，再以 `niceeval show @locator --execution --json` 公开读回。
- Asserts: Invocation 完成且有一个 Run；`bash-session` 为 passed/1；公开 execution 含 conversation、原生 Bash 工具、完成结果、随机 marker 与短随机 resume challenge。

```ts
// owner: docs/engineering/testing/e2e/adapter/claude-agent-sdk.md#adapter-claude-agent-sdk-live-compatibility
//
// 真实 SDK / provider Journey：候选包公开的 converter 只消费 SDKMessage，测试只经
// 安装后的 CLI 读回。没有 HTTP server、MCP 或私有 .niceeval 读取。

import { randomInt, randomUUID } from "node:crypto";
import { mkdir } from "node:fs/promises";
import { join } from "node:path";
import {
  assertExpEvalOutcomes,
  command,
  only,
  retryFailedExpEvalsOnce,
  type ExpEvalEvent,
  type ProcessReceipt,
  withProcess,
  withTempDir,
} from "@niceeval/testkit";
import { beforeAll, expect, it } from "vitest";

const EVAL_ID = "bash-session";
const REQUIRED_LIVE_SECRETS = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"] as const;
const niceevalBin = join(process.cwd(), "node_modules", ".bin", "niceeval");
const niceeval = command([niceevalBin]);
let marker!: string;
let sentinel!: string;
let runReceipt!: ProcessReceipt;
let evalEvents!: readonly ExpEvalEvent[];
let locator!: string;

function requireLiveSecrets(): void {
  const missing = REQUIRED_LIVE_SECRETS.filter((name) => !process.env[name]);
  if (missing.length > 0) {
    throw new Error(
      `[configuration] Claude Agent SDK live E2E requires ${missing.join(", ")}; ` +
        "the live test is not skipped when secrets are absent",
    );
  }
}

beforeAll(async () => {
  requireLiveSecrets();

  marker = `niceeval-claude-sdk-bash-${randomUUID()}`;
  // Resume only needs an unpredictable challenge that was present in the first
  // turn. A UUID makes the live model's character-perfect transcription, rather
  // than SDK session continuity, the dominant source of failure.
  sentinel = `NE-${randomInt(1_000, 10_000)}`;

  await withTempDir("niceeval-claude-agent-sdk-", async (tempRoot) => {
    const privateHome = join(tempRoot, "home");
    const workspace = join(tempRoot, "workspace");
    await Promise.all([mkdir(privateHome, { recursive: true }), mkdir(workspace, { recursive: true })]);

    const runExp = (args: readonly string[]) =>
      withProcess(
        [niceevalBin, "exp", ...args],
        {
        processGroup: true,
        timeoutMs: 13 * 60_000,
        env: {
          HOME: privateHome,
          CLAUDE_CONFIG_DIR: join(privateHome, ".claude"),
          NICEEVAL_CLAUDE_AGENT_SDK_HOME: privateHome,
          NICEEVAL_CLAUDE_AGENT_SDK_WORKSPACE: workspace,
          NICEEVAL_CLAUDE_AGENT_SDK_MARKER: marker,
          NICEEVAL_CLAUDE_AGENT_SDK_SENTINEL: sentinel,
        },
        },
        async (handle) => await handle.done,
      );

    runReceipt = await runExp(["--rerun", "all", "--json"]);
    const firstEvents = runReceipt.expEvalEvents();
    const failed = firstEvents.filter((event) => event.verdict === "failed");
    expect(
      firstEvents.filter(
        (event) => event.verdict === "errored" || event.verdict === "skipped",
      ),
      runReceipt.diagnostic(),
    ).toHaveLength(0);
    expect(runReceipt.exitCode, runReceipt.diagnostic()).toBe(failed.length > 0 ? 1 : 0);

    const retried = await retryFailedExpEvalsOnce({
      events: firstEvents,
      targets: failed,
      runRetry: (event) =>
        runExp(["ci", event.evalId, "--rerun", "all", "--json"]),
    });
    if (retried.retries.length > 0) {
      process.stderr.write(
        `[niceeval e2e] retried ${retried.retries.length} assertion-failed Eval once; ` +
          `first Invocation ${runReceipt.expReceipt().invocationId} remains recorded\n`,
      );
    }
    evalEvents = retried.events;
  });

  locator = only(
    evalEvents,
    (event) => event.evalId === EVAL_ID,
    () => runReceipt.diagnostic(),
  ).locator;
}, 14 * 60_000);

it("真实 Claude Agent SDK converter 的 Eval 以通过 verdict 完成", () => {
  // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md）：
  // completion 与 runIds；成败由带身份的 eval 事件精确断言，live provider
  // 故障不会冒充通过。
  const inv = runReceipt.expReceipt();
  expect(inv.completion, runReceipt.diagnostic()).toBe("completed");
  expect(inv.runIds, runReceipt.diagnostic()).toHaveLength(1);
  assertExpEvalOutcomes(
    evalEvents,
    [
      // bash-session：真实 SDK stream 须归一 Bash 调用并在续接轮保留 sentinel；期望 passed/1。
      {
        evalId: EVAL_ID,
        experimentId: "ci",
        verdict: "passed",
        attempts: 1,
        passed: 1,
      },
    ],
    () => runReceipt.diagnostic(),
  );
});

it("show --execution 读回 Claude Agent SDK converter 的代表性证据", async () => {
  const execution = await niceeval.run(["show", locator, "--execution", "--json"]);
  expect(execution.exitCode, execution.diagnostic()).toBe(0);
  // Conversation keeps the source-native tool, its unmodified input marker,
  // completed result, and resumed assistant response in the public machine view.
  expect(execution.stdout).toContain('"conversation"');
  expect(execution.stdout).toMatch(/"tool":"(?:shell|Bash)"/);
  expect(execution.stdout).toContain('"kind":"tool-result"');
  expect(execution.stdout).toContain(marker);
  expect(execution.stdout).toContain(sentinel);
});
```

### Verification receipt

- Candidate: PR head `aed5b691464461600c35b760d36b20db2efb4408`；CI tarball SHA-256 `8cdad3810edb01c9c30efd758cabcf0880f85267cb5de0dfaf777a34d489cf6b`。
- Red: GitHub Actions run 32331659565, `adapter/claude-agent-sdk` outcome stage。首次与精确补跑均只在 `includes("niceeval-claude-sdk-session-09cea6a2-…")` 失败，公开 `show @locator --json` 读到模型返回 `niceeval-claude-sdk-session-09cea2a-…`；Bash、usage、session id 与 resume turn 均完整。PR run 32332241800 中 `host-3` 已通过，但 `host-1` 在 Runner 尚有两个文件未完成时于四分钟 job 门被取消；拆出 `host-4` 后，run 32332730535 证明资源竞争消失，run 32333241930 进一步确认默认 worker 数仍使 Runner test invocation 超过 manifest 的四分钟门；显式四 workers 后，run 32334163932 已在四分钟内完成最后一个测试文件，但与测试预算同为四分钟的 cell 外层门在汇总前取消了 step；run 32334658564 的 5 分钟 cell 正常收尾，但 recovery owner 仍排队至 240 秒；八 workers 曾在 run 32335417670 全绿，却在 clean-head run 32335977962 中仍超时；十 workers 在 run 32337066369 把 recovery 的 pause-holder Agent 拖过其 60 秒产品 deadline，证明继续加并发会污染语义结果。
- Green: `pnpm typecheck` 通过；`pnpm lint` 通过（12 files / 46 tests，Mint validate 与 broken-links 通过）；`pnpm e2e plan --lane main --repo adapter/claude-agent-sdk --json` 精确选择 `host-3`；全量 main plan 将 `runner` 独立放入 `host-4`，`host-1` 只保留 `adapter/openai-compat`、`migrate` 与 `package`；`taskset -c 0-3 pnpm e2e run --candidate <8cdad…tgz> --repo runner` 在四 CPU affinity、四 workers、长 owner 优先排序下 14 files / 28 tests 全绿，Vitest 169.84s，root summary `1 passed, 0 regression` 且 scratch removed。最终 GitHub Actions run 32337815262 全矩阵与 gate 通过：Claude `host-3` 2m14s，Runner `host-4` 14 files 全绿、Vitest 197.85s、完整 job 4m19s；CI run 32337815274 的 typecheck、docs lint 与 docs-site 全绿。
- Repeatability: live owner 按约定使用一次授权的线上全量 E2E，不进入确定性 takeover 矩阵。
- Fixed conditions: `@anthropic-ai/claude-agent-sdk@0.3.226` lockfile；Node 24；标准 GitHub-hosted `ubuntu-24.04` public-repository runner（GitHub 当前规格为 4 vCPU）；同一 owner、真实 provider、隔离 HOME/workspace；marker 仍为 UUID，resume challenge 改为每次随机的 `NE-####`。
- Unit count: not applicable — no Unit changed
