### PR TITLE
feat(record): 自动迁移已由 Git 保存的旧 Record

### DIFF
--- a/.agents/friction-log/20260820131045-成本迁移状态逐-slot-重复且缺少/friction.md
+++ b/.agents/friction-log/20260820131045-成本迁移状态逐-slot-重复且缺少/friction.md
@@ -1,0 +1,28 @@
+---
+title: '成本迁移状态逐 slot 重复且缺少 niceeval migrate 动作'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+当所有选中 slot 都因 Observability v1 无法读取 Usage 时，顶层成本投影应汇总为 `migration-required`，并在 `niceeval show` 中给出一次明确的 `niceeval migrate` 恢复动作；逐 slot 原因应保持可诊断但不淹没摘要。
+
+## Current Behavior
+
+在 NiceEval-Eval 的历史 Record 上运行 `pnpm exec niceeval show`，Total cost 显示 `cost projection unavailable`，随后在同一单元格逐行重复数十个 `usage-migration-required` 与 `member-not-recorded`。输出没有给出 `niceeval migrate`，用户无法从默认报告判断这是可恢复的 Observability v1 → v2 迁移，而容易误解为所有成本事实损坏。
+
+## Possible Solution
+
+让标准 Report 识别顶层 `CostProjectionMigrationRequired`，只显示一次 migration-required 摘要与 `niceeval migrate` 动作；把 canonicalized per-slot reasons 放在显式详情页或折叠视图。混合 current/v1 且仍有金额时继续保持 partial。
+
+## Minimal Reproducible Example
+
+1. 使用当前 NiceEval 打开一个包含 Observability v1 Usage 的已封口 Record。
+2. 运行 `pnpm exec niceeval show`。
+3. 观察 Total cost 单元格重复输出 `usage-migration-required`，但没有文档要求的 `niceeval migrate` 恢复动作。
+
+NiceEval-Eval 当前 Record 的 Run range 为 2026-08-18 13:17 至 2026-08-19 11:48；Observability v2 于 2026-08-19 20:07 合入。
+
+## Context
+
+`docs/feature/reports/cost-projections/library.md` 明确要求：所有 slot 都因 Observability v1 不可读时，顶层 projection 与 metric state 为 `migration-required`，Report 显示 `niceeval migrate`，不能只把原因藏在 reasons。当前输出与该契约不符。

--- a/docs/engineering/testing/e2e/migrate.md
+++ b/docs/engineering/testing/e2e/migrate.md
@@ -5,29 +5,30 @@
 
 ## Current-to-current handoff bootstrap
 
-初始 owner 把 `producer` 和 `candidate` 绑定为两个命令身份，但两者都使用当前 candidate。
+bootstrap owner 把 `producer` 和 `candidate` 绑定为两个当前命令身份。
 producer 运行确定性 Experiment 并持久化 Record。candidate 在同一个私有 case 项目中启动独立的
 `show --run ... --json` 命令，并必须选中该次公开 Run 身份。
 
 该 owner 只证明持久化交接和可替换的 producer 接缝。它不声称旧版兼容、旧 schema 迁移、
 格式转换后的 ID 保留，也不声称已接管 legacy producer 的可靠性。
 
-当可验证的旧包可用时，root runner 负责该包身份，测试只替换 producer 命令前缀。
-直接读取仅适用于当前 reader 支持的 Record 版本；更旧的 Record major 仍须经过产品的显式迁移路径。
+legacy migration owner 另以固定 npm alias 安装并证明旧 producer 的 registry identity；candidate 仍只来自根 runner
+注入的唯一 tarball，不建立第二份 candidate 信任链。
 
 ## Observability v1 to v2
 
-`e2e/migrate/test/handoff.test.ts` 是显式 family migration 的成功 Journey owner。它把签入的 literal
-Observability v1 Record 复制到隔离消费项目，从安装后的 candidate 依次执行公开 `show` 与
-`niceeval migrate`：
+`e2e/migrate/test/handoff.test.ts` 是 automatic migration 的成功 Journey owner。它固定并 attested npm
+`niceeval@0.13.0`（registry SRI 亦为签入 expected），由其真实 CLI 运行确定性 Experiment 产生旧 Record：
 
-- migration 前 `show --json` 返回 `analysis-migration-required`，不误读旧 bytes；
-- 没有 `--yes` 时只打印包含两个 attachment 的计划；
-- clean Git restore point 下迁移成功，两个 envelope 变成 v2，payload、未知 family 与 draft bytes 不变；
-- migration-required 与普通 missing 混合时 Report 保持 `partial`，不输出错误的迁移恢复动作；
-- migration 后同一 Run 可由 `show` 读取，再次运行得到 `already-current`；
+- candidate 第一次 `show --run ... --json` 在 portable Record 尚未由 Git HEAD 保存时 fail closed，提示先保存；
+- 测试把 opaque Record directory 执行真实 `git add` / `git commit`；
+- 第二次同一 `show` 无确认自动原地迁移，stderr 只给一次 restore commit/目标 receipt；
+- 正常 show 结果仍选择同一 Run，并显示旧 producer 已证明通过的结果；
+- 再用同一 npm 0.13.0 CLI 对 root2 执行真实 `exp`，旧 writer fail closed，且 opaque Record Git diff
+  前后完全相同。
 
-其它独立输入与修复动作各自由一个最小 owner 负责。
+测试不读取私有 Record 文件来断言产品结果，也不以手写 v1 fixture 作为成功 owner。explicit `niceeval migrate`
+的计划、确认、诊断和 sentinel/Git 恢复继续由下列最小 owner 分别负责。
 
 ### Interrupted migration recovery
 
@@ -65,8 +66,8 @@ Observability v1 Record 复制到隔离消费项目，从安装后的 candidate 
 
 ### Report migration metric guard
 
-`report-guard.test.ts` 证明 Report 拒绝 ledger 缺少 denominator Slot 的伪造 migration-required metric；成功 Journey 同时证明非零全迁移状态保留。
+`report-guard.test.ts` 用 current candidate 的真实 `exp` 生成 current Record，再证明 Report 拒绝 ledger 缺少 denominator Slot 的伪造 metric；它不以旧 Record 的前置失败掩盖 Report 边界。
 
-fixture 的 root schemaVersion 与两个 Observability schemaVersion 都是独立字面量，不由 candidate
-生成 expected。它只验收 Record root v1 内的 Observability family 1→2，不把旧 `niceeval.results`
-或未来 Record root major 宣称为可迁移输入。
+恢复与故障 owner 的 fixture 仍把 root schemaVersion 与两个 Observability schemaVersion 写成独立字面量，不由
+candidate 生成 expected；它们只拥有恢复与故障边界。固定 chain 同时把 Record root epoch 1 与 Observability
+family 1 升到 2，不把旧 `niceeval.results` 或 future/unknown format 宣称为可迁移输入。

--- a/docs/feature/record/README.md
+++ b/docs/feature/record/README.md
@@ -16,7 +16,7 @@ composition SDK，供 NiceEval CLI、替代 CLI / Web host 或深度应用集成
 
 ```json
 // record.json
-{ "format": "niceeval.record", "schemaVersion": 1 }
+{ "format": "niceeval.record", "schemaVersion": 2 }
 
 // runs/<RunId>/attempts/<AttemptId>/attachments/niceeval.assertions/attachment.json
 { "family": "niceeval.assertions", "schemaVersion": 1 }
@@ -85,10 +85,10 @@ registration point 或 migration registration。此前未保存且不可恢复�
 要么扩展既有 family，要么由 NiceEval 增加新的 fixed family definition。它不能成为调用方定义的第三方
 durable family。
 
-NiceEval 也可以在后续 catalog 中加入另一个固定 family，例如 `niceeval.energy`。这只增加该 family 自己的
-definition、`owners` map 与 schemaVersion，不升级 Core。较早 reader 保留它在磁盘上的完整目录和 bytes，
-忽略它并继续读取 Core 与认识的 family；只有请求 energy 的 AnalysisInput 或 DomainView 才得到
-`unsupported`。
+current catalog、root 与 Core 共同构成 durable writer epoch。ordinary reader 和 writer 只接受这一整套 exact
+current definition；未知 family、known family 的 future 版本和 root/Core epoch 不匹配都在 Analysis、Report 或
+Runner 形成前 fail closed。新增 fixed family 或改变既有 family 的 current 版本时必须同步升级 root epoch，防止旧
+writer 在迁移后继续追加旧格式。
 
 Core 的 `Schema.Encoded` 只允许 exact JSON，禁止 blob ref。Attachment owner 的 encoded side 仍是 exact JSON，
 但可含由该 owner 的 declaration 唯一 mint 的 `RecordBlobRef`。一个 ref 只能指向同 owner、同 family 下的一份
@@ -140,19 +140,19 @@ reader、writer 和固定 family 必须接受的 root、Core 与 Attachment shap
 身份、预期 Slot 和问题的 `RecordSelection`。查询需要某条 trace、diff 或 Evidence 时，才读取并校验对应
 Attachment。
 
-Record 的首次正式格式是 schemaVersion `1`，没有已发布 predecessor（前代格式）。未来 schemaVersion 变化时，
-maintenance 只执行固定的相邻步骤，例如 `1 → 2`。兼容性按对象判断：
+Record 的 current root 是 schemaVersion `2`。schemaVersion `1` 是 npm `niceeval@0.13.0` 可产生的已发布
+predecessor；固定的 `1 → 2` chain 同时升级 root epoch 与 Observability v1 envelope。兼容性如下：
 
 | 碰到的 bytes | ordinary reader 的动作 |
 |---|---|
-| root 或 Core 的 schemaVersion 不匹配 | 若 maintenance 有相邻步骤，返回 `migration-required`；否则 `unsupported-format`，不形成 session |
-| 已知 fixed family 的旧 schemaVersion | 返回 `migration-required`，普通读取不兼容，必须显式 migrate |
-| 未知的独立 future family | 保留 bytes、忽略该 family，继续读取 Core 和认识的 family |
+| root/Core epoch 或已知 fixed family 是完整可自动迁移的 predecessor | ordinary 入口先退出检查 scope，再进入 Git-safe automatic maintenance；迁移成功后全新打开 current session |
+| root/Core epoch 或 known family 是 future、unknown 或无完整 chain | `unsupported-format`，不形成 session |
+| 未知 family | `unsupported-format`，不形成 session |
 | current catalog 中缺少的 family | 在请求它时返回 `not-recorded` |
 | 带 `/vN` 后缀的未发布 family 草案 | `unsupported-format`；它不能伪装为独立 future family |
 
-未知 family 的局部容忍不让 reader 猜测 payload 或 blob closure，也不让 Report 看见原始内容。它只保护可读的
-历史；依赖该 family 的能力保持 `unsupported`，直到使用认识该 definition 的 NiceEval。
+ordinary reader 不局部容忍未知或 future bytes。maintenance 可以在已知 migration plan 中逐字保留不属于目标的
+portable bytes，但全量 exact current 验证必须认识最终 inventory；否则迁移和普通打开都拒绝。
 
 ## 从 Record 到闭合输出
 

--- a/docs/feature/record/architecture.md
+++ b/docs/feature/record/architecture.md
@@ -164,8 +164,8 @@ closure 与 integrity 验证。当前每个 family 文件恰有一个 `defineRec
 但只有 `definition.ts` 保留该入口。总 catalog 只列六个 declaration，不复制 owner shape 或 payload Schema。
 Observability 与 Artifacts 各有一个 family declaration；`owners.attempt` 与 `owners.run` 不会形成第二个 family。
 
-未知 stable family 保留其目录与 bytes，跳过 payload / blob 解码，继续读取 Core 与已知 family。请求它的
-AnalysisInput 或 DomainView 才得到 `unsupported`。已知 family 的旧 schemaVersion 则走显式 migration。
+ordinary reader 与 writer 只接受 exact current catalog。未知 stable family、known family 的 future 版本与
+root/Core epoch 不匹配都在 session 形成前拒绝；历史版本只可由 maintenance 的固定完整 chain 迁移。
 
 ### Schema 允许集
 
@@ -208,7 +208,7 @@ root 的 exact JSON 是：
 ```ts
 type RecordDocument = {
   readonly format: "niceeval.record";
-  readonly schemaVersion: 1;
+  readonly schemaVersion: 2;
   readonly recordId: RecordId;
 };
 ```
@@ -362,10 +362,10 @@ Assertions 的 criterion、Evidence 与局部错误规则由 [Assertions archite
 拥有。Observability 的精确 shape 由 [Observability Attachment](architecture/observability-attachments.md)
 拥有。本页定义它们共同的 durable boundary。
 
-future NiceEval catalog 可以增加独立 fixed family，例如 `niceeval.energy`，而不改变 root 或 Core。它有自己的
-stable family name、numeric schemaVersion、`owners` map、definition 与 collector；它仍不是第三方扩展点。
-早期 reader 在扫描 owner attachment directory 时保留未知 family 的完整 bytes，跳过 payload / blob 解释，
-继续验证 Core 和认识的 family。
+future NiceEval catalog 可以增加独立 fixed family，例如 `niceeval.energy`，但发布时必须同时升级 root writer
+epoch。它仍有自己的 stable family name、numeric schemaVersion、`owners` map、definition 与 collector，且不是
+第三方扩展点。旧 reader 在扫描到未知 family 时 fail closed，不能让 Analysis、Report 或 Runner 读取一个只验证了
+部分 catalog 的 Record。
 
 ```ts
 type FileChangesAttachment = {
@@ -598,35 +598,40 @@ Runner 收到可处理的 `SIGINT` 后会先停止派发并关闭每个已知 Sl
 
 ## Maintenance、兼容性与相邻迁移
 
-schemaVersion `1` 是当前 root / Core 的唯一可读、可写版本；fixed family 各自拥有 current 版本。
-ordinary reader 按下表区分不兼容和局部
-未知数据：
+schemaVersion `2` 是当前 root / Core 的唯一可读、可写 writer epoch；fixed family 各自拥有 current 版本。
+schemaVersion `1` 与 Observability v1 只有在固定完整 `1 → 2` chain 中才是 predecessor：
 
 | 发现的内容 | ordinary reader | maintenance |
 |---|---|---|
-| root 或 Core schemaVersion 不匹配 | `migration-required`（有相邻步骤）或 `unsupported-format`；不形成 session | 只运行静态定义的相邻 step |
-| 已知 family 的旧 schemaVersion | `migration-required`；ordinary read 不兼容 | 显式迁移该已知 family 的 definition |
-| 已知 family 的 future/无链 schemaVersion | `unsupported` | `unsupported-format`；提示使用写出该版本的 NiceEval |
-| 未知的独立 future family | 保留 directory、payload 与 blob bytes；不解释，继续读取 Core / 已知 family | 不迁移、也不删除 |
+| root/Core epoch 与全部 family 命中完整 automatic-safe chain | ordinary 入口不得形成 session；Git-safe automatic maintenance 成功后全新打开 | 同一 exclusive session plan/apply，并同时升级 root epoch与目标 family |
+| root/Core 或已知 family 是 future/无链 schemaVersion | `unsupported-format`；不形成 session | `unsupported-format`；提示使用写出该版本的 NiceEval |
+| 未知 family | `unsupported-format`；不形成 session | `unsupported-format`；不猜 payload、closure 或迁移 |
 | current catalog family 缺失 | 按请求得到 `not-recorded` | 不补写历史事实 |
 | 带 `/vN` 后缀的未发布 family 草案 | `unsupported-format`；不得按未知 family 容忍 | 不进入迁移链 |
 
-未知 family 不是 schemaVersion 不匹配的 known family。它的 stable name 尚未被该 reader 的 catalog 认识，
-所以 reader 没有 payload schema、closure rule 或 projection 可以安全执行。任何 `AnalysisInput` 或
-`DomainViewRequest` 依赖它时，只返回 `unsupported`；其它 Analysis 结果和 Report
-闭合输出不受污染。
+未知 family 没有 payload schema、closure rule 或 projection 可供当前版本验证，因此整个 ordinary open
+fail closed；它不能再作为局部 `unsupported` 进入 Analysis。
 
-Observability schemaVersion `2` 由 `maintenance` facet 提供固定 `1 → 2` step。step 只依赖已保存的
-两个 owner payload 与 own blob closure，并逐字保留 label、blob refs 与 blob bytes。它不调用第三方
-converter，也不从当前 worktree、网络或运行时算法补写历史事实。
+Record root schemaVersion `2` 与 Observability schemaVersion `2` 由 `maintenance` facet 提供固定的联合
+`1 → 2` step。step 只依赖已保存的两个 owner payload 与 own blob closure，并逐字保留 label、blob refs 与
+blob bytes；root epoch 最后升级。它不调用第三方 converter，也不从当前 worktree、网络或运行时算法补写历史事实。
 
 有相邻步骤时，maintenance 在首次写 portable byte 前完成 Git preflight：Record 位于 Git worktree，
 完整 portable inventory 由 HEAD 跟踪，index 与 worktree 对该 inventory 干净。计划还绑定 repository
 identity、HEAD、Record path、`recordId`、source inventory 与 NiceEval migration implementation identity。
 
-迁移在 exclusive maintenance lease 下原地逐步执行，完整校验 Core、所有认识的 fixed family 与它们的
-blob closure 后才结束。未知 future family 保持逐字节不动。NiceEval 不创建 staging、backup、rollback 或
-root replacement。
+迁移在 exclusive maintenance lease 下原地逐步执行，完整校验 exact current Core、完整 catalog 与所有 blob
+closure 后才结束。未知或 future family 使计划失败。NiceEval 不创建 staging、backup、rollback 或 root replacement。
+
+`show`、`view` 与 `exp` 在 ordinary session、Run/claim/Sandbox 或付费调用前先做短检查。current fast path
+直接 ordinary open，不要求 Git clean。
+
+需要迁移时先关闭检查 scope，再取得 exclusive maintenance。plan/apply 绑定并复核 HEAD、
+Record identity、portable inventory、source bytes 与 migration identity。只有完整、无损、automatic-safe chain
+且 HEAD 已跟踪全部 portable bytes、Record path 的 index/worktree 干净时才无确认迁移。
+
+成功并全量验证后释放 maintenance，再新开 ordinary session。非 Git、dirty/untracked/ignored、read-only、
+lease busy、不完整 chain、future/unknown 或失败都给出 typed blocker，绝不继续 ordinary open。
 
 计划同时绑定每个目标 envelope 的 exact source bytes。首次改写前的 `migration.in-progress` 只保存已验证的 restore commit。
 

--- a/docs/feature/record/architecture/observability-attachments.md
+++ b/docs/feature/record/architecture/observability-attachments.md
@@ -178,10 +178,9 @@ type ObservabilityTarget =
 ```
 
 `partial` 表示这份已写入 Attachment 的事实有明确缺口，不表示没有发生。`not-recorded` 与 `invalid`
-是 Record reader 的外层结果，不是 payload state，不能被当成空数组。Observability v1 是 current family 的
-已知旧 schema，ordinary reader 返回 `migration-required`，不产生局部兼容读。没有固定迁移路径的其它版本
-局部 `unsupported`。未知 independent future family 适用另一条规则：reader 保留其 bytes、跳过解释，继续读取
-其它认识的 family。
+是 Record reader 的外层结果，不是 payload state，不能被当成空数组。Observability v1 与 root epoch 1 是固定
+联合 migration source，ordinary reader 不产生局部兼容读。没有完整固定迁移路径的版本与未知 family 都使
+ordinary open fail closed。
 
 producer 为 turn、item、call、command、usage observation、interval 和 diagnostic mint 不可推导的
 family-local identity。identity 不得由数组下标、文本、时间、provider、path 或目录名计算。
@@ -499,10 +498,9 @@ Host 只把完整的 `available` internal snapshot 交给 Analysis。读取命�
 统一 inline 与 blob storage；选择 Run、汇总 command success、计算成本或连接另一份 Attachment 仍属于
 Analysis Calculation，不能回写 Record。Report 不取得这个 snapshot、reader 或 blob capability。
 
-schemaVersion `2` 的 maintenance facet 提供固定 `1 → 2` step。ordinary reader 遇到 v1 只返回
-`migration-required`；v1 codec 仅在显式 maintenance 中 lazy 加载，不形成局部兼容读。迁移逐字保留两个 owner
-的 payload、label、blob refs 与 blob bytes，只把 envelope 升为 v2；它不把旧 label 猜成新 coordinate。
+schemaVersion `2` 的 maintenance facet 与 root epoch 2 提供固定联合 `1 → 2` step。v1 codec 仅在
+maintenance 中 lazy 加载，不形成局部兼容读。迁移逐字保留两个 owner 的 payload、label、blob refs 与 blob
+bytes，先升级 envelope、完整验证后最后升级 root epoch；它不把旧 label 猜成新 coordinate。
 
-较早 reader 遇到 v2 时，在解码 payload 前把 Observability 局部标为 `unsupported`。Core 和不依赖该 family
-的事实仍可读；依赖 Observability 的 Analysis 与 Report 必须传播 `unsupported` 或 `migration-required`，
-不能折成 `invalid`、`not-recorded` 或错误展示。独立未知 future family 不触发这条 migration。
+较早 reader 遇到 v2，或当前 reader 遇到未知/future family 时，必须在 ordinary session 形成前拒绝整份 Record。
+Analysis 与 Report 不再接收来自非 current catalog 的 `unsupported` 或 `migration-required` 局部值。

--- a/docs/feature/record/cli.md
+++ b/docs/feature/record/cli.md
@@ -1,9 +1,9 @@
 # Record CLI
 
 CLI 通过 [Record Library](library.md) 打开 exact current Record protocol：root 是
-`{ format: "niceeval.record", schemaVersion: 1 }`。它不在 `show`、`view`、`exp` 或 `clean` 中自动迁移
-字节；不相容格式必须先由显式 `niceeval migrate` 处理，才能形成 `RecordReadSession`。缺少规范的零字节普通文件 `complete`
-的目录不是 Run。
+`{ format: "niceeval.record", schemaVersion: 2 }`。`show`、`view` 与 `exp` 在任何 ordinary session、Run、
+claim、Sandbox 或付费调用前检查格式；完整且 automatic-safe 的旧格式在 Git 安全门后无确认原地迁移，再以全新
+ordinary session 继续。缺少规范的零字节普通文件 `complete` 的目录不是 Run。
 
 CLI 是五个 Host composition SDK 的一个调用者。`exp` 与 `accept` 经 `experimentHost`，Record I/O 经
 `recordHost`。dispatch claim 与 lease 经 `coordinationHost`，Sample 经 `analysisHost`。`show`、`view` 与
@@ -44,13 +44,10 @@ details: niceeval clean
 fixed family 显示 `not-recorded`；closure 或 exact payload 无效显示 `invalid`。这些局部问题不把其它有效
 Run 从 selection 中移除。
 
-root 或 Core schemaVersion 不匹配时，CLI 返回 `migration-required`（有固定相邻步骤）或
-`unsupported-format`，不形成 reader。已知 family 的旧 schemaVersion 同样要求显式 migrate，ordinary read
-不兼容。
-
-未知独立 future family 例外：CLI 保留其 directory、payload 与 blob bytes，跳过解释并继续读取 Core 与
-认识的 family。依赖它的 AnalysisInput 或 DomainView 显示 `unsupported`。带 `/vN` 后缀的
-未发布 family 草案不是这种 future family，仍返回 `unsupported-format`。
+root/Core epoch、fixed catalog 或 family version 不 exact current 时不形成 reader。若命中完整、无损且
+automatic-safe 的固定 chain，CLI 先释放检查 scope，再取得 exclusive maintenance session。该 session
+复核 Git HEAD、Record identity、portable inventory、source bytes 与 migration identity。成功后释放 maintenance
+并重新打开。未知/future family、无完整 chain 或任何安全门失败都返回 typed error，不进入 Analysis 或 Report。
 
 读到 `available` 后，payload 已 deep-freeze，blob closure 已验证并 materialize。Analysis 与 Report
 不会再次打开 storage。形成 value 前的 I/O 或 permission failure 仍是 typed read failure，不会伪装成
@@ -58,7 +55,7 @@ root 或 Core schemaVersion 不匹配时，CLI 返回 `migration-required`（有
 
 ## `exp` 与 `exp --dry`
 
-`niceeval exp` 在模型、Sandbox、外部命令或付费调用前打开 current Record，并取得 shared append
+`niceeval exp` 在模型、Sandbox、外部命令、claim 或付费调用前完成上述 current/automatic maintenance gate，再取得 shared append
 lease。它创建一个全新的 RunId 和 `runs/<RunId>/`；不会锁住其它 Run writer，也不会更新 root manifest、
 counter、`latest` 或共享 summary。
 
@@ -98,19 +95,25 @@ niceeval clean [--record <root>] [--yes]
 niceeval migrate [--record <root>] [--yes]
 ```
 
-root / Core schemaVersion `1` 没有已发布 predecessor。所有 fixed family 也处于 current 时，`migrate`
+root / Core schemaVersion `2` 是 current。所有 fixed family 也处于 current 时，`migrate`
 对完整 current Record 返回：
 
 ```text
-Record is already current: niceeval.record (schemaVersion 1)
+Record is already current: niceeval.record (schemaVersion 2)
 ```
 
 root / Core 不相容时，若有固定相邻步骤则返回 `migration-required`，否则 `unsupported-format`，并且不写盘。
 已知 family 的旧 schemaVersion 也经这条 maintenance 路径迁移。未发布的斜杠版本草案不是 migration source。
-未知 independent future family 不迁移，也不删除。CLI 不猜测中间格式，不接受第三方 converter。
+未知或 future family 不迁移，直接拒绝。CLI 不猜测中间格式，不接受第三方 converter。
 
-Observability v1 由固定 `1 → 2` maintenance step 迁移；两个 owner 的 payload、label、blob refs 与 blob bytes
-逐字保留，只更新 envelope。历史格式完成或由 Git 恢复后，才可打开为 current reader。
+npm `niceeval@0.13.0` 写出的 root epoch 1 / Observability v1 由固定联合 `1 → 2` maintenance step 迁移；
+两个 owner 的 payload、label、blob refs 与 blob bytes 逐字保留，root epoch 最后升级。历史格式完成或由 Git
+恢复后，才可打开为 current reader。
+
+automatic policy 与本节 explicit policy 分开：自动路径不打印计划、不询问确认，只接受完整 automatic-safe chain，
+并要求 HEAD 已跟踪全部 portable bytes且 Record path 的 index/worktree clean。非 Git、未保存、dirty、untracked、
+ignored、read-only、lease busy、future/unknown、不完整 chain 或失败都 fail closed，并要求用户保存 Record 或处理
+具名 blocker。自动成功只向 stderr 输出一次含 restore commit 与目标 epoch 的简短 receipt，随后正常输出原命令结果。
 
 存在固定相邻步骤时，命令先做只读 Git preflight，并打印计划。预检要求：
 
@@ -136,14 +139,15 @@ preflight 失败或 sentinel 创建失败都发生在首个 portable write 前�
 | code/state | 含义 | 下一步 |
 |---|---|---|
 | `already-current` | root / Core 是 schemaVersion `1`，所有 fixed family 也处于 current | 不修改 Record |
-| `migration-required` | root / Core 或已知 family 有固定相邻 migration | 运行 `niceeval migrate`；ordinary reader 不改盘 |
+| `record-auto-migration-git-save-required` | automatic-safe predecessor 尚未由 Git HEAD 完整保存，或 Record path dirty | 先 `git add` / `git commit` 保存全部 portable bytes，再重试原命令 |
+| `migration-required` | explicit inspection 发现固定相邻 migration | 检查计划并运行 `niceeval migrate`；ordinary reader 不读旧格式 |
 | `unsupported-format` | root / Core 无支持步骤、known family 是 future/无链版本，或 family 名使用未发布 `/vN` 草案 | 使用写出该格式的 NiceEval；不要按损坏数据恢复 |
 | `record-maintenance-busy` | maintenance 与 reader/writer/clean 冲突 | 关闭占用命令后重试 |
 | `record-migration-plan-stale` / `record-migration-git-restore-required` | apply 前计划或 Git 状态已变化，尚未写 portable byte | 保留当前编辑，重新检查并形成新计划；不要执行旧计划的 restore |
 | `record-migration-recovery-required` | sentinel 已创建，迁移写入或最终校验失败 | 仅在 `restoreSafe` 证明成立时按命令恢复；否则先人工检查并保留并发编辑 |
 | `incomplete-run` | Run 缺少规范的零字节普通文件 `complete` | 有效 Run 继续可用；用 `niceeval clean` 检查 |
 | `not-recorded` | 已封口 owner 没有请求的 fixed family | 让 query 按其 missing policy 处理 |
-| `unsupported` | input 或 view 依赖本版本不认识的 future family | 使用认识该 family 的 NiceEval；其它结果继续可用 |
+| `unsupported-format` | root/Core/family 是 future、unknown 或无完整 chain | 使用写出该格式的 NiceEval；不会形成部分 ordinary session |
 | `invalid` | envelope、payload、ref 或 closure 无效 | 检查该 family；其它有效事实继续可用 |
 
 ## Git、复制与分享

--- a/docs/feature/record/library.md
+++ b/docs/feature/record/library.md
@@ -135,7 +135,7 @@ interface CreateReferenceRunRequest extends CreateRunRequest {}
 RunContext，并 refine `context.experimentId === experimentId`；它把这个已验证值带入 draft，只有 `seal()` 时
 将它作为 `RunDocument.context` 写入 `run.json`。不能在 session 创建后以当前配置或补丁重新设定 context。
 
-`current` 只接受 package-private definition 中的 root `{ format: "niceeval.record", schemaVersion: 1 }` 与匹配的 Core。
+`current` 只接受 package-private definition 中的 root `{ format: "niceeval.record", schemaVersion: 2 }` 与匹配的 Core。
 root / Core 不兼容时，若 maintenance 有固定相邻步骤则返回 `migration-required`，否则
 `unsupported-format`；session 根本不会形成。带 `/vN` 后缀的未发布 family 草案也是
 `unsupported-format`，不能伪装成独立 future family。
@@ -157,9 +157,8 @@ Attachment envelope 的 shape 是 `{ family, schemaVersion }`。family 是稳定
 Observability 与 Artifacts 各自只有一个 package-private definition；其 owner-specific payload 位于同一
 `owners` map，不是公开的 attempt / run family pair。
 
-future NiceEval catalog 可在不改变 Core 的情况下加入 `niceeval.energy` 等独立 fixed family。它具有自己的
-static definition 与 `owners` map；应用作者仍不能定义 family。较早 reader 发现未知 stable family 时保留
-该目录的所有 bytes，跳过 payload / blob 解码，继续读取 Core 与认识的 family。
+future NiceEval catalog 可加入 `niceeval.energy` 等独立 fixed family，但必须同时递增 root writer epoch。应用作者
+仍不能定义 family。较早 reader 发现未知 stable family 时在 session 形成前 fail closed，不跳过 catalog 验证。
 
 每个 fixed collector 通过 private definition mint `RecordBlobRef`。它写出的 payload 是 deep-frozen JSON
 snapshot；全部 own blob 通过 closure 验证后才可从内存获得 defensive copy。没有可从
@@ -174,9 +173,9 @@ permission 或 materialize failure 仍是 `RecordReadError`。
 partial 空前缀和 `not-recorded` 因而保持可区分。内部 reader 只把归因策略、collection 与 ordered send 区间
 trajectory（轨迹）交给 Analysis，绝不提供按 path 汇总的 `changes` 或 durable `net`。
 
-已知 family 的旧 schemaVersion 是 `migration-required`，ordinary reader 不做局部兼容读。未知 independent
-future family 则局部容忍：reader 保留它，且继续读取其它事实；依赖它的 input / view 是 `unsupported`。
-它不同于 `not-recorded` 与 `migration-required`。
+已知 family 的旧 schemaVersion 只有命中完整 maintenance chain 时可迁移；ordinary reader 不做局部兼容读。
+未知 independent future family、known future version 与无完整 chain 的旧版本都拒绝 ordinary open。它们不同于
+current catalog family 缺失所表达的 `not-recorded`。
 
 ## Reader：RecordReadSession
 
@@ -219,8 +218,8 @@ Run 可以整体进入或整体不进入本次选择；缺少规范的零字节�
 
 selected ref 都是当前 session 签发的 nominal handle（名义句柄）。它们不能靠对象复制、ID 拼接或跨 Scope
 重用。Analysis 的 `AnalysisInput` 或 `DomainViewRequest` 真正需要事实时，package-private adapter 才以
-`{ owner, fixed definition }` 读取并缓存对应 Attachment。请求未知 future family 时，它缓存
-`unsupported`，但不解码磁盘 bytes。verified cache 可以省 I/O，不能成为 absence、
+`{ owner, fixed definition }` 读取并缓存对应 Attachment。未知或 future family 已在 session 形成前被拒绝，
+不会进入 Analysis cache。verified cache 可以省 I/O，不能成为 absence、
 candidate set 或 latest 的权威依据。
 
 ## Writer：RunWriteSession
@@ -364,24 +363,31 @@ interface RecordMaintenanceSession {
 }
 ```
 
-schemaVersion `1` 的 current root / Core 没有已发布 predecessor。所有 fixed family 也处于 current 时，
+schemaVersion `2` 是 current root / Core writer epoch。所有 fixed family 也处于 current 时，
 `inspect()` 与 `planMigrate()` 返回 `already-current`；`applyMigrate()` 不运行，也不写 portable byte。
 
 root / Core 不相容时，`inspect()` 返回 `migration-required` 或 `unsupported-format`。已知 family 的旧
 schemaVersion 同样需要显式 migration。
 
-未知 independent future family 保持 bytes 不动，不进入 migration plan。known family 的 future/无链版本和
-未发布的斜杠版本草案返回 `unsupported-format`，不会被猜测成损坏数据或 migration source。
+未知/future family、known family 的 future/无链版本和未发布的斜杠版本草案返回 `unsupported-format`，不会被
+猜测成损坏数据或 migration source。
 
-Observability schemaVersion `2` 同批在 maintenance facet 内提供固定 `1 → 2` step。它只从已保存的两个
+root epoch 2 与 Observability schemaVersion `2` 同批在 maintenance facet 内提供固定联合 `1 → 2` step。它只从已保存的两个
 owner payload 和 own blob closure 形成目标 bytes，不能读取当前 worktree、网络、第三方 converter 或运行时
 算法。没有无损步骤时，maintenance 在改盘前拒绝计划；它不伪造新事实。
 
 计划绑定 Git repository、HEAD、Record path、`recordId`、current format 与 portable-byte inventory。它还绑定每个目标 envelope 的 exact source bytes 和 NiceEval migration implementation identity。`applyMigrate()` 重新验证这些值，避免把陈旧计划应用到变化后的 Record。
 
 迁移只允许 Record 已纳入 Git 且 worktree/index 干净时执行。它在 exclusive maintenance lease 下原地
-逐步改写，并完整校验 current Core、认识的 fixed family 与 blob closure。未知 independent future family
-保持原有 directory 与 bytes。NiceEval 不创建 staging、backup、rollback 或 root replacement。
+逐步改写，并完整校验 exact current Core、完整 catalog 与 blob closure。未知/future family 使计划失败。
+NiceEval 不创建 staging、backup、rollback 或 root replacement。root epoch 在所有 portable target 写入并校验后最后升级，
+阻止旧 writer 再次追加 v1。
+
+ordinary Host 入口在建立任何 read/append session 或执行外部副作用前调用内部 automatic gate。current fast path
+不检查 Git clean。需要迁移时，检查 Scope 必须先关闭。随后 exclusive maintenance session 在同一
+session 内完成 plan/apply，并绑定、复核 HEAD、Record identity、portable inventory、source bytes 与
+migration identity。成功全量 exact-current 验证并释放 maintenance 后，调用方只能全新打开 ordinary
+session，不得升级既有 read lease。
 
 首次改写前的 `migration.in-progress` 只保存已验证的 restore commit。失败或中断后，maintenance 先证明 HEAD 未变化，且 dirty path 只有 sentinel 与已写成 canonical v2 的计划目标。证明成立时，CLI 才给出限定到 Record root 的 Git restore 与 tracked-byte 验证命令；否则只要求人工检查并保留并发编辑。验证 worktree/index 都等于该 commit 后才清除 sentinel，再重新形成计划。
 

--- a/docs/feature/record/use-case/RecordAttachment怎样保存运行事实.md
+++ b/docs/feature/record/use-case/RecordAttachment怎样保存运行事实.md
@@ -73,10 +73,9 @@ owner/family 时读取和验证它。`available` snapshot 包含 deep-frozen pay
 读取 blob 时返回 defensive copy，不重开文件。Scope 关闭后，已经形成的 snapshot 仍可同步消费。
 
 历史 owner 缺少 current catalog 中请求的 family 时返回 `not-recorded`。`invalid` 只影响请求该事实的 query，
-不能把其它 Core 或 family 伪装为失败。已知 family 的旧 schemaVersion 要求显式 migrate，ordinary reader
-不兼容。未知独立 future family 保留在磁盘、跳过解释，不影响 Core 与认识的 family；只有请求它的
-AnalysisInput / DomainView 返回 `unsupported`。带 `/vN` 后缀的未发布 family 草案仍是
-`unsupported-format`。
+不能把其它 Core 或 family 伪装为失败。已知 family 的旧 schemaVersion 不进入 ordinary reader；只在完整固定
+chain 存在时可 maintenance migrate。未知独立 future family、已知 future 版本与带 `/vN` 后缀的未发布草案都使
+整份 Record 在 session 形成前返回 `unsupported-format`。
 
 ## 不能写进 Attachment 的内容
 

--- a/docs/feature/record/use-case/上层变化不改持久格式.md
+++ b/docs/feature/record/use-case/上层变化不改持久格式.md
@@ -47,15 +47,13 @@ measure。Report 只消费闭合的 Analysis 结果。改变指标、统计口�
 
 ## current 读取与以后版本
 
-current root 固定为 `{ format: "niceeval.record", schemaVersion: 1 }`。每个 Attachment envelope 都以稳定
+current root 固定为 `{ format: "niceeval.record", schemaVersion: 2 }`。每个 Attachment envelope 都以稳定
 family name 加 numeric schemaVersion 表示自己。ordinary reader 只读取 current definition；`niceeval migrate`
 对完整 current Record 返回 `already-current`。
 
-root / Core 不相容时返回 `migration-required` 或 `unsupported-format`。已知 family 的旧 schemaVersion
-必须显式 migrate。独立未知 future family 保留 bytes、跳过解释，Core 与认识的 family 仍可读取。
-
-依赖未知 family 的能力是 `unsupported`。未发布的带 `/vN` 后缀草案不属于 future family，
-也不属于 migration source。
+root / Core 不相容时 maintenance 返回 `migration-required` 或 `unsupported-format`。已知 family 的旧
+schemaVersion 只在完整固定 chain 存在时可 migrate。独立未知 future family、已知 future 版本与未发布的
+`/vN` 后缀草案都在 ordinary session 形成前拒绝整份 Record。
 
 当 NiceEval 把任一 root、Core 或 fixed family 升到下一 schemaVersion 时，必须把固定相邻
 migration 与新 schema 一起发布。迁移只能从

--- a/docs/feature/record/use-case/显式迁移Record-major.md
+++ b/docs/feature/record/use-case/显式迁移Record-major.md
@@ -3,19 +3,19 @@
 本页说明 `niceeval migrate` 怎样区分 Core 不兼容、已知 family 的升级与未知 future family。契约单源
 始终在 [Record Architecture](../architecture.md) 和 [Record CLI](../cli.md#migrate)。
 
-## root schemaVersion `1` 的结果
+## root schemaVersion `2` 的结果
 
 完整 current Record 的 root 是：
 
 ```json
-{ "format": "niceeval.record", "schemaVersion": 1 }
+{ "format": "niceeval.record", "schemaVersion": 2 }
 ```
 
 它没有已发布 predecessor。所有 fixed family 也处于 current 时，命令不写盘：
 
 ```sh
 niceeval migrate --record .niceeval/record
-# Record is already current: niceeval.record (schemaVersion 1)
+# Record is already current: niceeval.record (schemaVersion 2)
 ```
 
 兼容性不把所有未认识 bytes 混成一个错误：
@@ -24,12 +24,11 @@ niceeval migrate --record .niceeval/record
 |---|---|---|
 | root / Core 与 current 不兼容 | `migration-required` 或 `unsupported-format` | 只在有固定相邻步骤时迁移 |
 | 已知 family 的旧 schemaVersion | `migration-required` | 显式迁移该 known family |
-| 未知独立 future family | 忽略且继续读取其它事实 | 保留 directory、payload 与 blob bytes |
+| 未知独立 future family | `unsupported-format`，不形成 session | 拒绝迁移，不触碰 bytes |
 | current catalog family 缺失 | 请求时 `not-recorded` | 不补写历史事实 |
 | 带 `/vN` 后缀的未发布 family 草案 | `unsupported-format` | 不推测、也不迁移 |
 
-未知 family 的局部容忍只保护可读的历史。它不能让 reader 解释 payload、验证 blob closure 或把事实交给
-Report。`AnalysisInput` 或 `DomainViewRequest` 依赖该 family 时才返回 `unsupported`。
+未知 family 不再局部容忍；一旦 portable inventory 出现它，ordinary reader 和 migration 都 fail closed。
 
 ## Observability `1 → 2` 的固定步骤
 
@@ -37,7 +36,8 @@ Report。`AnalysisInput` 或 `DomainViewRequest` 依赖该 family 时才返回 `
 `1 → 2` maintenance step。步骤只处理已保存的 attempt / run payload 与 own blob closure，
 逐字保留 label、blob refs 和 blob bytes，只更新 envelope。
 
-future root / Core schemaVersion 发布时，仍必须另行同批提供它自己的固定相邻步骤。
+root epoch `1 → 2` 与 Observability `1 → 2` 是同一固定联合步骤；root epoch 最后写入。future
+root / Core schemaVersion 发布时，仍必须另行同批提供它自己的固定相邻步骤。
 
 迁移可以重新编码 bytes、mint 新 blob ref 或重排 canonical object key。它不能：
 
@@ -67,8 +67,6 @@ exclusive maintenance lease
 原地运行固定的相邻步骤
         ↓
 完整校验 Core 与认识的 family closure
-        ↓
-未知 future family 保持原有 bytes
         ↓
 完成后才允许新的 openRead
 ```

--- a/docs/feature/record/use-case/未来功能不扩张核心格式.md
+++ b/docs/feature/record/use-case/未来功能不扩张核心格式.md
@@ -25,11 +25,10 @@
 Adapter、Plugin 和 Report 作者只能消费 NiceEval catalog 已发布的 family，不能把 GPU 能耗、私有 trace 或
 额外 file evidence 写成第三方 durable identity。若一项不可恢复事实确实需要保存，NiceEval 可以定义
 `niceeval.energy` 等新的 fixed family，并裁决其 owner、exact payload、cardinality、closure、collector 与
-schemaVersion。这个新增 family 不改变 root 或 Core。
+schemaVersion。这个新增 family 不改变 Core 事实，但必须同批递增 root writer epoch，让旧 writer 不能继续写入不完整 catalog。
 
-旧 reader 保留未知 future family 的 directory、payload 与 blob bytes，跳过解释并继续读取 Core 与认识的
-family。只有依赖 energy 的 input 或 domain view 是 `unsupported`。旧 reader 遇到已知
-family 的旧 schemaVersion 则要求显式 migration；两种情形不能混同。
+旧 reader 遇到未知 future family 时在 ordinary session 形成前拒绝整份 Record，不把部分 Core 或已知
+family 交给 Analysis / Report。已知 family 的旧 schemaVersion 仅在存在完整固定 chain 时可 migration。
 
 ## 事实、行为和派生结果不能互换
 
@@ -42,11 +41,11 @@ reuse gate 明确声明所需 facts 和 behavior identity。
 
 ## schemaVersion 的版本边界
 
-current root 固定为 `{ format: "niceeval.record", schemaVersion: 1 }`。所有 fixed family 也处于 current 时，
+current root 固定为 `{ format: "niceeval.record", schemaVersion: 2 }`。所有 fixed family 也处于 current 时，
 `niceeval migrate` 才返回 `already-current`。root / Core 不相容时，工具返回 `migration-required` 或
 `unsupported-format`。
 
-已知 family 的旧 schemaVersion 也只能经 maintenance 迁移。未知独立 future family 保持不动并局部容忍。
+已知 family 的旧 schemaVersion 也只能经 maintenance 迁移。未知独立 future family 与已知 future 版本都拒绝 ordinary open。
 未发布的带 `/vN` 后缀草案是 `unsupported-format`，不能借由这个规则伪装成 future family。
 
 任一 root、Core 或 fixed family 升到下一 schemaVersion 时，NiceEval 同时交付固定相邻
@@ -58,7 +57,7 @@ maintenance step，且只从保存的 closure 形成新 bytes。历史格式在�
 - 用 optional field、自由 object 或多个 shape 猜一个 schema version；
 - 让 generic writer 接受任意 JSON、path、bytes 或手写 blob ref；
 - 把 session、claim、lease、migration history 或 cache 写进 Record；
-- 普通 open 自动迁移或把另一 schema 伪装成 current 值；
+- 在 ordinary read lease 内升级，或把另一 schema 伪装成 current 值；
 - 为了少做 migration，把 Core 改成 `Record<string, unknown>`；
 - 让第三方 converter 或当前业务算法重写历史事实。
 

--- a/docs/feature/record/use-case/源码Attachment怎样安全演进.md
+++ b/docs/feature/record/use-case/源码Attachment怎样安全演进.md
@@ -32,9 +32,9 @@ Sources schemaVersion `2` 发布时，NiceEval 必须同时判断 `1 → 2` 是�
 读取当前 worktree 或调用第三方 code。目标 blob 重新属于 schemaVersion `2` 的 own closure，不能把旧 `RecordBlobRef`、path
 或 key 冒充新 ref。
 
-已知 `niceeval.sources` 的旧 schemaVersion 使 ordinary read 返回 `migration-required`。它与独立未知 future
-family 不同：例如较早 reader 看到 `niceeval.energy` 时保留其 bytes、跳过解释并继续读取 Sources；它不会试图
-把 unknown energy 当成 Sources 的旧版本，也不会把它加入 migration plan。
+已知 `niceeval.sources` 的旧 schemaVersion 使 ordinary open 在 session 形成前拒绝，再由入口的
+automatic maintenance gate 决定是否可无确认迁移。独立未知 future family 不会被当成 Sources 的旧版本；
+它会让整份 Record fail closed，也不会进入 migration plan。
 
 ## Source identity 保持或整体改变
 

--- a/docs/feature/reports/cost-projections/library.md
+++ b/docs/feature/reports/cost-projections/library.md
@@ -257,22 +257,8 @@ interface CostProjectionUnavailable {
   readonly ledger: readonly CostLedgerEntry[];
 }
 
-interface CostProjectionMigrationRequired {
-  readonly state: "migration-required";
-  readonly basis: "unavailable";
-  readonly profile: CostProjectionProfile;
-  readonly aggregate: CostProjectionAggregate;
-  readonly observed: null;
-  readonly estimated: null;
-  readonly combined: null;
-  readonly observedOtherCurrencies: readonly ObservedOtherCurrency[];
-  readonly reasons: readonly CostCoverageReason[];
-  readonly ledger: readonly CostLedgerEntry[];
-}
-
 type CostProjectionValue =
   | CostProjectionKnown
-  | CostProjectionMigrationRequired
   | CostProjectionUnavailable;
 
 interface CostMetricValue extends MetricValue<number> {
@@ -289,7 +275,7 @@ declare function totalCostUSD(profile: PricingProfile): CostMeasure;
 `aggregate(ctx.scope, { values: { cost: costUSD(profile) } })` 返回的 `cost` cell 是作者可观察的 `CostMetricValue`。
 它的 `cell.projection` 是 `CostProjectionValue`。
 
-两者与 `CostProjectionState`、`CostProjectionMigrationRequired`、`CostBasis`、ledger、reason 和 component data types 都是 `niceeval/report` 的 type-only exports。
+两者与 `CostProjectionState`、`CostBasis`、ledger、reason 和 component data types 都是 `niceeval/report` 的 type-only exports。
 具体字段以上面的 Library 形状为准。
 
 Analysis 从 sealed Usage 和 Profile 构造每个 slot-provider `ledger` entry。`branch` 只能是 `observed`、`estimated` 或
@@ -300,9 +286,9 @@ order 输出。reason 不携带自由文本、费率或第二份输入，词表�
 Analysis 在 `aggregate` 保留 exact total；mean 以 `numerator / denominator` 的 rational 形式保留，之后才按 Profile display 做
 half-away-from-zero 格式化。它不经过 binary floating-point，也不把 unavailable slot 当作零。
 
-当所有选中 slot 都因 Observability v1 而无法读取 Usage，顶层 projection 与 metric state 都是
-`migration-required`，Report 显示 `niceeval migrate` 恢复动作；不能只把原因藏在 `reasons`。v1/current 混合且
-仍有已知金额时保持 `partial`，coverage 只计入实际贡献的 slot。
+Report 只在 exact current Record session 上执行，因此不会收到 Observability v1、unknown/future family 或
+`migration-required` metric。ordinary 入口要么在进入 Report 前完成 Git-safe automatic migration 并全新打开，
+要么以 typed migration blocker fail closed；不得构造 v1/current 混合 ledger。
 
 `profile.provenance` 原样进入 `CostProjectionProfile.provenance`，其形状始终是 `{ kind: "declared-rate-card", source, asOf }`。
 显示层不能重算 ledger、total 或 mean。

--- a/e2e/migrate/agents/legacy-deterministic.ts
+++ b/e2e/migrate/agents/legacy-deterministic.ts
@@ -1,0 +1,20 @@
+import { completeEvidenceCoverage, defineAgent } from "niceeval-legacy-0-13/adapter";
+
+export const legacyDeterministicAgent = defineAgent({
+  name: "migrate-handoff-legacy-deterministic",
+  evidenceCoverage: completeEvidenceCoverage,
+  async send(input, context) {
+    if (context.signal.aborted) throw new Error("deterministic migrate agent aborted");
+    context.session.capture("migrate-handoff-legacy-session");
+    return {
+      status: "completed" as const,
+      events: [{
+        type: "message" as const,
+        role: "assistant" as const,
+        text: `persisted-handoff:${input.text}`,
+      }],
+      data: { marker: "migrate-handoff-legacy" },
+      usage: { inputTokens: 1, outputTokens: 1, costUSD: 0 },
+    };
+  },
+});

--- a/e2e/migrate/evals/legacy-handoff.eval.ts.legacy-disabled
+++ b/e2e/migrate/evals/legacy-handoff.eval.ts.legacy-disabled
@@ -1,0 +1,11 @@
+import { defineEval } from "niceeval-legacy-0-13";
+import { includes } from "niceeval-legacy-0-13/expect";
+
+export default defineEval({
+  description: "Persist one deterministic legacy result for automatic migration",
+  async test(t) {
+    const turn = await t.send("handoff-input");
+    await turn.succeeded().orStop();
+    t.check(turn.message, includes("persisted-handoff:handoff-input"));
+  },
+});

--- a/e2e/migrate/experiments/legacy-handoff.ts.legacy-disabled
+++ b/e2e/migrate/experiments/legacy-handoff.ts.legacy-disabled
@@ -1,0 +1,8 @@
+import { defineExperiment } from "niceeval-legacy-0-13";
+import { legacyDeterministicAgent } from "../agents/legacy-deterministic.ts";
+
+export default defineExperiment({
+  description: "Persisted legacy Record for automatic migration",
+  agent: legacyDeterministicAgent,
+  evals: ["legacy-handoff"],
+});

--- a/e2e/migrate/fixtures/observability-v1-record/runs/2ce48d15-5278-46f7-a512-7235a3362c24/attachments/example.future/opaque.txt
+++ b/e2e/migrate/fixtures/observability-v1-record/runs/2ce48d15-5278-46f7-a512-7235a3362c24/attachments/example.future/opaque.txt
@@ -1,1 +1,0 @@
-future-family-bytes-must-survive

--- a/e2e/migrate/package.json
+++ b/e2e/migrate/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.7",
+    "niceeval-legacy-0-13": "npm:niceeval@0.13.0",
     "typescript": "5.7.2",
     "vitest": "4.1.9"
   }

--- a/e2e/migrate/pnpm-lock.yaml
+++ b/e2e/migrate/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       niceeval:
         specifier: 0.4.6
-        version: 0.4.6(react@19.2.8)
+        version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.3)
       react:
         specifier: ^19.2.7
         version: 19.2.8
@@ -21,14 +21,92 @@ importers:
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.18
+      niceeval-legacy-0-13:
+        specifier: npm:niceeval@0.13.0
+        version: niceeval@0.13.0(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(ws@8.21.3)(zod@3.25.76)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))
+        version: 4.1.9(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0))
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@effect/cluster@0.60.2':
+    resolution: {integrity: sha512-GEODN5kvFJ0L0XSkANcS8s6lfhjrrA8x/ezYUV/lXerqCHf5xo3ZTPUanGMHu5Byvikng0mZDcyNvke2sGjfSQ==}
+    peerDependencies:
+      '@effect/platform': ^0.97.1
+      '@effect/rpc': ^0.76.2
+      '@effect/sql': ^0.52.1
+      '@effect/workflow': ^0.19.1
+      effect: ^3.22.1
+
+  '@effect/experimental@0.61.1':
+    resolution: {integrity: sha512-+P+PgGQeE2fXmsm63YoyENNcQIc7OiCkY4/HLkEdTvq93syfGIpwDfQD8u3xODMHJhZ5ZtRZHH4+UedFO0tLiA==}
+    peerDependencies:
+      '@effect/platform': ^0.97.1
+      effect: ^3.22.1
+      ioredis: ^5
+      lmdb: ^3
+    peerDependenciesMeta:
+      ioredis:
+        optional: true
+      lmdb:
+        optional: true
+
+  '@effect/platform-node-shared@0.61.1':
+    resolution: {integrity: sha512-MJAJ1Nc43pYJb5ulFtdNID8klNyRLcbQ0zZ7XYRcBAlT/DrCyN4yAD89AzosmUyfOU+LMHdc8LTMt4rKNEMFaA==}
+    peerDependencies:
+      '@effect/cluster': ^0.60.1
+      '@effect/platform': ^0.97.1
+      '@effect/rpc': ^0.76.1
+      '@effect/sql': ^0.52.1
+      effect: ^3.22.1
+
+  '@effect/platform-node@0.108.1':
+    resolution: {integrity: sha512-BlPW+k/AaVS2ofPGZY1IV3HfLQ3gKGTfkY/jPVOJNOB9NiWb6ufAKOsuNTSAIYP8EzYxTH8tKOENXUXUcANoZA==}
+    peerDependencies:
+      '@effect/cluster': ^0.60.2
+      '@effect/platform': ^0.97.1
+      '@effect/rpc': ^0.76.2
+      '@effect/sql': ^0.52.1
+      effect: ^3.22.1
+
+  '@effect/platform@0.97.1':
+    resolution: {integrity: sha512-IevWxwmrxCdeXxbXDx/hiOstHtERRigd1nhZSuHgiFEl7NkBmS/5GVWsRacq4NfJN2uCXqggETKNwij15VEpew==}
+    peerDependencies:
+      effect: ^3.22.1
+
+  '@effect/rpc@0.76.2':
+    resolution: {integrity: sha512-x/4jvjufr1m3QWAace7G5Xh09DDcaeU7ijvS0Qumkan/hM89n19JClYnlV3IW93RACZInbgdyOVA+4kOQJ+JQQ==}
+    peerDependencies:
+      '@effect/platform': ^0.97.1
+      effect: ^3.22.1
+
+  '@effect/sql@0.52.1':
+    resolution: {integrity: sha512-dUVPjlUgpga6sDa/MtYipHAqzHx2St41hxI00nXTBt4IBBJaf2lTGaOvlEoBg/q6PHVAgSoKnxe19pWUvabC9g==}
+    peerDependencies:
+      '@effect/experimental': ^0.61.1
+      '@effect/platform': ^0.97.1
+      effect: ^3.22.1
+
+  '@effect/workflow@0.19.1':
+    resolution: {integrity: sha512-irU6ddHdIxYOhv0cJiJTk2AUxRmPYjRJ5JdB5UCvpJC4vLCyR2XyKspiCNDiEX1aSGPhVWEXhVMWXR1cErMS3A==}
+    peerDependencies:
+      '@effect/experimental': ^0.61.1
+      '@effect/platform': ^0.97.1
+      '@effect/rpc': ^0.76.2
+      effect: ^3.22.1
 
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
@@ -186,11 +264,132 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
+  '@parcel/watcher-android-arm64@2.6.0':
+    resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    resolution: {integrity: sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    resolution: {integrity: sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    resolution: {integrity: sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.6.0':
+    resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
+    engines: {node: '>= 10.0.0'}
 
   '@rolldown/binding-android-arm64@1.2.3':
     resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
@@ -291,17 +490,186 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.1':
+    resolution: {integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/react@19.2.18':
     resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
@@ -353,6 +721,9 @@ packages:
       react-native-b4a:
         optional: true
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   bare-events@2.9.1:
     resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
     peerDependencies:
@@ -393,12 +764,26 @@ packages:
   binary-search@1.3.6:
     resolution: {integrity: sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   cheminfo-types@1.15.0:
     resolution: {integrity: sha512-shv45WN2u0yN9EHH1bisNrv+fy4Cw+eLM5lOoriP67mePrwbHZ1kJqg90C8GEU7K1A8gJsicEoVZHcuBbuul/w==}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   compute-cosine-similarity@1.1.0:
     resolution: {integrity: sha512-FXhNx0ILLjGi9Z9+lglLzM12+0uoTnYkHm7GiadXDAr0HGVLm25OivUS1B/LPkbzzvlcXz/1EvWg9ZYyJSdhTw==}
@@ -412,12 +797,202 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.1:
+    resolution: {integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.23:
+    resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   effect@3.22.1:
     resolution: {integrity: sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ==}
@@ -425,10 +1000,17 @@ packages:
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
+
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -439,6 +1021,9 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -465,13 +1050,45 @@ packages:
   fft.js@4.0.4:
     resolution: {integrity: sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==}
 
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-any-array@3.0.0:
     resolution: {integrity: sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -483,6 +1100,22 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kubernetes-types@1.30.0:
+    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -561,8 +1194,147 @@ packages:
   linear-sum-assignment@1.0.9:
     resolution: {integrity: sha512-1T2Ek3sxpt2mBHeBFMRJEikiIK/yIOwf+mrxv/DkAU/5ddnCMndZL//hFH7QuHa1tbaQADzsf9t7rkGZKqoFfQ==}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
 
   ml-array-max@2.0.0:
     resolution: {integrity: sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==}
@@ -582,6 +1354,19 @@ packages:
   ml-xsadd@3.0.1:
     resolution: {integrity: sha512-Fz2q6dwgzGM8wYKGArTUTZDGa4lQFA2Vi6orjGeTVRy22ZnQFKlJuwS9n8NRviqz1KHAHAzdKJwbnYhdo38uYg==}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@1.12.1:
+    resolution: {integrity: sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==}
+
+  multipasta@0.2.8:
+    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
+
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
@@ -590,6 +1375,37 @@ packages:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  niceeval@0.13.0:
+    resolution: {integrity: sha512-aHSNZdzfu6QxkDpsfIS+xRTDRNirvfMOGzexnuZba3H46QdadjewfL5brv5y54UAnynxT2g6gntfPkk180D8+A==}
+    engines: {node: '>=24'}
+    hasBin: true
+    peerDependencies:
+      '@ai-sdk/otel': '>=1.0.0'
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.200.0'
+      '@opentelemetry/sdk-trace-node': '>=2.0.0'
+      '@vercel/sandbox': '>=2.0.0'
+      ai: '>=5.0.0'
+      braintrust: '>=0.0.150'
+      dockerode: '>=4.0.0'
+      e2b: '>=2.0.0'
+    peerDependenciesMeta:
+      '@ai-sdk/otel':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/sdk-trace-node':
+        optional: true
+      '@vercel/sandbox':
+        optional: true
+      ai:
+        optional: true
+      braintrust:
+        optional: true
+      dockerode:
+        optional: true
+      e2b:
+        optional: true
 
   niceeval@0.4.6:
     resolution: {integrity: sha512-SYZ1Pz4bNk7HNbUZfYLqAW9gJyTE3DTtC79e7OFg4rQDfWJY8SsgJ5YQZK1vLHhTVqX0O+kFhd0GEjDIPZfVrw==}
@@ -628,6 +1444,13 @@ packages:
       react-dom:
         optional: true
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
@@ -652,6 +1475,12 @@ packages:
       zod:
         optional: true
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -662,6 +1491,12 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -669,18 +1504,50 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.2.3:
     resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -697,6 +1564,9 @@ packages:
 
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
@@ -722,6 +1592,13 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
   tsx@4.23.12:
     resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
     engines: {node: '>=18.0.0'}
@@ -735,11 +1612,44 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
+  uuid@14.0.2:
+    resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
+    hasBin: true
+
   validate.io-array@1.0.6:
     resolution: {integrity: sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==}
 
   validate.io-function@1.0.2:
     resolution: {integrity: sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
@@ -830,6 +1740,23 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -838,7 +1765,90 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
+  '@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)':
+    dependencies:
+      '@effect/platform': 0.97.1(effect@3.22.1)
+      '@effect/rpc': 0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      '@effect/sql': 0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      '@effect/workflow': 0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
+      effect: 3.22.1
+      kubernetes-types: 1.30.0
+
+  '@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)':
+    dependencies:
+      '@effect/platform': 0.97.1(effect@3.22.1)
+      effect: 3.22.1
+      uuid: 11.1.1
+
+  '@effect/platform-node-shared@0.61.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)':
+    dependencies:
+      '@effect/cluster': 0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
+      '@effect/platform': 0.97.1(effect@3.22.1)
+      '@effect/rpc': 0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      '@effect/sql': 0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      '@parcel/watcher': 2.6.0
+      effect: 3.22.1
+      multipasta: 0.2.8
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@0.108.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)':
+    dependencies:
+      '@effect/cluster': 0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
+      '@effect/platform': 0.97.1(effect@3.22.1)
+      '@effect/platform-node-shared': 0.61.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
+      '@effect/rpc': 0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      '@effect/sql': 0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      effect: 3.22.1
+      mime: 3.0.0
+      undici: 7.29.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform@0.97.1(effect@3.22.1)':
+    dependencies:
+      effect: 3.22.1
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.12.1
+      multipasta: 0.2.8
+
+  '@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)':
+    dependencies:
+      '@effect/platform': 0.97.1(effect@3.22.1)
+      effect: 3.22.1
+      msgpackr: 1.12.1
+
+  '@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)':
+    dependencies:
+      '@effect/experimental': 0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      '@effect/platform': 0.97.1(effect@3.22.1)
+      effect: 3.22.1
+      uuid: 11.1.1
+
+  '@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)':
+    dependencies:
+      '@effect/experimental': 0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      '@effect/platform': 0.97.1(effect@3.22.1)
+      '@effect/rpc': 0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1)
+      effect: 3.22.1
 
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
@@ -918,9 +1928,95 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
   '@oxc-project/types@0.143.0': {}
+
+  '@parcel/watcher-android-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.6.0':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.6.0':
+    optional: true
+
+  '@parcel/watcher@2.6.0':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.5
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.6.0
+      '@parcel/watcher-darwin-arm64': 2.6.0
+      '@parcel/watcher-darwin-x64': 2.6.0
+      '@parcel/watcher-freebsd-x64': 2.6.0
+      '@parcel/watcher-linux-arm-glibc': 2.6.0
+      '@parcel/watcher-linux-arm-musl': 2.6.0
+      '@parcel/watcher-linux-arm64-glibc': 2.6.0
+      '@parcel/watcher-linux-arm64-musl': 2.6.0
+      '@parcel/watcher-linux-x64-glibc': 2.6.0
+      '@parcel/watcher-linux-x64-musl': 2.6.0
+      '@parcel/watcher-win32-arm64': 2.6.0
+      '@parcel/watcher-win32-x64': 2.6.0
 
   '@rolldown/binding-android-arm64@1.2.3':
     optional: true
@@ -973,9 +2069,138 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.1
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.13.3':
     dependencies:
@@ -984,6 +2209,24 @@ snapshots:
   '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/unist@3.0.3': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vercel/analytics@2.0.1(react@19.2.8)':
+    optionalDependencies:
+      react: 19.2.8
+
+  '@vercel/speed-insights@2.0.0(react@19.2.8)':
+    optionalDependencies:
+      react: 19.2.8
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -994,13 +2237,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.9(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))':
+  '@vitest/mocker@4.1.9(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -1037,7 +2280,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  autoevals@0.0.132:
+  autoevals@0.0.132(ws@8.21.3):
     dependencies:
       ajv: 8.20.0
       compute-cosine-similarity: 1.1.0
@@ -1045,7 +2288,7 @@ snapshots:
       js-yaml: 4.3.1
       linear-sum-assignment: 1.0.9
       mustache: 4.2.0
-      openai: 6.49.0(zod@3.25.76)
+      openai: 6.49.0(ws@8.21.3)(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
@@ -1055,6 +2298,8 @@ snapshots:
       - ws
 
   b4a@1.8.1: {}
+
+  bail@2.0.2: {}
 
   bare-events@2.9.1: {}
 
@@ -1087,9 +2332,17 @@ snapshots:
 
   binary-search@1.3.6: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
+  character-entities@2.0.2: {}
+
   cheminfo-types@1.15.0: {}
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
 
   compute-cosine-similarity@1.1.0:
     dependencies:
@@ -1110,9 +2363,225 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.1
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.1
+
+  cytoscape@3.34.1: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.23: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   effect@3.22.1:
     dependencies:
@@ -1120,6 +2589,8 @@ snapshots:
       fast-check: 3.23.2
 
   es-module-lexer@2.3.1: {}
+
+  es-toolkit@1.51.0: {}
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -1150,6 +2621,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.2
       '@esbuild/win32-x64': 0.28.2
 
+  escape-string-regexp@5.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -1161,6 +2634,8 @@ snapshots:
       - bare-abort-controller
 
   expect-type@1.4.0: {}
+
+  extend@3.0.2: {}
 
   fast-check@3.23.2:
     dependencies:
@@ -1178,10 +2653,32 @@ snapshots:
 
   fft.js@4.0.4: {}
 
+  find-my-way-ts@0.1.6: {}
+
   fsevents@2.3.3:
     optional: true
 
+  hachure-fill@0.5.2: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  import-meta-resolve@4.2.0: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
   is-any-array@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-plain-obj@4.1.0: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -1190,6 +2687,18 @@ snapshots:
       argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
+  kubernetes-types@1.30.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -1246,9 +2755,336 @@ snapshots:
       ml-matrix: 6.15.0
       ml-spectra-processing: 14.33.0
 
+  lodash-es@4.18.1: {}
+
+  longest-streak@3.1.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  mermaid@11.16.1:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.1)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.23
+      dompurify: 3.4.13
+      es-toolkit: 1.51.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.2
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mime@3.0.0: {}
 
   ml-array-max@2.0.0:
     dependencies:
@@ -1280,18 +3116,80 @@ snapshots:
 
   ml-xsadd@3.0.1: {}
 
+  ms@2.1.3: {}
+
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@1.12.1:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
+  multipasta@0.2.8: {}
+
   mustache@4.2.0: {}
 
   nanoid@3.3.18: {}
 
-  niceeval@0.4.6(react@19.2.8):
+  niceeval@0.13.0(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(ws@8.21.3)(zod@3.25.76):
     dependencies:
-      autoevals: 0.0.132
+      '@effect/platform-node': 0.108.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
+      '@vercel/analytics': 2.0.1(react@19.2.8)
+      '@vercel/speed-insights': 2.0.0(react@19.2.8)
+      autoevals: 0.0.132(ws@8.21.3)
+      effect: 3.22.1
+      mermaid: 11.16.1
+      openai: 6.49.0(ws@8.21.3)(zod@3.25.76)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      remark: 15.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      tar-stream: 3.2.0
+      tsx: 4.23.12
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@effect/cluster'
+      - '@effect/platform'
+      - '@effect/rpc'
+      - '@effect/sql'
+      - '@remix-run/react'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - '@sveltejs/kit'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - next
+      - nuxt
+      - react-native-b4a
+      - supports-color
+      - svelte
+      - utf-8-validate
+      - vue
+      - vue-router
+      - ws
+      - zod
+
+  niceeval@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.3):
+    dependencies:
+      autoevals: 0.0.132(ws@8.21.3)
       effect: 3.22.1
       tar-stream: 3.2.0
       tsx: 4.23.12
     optionalDependencies:
       react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - '@smithy/hash-node'
@@ -1301,17 +3199,36 @@ snapshots:
       - react-native-b4a
       - ws
 
+  node-addon-api@7.1.1: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
   obug@2.1.4: {}
 
-  openai@6.49.0(zod@3.25.76):
+  openai@6.49.0(ws@8.21.3)(zod@3.25.76):
     optionalDependencies:
+      ws: 8.21.3
       zod: 3.25.76
+
+  package-manager-detector@1.8.0: {}
+
+  path-data-parser@0.1.0: {}
 
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.26:
     dependencies:
@@ -1321,9 +3238,51 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react@19.2.8: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   require-from-string@2.0.2: {}
+
+  robust-predicates@3.0.3: {}
 
   rolldown@1.2.3:
     dependencies:
@@ -1345,6 +3304,19 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.3
       '@rolldown/binding-win32-x64-msvc': 1.2.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1361,6 +3333,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  stylis@4.4.0: {}
 
   tar-stream@3.2.0:
     dependencies:
@@ -1397,6 +3371,10 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
+  trough@2.2.0: {}
+
+  ts-dedent@2.3.0: {}
+
   tsx@4.23.12:
     dependencies:
       esbuild: 0.28.2
@@ -1407,11 +3385,56 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@7.29.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  uuid@11.1.1: {}
+
+  uuid@14.0.2: {}
+
   validate.io-array@1.0.6: {}
 
   validate.io-function@1.0.2: {}
 
-  vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12):
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -1423,11 +3446,12 @@ snapshots:
       esbuild: 0.28.2
       fsevents: 2.3.3
       tsx: 4.23.12
+      yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)):
+  vitest@4.1.9(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12))
+      '@vitest/mocker': 4.1.9(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -1444,7 +3468,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
@@ -1456,8 +3480,14 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  ws@8.21.3: {}
+
+  yaml@2.9.0: {}
+
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}

--- a/e2e/migrate/test/current-handoff.test.ts
+++ b/e2e/migrate/test/current-handoff.test.ts
@@ -4,7 +4,7 @@ import { createE2EContext, type ExpEvalEvent, type ExpEvent } from "@niceeval/te
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
 
-const installedNiceeval = [join(process.cwd(), "node_modules", ".bin", "niceeval")] as const;
+const installedNiceeval = [process.execPath, join(process.cwd(), "node_modules", "niceeval", "bin", "niceeval.js")] as const;
 const e2e = createE2EContext({
   repoId: "migrate",
   project: {

--- a/e2e/migrate/test/handoff.test.ts
+++ b/e2e/migrate/test/handoff.test.ts
@@ -1,101 +1,107 @@
 // owner: docs/engineering/testing/e2e/migrate.md#observability-v1-to-v2
-// regression: memory/results-schema-version-history.md#observability-family-1--2
 
-import { readFileSync } from "node:fs";
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "vitest";
-import { ATTEMPT_ID, commitRecord, copyV1Fixture, e2e, RUN_ID, sha256 } from "./support.ts";
+import { attestLegacyProducer, commitRecord, e2e } from "./support.ts";
 
-test("Observability v1 Record 经过显式迁移后由当前 candidate 完整读取", async () => {
+test("Git 保存的 npm 0.13.0 Record 自动迁移后显示同一结果并拒绝旧 writer", async () => {
   await e2e.case(
-    "observability-v1",
+    "observability-v1-auto-migrate",
     { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
-    async ({ paths, commands: { candidate, producer }, run }) => {
-      const recordRoot = join(paths.projectRoot, ".niceeval", "record");
-      copyV1Fixture(paths.sourceRoot, recordRoot);
-      const attemptAttachment = join(recordRoot, "runs", RUN_ID, "attempts", ATTEMPT_ID, "attachments", "niceeval.observability");
-      const runAttachment = join(recordRoot, "runs", RUN_ID, "attachments", "niceeval.observability");
-      const sourceNavigationAttachment = join(recordRoot, "runs", RUN_ID, "attempts", ATTEMPT_ID, "attachments", "niceeval.source-navigation");
-      const attemptPayloadBefore = sha256(join(attemptAttachment, "payload.json"));
-      const runPayloadBefore = sha256(join(runAttachment, "payload.json"));
-      const sourceNavigationBefore = sha256(join(sourceNavigationAttachment, "payload.json"));
-      const unknownPath = join(recordRoot, "runs", RUN_ID, "attachments", "example.future", "opaque.txt");
-      const unknownBefore = readFileSync(unknownPath, "utf8");
-      const draftEnvelope = join(recordRoot, "runs", "draft-run", "attachments", "niceeval.observability", "attachment.json");
-      const draftBefore = readFileSync(draftEnvelope, "utf8");
+    async ({ paths, commands: { candidate, legacyProducer }, run }) => {
+      attestLegacyProducer(paths.projectRoot);
 
-      const blockedRead = await candidate.run(["show", "--run", RUN_ID, "--json"]);
-      expect(blockedRead.exitCode, blockedRead.diagnostic()).toBe(0);
-      expect(blockedRead.stdout, blockedRead.diagnostic()).toContain('"state":"migration-required"');
-      expect(blockedRead.stdout, blockedRead.diagnostic()).toContain('"code":"analysis-migration-required"');
-      expect(blockedRead.stdout, blockedRead.diagnostic()).not.toContain('"domain":"source-navigation","state":"invalid"');
+      const configPath = join(paths.projectRoot, "niceeval.config.ts");
+      const currentConfig = readFileSync(configPath, "utf8");
+      const hiddenDefinitions = [
+        "evals/handoff.eval.ts",
+        "experiments/handoff.ts",
+        "experiments/missing-usage.ts",
+      ].map((relativePath) => [
+        join(paths.projectRoot, relativePath),
+        join(paths.projectRoot, `${relativePath}.current-disabled`),
+      ] as const);
+      const legacyDefinitions = [
+        "evals/legacy-handoff.eval.ts",
+        "experiments/legacy-handoff.ts",
+      ].map((relativePath) => [
+        join(paths.projectRoot, `${relativePath}.legacy-disabled`),
+        join(paths.projectRoot, relativePath),
+      ] as const);
+      const runLegacyExperiment = async () => {
+        try {
+          for (const [source, hidden] of hiddenDefinitions) renameSync(source, hidden);
+          for (const [disabled, active] of legacyDefinitions) renameSync(disabled, active);
+          writeFileSync(configPath, [
+            'import { defineConfig } from "niceeval-legacy-0-13";',
+            "export default defineConfig({",
+            '  name: "e2e: persisted legacy Record",',
+            "  timeoutMs: 60_000,",
+            "  maxConcurrency: 1,",
+            "});",
+            "",
+          ].join("\n"));
+          return await legacyProducer.run(["exp", "legacy-handoff", "--rerun", "all", "--json"]);
+        } finally {
+          writeFileSync(configPath, currentConfig);
+          for (const [disabled, active] of legacyDefinitions.toReversed()) renameSync(active, disabled);
+          for (const [source, hidden] of hiddenDefinitions.toReversed()) renameSync(hidden, source);
+        }
+      };
+      const produced = await runLegacyExperiment();
+      expect(produced.exitCode, produced.diagnostic()).toBe(0);
+      const receipt = produced.expReceipt();
+      expect(receipt.completion, produced.diagnostic()).toBe("completed");
+      expect(receipt.runIds, produced.diagnostic()).toHaveLength(1);
+      const runId = receipt.runIds[0]!;
+      expect(produced.stdout, produced.diagnostic()).toContain('"evalId":"legacy-handoff"');
+      expect(produced.stdout, produced.diagnostic()).toContain('"verdict":"passed"');
 
-      const blockedNavigation = await candidate.run(["show", "--run", RUN_ID, "--report", "./reports/source-navigation.tsx", "--page", "/source-navigation", "--json"]);
-      expect(blockedNavigation.exitCode, blockedNavigation.diagnostic()).toBe(0);
-      expect(blockedNavigation.stdout, blockedNavigation.diagnostic()).toContain("source-navigation:migration-required");
+      const unsaved = await candidate.run(["show", "--run", runId, "--json"]);
+      expect(unsaved.exitCode, unsaved.diagnostic()).toBe(1);
+      expect(unsaved.stderr, unsaved.diagnostic()).toContain("record-auto-migration-git-save-required");
+      expect(unsaved.stderr, unsaved.diagnostic()).toContain("git add");
+      expect(unsaved.stdout, unsaved.diagnostic()).not.toContain('"selection"');
 
-      const blockedCost = await candidate.run(["show", "--run", RUN_ID, "--report", "./reports/cost-state.tsx", "--page", "/cost-state"]);
-      expect(blockedCost.exitCode, blockedCost.diagnostic()).toBe(0);
-      expect(blockedCost.stdout, blockedCost.diagnostic()).toContain("cost:migration-required:0/1");
-      expect(blockedCost.stdout, blockedCost.diagnostic()).toContain("cost projection requires migration — run niceeval migrate");
+      await commitRecord(run, "record: save npm 0.13.0 run");
 
-      const currentRun = await producer.run(["exp", "handoff", "--rerun", "all", "--json"]);
-      expect(currentRun.exitCode, currentRun.diagnostic()).toBe(0);
-      const currentRunId = currentRun.expReceipt().runIds[0]!;
-      const mixedCost = await candidate.run(["show", "--run", RUN_ID, "--run", currentRunId, "--report", "./reports/cost-state.tsx", "--page", "/cost-state"]);
-      expect(mixedCost.exitCode, mixedCost.diagnostic()).toBe(0);
-      expect(mixedCost.stdout, mixedCost.diagnostic()).toContain("cost:partial:1/2");
-
-      const missingUsageRun = await producer.run(["exp", "missing-usage", "--rerun", "all", "--json"]);
-      expect(missingUsageRun.exitCode, missingUsageRun.diagnostic()).toBe(0);
-      const missingUsageRunId = missingUsageRun.expReceipt().runIds[0]!;
-      const mixedMissing = await candidate.run([
-        "show",
-        "--run",
-        RUN_ID,
-        "--run",
-        missingUsageRunId,
-        "--report",
-        "./reports/tokens-state.tsx",
-        "--page",
-        "/tokens-state",
-      ]);
-      expect(mixedMissing.exitCode, mixedMissing.diagnostic()).toBe(0);
-      expect(mixedMissing.stdout, mixedMissing.diagnostic()).toContain("tokens:partial:0/2");
-      expect(mixedMissing.stdout, mixedMissing.diagnostic()).not.toContain("requires migration");
-
-      await commitRecord(run, "fixture: observability v1");
-      const confirmation = await candidate.run(["migrate"]);
-      const restoreCommit = await run(["git", "rev-parse", "HEAD"]);
-      expect(restoreCommit.exitCode, restoreCommit.diagnostic()).toBe(0);
-      expect(confirmation.exitCode, confirmation.diagnostic()).toBe(1);
-      expect(confirmation.stdout, confirmation.diagnostic()).toContain("attachments: 2");
-      expect(confirmation.stdout, confirmation.diagnostic()).toContain("backup: git-restore-point");
-      expect(confirmation.stderr, confirmation.diagnostic()).toContain("record-migration-confirmation-required");
-
-      const migrated = await candidate.run(["migrate", "--yes"]);
-      expect(migrated.exitCode, migrated.diagnostic()).toBe(0);
-      expect(migrated.stdout, migrated.diagnostic()).toContain("Record migration migrated.");
-      expect(JSON.parse(readFileSync(join(attemptAttachment, "attachment.json"), "utf8"))).toEqual({ family: "niceeval.observability", schemaVersion: 2 });
-      expect(JSON.parse(readFileSync(join(runAttachment, "attachment.json"), "utf8"))).toEqual({ family: "niceeval.observability", schemaVersion: 2 });
-      expect(sha256(join(attemptAttachment, "payload.json"))).toBe(attemptPayloadBefore);
-      expect(sha256(join(runAttachment, "payload.json"))).toBe(runPayloadBefore);
-      expect(sha256(join(sourceNavigationAttachment, "payload.json"))).toBe(sourceNavigationBefore);
-      expect(readFileSync(unknownPath, "utf8")).toBe(unknownBefore);
-      expect(readFileSync(draftEnvelope, "utf8")).toBe(draftBefore);
-
-      const changed = await run(["git", "diff", "--name-only"]);
-      expect(changed.exitCode, changed.diagnostic()).toBe(0);
-      expect(changed.stdout.trim().split("\n").sort()).toEqual([
-        `.niceeval/record/runs/${RUN_ID}/attachments/niceeval.observability/attachment.json`,
-        `.niceeval/record/runs/${RUN_ID}/attempts/${ATTEMPT_ID}/attachments/niceeval.observability/attachment.json`,
-      ].sort());
-      const shown = await candidate.run(["show", "--run", RUN_ID, "--json"]);
+      const shown = await candidate.run(["show", "--run", runId, "--json"]);
       expect(shown.exitCode, shown.diagnostic()).toBe(0);
-      expect(shown.json<{ selection: { runIds: readonly string[] } }>().selection.runIds).toEqual([RUN_ID]);
-      const idempotent = await candidate.run(["migrate", "--yes"]);
-      expect(idempotent.exitCode, idempotent.diagnostic()).toBe(0);
-      expect(idempotent.stdout, idempotent.diagnostic()).toContain("already-current");
+      expect(shown.stderr, shown.diagnostic()).toContain("Record automatically migrated");
+      expect(shown.stderr, shown.diagnostic()).toContain("restore commit");
+      const output = shown.json<{
+        selection: { runIds: readonly string[] };
+        data: { rows: readonly [{ passRate: { state: string; value: number } }] };
+      }>();
+      expect(output.selection.runIds).toEqual([runId]);
+      expect(output.data.rows[0]?.passRate).toMatchObject({ state: "available", value: 1 });
+
+      const beforeOldWriter = await run(["git", "diff", "--binary", "--", ".niceeval/record"]);
+      expect(beforeOldWriter.exitCode, beforeOldWriter.diagnostic()).toBe(0);
+      const beforeOldWriterStatus = await run([
+        "git", "status", "--porcelain=v1", "--untracked-files=all", "--", ".niceeval/record",
+      ]);
+      expect(beforeOldWriterStatus.exitCode, beforeOldWriterStatus.diagnostic()).toBe(0);
+
+      const oldWriterRejected = await runLegacyExperiment();
+      expect(oldWriterRejected.exitCode, oldWriterRejected.diagnostic()).toBe(1);
+      expect(oldWriterRejected.stderr, oldWriterRejected.diagnostic()).toContain("record-format-unsupported");
+      expect(oldWriterRejected.stdout, oldWriterRejected.diagnostic()).not.toContain('"event":"run"');
+
+      const afterOldWriter = await run(["git", "diff", "--binary", "--", ".niceeval/record"]);
+      expect(afterOldWriter.exitCode, afterOldWriter.diagnostic()).toBe(0);
+      expect(afterOldWriter.stdout).toBe(beforeOldWriter.stdout);
+      const afterOldWriterStatus = await run([
+        "git", "status", "--porcelain=v1", "--untracked-files=all", "--", ".niceeval/record",
+      ]);
+      expect(afterOldWriterStatus.exitCode, afterOldWriterStatus.diagnostic()).toBe(0);
+      expect(afterOldWriterStatus.stdout).toBe(beforeOldWriterStatus.stdout);
+
+      const stillShown = await candidate.run(["show", "--run", runId, "--json"]);
+      expect(stillShown.exitCode, stillShown.diagnostic()).toBe(0);
+      expect(stillShown.stderr, stillShown.diagnostic()).not.toContain("Record automatically migrated");
+      expect(stillShown.json<{ selection: { runIds: readonly string[] } }>().selection.runIds).toEqual([runId]);
     },
   );
 });

--- a/e2e/migrate/test/report-guard.test.ts
+++ b/e2e/migrate/test/report-guard.test.ts
@@ -1,13 +1,15 @@
 // owner: docs/engineering/testing/e2e/migrate.md#report-migration-metric-guard
 
-import { join } from "node:path";
 import { expect, test } from "vitest";
-import { copyV1Fixture, e2e, RUN_ID } from "./support.ts";
+import { e2e } from "./support.ts";
 
-test("Report 拒绝 ledger 缺 Slot 的 migration-required metric", async () => {
-  await e2e.case("report-incomplete-ledger", async ({ paths, commands: { candidate } }) => {
-    copyV1Fixture(paths.sourceRoot, join(paths.projectRoot, ".niceeval", "record"));
-    const rejected = await candidate.run(["show", "--run", RUN_ID, "--report", "./reports/invalid-migration-metric.tsx", "--page", "/invalid-migration-metric"]);
+test("Report 拒绝 ledger 缺 Slot 的伪造 metric", async () => {
+  await e2e.case("report-incomplete-ledger", async ({ commands: { candidate } }) => {
+    const produced = await candidate.run(["exp", "handoff", "--rerun", "all", "--json"]);
+    expect(produced.exitCode, produced.diagnostic()).toBe(0);
+    const [runId] = produced.expReceipt().runIds;
+    expect(runId, produced.diagnostic()).toBeDefined();
+    const rejected = await candidate.run(["show", "--run", runId!, "--report", "./reports/invalid-migration-metric.tsx", "--page", "/invalid-migration-metric"]);
     expect(rejected.exitCode, rejected.diagnostic()).toBe(1);
     expect(rejected.stderr, rejected.diagnostic()).toContain("Table rows[0].metric has unsupported object type");
   });

--- a/e2e/migrate/test/support.ts
+++ b/e2e/migrate/test/support.ts
@@ -6,7 +6,8 @@ import { expect } from "vitest";
 
 export const RUN_ID = "2ce48d15-5278-46f7-a512-7235a3362c24";
 export const ATTEMPT_ID = "ae2047b7-d0ef-4f1d-8a2f-ae2b27e7b4ad";
-const installedNiceeval = [join(process.cwd(), "node_modules", ".bin", "niceeval")] as const;
+const installedNiceeval = [process.execPath, join(process.cwd(), "node_modules", "niceeval", "bin", "niceeval.js")] as const;
+const legacyNiceeval = [process.execPath, join(process.cwd(), "node_modules", "niceeval-legacy-0-13", "bin", "niceeval.js")] as const;
 
 export const e2e = createE2EContext({
   repoId: "migrate",
@@ -16,8 +17,22 @@ export const e2e = createE2EContext({
     omitTopLevel: [".e2e-artifacts", ".niceeval", "node_modules", "test"],
     links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
   },
-  commands: { candidate: installedNiceeval, producer: installedNiceeval },
+  commands: { candidate: installedNiceeval, producer: installedNiceeval, legacyProducer: legacyNiceeval },
 });
+
+export const LEGACY_PRODUCER_VERSION = "0.13.0";
+export const LEGACY_PRODUCER_INTEGRITY = "sha512-aHSNZdzfu6QxkDpsfIS+xRTDRNirvfMOGzexnuZba3H46QdadjewfL5brv5y54UAnynxT2g6gntfPkk180D8+A==";
+
+export function attestLegacyProducer(projectRoot: string): void {
+  const metadata = JSON.parse(readFileSync(join(projectRoot, "node_modules", "niceeval-legacy-0-13", "package.json"), "utf8")) as {
+    readonly name?: unknown;
+    readonly version?: unknown;
+  };
+  expect(metadata).toMatchObject({ name: "niceeval", version: LEGACY_PRODUCER_VERSION });
+  const lockfile = readFileSync(join(projectRoot, "pnpm-lock.yaml"), "utf8");
+  expect(lockfile).toContain("niceeval@0.13.0");
+  expect(lockfile).toContain(`integrity: ${LEGACY_PRODUCER_INTEGRITY}`);
+}
 
 export function copyV1Fixture(sourceRoot: string, recordRoot: string): void {
   cpSync(join(sourceRoot, "fixtures", "observability-v1-record"), recordRoot, { recursive: true });

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -4,9 +4,9 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     // Runner cases spend most of their wall time waiting on isolated child
-    // processes. Keep four file workers explicit on the public GitHub-hosted
-    // runner so environment-derived defaults cannot serialize this I/O workload.
-    maxWorkers: 4,
+    // processes. Use two file workers per public-runner vCPU so long lifecycle
+    // files start early instead of sitting behind other I/O-bound owners.
+    maxWorkers: 8,
     testTimeout: 240_000,
     hookTimeout: 120_000,
   },

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -1,12 +1,33 @@
 import { defineConfig } from "vitest/config";
+import { BaseSequencer, type TestSpecification } from "vitest/node";
+
+const criticalPathOwners = [
+  "shared-state-recovery.test.ts",
+  "shared-state-lifecycle.test.ts",
+  "shared-state-startup-authority.test.ts",
+] as const;
+
+class RunnerSequencer extends BaseSequencer {
+  override async sort(files: TestSpecification[]): Promise<TestSpecification[]> {
+    const sorted = await super.sort(files);
+    return sorted.sort((left, right) => {
+      const priority = (moduleId: string) => {
+        const index = criticalPathOwners.findIndex((file) => moduleId.endsWith(`/${file}`));
+        return index === -1 ? criticalPathOwners.length : index;
+      };
+      return priority(left.moduleId) - priority(right.moduleId);
+    });
+  }
+}
 
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
-    // Runner cases spend most of their wall time waiting on isolated child
-    // processes. Ten workers start the long recovery owner after at most one
-    // short wave without overloading four-core CI with every file at once.
-    maxWorkers: 10,
+    // Start long child-process journeys first, then keep concurrency at the
+    // public runner's four-vCPU capacity so individual Agent deadlines remain
+    // meaningful under load.
+    sequence: { sequencer: RunnerSequencer },
+    maxWorkers: 4,
     testTimeout: 240_000,
     hookTimeout: 120_000,
   },

--- a/e2e/runner/vitest.config.ts
+++ b/e2e/runner/vitest.config.ts
@@ -4,9 +4,9 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     // Runner cases spend most of their wall time waiting on isolated child
-    // processes. Use two file workers per public-runner vCPU so long lifecycle
-    // files start early instead of sitting behind other I/O-bound owners.
-    maxWorkers: 8,
+    // processes. Ten workers start the long recovery owner after at most one
+    // short wave without overloading four-core CI with every file at once.
+    maxWorkers: 10,
     testTimeout: 240_000,
     hookTimeout: 120_000,
   },

--- a/e2e/scripts/injection.ts
+++ b/e2e/scripts/injection.ts
@@ -140,22 +140,22 @@ export async function buildCandidateTarball(
 
 /**
  * Extract the `resolution.integrity` pnpm recorded for the `niceeval@file:...`
- * package entry in a pnpm-lock.yaml. Throws (does not guess) if there isn't
- * exactly one such entry — zero means niceeval never resolved to a local
- * tarball at all, more than one means an ambiguous/partial injection.
+ * package entry in a pnpm-lock.yaml. Registry-pinned historical producer
+ * aliases are deliberately outside this candidate identity. Throws (does not
+ * guess) unless there is exactly one local-tarball candidate entry.
  */
 export function extractNiceevalIntegrity(lockfileText: string): string {
-  const entryRe = /^ {2}niceeval@[^\n]*:\n {4}resolution:\s*\{[^}\n]*integrity:\s*(sha512-[A-Za-z0-9+/=]+)/gm;
+  const entryRe = /^ {2}niceeval@file:[^\n]*:\n {4}resolution:\s*\{[^}\n]*integrity:\s*(sha512-[A-Za-z0-9+/=]+)/gm;
   const matches = [...lockfileText.matchAll(entryRe)];
 
   if (matches.length === 0) {
     throw new Error(
-      'no "niceeval@..." package entry with a resolution.integrity found in pnpm-lock.yaml — niceeval may not have resolved to the injected tarball at all',
+      'no "niceeval@file:..." package entry with a resolution.integrity found in pnpm-lock.yaml — niceeval may not have resolved to the injected tarball at all',
     );
   }
   if (matches.length > 1) {
     throw new Error(
-      `found ${matches.length} "niceeval@..." package entries in pnpm-lock.yaml — expected exactly one; a partial or ambiguous injection`,
+      `found ${matches.length} "niceeval@file:..." package entries in pnpm-lock.yaml — expected exactly one local candidate; a partial or ambiguous injection`,
     );
   }
   return matches[0][1];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,7 @@ import {
   resolveTrustedModulePath,
   type ThemeDefinition,
 } from "./report/host/node.ts";
-import { runRecordCliCommand } from "./cli/record.ts";
+import { ensureAutomaticRecordMigration, runRecordCliCommand } from "./cli/record.ts";
 import { selectedEvalsForRun } from "./runner/eval-selection.ts";
 import { stopAllSandboxes } from "./sandbox/registry.ts";
 import {
@@ -3063,6 +3063,26 @@ function reportExecutionFailure(error: unknown): CliFailure {
   }
 }
 
+function automaticRecordMigrationFailure(error: unknown): CliFailure {
+  const code = failureCode(error);
+  if (code === "record-auto-migration-git-save-required") {
+    return usageError(
+      "record-auto-migration-git-save-required\n" +
+      "Save every portable Record byte first (for example: git add .niceeval/record && git commit), then retry the same command.\n",
+    );
+  }
+  if (code === "record-maintenance-busy" || code === "record-writer-busy") {
+    return usageError(`${code}\nClose the command using this Record, then retry.\n`);
+  }
+  if (code === "record-format-unsupported") {
+    return usageError("record-format-unsupported\nUse the NiceEval version that wrote this future or unknown Record format.\n");
+  }
+  if (code === "record-migration-recovery-required" || code === "record-migration-interrupted") {
+    return usageError(`${code}\nRestore and verify the complete Record from Git before retrying.\n`);
+  }
+  return cliFailure("automatically migrate Record", error);
+}
+
 /** Preserve the actionable dimension and target from the Host's closed budget error. */
 function reportBuildBudgetExceededMessage(error: unknown): string {
   const budget = stringProperty(error, "budget");
@@ -3724,6 +3744,18 @@ export const cliProgram = (interruption?: CliInterruptionOwnership) => Effect.ge
   if (flags.version) {
     yield* writeStdout((yield* packageVersion()) + "\n");
     return 0;
+  }
+
+  if (command === "show" || command === "view" || command === "exp") {
+    const migrated = yield* ensureAutomaticRecordMigration({
+      cwd,
+      ...(flags.record === undefined ? {} : { record: flags.record }),
+    }).pipe(Effect.mapError(automaticRecordMigrationFailure));
+    if (migrated !== null) {
+      yield* writeStderr(
+        `Record automatically migrated to schemaVersion ${migrated.targetSchemaVersion}; restore commit ${migrated.restoreCommit}.\n`,
+      );
+    }
   }
 
   if (command === "debug") {

--- a/src/cli/record.ts
+++ b/src/cli/record.ts
@@ -8,6 +8,12 @@ import {
   type RecordRoot,
 } from "../record/index.ts";
 import { recordHost } from "../record/host/index.ts";
+import { RECORD_SCHEMA_VERSION } from "../record/model/identifiers.ts";
+import {
+  RecordAutoMigrationGitSaveRequired,
+  RecordMigrationRequired,
+} from "../record/reader/errors.ts";
+import { RecordFileSystem, recordPortablePath } from "../record/platform/services.ts";
 
 export type RecordCliCommand = "clean" | "migrate";
 
@@ -39,6 +45,56 @@ function output(input: {
 }
 
 export const NodeRecordCliLive = NodeRecordLive;
+
+export interface AutomaticRecordMigrationReceipt {
+  readonly restoreCommit: string;
+  readonly targetSchemaVersion: typeof RECORD_SCHEMA_VERSION;
+}
+
+/**
+ * Preflight for ordinary CLI entry points. Every Scope is closed before the
+ * next lease kind is acquired: read check -> exclusive maintenance -> caller's
+ * fresh ordinary open.
+ */
+export function ensureAutomaticRecordMigration(input: {
+  readonly cwd: string;
+  readonly record?: string;
+}) {
+  const root = makeRecordRoot(resolve(input.cwd, input.record ?? ".niceeval/record"));
+  if (Either.isLeft(root)) return Effect.fail(root.left);
+  return Effect.gen(function* () {
+    const fileSystem = yield* RecordFileSystem;
+    if ((yield* fileSystem.pathKind(recordPortablePath(root.right, "record.json"))) === "missing") {
+      return null;
+    }
+    const checked = yield* Effect.either(Effect.scoped(recordHost.current.openRead({ root: root.right })));
+    if (Either.isRight(checked)) return null;
+    if (!(checked.left instanceof RecordMigrationRequired)) return yield* Effect.fail(checked.left);
+
+    return yield* Effect.scoped(Effect.gen(function* () {
+      const session = yield* recordHost.maintenance.open({ root: root.right });
+      const plan = yield* session.planMigrate();
+      if (plan.state !== "migration-required") {
+        return yield* Effect.fail(checked.left);
+      }
+      if (plan.backup.state !== "git-restore-point") {
+        return yield* Effect.fail(new RecordAutoMigrationGitSaveRequired({
+          code: "record-auto-migration-git-save-required",
+        }));
+      }
+      yield* session.applyMigrate(plan).pipe(
+        Effect.catchTag("RecordMigrationGitRestoreRequired", () =>
+          Effect.fail(new RecordAutoMigrationGitSaveRequired({
+            code: "record-auto-migration-git-save-required",
+          }))),
+      );
+      return Object.freeze({
+        restoreCommit: plan.backup.commit,
+        targetSchemaVersion: RECORD_SCHEMA_VERSION,
+      });
+    }));
+  });
+}
 
 function resolveRecordRoot(
   input: RunRecordCliCommandInput,
@@ -194,7 +250,7 @@ function migrateCommand(input: {
       ? `Record migration plan: already-current\nformat: ${plan.format}\n`
       : plan.state === "unsupported-format"
         ? `Record migration plan: unsupported-format\nformat: ${plan.format}\n`
-        : `Record migration plan: migration-required\nformat: ${plan.format}\nattachments: ${plan.attachments.length}\nbackup: ${plan.backup.state}${plan.backup.state === "git-restore-point" ? `\nrestore commit: ${plan.backup.commit}` : ""}\n`;
+        : `Record migration plan: migration-required\nformat: ${plan.format}\nroot: ${plan.root === null ? "current" : `${plan.root.fromSchemaVersion} -> ${plan.root.toSchemaVersion}`}\nattachments: ${plan.attachments.length}\nbackup: ${plan.backup.state}${plan.backup.state === "git-restore-point" ? `\nrestore commit: ${plan.backup.commit}` : ""}\n`;
     if (plan.state === "unsupported-format") {
       return output({
         exitCode: 1,

--- a/src/record/host/runtime.ts
+++ b/src/record/host/runtime.ts
@@ -110,6 +110,7 @@ import {
   RecordFormatUnsupported,
   RecordHandleInvalid,
   RecordMigrationInvalid,
+  RecordMigrationRequired,
   RecordMigrationGitRestoreRequired,
   RecordMigrationInterruptedState,
   RecordMigrationPlanStale,
@@ -123,6 +124,7 @@ import {
 import {
   RECORD_FORMAT_DOCUMENT_MAXIMUM_BYTES,
   readCurrentRecordFormat,
+  readRecordFormatForMaintenance,
 } from "../reader/format.ts";
 import {
   readFixedRecordAttachment,
@@ -401,12 +403,14 @@ function currentFormatInspection(
   fileSystem: RecordFileSystemService,
   root: RecordRoot,
 ): Effect.Effect<RecordFormatInspection, RecordMaintenanceError> {
-  return readCurrentRecordFormat(fileSystem, root).pipe(
-    Effect.flatMap(() =>
+  return readRecordFormatForMaintenance(fileSystem, root).pipe(
+    Effect.flatMap((format) =>
       Effect.map(
         planAttachmentMigration({ fileSystem, root }),
         (attachments): RecordFormatInspection => ({
-          state: attachments.targets.length === 0 ? "already-current" : "migration-required",
+          state: format.sourceSchemaVersion === RECORD_SCHEMA_VERSION && attachments.targets.length === 0
+            ? "already-current"
+            : "migration-required",
           format: RECORD_FORMAT,
         }),
       )
@@ -1232,6 +1236,7 @@ function openCurrentRead(input: {
       return yield* Effect.fail(migrationInterrupted());
     }
     const current = yield* readCurrentRecordFormat(fileSystem, input.root);
+    yield* ensureOrdinaryCurrentAttachments({ fileSystem, root: input.root });
     yield* coordination.verifyRecordIdentity({ root: input.root, recordId: current.document.recordId });
     const lifecycle: ReaderLifecycle = { closed: false };
     const runtime: ReaderRuntime = {
@@ -2434,6 +2439,7 @@ function openNewRuntime(
     }
     yield* initializeRecord({ root: request.root, fileSystem, entropy });
     const current = yield* readCurrentRecordFormat(fileSystem, request.root);
+    yield* ensureOrdinaryCurrentAttachments({ fileSystem, root: request.root });
     yield* coordination.verifyRecordIdentity({ root: request.root, recordId: current.document.recordId });
     const runId = yield* createFreshRunDirectory(request.root, fileSystem, entropy);
     const mutex = yield* Effect.makeSemaphore(1);
@@ -2525,6 +2531,74 @@ const attemptMigrationDescriptors = Object.freeze([
   migrationDescriptor(NiceEvalRecordFamilyCatalog.sourceNavigation),
   migrationDescriptor(NiceEvalRecordFamilyCatalog.artifacts.attempt),
 ]);
+
+function validateAttachmentDirectoryInventory(input: {
+  readonly fileSystem: RecordFileSystemService;
+  readonly directory: ReturnType<typeof recordPortablePath>;
+  readonly allowed: ReadonlySet<string>;
+}): Effect.Effect<void, RecordFileSystemError | RecordFormatUnsupported> {
+  return Effect.gen(function* () {
+    const kind = yield* input.fileSystem.pathKind(input.directory);
+    if (kind === "missing") return;
+    if (kind !== "directory") {
+      return yield* Effect.fail(new RecordFormatUnsupported({
+        code: "record-format-unsupported",
+        format: "attachment-inventory",
+      }));
+    }
+    const entries = yield* input.fileSystem.listDirectory({
+      directory: input.directory,
+      maximumEntries: 256,
+    });
+    const unsupported = entries.find((entry) => entry.kind !== "directory" || !input.allowed.has(entry.name));
+    if (unsupported !== undefined) {
+      return yield* Effect.fail(new RecordFormatUnsupported({
+        code: "record-format-unsupported",
+        format: `unknown-family:${unsupported.name}`,
+      }));
+    }
+  });
+}
+
+function validateCurrentFamilyInventory(
+  fileSystem: RecordFileSystemService,
+  root: RecordRoot,
+): Effect.Effect<void, RecordFileSystemError | RecordFormatUnsupported> {
+  const runFamilies = new Set(runMigrationDescriptors.map((descriptor) => descriptor.family));
+  const attemptFamilies = new Set(attemptMigrationDescriptors.map((descriptor) => descriptor.family));
+  return Effect.gen(function* () {
+    const runs = yield* fileSystem.listDirectory({
+      directory: recordPortablePath(root, "runs"),
+      maximumEntries: MAXIMUM_RUN_ENTRIES,
+    });
+    for (const entry of runs) {
+      if (entry.kind !== "directory") continue;
+      const runId = decodeRunId(entry.name);
+      if (runId === undefined || !(yield* isSealedRun(fileSystem, root, runId))) continue;
+      yield* validateAttachmentDirectoryInventory({
+        fileSystem,
+        directory: recordPortablePath(root, "runs", runId, "attachments"),
+        allowed: runFamilies,
+      });
+      const attemptsDirectory = recordPortablePath(root, "runs", runId, "attempts");
+      if ((yield* fileSystem.pathKind(attemptsDirectory)) !== "directory") continue;
+      const attempts = yield* fileSystem.listDirectory({
+        directory: attemptsDirectory,
+        maximumEntries: MAXIMUM_ATTEMPT_ENTRIES,
+      });
+      for (const attempt of attempts) {
+        if (attempt.kind !== "directory") continue;
+        const attemptId = decodeAttemptId(attempt.name);
+        if (attemptId === undefined) continue;
+        yield* validateAttachmentDirectoryInventory({
+          fileSystem,
+          directory: recordPortablePath(root, "runs", runId, "attempts", attemptId, "attachments"),
+          allowed: attemptFamilies,
+        });
+      }
+    }
+  });
+}
 
 function migrationAttachmentDirectory(
   root: RecordRoot,
@@ -2661,7 +2735,15 @@ interface PlannedMigrationSource {
   readonly envelopeBytes: Uint8Array;
 }
 
-const migrationPlanSources = new WeakMap<object, readonly PlannedMigrationSource[]>();
+interface PlannedMigrationSources {
+  readonly attachments: readonly PlannedMigrationSource[];
+  readonly rootBytes: Uint8Array | null;
+  readonly record: RecordDocument;
+  readonly implementationIdentity: typeof RECORD_MIGRATION_IMPLEMENTATION_ID;
+}
+
+const RECORD_MIGRATION_IMPLEMENTATION_ID = "niceeval.record/root-1-observability-1-to-root-2-observability-2/v1" as const;
+const migrationPlanSources = new WeakMap<object, PlannedMigrationSources>();
 
 function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
   return left.byteLength === right.byteLength && left.every((byte, index) => byte === right[index]);
@@ -2682,6 +2764,7 @@ function sameMigrationPlan(left: RecordMigrationPlan, right: RecordMigrationPlan
   if (left.state !== right.state || left.format !== right.format) return false;
   if (left.state !== "migration-required" || right.state !== "migration-required") return true;
   if (JSON.stringify(left.backup) !== JSON.stringify(right.backup)) return false;
+  if (JSON.stringify(left.root) !== JSON.stringify(right.root)) return false;
   if (left.attachments.length !== right.attachments.length) return false;
   return left.attachments.every((target, index) => {
     const candidate = right.attachments[index];
@@ -2701,8 +2784,9 @@ function planAttachmentMigration(input: {
 }): Effect.Effect<{
   readonly targets: readonly RecordAttachmentMigrationTarget[];
   readonly sources: readonly PlannedMigrationSource[];
-}, RecordMaintenanceError> {
+}, RecordFileSystemError | RecordFormatUnsupported | RecordMigrationInvalid> {
   return Effect.gen(function* () {
+    yield* validateCurrentFamilyInventory(input.fileSystem, input.root);
     const targets: RecordAttachmentMigrationTarget[] = [];
     const sources: PlannedMigrationSource[] = [];
     for (const location of yield* knownMigrationAttachments(input.fileSystem, input.root)) {
@@ -2741,16 +2825,41 @@ function planAttachmentMigration(input: {
   });
 }
 
+function ensureOrdinaryCurrentAttachments(input: {
+  readonly fileSystem: RecordFileSystemService;
+  readonly root: RecordRoot;
+}): Effect.Effect<void, RecordReaderOpenError> {
+  return planAttachmentMigration(input).pipe(
+    Effect.flatMap((plan) => plan.targets.length === 0
+      ? Effect.void
+      : Effect.fail(new RecordMigrationRequired({
+          code: "record-migration-required",
+          source: "niceeval.record attachment predecessor",
+          target: `${RECORD_FORMAT}@${RECORD_SCHEMA_VERSION}`,
+          command: "niceeval migrate",
+        }))),
+    Effect.mapError((error): RecordReaderOpenError => error instanceof RecordMigrationInvalid
+      ? bootstrapInvalid()
+      : error),
+  );
+}
+
 function migrationPlan(input: {
   readonly fileSystem: RecordFileSystemService;
   readonly root: RecordRoot;
   readonly git: RecordGitService;
 }): Effect.Effect<RecordMigrationPlan, RecordMaintenanceError> {
   return Effect.gen(function* () {
-    const current = yield* readCurrentRecordFormat(input.fileSystem, input.root);
-    yield* validateSealedCoreForMigration(input.fileSystem, input.root, current.document);
+    const format = yield* readRecordFormatForMaintenance(input.fileSystem, input.root);
+    yield* validateSealedCoreForMigration(input.fileSystem, input.root, format.document);
     const attachments = yield* planAttachmentMigration(input);
-    if (attachments.targets.length === 0) {
+    const rootMigration = format.sourceSchemaVersion === RECORD_SCHEMA_VERSION
+      ? null
+      : Object.freeze({
+          fromSchemaVersion: format.sourceSchemaVersion,
+          toSchemaVersion: RECORD_SCHEMA_VERSION,
+        });
+    if (rootMigration === null && attachments.targets.length === 0) {
       return Object.freeze({ state: "already-current" as const, format: RECORD_FORMAT });
     }
     const backup = yield* input.git.inspectBackupState(input.root);
@@ -2758,9 +2867,15 @@ function migrationPlan(input: {
       state: "migration-required" as const,
       format: RECORD_FORMAT,
       backup,
+      root: rootMigration,
       attachments: attachments.targets,
     });
-    migrationPlanSources.set(plan, attachments.sources);
+    migrationPlanSources.set(plan, Object.freeze({
+      attachments: attachments.sources,
+      rootBytes: rootMigration === null ? null : format.sourceBytes,
+      record: format.document,
+      implementationIdentity: RECORD_MIGRATION_IMPLEMENTATION_ID,
+    }));
     return plan;
   });
 }
@@ -2910,6 +3025,17 @@ function migrationRecoveryIsSafe(input: {
     if (Either.isLeft(encoded)) return false;
     const currentEnvelopeBytes = jsonBytes(encoded.right);
     const expectedPaths = [recordPortablePath(input.root, "migration.in-progress")];
+    const currentRoot = yield* input.fileSystem.readFile({
+      file: recordPortablePath(input.root, "record.json"),
+      maximumBytes: RECORD_FORMAT_DOCUMENT_MAXIMUM_BYTES,
+    });
+    if (currentRoot !== undefined) {
+      const parsed = parseJson(currentRoot);
+      if (
+        typeof parsed === "object" && parsed !== null &&
+        Reflect.get(parsed, "schemaVersion") === RECORD_SCHEMA_VERSION
+      ) expectedPaths.push(recordPortablePath(input.root, "record.json"));
+    }
     for (const location of yield* knownMigrationAttachments(input.fileSystem, input.root)) {
       if (location.descriptor.family !== NiceEvalRecordAttachments.observability.family) continue;
       const path = migrationEnvelopePath(input.root, location);
@@ -2947,7 +3073,11 @@ function openMaintenance(input: {
       return yield* Effect.fail(migrationInterrupted(restoreCommit, restoreSafe));
     }
     const inspect = () => currentFormatInspection(fileSystem, input.root);
-    const planMigrate = () => migrationPlan({ fileSystem, root: input.root, git });
+    const planMigrate = () => Effect.gen(function* () {
+      const format = yield* readRecordFormatForMaintenance(fileSystem, input.root);
+      yield* coordination.verifyRecordIdentity({ root: input.root, recordId: format.document.recordId });
+      return yield* migrationPlan({ fileSystem, root: input.root, git });
+    });
     return Object.freeze({
       inspect,
       planMigrate,
@@ -2973,7 +3103,12 @@ function openMaintenance(input: {
           }
           const restoreCommit = currentPlan.backup.commit;
           const plannedSources = migrationPlanSources.get(currentPlan);
-          if (plannedSources === undefined || plannedSources.length !== currentPlan.attachments.length) {
+          if (
+            plannedSources === undefined ||
+            plannedSources.implementationIdentity !== RECORD_MIGRATION_IMPLEMENTATION_ID ||
+            plannedSources.attachments.length !== currentPlan.attachments.length ||
+            (currentPlan.root === null) !== (plannedSources.rootBytes === null)
+          ) {
             return yield* Effect.fail(migrationInvalid(NiceEvalRecordAttachments.observability.family));
           }
           let portableTargetWritten = false;
@@ -2991,12 +3126,32 @@ function openMaintenance(input: {
             return yield* Effect.fail(migrationPlanStale());
           }
           yield* Effect.gen(function* () {
-            for (const source of plannedSources) {
+            for (const source of plannedSources.attachments) {
               yield* migrateObservabilityAttachment({
                 fileSystem,
                 root: input.root,
                 target: source.target,
                 expectedEnvelopeBytes: source.envelopeBytes,
+              });
+              portableTargetWritten = true;
+            }
+            if (plannedSources.rootBytes !== null) {
+              const rootPath = recordPortablePath(input.root, "record.json");
+              const sourceBeforeRootWrite = yield* fileSystem.readFile({
+                file: rootPath,
+                maximumBytes: RECORD_FORMAT_DOCUMENT_MAXIMUM_BYTES,
+              });
+              if (
+                sourceBeforeRootWrite === undefined ||
+                !bytesEqual(sourceBeforeRootWrite, plannedSources.rootBytes)
+              ) return yield* Effect.fail(migrationPlanStale());
+              const encodedRoot = encodeRecordDocument(plannedSources.record);
+              if (Either.isLeft(encodedRoot)) return yield* Effect.fail(migrationInvalid("niceeval.core"));
+              yield* fileSystem.writeFile({
+                file: rootPath,
+                bytes: jsonBytes(encodedRoot.right),
+                maximumBytes: RECORD_FORMAT_DOCUMENT_MAXIMUM_BYTES,
+                mode: "replace-no-follow",
               });
               portableTargetWritten = true;
             }

--- a/src/record/host/types.ts
+++ b/src/record/host/types.ts
@@ -389,6 +389,10 @@ export type RecordMigrationPlan =
       readonly state: "migration-required";
       readonly format: "niceeval.record";
       readonly backup: RecordBackupState;
+      readonly root: {
+        readonly fromSchemaVersion: number;
+        readonly toSchemaVersion: number;
+      } | null;
       readonly attachments: readonly RecordAttachmentMigrationTarget[];
     }
   | {

--- a/src/record/model/core.ts
+++ b/src/record/model/core.ts
@@ -14,7 +14,7 @@ import type { RunContext } from "./run-context.ts";
 /** The current root header keeps stable identity separate from schema version. */
 export interface RecordDocument {
   readonly format: RecordFormat;
-  readonly schemaVersion: 1;
+  readonly schemaVersion: 2;
   readonly recordId: RecordId;
 }
 

--- a/src/record/model/identifiers.ts
+++ b/src/record/model/identifiers.ts
@@ -58,7 +58,7 @@ export type CanonicalProjectRelativePath = string & Brand.Brand<
 
 /** Stable root identity; evolution is carried by the separate numeric header. */
 export const RECORD_FORMAT = "niceeval.record" as const;
-export const RECORD_SCHEMA_VERSION = 1 as const;
+export const RECORD_SCHEMA_VERSION = 2 as const;
 
 export type RecordFormat =
   typeof RECORD_FORMAT & Brand.Brand<typeof RECORD_FORMAT_ID_BRAND>;

--- a/src/record/reader/errors.ts
+++ b/src/record/reader/errors.ts
@@ -54,6 +54,13 @@ export class RecordMigrationGitRestoreRequired extends Schema.TaggedError<Record
   code: Schema.Literal("record-migration-git-restore-required"),
 }) {}
 
+/** Automatic migration requires every portable byte to be saved at clean HEAD. */
+export class RecordAutoMigrationGitSaveRequired extends Schema.TaggedError<RecordAutoMigrationGitSaveRequired>(
+  "@niceeval/record/RecordAutoMigrationGitSaveRequired",
+)("RecordAutoMigrationGitSaveRequired", {
+  code: Schema.Literal("record-auto-migration-git-save-required"),
+}) {}
+
 /** A known historical attachment cannot be proven safe to advance in place. */
 export class RecordMigrationInvalid extends Schema.TaggedError<RecordMigrationInvalid>(
   "@niceeval/record/RecordMigrationInvalid",

--- a/src/record/reader/format.ts
+++ b/src/record/reader/format.ts
@@ -1,5 +1,6 @@
-import { Effect, Either } from "effect";
-import { decodeRecordDocument } from "../codec/core.ts";
+import { Effect, Either, Schema } from "effect";
+import { decodeRecordDocument, RecordExactParseOptions } from "../codec/core.ts";
+import { RecordIdSchema } from "../codec/identifiers.ts";
 import type { RecordDocument } from "../model/core.ts";
 import { RECORD_FORMAT, RECORD_SCHEMA_VERSION } from "../model/identifiers.ts";
 import type { RecordFileSystemError } from "../platform/errors.ts";
@@ -11,6 +12,7 @@ import type { RecordRoot } from "../platform/root.ts";
 import {
   RecordBootstrapInvalid,
   RecordFormatUnsupported,
+  RecordMigrationRequired,
 } from "./errors.ts";
 
 /** `record.json` contains only root identity, so its read has a hard small cap. */
@@ -18,6 +20,11 @@ export const RECORD_FORMAT_DOCUMENT_MAXIMUM_BYTES = 64 * 1024;
 
 export interface CurrentRecordFormatRead {
   readonly document: RecordDocument;
+}
+
+export interface MaintenanceRecordFormatRead extends CurrentRecordFormatRead {
+  readonly sourceSchemaVersion: 1 | typeof RECORD_SCHEMA_VERSION;
+  readonly sourceBytes: Uint8Array;
 }
 
 function bootstrapInvalid(
@@ -56,18 +63,22 @@ function schemaVersionOf(value: unknown): number | undefined {
 
 function classifyRecordDocument(
   value: unknown,
-): Either.Either<CurrentRecordFormatRead, RecordBootstrapInvalid | RecordFormatUnsupported> {
+): Either.Either<CurrentRecordFormatRead, RecordBootstrapInvalid | RecordFormatUnsupported | RecordMigrationRequired> {
   const format = formatOf(value);
   if (format === undefined) return Either.left(bootstrapInvalid("record-document-invalid"));
   if (format !== RECORD_FORMAT) {
     return Either.left(new RecordFormatUnsupported({ code: "record-format-unsupported", format }));
   }
-  // A same-format numeric header is not automatically a reverse migration.
-  // This package currently declares no adjacent root chain, so both a future
-  // root and a hypothetical older root are unsupported rather than a fake
-  // `N -> current` migration-required result.
   const schemaVersion = schemaVersionOf(value);
-  if (schemaVersion !== undefined && schemaVersion !== RECORD_SCHEMA_VERSION) {
+  if (schemaVersion === 1) {
+    return Either.left(new RecordMigrationRequired({
+      code: "record-migration-required",
+      source: `${RECORD_FORMAT}@1`,
+      target: `${RECORD_FORMAT}@${RECORD_SCHEMA_VERSION}`,
+      command: "niceeval migrate",
+    }));
+  }
+  if (schemaVersion !== RECORD_SCHEMA_VERSION) {
     return Either.left(new RecordFormatUnsupported({ code: "record-format-unsupported", format }));
   }
   const decoded = decodeRecordDocument(value);
@@ -76,18 +87,24 @@ function classifyRecordDocument(
     : Either.right(Object.freeze({ document: decoded.right }));
 }
 
-/**
- * Reads only the bounded current root header. Migration-required is emitted
- * only by an actually declared adjacent chain; this current root has none.
- */
-export function readCurrentRecordFormat(
-  fileSystem: RecordFileSystemService,
-  root: RecordRoot,
-): Effect.Effect<
-  CurrentRecordFormatRead,
-  RecordFileSystemError | RecordBootstrapInvalid | RecordFormatUnsupported
-> {
-  const readDocument = fileSystem.readFile({
+function legacyRecordDocument(value: unknown): RecordDocument | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    Object.keys(record).length !== 3 ||
+    record.format !== RECORD_FORMAT ||
+    record.schemaVersion !== 1
+  ) return undefined;
+  const recordId = Schema.decodeUnknownEither(RecordIdSchema, RecordExactParseOptions)(record.recordId);
+  return Either.isLeft(recordId) ? undefined : Object.freeze({
+    format: RECORD_FORMAT as RecordDocument["format"],
+    schemaVersion: RECORD_SCHEMA_VERSION,
+    recordId: recordId.right,
+  });
+}
+
+function readFormatBytes(fileSystem: RecordFileSystemService, root: RecordRoot) {
+  return fileSystem.readFile({
     file: recordPortablePath(root, "record.json"),
     maximumBytes: RECORD_FORMAT_DOCUMENT_MAXIMUM_BYTES,
   }).pipe(
@@ -95,12 +112,62 @@ export function readCurrentRecordFormat(
       Effect.fail(bootstrapInvalid("record-format-document-limit-exceeded")),
     ),
   );
+}
 
-  return Effect.flatMap(readDocument, (bytes) => {
-    if (bytes === undefined) return Effect.fail(bootstrapInvalid("record-document-invalid"));
+/**
+ * Reads only the bounded exact-current root header. The one published
+ * predecessor is reported as migration-required but is never decoded as current.
+ */
+export function readCurrentRecordFormat(
+  fileSystem: RecordFileSystemService,
+  root: RecordRoot,
+): Effect.Effect<
+  CurrentRecordFormatRead,
+  RecordFileSystemError | RecordBootstrapInvalid | RecordFormatUnsupported | RecordMigrationRequired
+> {
+  return Effect.gen(function* () {
+    const bytes = yield* readFormatBytes(fileSystem, root);
+    if (bytes === undefined) return yield* Effect.fail(bootstrapInvalid("record-document-invalid"));
     const parsed = parseRecordJson(bytes);
-    if (Either.isLeft(parsed)) return Effect.fail(parsed.left);
+    if (Either.isLeft(parsed)) return yield* Effect.fail(parsed.left);
     const classified = classifyRecordDocument(parsed.right);
-    return Either.isLeft(classified) ? Effect.fail(classified.left) : Effect.succeed(classified.right);
+    if (Either.isLeft(classified)) return yield* Effect.fail(classified.left);
+    return classified.right;
+  });
+}
+
+/** Maintenance-only exact recognition of the one published root predecessor. */
+export function readRecordFormatForMaintenance(
+  fileSystem: RecordFileSystemService,
+  root: RecordRoot,
+): Effect.Effect<
+  MaintenanceRecordFormatRead,
+  RecordFileSystemError | RecordBootstrapInvalid | RecordFormatUnsupported
+> {
+  return Effect.gen(function* () {
+    const bytes = yield* readFormatBytes(fileSystem, root);
+    if (bytes === undefined) return yield* Effect.fail(bootstrapInvalid("record-document-invalid"));
+    const parsed = parseRecordJson(bytes);
+    if (Either.isLeft(parsed)) return yield* Effect.fail(parsed.left);
+    const version = schemaVersionOf(parsed.right);
+    if (version === RECORD_SCHEMA_VERSION) {
+      const decoded = decodeRecordDocument(parsed.right);
+      if (Either.isLeft(decoded)) return yield* Effect.fail(bootstrapInvalid("record-document-invalid"));
+      return Object.freeze({
+        document: decoded.right,
+        sourceSchemaVersion: RECORD_SCHEMA_VERSION,
+        sourceBytes: bytes,
+      });
+    }
+    if (version === 1) {
+      const document = legacyRecordDocument(parsed.right);
+      if (document === undefined) return yield* Effect.fail(bootstrapInvalid("record-document-invalid"));
+      return Object.freeze({ document, sourceSchemaVersion: 1 as const, sourceBytes: bytes });
+    }
+    const format = formatOf(parsed.right);
+    return yield* Effect.fail(new RecordFormatUnsupported({
+      code: "record-format-unsupported",
+      format: format ?? "unknown",
+    }));
   });
 }


### PR DESCRIPTION
## Problem

- User goal: 用当前 NiceEval 直接查看由已发布旧版本写出的 Record，同时确保不兼容数据不会进入 Analysis、Report 或新的写入流程。
- Current limitation: 当前 CLI 会让旧 Attachment 继续进入下游并重复显示 `usage-migration-required`；显式 migrate 也没有成为普通命令的 fail-closed 前置门。
- Required capability: Record 必须有全局 writer epoch、严格 current reader，以及只在 Git 提供完整恢复点时执行的固定无损自动迁移链。
- User outcome: `show`、`view`、`exp` 会在任何普通 session 或外部副作用前处理旧 Record；未保存时给出可执行错误，保存后自动迁移并继续原命令。

## Use cases

### 查看 npm 0.13.0 写出的历史实验

- Coverage: `happy path | lifecycle | failure | unsupported`
- Starting point: `.niceeval/record` 由 `niceeval@0.13.0` 的真实 `exp` 写出。
- Copyable usage or trigger: `niceeval show --run <run-id> --json`
- Observable result or diagnostic: Record 未被 Git 完整保存时退出 1 并提示 `git add .niceeval/record && git commit`；保存后，同一命令无确认迁移 root/Observability 1→2，并显示同一个 passed Run。迁移后旧 0.13.0 writer 会以 `record-format-unsupported` fail closed。
- Contract: `docs/feature/record/use-case/显式迁移Record-major.md`

## CLI

### Changed

#### Case: `niceeval show|view|exp`

- Before usage or result: `niceeval show --run <old-run>` 继续读取旧 Attachment，Report 中出现大量 `usage-migration-required`，没有阻止不兼容 Record 进入下游。
- After usage or result: 同一命令先执行 automatic maintenance gate；Git 未保存时退出 1，保存后自动迁移一次并在 stderr 输出目标 schemaVersion 与 restore commit，然后继续原命令。
- User impact: current Record 的快路径不要求 Git clean；只有确实需要迁移时才要求全部 portable bytes 已跟踪且 index/worktree 干净。future/unknown family、无完整迁移链、busy/read-only 或恢复状态一律拒绝继续。

#### Case: `niceeval migrate`

- Before usage or result: 只计划 Attachment envelope，root 一直保持 schemaVersion 1。
- After usage or result: 显式命令保留 plan/确认/恢复用途，并把 root 1→2 与 Observability 1→2 作为同一联合步骤；root 最后写入。
- User impact: 诊断和人工恢复入口仍然存在，但普通 `show|view|exp` 不再要求用户先手工运行它。

## Observable behavior and data contracts

### Changed

#### Case: ordinary Record open

- Before usage or result: reader 可局部跳过 unknown family，旧 writer 也能继续向同一个 root1 Record 追加。
- After usage or result: reader/writer 只接受 exact-current root epoch 2 和 current fixed catalog；unknown/future family 在 session 建立前返回 `record-format-unsupported`。
- User impact: 不兼容数据不会进入 Analysis/Report/Runner；迁移后的 root2 也会阻止旧 0.13.0 writer 回写 v1 数据。

## Record schema and stored-data upgrade

### Case: write a new Record

- Action: `niceeval exp <experiment>`
- Result: `record.json` 写入 `{ "format": "niceeval.record", "schemaVersion": 2, "recordId": "..." }`；fixed family 必须与 current catalog 一致。

### Case: read an existing Record

- Action: `niceeval show --run <run-id> --json`
- Result: exact-current 直接读取；已发布 root1/Observability v1 只有在固定联合 chain 和 Git restore point 同时成立时自动迁移；其它旧版、future 或 unknown 格式直接拒绝。

### Case: upgrade or recover stored data

- Version: `1 -> 2`
- Before: v1 把 canonical `session2/turn1` 降格为私有编码，并让 downstream 猜测兼容；普通读取可继续接触旧事实。
- After: root epoch 与 Observability envelope 联合升级，旧 payload、labels、blob refs 和 blob bytes 原样保留；root epoch 最后提交，随后重新执行 exact-current open。
- Safety: plan/apply 在同一 exclusive maintenance session 中绑定并复核 Git HEAD、Record identity、portable inventory、source bytes 和 migration implementation identity。sentinel 是第一笔 portable write；失败后保留 Git 恢复信息。迁移幂等，current fast path 不改盘。
- User impact: 先提交完整 `.niceeval/record`，然后重试原 `show|view|exp`；无需确认或另跑 migrate。非 Git/dirty/untracked/ignored Record 不会自动改盘。
- Evidence: `docs/feature/record/architecture.md`; `pnpm e2e --repo migrate -- --run test/handoff.test.ts` → 1 passed。

## Terminology

### Added terms

None

### Removed terms

None

## Tests

### `e2e/migrate/test/handoff.test.ts`

- Purpose: `feature + bug regression`
- Protects: 真实 0.13.0 Record 的 Git-save gate、自动迁移、结果保留，以及迁移后旧 writer 不得回污染。
- Runs: npm `niceeval@0.13.0 exp` → current `show`（未保存）→ Git commit → current `show`（迁移）→ 旧 `exp` → current `show`。
- Asserts: 首次退出 1 且没有 selection；第二次显示同一 passed Run；旧 writer 被拒绝；Record opaque diff/status 前后相同。

```ts
// owner: docs/engineering/testing/e2e/migrate.md#observability-v1-to-v2

import { readFileSync, renameSync, writeFileSync } from "node:fs";
import { join } from "node:path";
import { expect, test } from "vitest";
import { attestLegacyProducer, commitRecord, e2e } from "./support.ts";

test("Git 保存的 npm 0.13.0 Record 自动迁移后显示同一结果并拒绝旧 writer", async () => {
  await e2e.case(
    "observability-v1-auto-migrate",
    { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
    async ({ paths, commands: { candidate, legacyProducer }, run }) => {
      attestLegacyProducer(paths.projectRoot);

      const configPath = join(paths.projectRoot, "niceeval.config.ts");
      const currentConfig = readFileSync(configPath, "utf8");
      const hiddenDefinitions = [
        "evals/handoff.eval.ts",
        "experiments/handoff.ts",
        "experiments/missing-usage.ts",
      ].map((relativePath) => [
        join(paths.projectRoot, relativePath),
        join(paths.projectRoot, `${relativePath}.current-disabled`),
      ] as const);
      const legacyDefinitions = [
        "evals/legacy-handoff.eval.ts",
        "experiments/legacy-handoff.ts",
      ].map((relativePath) => [
        join(paths.projectRoot, `${relativePath}.legacy-disabled`),
        join(paths.projectRoot, relativePath),
      ] as const);
      const runLegacyExperiment = async () => {
        try {
          for (const [source, hidden] of hiddenDefinitions) renameSync(source, hidden);
          for (const [disabled, active] of legacyDefinitions) renameSync(disabled, active);
          writeFileSync(configPath, [
            'import { defineConfig } from "niceeval-legacy-0-13";',
            "export default defineConfig({",
            '  name: "e2e: persisted legacy Record",',
            "  timeoutMs: 60_000,",
            "  maxConcurrency: 1,",
            "});",
            "",
          ].join("\n"));
          return await legacyProducer.run(["exp", "legacy-handoff", "--rerun", "all", "--json"]);
        } finally {
          writeFileSync(configPath, currentConfig);
          for (const [disabled, active] of legacyDefinitions.toReversed()) renameSync(active, disabled);
          for (const [source, hidden] of hiddenDefinitions.toReversed()) renameSync(hidden, source);
        }
      };
      const produced = await runLegacyExperiment();
      expect(produced.exitCode, produced.diagnostic()).toBe(0);
      const receipt = produced.expReceipt();
      expect(receipt.completion, produced.diagnostic()).toBe("completed");
      expect(receipt.runIds, produced.diagnostic()).toHaveLength(1);
      const runId = receipt.runIds[0]!;
      expect(produced.stdout, produced.diagnostic()).toContain('"evalId":"legacy-handoff"');
      expect(produced.stdout, produced.diagnostic()).toContain('"verdict":"passed"');

      const unsaved = await candidate.run(["show", "--run", runId, "--json"]);
      expect(unsaved.exitCode, unsaved.diagnostic()).toBe(1);
      expect(unsaved.stderr, unsaved.diagnostic()).toContain("record-auto-migration-git-save-required");
      expect(unsaved.stderr, unsaved.diagnostic()).toContain("git add");
      expect(unsaved.stdout, unsaved.diagnostic()).not.toContain('"selection"');

      await commitRecord(run, "record: save npm 0.13.0 run");

      const shown = await candidate.run(["show", "--run", runId, "--json"]);
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      expect(shown.stderr, shown.diagnostic()).toContain("Record automatically migrated");
      expect(shown.stderr, shown.diagnostic()).toContain("restore commit");
      const output = shown.json<{
        selection: { runIds: readonly string[] };
        data: { rows: readonly [{ passRate: { state: string; value: number } }] };
      }>();
      expect(output.selection.runIds).toEqual([runId]);
      expect(output.data.rows[0]?.passRate).toMatchObject({ state: "available", value: 1 });

      const beforeOldWriter = await run(["git", "diff", "--binary", "--", ".niceeval/record"]);
      expect(beforeOldWriter.exitCode, beforeOldWriter.diagnostic()).toBe(0);
      const beforeOldWriterStatus = await run([
        "git", "status", "--porcelain=v1", "--untracked-files=all", "--", ".niceeval/record",
      ]);
      expect(beforeOldWriterStatus.exitCode, beforeOldWriterStatus.diagnostic()).toBe(0);

      const oldWriterRejected = await runLegacyExperiment();
      expect(oldWriterRejected.exitCode, oldWriterRejected.diagnostic()).toBe(1);
      expect(oldWriterRejected.stderr, oldWriterRejected.diagnostic()).toContain("record-format-unsupported");
      expect(oldWriterRejected.stdout, oldWriterRejected.diagnostic()).not.toContain('"event":"run"');

      const afterOldWriter = await run(["git", "diff", "--binary", "--", ".niceeval/record"]);
      expect(afterOldWriter.exitCode, afterOldWriter.diagnostic()).toBe(0);
      expect(afterOldWriter.stdout).toBe(beforeOldWriter.stdout);
      const afterOldWriterStatus = await run([
        "git", "status", "--porcelain=v1", "--untracked-files=all", "--", ".niceeval/record",
      ]);
      expect(afterOldWriterStatus.exitCode, afterOldWriterStatus.diagnostic()).toBe(0);
      expect(afterOldWriterStatus.stdout).toBe(beforeOldWriterStatus.stdout);

      const stillShown = await candidate.run(["show", "--run", runId, "--json"]);
      expect(stillShown.exitCode, stillShown.diagnostic()).toBe(0);
      expect(stillShown.stderr, stillShown.diagnostic()).not.toContain("Record automatically migrated");
      expect(stillShown.json<{ selection: { runIds: readonly string[] } }>().selection.runIds).toEqual([runId]);
    },
  );
});
```

### `e2e/migrate/test/current-handoff.test.ts`

- Purpose: `bug regression`
- Protects: 安装历史 producer alias 后，current producer/candidate 仍调用 candidate 自己的公开 bin，而不是 pnpm `.bin` 冲突目标。
- Runs: current candidate `exp`，随后独立 current candidate `show`。
- Asserts: Run 完成且 verdict passed，独立进程选择同一 Run。

```ts
// owner: docs/engineering/testing/e2e/migrate.md#current-to-current-handoff-bootstrap

import { createE2EContext, type ExpEvalEvent, type ExpEvent } from "@niceeval/testkit";
import { join, resolve } from "node:path";
import { expect, test } from "vitest";

const installedNiceeval = [process.execPath, join(process.cwd(), "node_modules", "niceeval", "bin", "niceeval.js")] as const;
const e2e = createE2EContext({
  repoId: "migrate",
  project: {
    from: process.cwd(),
    prefix: "niceeval-e2e-migrate-",
    omitTopLevel: [".e2e-artifacts", ".niceeval", "node_modules", "test"],
    links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
  },
  // Both identities intentionally point at the current candidate today. A future
  // compatibility owner replaces only producer's prefix with an attested old build.
  commands: {
    producer: installedNiceeval,
    candidate: installedNiceeval,
  },
});

test("当前 producer 的持久化结果可由独立 candidate show 进程读取", async () => {
  await e2e.case(
    "current-handoff",
    { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
    async ({ commands: { producer, candidate } }) => {
      const run = await producer.run(["exp", "handoff", "--rerun", "all", "--json"]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      const receipt = run.expReceipt();
      expect(receipt.completion, run.diagnostic()).toBe("completed");
      expect(receipt.runIds, run.diagnostic()).toHaveLength(1);
      const evalEvent = run.ndjson<ExpEvent>().find(
        (event): event is ExpEvalEvent =>
          "event" in event && event.event === "eval" && event.evalId === "handoff",
      );
      expect(evalEvent, run.diagnostic()).toMatchObject({ verdict: "passed" });

      const shown = await candidate.run(["show", "--run", receipt.runIds[0]!, "--json"]);
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      const selection = shown
        .json<{ selection: { kind: "explicit-runs"; runIds: readonly string[] } }>()
        .selection;
      expect(selection.runIds, shown.diagnostic()).toEqual([receipt.runIds[0]!]);
    },
  );
});
```

### `e2e/migrate/test/report-guard.test.ts`

- Purpose: `bug regression`
- Protects: 自动迁移 fail-closed 前置门不能掩盖 Report 自己对伪造 migration metric 的拒绝边界。
- Runs: current candidate 真实 `exp`，再执行指定 Report 的 `show`。
- Asserts: current Run 成功生成；Report 以 unsupported metric object 退出 1。

```ts
// owner: docs/engineering/testing/e2e/migrate.md#report-migration-metric-guard

import { expect, test } from "vitest";
import { e2e } from "./support.ts";

test("Report 拒绝 ledger 缺 Slot 的伪造 metric", async () => {
  await e2e.case("report-incomplete-ledger", async ({ commands: { candidate } }) => {
    const produced = await candidate.run(["exp", "handoff", "--rerun", "all", "--json"]);
    expect(produced.exitCode, produced.diagnostic()).toBe(0);
    const [runId] = produced.expReceipt().runIds;
    expect(runId, produced.diagnostic()).toBeDefined();
    const rejected = await candidate.run(["show", "--run", runId!, "--report", "./reports/invalid-migration-metric.tsx", "--page", "/invalid-migration-metric"]);
    expect(rejected.exitCode, rejected.diagnostic()).toBe(1);
    expect(rejected.stderr, rejected.diagnostic()).toContain("Table rows[0].metric has unsupported object type");
  });
});
```

### `e2e/migrate/test/support.ts` and legacy producer fixtures

- Purpose: `feature`
- Protects: 测试确实调用 registry-pinned `niceeval@0.13.0`，并且 candidate 与 legacy bin 不会互相冒充。
- Runs: 读取安装包版本与 lockfile SRI；用独立 bin prefix 运行两个版本；Git 保存完整 Record。
- Asserts: legacy package name/version/SRI 精确匹配，所有 Git 命令成功。

```ts
import { createHash } from "node:crypto";
import { cpSync, readFileSync } from "node:fs";
import { join, resolve } from "node:path";
import { createE2EContext } from "@niceeval/testkit";
import { expect } from "vitest";

export const RUN_ID = "2ce48d15-5278-46f7-a512-7235a3362c24";
export const ATTEMPT_ID = "ae2047b7-d0ef-4f1d-8a2f-ae2b27e7b4ad";
const installedNiceeval = [process.execPath, join(process.cwd(), "node_modules", "niceeval", "bin", "niceeval.js")] as const;
const legacyNiceeval = [process.execPath, join(process.cwd(), "node_modules", "niceeval-legacy-0-13", "bin", "niceeval.js")] as const;

export const e2e = createE2EContext({
  repoId: "migrate",
  project: {
    from: process.cwd(),
    prefix: "niceeval-e2e-migrate-",
    omitTopLevel: [".e2e-artifacts", ".niceeval", "node_modules", "test"],
    links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
  },
  commands: { candidate: installedNiceeval, producer: installedNiceeval, legacyProducer: legacyNiceeval },
});

export const LEGACY_PRODUCER_VERSION = "0.13.0";
export const LEGACY_PRODUCER_INTEGRITY = "sha512-aHSNZdzfu6QxkDpsfIS+xRTDRNirvfMOGzexnuZba3H46QdadjewfL5brv5y54UAnynxT2g6gntfPkk180D8+A==";

export function attestLegacyProducer(projectRoot: string): void {
  const metadata = JSON.parse(readFileSync(join(projectRoot, "node_modules", "niceeval-legacy-0-13", "package.json"), "utf8")) as {
    readonly name?: unknown;
    readonly version?: unknown;
  };
  expect(metadata).toMatchObject({ name: "niceeval", version: LEGACY_PRODUCER_VERSION });
  const lockfile = readFileSync(join(projectRoot, "pnpm-lock.yaml"), "utf8");
  expect(lockfile).toContain("niceeval@0.13.0");
  expect(lockfile).toContain(`integrity: ${LEGACY_PRODUCER_INTEGRITY}`);
}

export function copyV1Fixture(sourceRoot: string, recordRoot: string): void {
  cpSync(join(sourceRoot, "fixtures", "observability-v1-record"), recordRoot, { recursive: true });
}

export function sha256(path: string): string {
  return createHash("sha256").update(readFileSync(path)).digest("hex");
}

export async function commitRecord(
  run: (command: readonly [string, ...string[]]) => Promise<{
    readonly exitCode: number | null;
    readonly diagnostic: () => string;
  }>,
  message: string,
): Promise<void> {
  for (const args of [
    ["init", "-q"],
    ["config", "user.email", "e2e@niceeval.local"],
    ["config", "user.name", "NiceEval E2E"],
    ["add", "-f", ".niceeval/record"],
    ["commit", "-qm", message],
  ] as const) {
    const git = await run(["git", ...args]);
    expect(git.exitCode, git.diagnostic()).toBe(0);
  }
}
```

Legacy producer agent/eval/experiment are small, deterministic fixtures under `e2e/migrate/{agents,evals,experiments}`. The candidate injection attestation now matches only `niceeval@file:` lockfile entries, so the registry-pinned legacy alias cannot satisfy candidate identity.

### Verification receipt

- Candidate: `cff2ddda`; post-merge tarball SHA-256 `5349af17cec679a9628e8a46f9d0e98d39eece08d61b57a58c875e56aa75dd89`.
- Red: pre-fix candidate `a4efec4a`; real 0.13.0 `exp` produced a passed Run, but the first unsaved current `show` exited 0 and exposed `selection` instead of failing before downstream.
- Green: `pnpm e2e --repo migrate -- --run test/handoff.test.ts` → 1 file / 1 test passed; artifact `/tmp/niceeval-e2e-artifacts-ETDknF`.
- Repeatability: takeover reused candidate SHA-256 `f9d829f5121e130dbb418c79ad8dd9c86b78e9e5b34f5eed155bb73f4ceac856`; isolated-copy, same-copy, full-suite pollution check and target-single all passed; summary `/tmp/niceeval-e2e-takeover-artifacts-KkgQFU/takeover-summary.json`.
- Fixed conditions: npm `niceeval@0.13.0` with SRI `sha512-aHSNZdzfu6QxkDpsfIS+xRTDRNirvfMOGzexnuZba3H46QdadjewfL5brv5y54UAnynxT2g6gntfPkk180D8+A==`; deterministic local agent; no provider call.
- Unit count: `not applicable — no Unit changed and the root package has no test script`.

Additional verification: `pnpm typecheck`; `pnpm lint` (12 files / 46 tests, Mint validate and broken links); full `pnpm e2e --repo migrate` (11 files / 12 tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789798737&installation_model_id=431746&pr_number=70&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F70&signature=63fe4e9a542b7b85e06c0c6ad9d6e7e6041f033d495db83240205116e1b6f586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->