### PR TITLE
feat(report): 按实验范围展示可比结果

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,9 +11,12 @@ description in the language of the user's latest request.
 
 Keep only product-surface sections that contain a real change. Delete empty
 directions and sections instead of writing "None". Under each included
-direction, present every change as a named user case with a concrete Before
-example, After example, and User impact. The case is the explanation: do not
-replace it with prose about a "contract", implementation mechanism, or change
+direction, present every change as a named user case with concrete, fenced
+Before and After inputs plus their literal observable outputs. Follow the
+examples with a short User impact paragraph. Do not use `Name: summary` bullets
+such as `Coverage:`, `Before usage or result:`, or `User impact:` in product
+sections. The case and its examples are the explanation: do not replace them
+with prose about a "contract", implementation mechanism, or change
 classification. Usage examples must begin at the public owner that consumes
 the value: `defineEval()`, `defineExperiment()`, report JSX, a CLI invocation,
 or a package script.
@@ -92,13 +95,30 @@ it also covers the relevant composition, lifecycle, failure, and unsupported
 boundaries.
 -->
 
-### `<user goal>`
+### Case: `<user goal>`
 
-- Coverage: `happy path | composition | lifecycle | failure | unsupported`
-- Starting point: <what the user already has>
-- Copyable usage or trigger: <the smallest complete usage beginning at a public owner>
-- Observable result or diagnostic: <what the user sees>
-- Contract: `<docs path to the complete use case, or "no separate use-case document">`
+#### Starting state
+
+```text
+<the minimum concrete files, config, or previously completed public action>
+```
+
+#### Action
+
+```<language>
+<the smallest copyable usage beginning at a public owner>
+```
+
+#### Result
+
+```text
+<literal stdout, stderr, JSON, rendered UI text, or other observable result>
+```
+
+Explain in prose why this result completes the workflow. Link the complete
+use-case document when one exists. Cover composition, lifecycle, failure, or
+unsupported boundaries with additional real cases only when they apply; do not
+list coverage classifications.
 
 ## Public API
 
@@ -106,25 +126,81 @@ boundaries.
 
 #### Case: `<package entry or symbol>`
 
-- Before usage or result: <copyable TypeScript example and observed result>
-- After usage or result: `removed`
-- User impact: <what stops working and the concrete migration or replacement>
+##### Before
+
+```ts
+<copyable TypeScript input>
+```
+
+```text
+<observed result>
+```
+
+##### After
+
+```text
+removed
+```
+
+##### User impact
+
+<what stops working and the concrete migration or replacement>
 
 ### Added
 
 #### Case: `<package entry or symbol>`
 
-- Before usage or result: `not available`
-- After usage or result: <copyable TypeScript example and observed result>
-- User impact: <what becomes possible>
+##### Before
+
+```ts
+<the attempted TypeScript usage>
+```
+
+```text
+<the compile or runtime failure proving it was unavailable>
+```
+
+##### After
+
+```ts
+<copyable TypeScript input>
+```
+
+```text
+<observed result>
+```
+
+##### User impact
+
+<what becomes possible>
 
 ### Changed
 
 #### Case: `<package entry or symbol>`
 
-- Before usage or result: <copyable TypeScript example and observed result>
-- After usage or result: <copyable replacement example and observed result>
-- User impact: <compatibility and migration effects>
+##### Before
+
+```ts
+<copyable TypeScript input>
+```
+
+```text
+<observed result>
+```
+
+##### After
+
+```ts
+<copyable replacement input>
+```
+
+```text
+<observed result>
+```
+
+##### User impact
+
+<compatibility and migration effects>
 
 ## CLI
 
@@ -132,25 +208,81 @@ boundaries.
 
 #### Case: `<command or flag>`
 
-- Before usage or result: <copyable shell command and observed result>
-- After usage or result: `removed`
-- User impact: <what stops working and the concrete migration or replacement>
+##### Before
+
+```sh
+<copyable command>
+```
+
+```text
+<literal stdout, stderr, and exit status when material>
+```
+
+##### After
+
+```text
+removed
+```
+
+##### User impact
+
+<what stops working and the concrete migration or replacement>
 
 ### Added
 
 #### Case: `<command or flag>`
 
-- Before usage or result: `not available`
-- After usage or result: <copyable shell command and observed result>
-- User impact: <stdout, stderr, exit code, JSON schema, default, or workflow effect>
+##### Before
+
+```sh
+<the attempted command>
+```
+
+```text
+<literal rejection and exit status>
+```
+
+##### After
+
+```sh
+<copyable command>
+```
+
+```text
+<literal stdout, stderr, JSON, and exit status when material>
+```
+
+##### User impact
+
+<workflow and automation effect>
 
 ### Changed
 
 #### Case: `<command or flag>`
 
-- Before usage or result: <copyable shell command and observed result>
-- After usage or result: <the same command, or its replacement, and the observed result>
-- User impact: <stdout, stderr, exit code, JSON schema, default, or migration change>
+##### Before
+
+```sh
+<copyable command>
+```
+
+```text
+<literal stdout, stderr, JSON, and exit status when material>
+```
+
+##### After
+
+```sh
+<the same command or its replacement>
+```
+
+```text
+<literal stdout, stderr, JSON, and exit status when material>
+```
+
+##### User impact
+
+<workflow, automation, default, or migration effect>
 
 ## Report components
 
@@ -158,25 +290,81 @@ boundaries.
 
 #### Case: `<component, prop, or report entry>`
 
-- Before usage or result: <copyable TSX example and rendered result>
-- After usage or result: `removed`
-- User impact: <author migration and reader-visible effect>
+##### Before
+
+```tsx
+<copyable Report JSX>
+```
+
+```text
+<rendered result>
+```
+
+##### After
+
+```text
+removed
+```
+
+##### User impact
+
+<author migration and reader-visible effect>
 
 ### Added
 
 #### Case: `<component, prop, or report entry>`
 
-- Before usage or result: `not available`
-- After usage or result: <copyable TSX example and rendered result>
-- User impact: <authoring and reader-visible capability>
+##### Before
+
+```tsx
+<the attempted Report JSX>
+```
+
+```text
+<compile or runtime failure proving it was unavailable>
+```
+
+##### After
+
+```tsx
+<copyable Report JSX>
+```
+
+```text
+<rendered result>
+```
+
+##### User impact
+
+<authoring and reader-visible capability>
 
 ### Changed
 
 #### Case: `<component, prop, or report entry>`
 
-- Before usage or result: <copyable TSX example and rendered result>
-- After usage or result: <copyable replacement TSX and rendered result>
-- User impact: <author migration and reader-visible effect>
+##### Before
+
+```tsx
+<copyable Report JSX>
+```
+
+```text
+<rendered result>
+```
+
+##### After
+
+```tsx
+<copyable replacement Report JSX>
+```
+
+```text
+<rendered result>
+```
+
+##### User impact
+
+<author migration and reader-visible effect>
 
 ## Observable behavior and data contracts
 
@@ -184,25 +372,81 @@ boundaries.
 
 #### Case: `<runtime behavior, record/schema, cache, provider, or output>`
 
-- Before usage or result: <concrete input and observed result>
-- After usage or result: `removed`
-- User impact: <effect on users, stored data, or automation and the replacement>
+##### Before
+
+```<language>
+<concrete input>
+```
+
+```text
+<observed output or state>
+```
+
+##### After
+
+```text
+removed
+```
+
+##### User impact
+
+<effect on users, stored data, or automation and the replacement>
 
 ### Added
 
 #### Case: `<runtime behavior, record/schema, cache, provider, or output>`
 
-- Before usage or result: `not available`
-- After usage or result: <concrete input and observed result>
-- User impact: <effect on users, stored data, or automation>
+##### Before
+
+```<language>
+<attempted input>
+```
+
+```text
+<observed absence or failure>
+```
+
+##### After
+
+```<language>
+<concrete input>
+```
+
+```text
+<observed output or state>
+```
+
+##### User impact
+
+<effect on users, stored data, or automation>
 
 ### Changed
 
 #### Case: `<runtime behavior, record/schema, cache, provider, or output>`
 
-- Before usage or result: <concrete input and observed result>
-- After usage or result: <the same input, or its replacement, and the observed result>
-- User impact: <compatibility, migration, stored data, or automation effect>
+##### Before
+
+```<language>
+<concrete input>
+```
+
+```text
+<observed output or state>
+```
+
+##### After
+
+```<language>
+<the same input or its replacement>
+```
+
+```text
+<observed output or state>
+```
+
+##### User impact
+
+<compatibility, migration, stored data, or automation effect>
 
 ## Record schema and stored-data upgrade
 
@@ -235,31 +479,91 @@ persisted implementation changes. Otherwise show only the applicable cases:
 
 ### Case: write a new Record
 
-- Action: <public writer or CLI command>
-- Result: <literal recognition header plus changed files, attachments, fields, references, or meanings>
+#### Action
+
+```sh
+<public writer or CLI command>
+```
+
+#### Result
+
+```text
+<literal recognition header plus changed files, attachments, fields, references, or meanings>
+```
 
 ### Case: read an existing Record
 
-- Action: <public reader or CLI command, including the historical producer version when needed>
-- Result: <direct read, migration, or exact rejection/recovery diagnostic>
+#### Action
+
+```sh
+<public reader or CLI command, including the historical producer version when needed>
+```
+
+#### Result
+
+```text
+<direct read, migration, or exact rejection/recovery diagnostic>
+```
 
 ### Case: upgrade or recover stored data
 
-- Version: `<N -> N | N -> M>`
-- Before: <what happens to existing data before this PR>
-- After: <what happens after this PR; include both reader directions when N -> N>
-- Safety: <preservation, atomicity, idempotence, interruption recovery, and known data loss; or why no migration runs>
-- User impact: <required action and observable result>
-- Evidence: <Record architecture; version history when N -> M; exact public verification command and result>
+#### Version
+
+`<N -> N | N -> M>`
+
+#### Before
+
+```sh
+<copyable public read or recovery command>
+```
+
+```text
+<what happens to existing data before this PR>
+```
+
+#### After
+
+```sh
+<copyable public read or recovery command>
+```
+
+```text
+<what happens after this PR; include both reader directions when N -> N>
+```
+
+#### Safety
+
+<preservation, atomicity, idempotence, interruption recovery, and known data loss; or why no migration runs>
+
+#### User impact
+
+<required action and observable result>
+
+#### Evidence
+
+<Record architecture; version history when N -> M; exact public verification command and result>
 
 ### Private persisted data
 
 <!-- Delete when private persistence is unaffected. -->
 
-- Case: <cache, index, temporary file, or layout scenario>
-- Before: <observable behavior or data-loss boundary>
-- After: <observable behavior or data-loss boundary>
-- User impact: <required action, recovery, or no action with concrete reason>
+### Case: <cache, index, temporary file, or layout scenario>
+
+#### Before
+
+```text
+<observable behavior or data-loss boundary>
+```
+
+#### After
+
+```text
+<observable behavior or data-loss boundary>
+```
+
+#### User impact
+
+<required action, recovery, or no action with concrete reason>
 
 ## Environment variables
 
@@ -267,30 +571,101 @@ persisted implementation changes. Otherwise show only the applicable cases:
 
 #### Case: `<VARIABLE_NAME>`
 
-- Before usage or result: <copyable shell/config example and observed result>
-- After usage or result: `removed`
-- Environment boundary: <scope, producer, consumer, inheritance, default, precedence, validation, and secret exposure>
-- User and security impact: <migration or "none">
+##### Before
+
+```sh
+<copyable environment and command input>
+```
+
+```text
+<observed result>
+```
+
+##### After
+
+```text
+removed
+```
+
+##### Environment boundary
+
+<scope, producer, consumer, inheritance, default, precedence, validation, and secret exposure>
+
+##### User and security impact
+
+<migration or "none">
 
 ### Added
 
 #### Case: `<VARIABLE_NAME>`
 
-- Before usage or result: `not available`
-- After usage or result: <copyable shell/config example, default, and observed result>
-- Environment boundary: <scope, producer, consumer, inheritance, precedence, validation, and secret exposure>
-- Necessity: <why an explicit API, CLI flag, config file, argument, or constant cannot own this value>
-- User and security impact: <workflow, default, migration, or "none">
+##### Before
+
+```sh
+<attempted environment and command input>
+```
+
+```text
+<observed absence or rejection>
+```
+
+##### After
+
+```sh
+<copyable environment and command input>
+```
+
+```text
+<default and observed result>
+```
+
+##### Environment boundary
+
+<scope, producer, consumer, inheritance, precedence, validation, and secret exposure>
+
+##### Necessity
+
+<why an explicit API, CLI flag, config file, argument, or constant cannot own this value>
+
+##### User and security impact
+
+<workflow, default, migration, or "none">
 
 ### Changed
 
 #### Case: `<VARIABLE_NAME>`
 
-- Before usage or result: <copyable shell/config example, default, and observed result>
-- After usage or result: <copyable shell/config example, default, and observed result>
-- Environment boundary: <scope, producer, consumer, inheritance, precedence, validation, and secret exposure>
-- Necessity: <why an explicit API, CLI flag, config file, argument, or constant cannot own this value>
-- User and security impact: <compatibility, migration, or "none">
+##### Before
+
+```sh
+<copyable environment and command input>
+```
+
+```text
+<default and observed result>
+```
+
+##### After
+
+```sh
+<copyable environment and command input>
+```
+
+```text
+<default and observed result>
+```
+
+##### Environment boundary
+
+<scope, producer, consumer, inheritance, precedence, validation, and secret exposure>
+
+##### Necessity
+
+<why an explicit API, CLI flag, config file, argument, or constant cannot own this value>
+
+##### User and security impact
+
+<compatibility, migration, or "none">
 
 ## Package scripts
 
@@ -298,25 +673,81 @@ persisted implementation changes. Otherwise show only the applicable cases:
 
 #### Case: `<pnpm script>`
 
-- Before usage or result: <copyable command and observed result>
-- After usage or result: `removed`
-- User impact: <development, CI, documentation, or release workflow migration>
+##### Before
+
+```sh
+<copyable command>
+```
+
+```text
+<observed result>
+```
+
+##### After
+
+```text
+removed
+```
+
+##### User impact
+
+<development, CI, documentation, or release workflow migration>
 
 ### Added
 
 #### Case: `<pnpm script>`
 
-- Before usage or result: `not available`
-- After usage or result: <copyable command and observed result>
-- User impact: <development, CI, documentation, or release workflow capability>
+##### Before
+
+```sh
+<attempted command>
+```
+
+```text
+<observed rejection>
+```
+
+##### After
+
+```sh
+<copyable command>
+```
+
+```text
+<observed result>
+```
+
+##### User impact
+
+<development, CI, documentation, or release workflow capability>
 
 ### Changed
 
 #### Case: `<pnpm script>`
 
-- Before usage or result: <copyable command and observed result>
-- After usage or result: <copyable command and observed result>
-- User impact: <development, CI, documentation, or release workflow change>
+##### Before
+
+```sh
+<copyable command>
+```
+
+```text
+<observed result>
+```
+
+##### After
+
+```sh
+<copyable command>
+```
+
+```text
+<observed result>
+```
+
+##### User impact
+
+<development, CI, documentation, or release workflow change>
 
 ## Terminology
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -283,9 +283,9 @@ jobs:
     # cell 的 matrix.container 为 null，仍直接运行在普通 GitHub runner。镜像已经包含 browser
     # 与系统依赖，不在每次 job 中运行 apt / `playwright install --with-deps`。
     container: ${{ matrix.container }}
-    # Repo test budgets are enforced by the root runner. Keep one additional
-    # minute for checkout, dependency installation, collection, and cleanup.
-    timeout-minutes: 5
+    # Each Repo owns its test budget through e2e.json timeoutMinutes. A cell may
+    # host several Repos concurrently, so a second job-wide budget would race
+    # their independent setup, test, collection, and cleanup lifecycles.
     # 同仓 PR 直接使用仓库级 secret；push、schedule 与显式 live dispatch 挂
     # 同名 Environment。所有路径都只注入 manifest 白名单中的 secret。
     environment: ${{ needs.prepare.outputs.inject-secrets == 'true' && needs.prepare.outputs.environment || fromJSON('null') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,10 +139,8 @@ jobs:
     name: release e2e (${{ matrix.id }})
     needs: prepare-release
     runs-on: ubuntu-24.04
-    # host / docker cell 保留四分钟性能门槛。browser cache 只覆盖浏览器二进制，
-    # `playwright install --with-deps` 的 apt 系统依赖不在 cache 中，给 browser cell
-    # 两分钟独立的镜像抖动余量，避免慢 apt 下载把已缓存的浏览器场景误判为 cancelled。
-    timeout-minutes: ${{ (contains(matrix.requires.browsers, 'chromium') || contains(matrix.requires.browsers, 'firefox') || contains(matrix.requires.browsers, 'webkit')) && 6 || 4 }}
+    # Each Repo owns its test budget through e2e.json timeoutMinutes. Do not add
+    # a cell-wide deadline that can cancel independent Repo cleanup or receipts.
     environment: release
     strategy:
       fail-fast: false

--- a/docs-site/zh/reference/cli.mdx
+++ b/docs-site/zh/reference/cli.mdx
@@ -176,6 +176,7 @@ E2B template name 与 Vercel snapshot ID 是 Provider 管理的任意字符串�
 | `--run` | string[] | `show` / `view` 可重复传入 `--run`;每次按完整 RunId 增加一个显式 Run,重复 identity 去重。 |
 | `--report` | string | `show` / `view` 命令专用：内建 `standard` 或受信任的 Report module 路径。 |
 | `--page` | string | `show` / `view` 命令专用:选择报告的初始页;`show` 渲染该页并在尾部附其余页索引,`view` 以它作初始路由。未命中的页 id 按用法错误退出并列出可用页 id。 |
+| `--group` | string | `show` / `view`：精确选择 `named/<key>` 或 `singleton/<experiment-id>` Experiment Group。 |
 | `--teardown` | boolean | `exp` 命令专用:补齐被强杀打断的实验级 teardown——只对选中的实验各执行一次 teardown(新进程语义),不派发 attempt、不跑 setup;没有遗留登记也照常执行。与 eval 前缀位置参数组合是用法错误。 |
 | `--recover-shared-state` | string | `exp --teardown` 专用:显式恢复一个永不自动接管的 sharedState lease；必须同时提供 --owner-token、--confirm-owner-terminated 和 --confirm-remote-quiesced。 |
 | `--owner-token` | string | `--recover-shared-state` 专用:要恢复的不可变 owner token；错误或过期 token 不会修改 lease。 |

--- a/docs-site/zh/reference/cli.mdx
+++ b/docs-site/zh/reference/cli.mdx
@@ -176,7 +176,6 @@ E2B template name 与 Vercel snapshot ID 是 Provider 管理的任意字符串�
 | `--run` | string[] | `show` / `view` 可重复传入 `--run`;每次按完整 RunId 增加一个显式 Run,重复 identity 去重。 |
 | `--report` | string | `show` / `view` 命令专用：内建 `standard` 或受信任的 Report module 路径。 |
 | `--page` | string | `show` / `view` 命令专用:选择报告的初始页;`show` 渲染该页并在尾部附其余页索引,`view` 以它作初始路由。未命中的页 id 按用法错误退出并列出可用页 id。 |
-| `--group` | string | `show` / `view`：精确选择 `named/<key>` 或 `singleton/<experiment-id>` Experiment Group。 |
 | `--teardown` | boolean | `exp` 命令专用:补齐被强杀打断的实验级 teardown——只对选中的实验各执行一次 teardown(新进程语义),不派发 attempt、不跑 setup;没有遗留登记也照常执行。与 eval 前缀位置参数组合是用法错误。 |
 | `--recover-shared-state` | string | `exp --teardown` 专用:显式恢复一个永不自动接管的 sharedState lease；必须同时提供 --owner-token、--confirm-owner-terminated 和 --confirm-remote-quiesced。 |
 | `--owner-token` | string | `--recover-shared-state` 专用:要恢复的不可变 owner token；错误或过期 token 不会修改 lease。 |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -126,6 +126,7 @@ Roadmap 提出的候选原语单列在「候选术语」,链接 Roadmap 入口;�
 | 中文 | English | 含义 | 契约 |
 |---|---|---|---|
 | 实验 | Experiment | 可签入的运行配置:Agent、model、judge 执行配置、flags、运行次数与预算；不定义 rubric、阈值或其它评分规则 | [Experiments](feature/experiments/README.md) |
+| 实验组 | Experiment Group | Experiment 的比较准入边界；具名组由 `experimentId` 第一段形成，根级 Experiment 各自形成单成员组 | [Experiments](feature/experiments/README.md#实验组与可比边界) |
 | 裁判执行配置 | JudgeConfig | 裁判 model、端点、凭据变量名与超时；可由 Experiment 做 A/B，不包含 rubric 或 severity | [Judge](feature/judge/library.md#模型与鉴权) |
 | 实验 flags | Flags | A/B 条件键,经 `ctx.flags` 给 Adapter、`t.flags` 给 eval | [实验值归属](feature/experiments/use-case/实验值归属/) |
 | 运行时观测 | Runtime observation | 运行时才知道、由 producer-owned typed RecordAttachment 保存的值；不自动进入 eligibility identity 或 Attempt Core | [实验值归属](feature/experiments/use-case/实验值归属/) |
@@ -222,6 +223,8 @@ Roadmap 提出的候选原语单列在「候选术语」,链接 Roadmap 入口;�
 |---|---|---|---|
 | 分析选择请求 | `AnalysisSelectionRequest` | 选择哪些已发布 Run 的纯配置，不携带 reader 或 I/O 能力 | [Analysis Library](feature/analysis/library.md) |
 | 分析样本 | `Sample` | host 从固定 `RecordSelection` 形成的 Scope-bound 作者输入；常驻身份与完整分母，重 payload 按需读取 | [Analysis](feature/analysis/README.md) |
+| 实验比较范围 | `ExperimentComparisonScope` | Analysis 从一份 Sample 按唯一实验组形成的私有品牌能力；共享父 Scope 寿命且只能单调收窄 | [Analysis Library](feature/analysis/library.md#实验组与比较范围) |
+| 结构不可比 | Non-comparable | 同组成员的 Eval 总体或 Measure population / basis 无法对齐的闭合状态；保留问题与 Evidence，但不产生排名或散点 | [Analysis Library](feature/analysis/library.md#结构可比性) |
 | Population | `Population` | Measure 解释的完整成员集合，拥有稳定 identity 与分母规则 | [Analysis Library](feature/analysis/library.md) |
 | Dimension | `Dimension` | 属于一个 Population、用于分组或稳定标识成员的 typed field | [Analysis Library](feature/analysis/library.md) |
 | Measure | `Measure` | 一次声明归并、denominator、missing 与 Evidence policy 的 typed 统计口径 | [Analysis Library](feature/analysis/library.md) |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -224,7 +224,7 @@ Roadmap 提出的候选原语单列在「候选术语」,链接 Roadmap 入口;�
 | 分析选择请求 | `AnalysisSelectionRequest` | 选择哪些已发布 Run 的纯配置，不携带 reader 或 I/O 能力 | [Analysis Library](feature/analysis/library.md) |
 | 分析样本 | `Sample` | host 从固定 `RecordSelection` 形成的 Scope-bound 作者输入；常驻身份与完整分母，重 payload 按需读取 | [Analysis](feature/analysis/README.md) |
 | 实验比较范围 | `ExperimentComparisonScope` | Analysis 从一份 Sample 按唯一实验组形成的私有品牌能力；共享父 Scope 寿命且只能单调收窄 | [Analysis Library](feature/analysis/library.md#实验组与比较范围) |
-| 结构不可比 | Non-comparable | 同组成员的 Eval 总体或 Measure population / basis 无法对齐的闭合状态；保留问题与 Evidence，但不产生排名或散点 | [Analysis Library](feature/analysis/library.md#结构可比性) |
+| 结构不可比 | Non-comparable | 同组成员的 Eval 总体无法对齐的闭合状态；保留问题与 Evidence，但不产生排名或散点 | [Analysis Library](feature/analysis/library.md#结构可比性) |
 | Population | `Population` | Measure 解释的完整成员集合，拥有稳定 identity 与分母规则 | [Analysis Library](feature/analysis/library.md) |
 | Dimension | `Dimension` | 属于一个 Population、用于分组或稳定标识成员的 typed field | [Analysis Library](feature/analysis/library.md) |
 | Measure | `Measure` | 一次声明归并、denominator、missing 与 Evidence policy 的 typed 统计口径 | [Analysis Library](feature/analysis/library.md) |

--- a/docs/engineering/testing/e2e/README.md
+++ b/docs/engineering/testing/e2e/README.md
@@ -51,7 +51,7 @@ test("show --json 经 pipe 仍交付完整文档", async () => {
   expect(Buffer.byteLength(result.stdout)).toBeGreaterThan(128 * 1024);
 
   const document = result.json<AttemptDocument>();
-  expect(document.format).toBe("niceeval.show/v1");
+  expect(document.format).toBe("niceeval.show");
   expect(document.data).toContainEqual(expect.objectContaining({ id: "tail-sentinel" }));
 });
 ```

--- a/docs/engineering/testing/e2e/README.md
+++ b/docs/engineering/testing/e2e/README.md
@@ -51,7 +51,7 @@ test("show --json 经 pipe 仍交付完整文档", async () => {
   expect(Buffer.byteLength(result.stdout)).toBeGreaterThan(128 * 1024);
 
   const document = result.json<AttemptDocument>();
-  expect(document.schema).toBe("niceeval.show/v2");
+  expect(document.format).toBe("niceeval.show/v1");
   expect(document.data).toContainEqual(expect.objectContaining({ id: "tail-sentinel" }));
 });
 ```

--- a/docs/engineering/testing/e2e/README.md
+++ b/docs/engineering/testing/e2e/README.md
@@ -51,7 +51,7 @@ test("show --json 经 pipe 仍交付完整文档", async () => {
   expect(Buffer.byteLength(result.stdout)).toBeGreaterThan(128 * 1024);
 
   const document = result.json<AttemptDocument>();
-  expect(document.schema).toBe("niceeval.show/v1");
+  expect(document.schema).toBe("niceeval.show/v2");
   expect(document.data).toContainEqual(expect.objectContaining({ id: "tail-sentinel" }));
 });
 ```

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -229,9 +229,10 @@ batch 是共机放置单位，不是限流单位；plan 不携带 CI 限流参�
 资源竞争、OOM 或尾延迟通过把 manifest 显式拆到 `docker-1`、`docker-2`、`docker-3` 等更多 matrix cell 处理，
 不能通过让同格 Repo 排队来换取通过；拆分不改变 lane 的精确 Repo 集。
 
-matrix cell 的 5 分钟外层上限包含 runner/action 启动、依赖安装、artifact 收集与 cleanup；这是 E2E 关键路径的性能门槛。
-每个 Repo 的产品执行预算仍由 manifest 自己收紧，外层比最长 host Repo 的 4 分钟测试预算多留一分钟编排余量，
-不能用 job 上限放宽 provider timeout。
+每个 Repo 的测试调用上限由自己的 manifest `timeoutMinutes` 独立声明；`host-1`、`docker-1`、`browser-1`
+等 batch 只决定共机放置，不拥有也不替换测试预算。同一个 matrix cell 可能并发运行多个预算不同的 Repo，workflow
+不得再设置 cell 级 `timeout-minutes`，否则会把依赖安装、独立测试、artifact 收集与 cleanup 的并发尾延迟混成第二个截止时间，
+并可能在 Repo 自己的预算到期前取消收据和资源回收。Provider 与产品调用的更窄 timeout 仍由对应 owner 明确声明，不能靠放宽 Repo 预算替代。
 
 每个 matrix cell 自己上传 receipt、summary、JUnit 与声明附件；Repo batch 的 artifact root 下仍按 Repo ID 分目录并
 保存独立 receipt，batch summary 列全该格 Repo。GitHub 原生汇总 matrix 成败，不再启动一个 job 下载并复述所有 cell 的结果。

--- a/docs/engineering/testing/e2e/report.md
+++ b/docs/engineering/testing/e2e/report.md
@@ -40,7 +40,7 @@ Record reader / writer，不扫描物理布局，也不复制 selection、decode
 
 - 普通 Page 的 `show` 只执行这个 Page；参数 Page 按 `decode()`、canonical `encode()`、`load()`、`render()` 读取给定 key。
 - 参数化 `show` 不调用 `enumerate()`。不属于当前 Sample 的 locator、identity 或 key 以类型化错误结束，而不是通过其它 Page 查找成员。
-- 自定义 `show --json` 只断言 target-execution manifest 的 schema、选中 route、标题、rendered text、空下载摘要与问题表。
+- 自定义 `show --json` 只断言 target-execution manifest 的 format、选中 route、标题、rendered text、空下载摘要与问题表。
   它没有 revision identity、全路由集合或其它 Page 的作者数据。
 - 内建 `show --json` 只断言选中 Page 的 Host-owned 领域文档。它不从 text、HTML 或一个通用作者树推断机器数据。
 
@@ -80,7 +80,7 @@ niceeval view --report <fixture> --no-open
 ### 6. 构建失败与数据状态
 
 - `MetricValue` 的 partial、empty、unsupported 和 failed 是可呈现的数据状态。它们在 Page text、view 和 static
-  中保留相同的 samples、total、issues 与 refs；内建 JSON 依其具名领域 schema 保留这些值。
+  中保留相同的 samples、total、issues 与 refs；内建 JSON 依其具名领域 format 保留这些值。
 - `show` 的目标 Page callback、参数 key 或成员资格失败时，命令返回单目标错误且从不交付 revision。
 - 参数枚举、未选中 Page、路径或全站校验失败时，static 不写完整站点，view 保留 last-good；这些错误不扩大
   `show` 的执行范围。
@@ -96,7 +96,7 @@ niceeval view --report <fixture> --no-open
 |---|---|---|
 | 标准 React JSX 作者源码以固定 Sample 构建完整站点。 | `report-execution-evidence` | 安装后的 `.tsx` Report 可由 `view` / `view --out` 枚举普通与参数 Page；overview 有 Hero HTTPS anchor、KPI/图表/层级文字、详情 href，且不暴露 raw Attempt DTO。 |
 | show 是独立的单目标终端阅读面。 | `report-show` 与 `report-project-current` | selector、选中 route、文字、完整 MetricValue、参数 key 成员资格与 project-current 身份。 |
-| JSON 是单目标机器阅读面。 | `report-show-json` | target schema、canonical order、选中 route、metadata、下载摘要与 problem table；不含全路由 revision oracle。 |
+| JSON 是单目标机器阅读面。 | `report-show-json` | target format、canonical order、选中 route、metadata、下载摘要与 problem table；不含全路由 revision oracle。 |
 | view 是同一 revision 的本机 HTTP 面。 | `report-config-reload` 与 `report-browser-journey` | last-good、最新 intent、固定响应、HTTP 边界和可访问内容。 |
 | static 是同一 revision 的离线文件面。 | `report-static-export` | 全部页面 closure、view 字节等价、existing-target 保护和无 JavaScript 阅读。 |
 | Source、Diff 和运行证据来自本次构建。 | `report-source-snapshot` 与 `report-execution-evidence` | 已生成页面或文件不从工作树或私有文件补造。 |
@@ -146,7 +146,7 @@ niceeval view --report <fixture> --no-open
 
 ### report-show-json
 
-`report-show.test.ts` 验证 locator、project-current、human 与 JSON 的单目标公开读回。它只断言选中 route 的 schema 与内容，
+`report-show.test.ts` 验证 locator、project-current、human 与 JSON 的单目标公开读回。它只断言选中 route 的 format 与内容，
 不拥有全路由或 revision oracle。fixture 会让无关参数 Page 的 `enumerate()` 失败，并证明两种 show 都不受影响。
 
 ### report-source-snapshot

--- a/docs/engineering/testing/e2e/report.md
+++ b/docs/engineering/testing/e2e/report.md
@@ -60,8 +60,10 @@ niceeval view --report <fixture> --no-open
 每对 response body 与文件 body 必须逐字节相同；固定 Host asset 也必须来自同一 revision。下载字节合同仍属于产品契约，但这个
 不发布 public Download 的代表 fixture 不为它伪造作者入口。
 
-浏览器在断网且禁用 JavaScript 时打开根页、参数页、Source 和 Diff。它仍能读取 marker、正文、导航、完整度、
-问题。测试拦截外部网络请求；任何为补读 Analysis、Source 详情或页面数据发出的请求都是失败。
+浏览器默认进入稳定排序的第一个实验组 Page；多组 Header 实验 selector 始终有当前值，语言也由原生 selector 切换。完整 Page router
+作为一组居中，不能因当前只有一个 Page 就退化成左右栏布局。切换实验后，Hero、告警、Summary、图表与 Table 都只反映所选组。
+浏览器在断网且禁用 JavaScript 时打开根页、参数页、Source 和 Diff，仍能通过 fallback 链接读取 marker、正文、导航、完整度、问题。
+测试拦截外部网络请求；任何为补读 Analysis、Source 详情或页面数据发出的请求都是失败。
 
 ### 5. view 的版本 oracle
 

--- a/docs/engineering/testing/e2e/verification.md
+++ b/docs/engineering/testing/e2e/verification.md
@@ -52,7 +52,7 @@ const document = JSON.parse(
     `pnpm exec niceeval show --run ${mainRunId} --report ${reportModule} --page ${overviewRoute} --json`,
   ),
 );
-assert.equal(document.schema, "niceeval.report-target-execution/v1");
+assert.equal(document.format, "niceeval.report-target-execution/v1");
 assert.equal(document.locale, "en");
 assert.equal(document.page.route, overviewRoute);
 assert.equal(document.page.pageId, "overview");

--- a/docs/feature/analysis/README.md
+++ b/docs/feature/analysis/README.md
@@ -115,6 +115,8 @@ CLI 的 `--run` 与精确 locator 只决定选择哪个历史事实。它们审�
 因而“范围外”“没有 Member”与“Core 损坏”不会混成同一个空值。它不能重新纳入已排除成员，也不能读取
 修改后的 Record。
 
+`experimentComparisonScope(sample, group)` 不是第二种 Sample selection。它在已固定 Sample 内选择唯一实验组，共享父 Scope 寿命，并保留组内全部非 excluded expected Slot 的分母与问题。它不用显示过滤重写 `total`，也不从当前源码补回 Sample 未选中的同组 Experiment。
+
 Scope 关闭后，`query()`、`aggregate()` 与 `narrowSample()` 以 `analysis-sample-closed` 失败，并且不再发起
 I/O。Snapshot 与已经得到的 SemanticFrame、ClosedRows 和 DomainView 不依赖该能力，关闭后仍可呈现或序列化。
 

--- a/docs/feature/analysis/library.md
+++ b/docs/feature/analysis/library.md
@@ -391,20 +391,14 @@ declare function experimentComparisonScope(
 
 组列表只从 selection 选中的 Run 派生。纯 `identity-mismatch` 的 excluded 历史不产生组或成员；Core invalid、not-dispatched 和 interrupted 仍属于已选 Run，留在组内并贡献问题。comparison member 是去重后的 `ExperimentId`，同一 Experiment 的多个 Run 合并为一个 member。
 
-population 从该 member 的全部非 excluded expected Slot 形成，按 `EvalId × evaluationKind` 去重。Attempt ordinal、Attempt 是否建立或 outcome 都不改变这个总体。根级 singleton 与当前 Sample 中只剩一个 member 的 named 组都可形成 comparable scope；它们可显示单行，但不声称相对排名。
+population 从该 member 的全部非 excluded expected Slot 形成，按 `EvalId` 去重。Attempt ordinal、Attempt 是否建立或 outcome 都不改变这个总体。根级 singleton 与当前 Sample 中只剩一个 member 的 named 组都可形成 comparable scope；它们可显示单行，但不声称相对排名。
 
 ### 结构可比性
 
-目录是作者的比较准入声明，Analysis 另行验证可证明的结构条件。同组 member 必须有相同的 `EvalId × evaluationKind` 总体；每个比较投影还必须使用兼容的 Measure population 与 basis。Pass 与 Score 可在同组的独立面板呈现，不互排。不同 Eval 集不自动取交集、补零或缩小分母。
+目录是作者的比较准入声明，Analysis 另行验证可证明的结构条件。同组 member 必须有相同的 `EvalId` 总体。Pass 与 Score 可在同组的独立面板呈现，不互排。不同 Eval 集不自动取交集、补零或缩小分母。
 
 ```ts
-type NonComparableReason =
-  | "eval-population-mismatch"
-  | "evaluation-kind-mismatch"
-  | "population-unavailable"
-  | "measure-population-mismatch"
-  | "measure-basis-mismatch"
-  | "measure-basis-unavailable";
+type NonComparableReason = "eval-population-mismatch";
 
 interface NonComparableIssue {
   readonly reason: NonComparableReason;

--- a/docs/feature/analysis/library.md
+++ b/docs/feature/analysis/library.md
@@ -391,7 +391,7 @@ declare function experimentComparisonScope(
 
 组列表只从 selection 选中的 Run 派生。纯 `identity-mismatch` 的 excluded 历史不产生组或成员；Core invalid、not-dispatched 和 interrupted 仍属于已选 Run，留在组内并贡献问题。comparison member 是去重后的 `ExperimentId`，同一 Experiment 的多个 Run 合并为一个 member。
 
-population 从该 member 的全部非 excluded expected Slot 形成，按 `EvalId` 去重。Attempt ordinal、Attempt 是否建立或 outcome 都不改变这个总体。根级 singleton 与当前 Sample 中只剩一个 member 的 named 组都可形成 comparable scope；它们可显示单行，但不声称相对排名。
+population（Eval ID 集合）从该 member 的全部非 excluded expected Slot 形成，按 `EvalId` 去重。Attempt ordinal、Attempt 是否建立或 outcome 都不改变这个总体。根级 singleton 与当前 Sample 中只剩一个 member 的 named 组都可形成 comparable scope；它们可显示单行，但不声称相对排名。
 
 ### 结构可比性
 

--- a/docs/feature/analysis/library.md
+++ b/docs/feature/analysis/library.md
@@ -360,6 +360,67 @@ declare function narrowSample(sample: Sample, selector: SampleSelector): Sample;
 只做单调交集：已排除成员不会重新纳入，操作不重新打开 Record，也不会更新 Snapshot 的历史事实。
 它是 Analysis 的范围操作，不是 Report 的显示筛选。
 
+## 实验组与比较范围
+
+`ExperimentComparisonScope` 是 Analysis 签发的私有品牌能力。它绑定一个父 `Sample` 与一个判别式实验组 identity，不能由作者构造、伪造品牌或在父 Scope 关闭后读取。
+
+```ts
+type ExperimentGroupIdentity =
+  | { readonly kind: "named"; readonly groupId: ExperimentGroupId }
+  | { readonly kind: "singleton"; readonly experimentId: ExperimentId };
+
+type ExperimentComparisonState =
+  | { readonly state: "comparable"; readonly members: readonly ExperimentId[] }
+  | {
+      readonly state: "non-comparable";
+      readonly members: readonly ExperimentId[];
+      readonly issues: readonly NonComparableIssue[];
+    };
+
+interface ExperimentComparisonScope {
+  readonly group: ExperimentGroupIdentity;
+  readonly comparison: ExperimentComparisonState;
+  // private brand and parent-Sample capability
+}
+
+declare function experimentComparisonScope(
+  sample: Sample,
+  group: ExperimentGroupIdentity,
+): ExperimentComparisonScope;
+```
+
+组列表只从 selection 选中的 Run 派生。纯 `identity-mismatch` 的 excluded 历史不产生组或成员；Core invalid、not-dispatched 和 interrupted 仍属于已选 Run，留在组内并贡献问题。comparison member 是去重后的 `ExperimentId`，同一 Experiment 的多个 Run 合并为一个 member。
+
+population 从该 member 的全部非 excluded expected Slot 形成，按 `EvalId × evaluationKind` 去重。Attempt ordinal、Attempt 是否建立或 outcome 都不改变这个总体。根级 singleton 与当前 Sample 中只剩一个 member 的 named 组都可形成 comparable scope；它们可显示单行，但不声称相对排名。
+
+### 结构可比性
+
+目录是作者的比较准入声明，Analysis 另行验证可证明的结构条件。同组 member 必须有相同的 `EvalId × evaluationKind` 总体；每个比较投影还必须使用兼容的 Measure population 与 basis。Pass 与 Score 可在同组的独立面板呈现，不互排。不同 Eval 集不自动取交集、补零或缩小分母。
+
+```ts
+type NonComparableReason =
+  | "eval-population-mismatch"
+  | "evaluation-kind-mismatch"
+  | "population-unavailable"
+  | "measure-population-mismatch"
+  | "measure-basis-mismatch"
+  | "measure-basis-unavailable";
+
+interface NonComparableIssue {
+  readonly reason: NonComparableReason;
+  readonly members: readonly ExperimentId[];
+  readonly actual: readonly {
+    readonly member: ExperimentId;
+    readonly population: JsonValue | null;
+    readonly basis: JsonValue | null;
+  }[];
+  readonly refs: readonly EvidenceRef[];
+  readonly params: Readonly<Record<string, JsonValue>>;
+}
+```
+
+`non-comparable` 是闭合业务状态；Report 呈现原因与修复信息，不输出排名或散点。把多个实验组伪造成一个 branded projection 则以 `analysis-comparison-group-mismatch` 失败，不能降级成 `non-comparable`。
+
 ## query 与 aggregate
 
 `aggregate()` 为普通 Report 直接返回闭合行。它从 by 与 values 推断共同 Population，并在读取事实前

--- a/docs/feature/experiments/README.md
+++ b/docs/feature/experiments/README.md
@@ -34,7 +34,7 @@ experiments/compare/nested/model.ts  -> Experiment compare/nested/model -> named
 experiments/smoke.ts                 -> Experiment smoke             -> singleton/smoke
 ```
 
-`named/<segment>` 取 `experimentId` 的第一段；更深的目录只组织成员。根级 Experiment 没有作者声明的同组成员，因此以 `singleton/<experimentId>` 形成自己的单成员组。两种 identity 是判别联合；named `foo` 与根级 Experiment `foo` 不冲突，CLI、route 与机器输出都不接受未带 kind 的 `foo`。
+`named/<segment>` 取 `experimentId` 的第一段；更深的目录只组织成员。根级 Experiment 没有作者声明的同组成员，因此以 `singleton/<experimentId>` 形成自己的单成员组。两种 identity 是 Analysis、Report route 与机器输出中的判别联合，不成为另一套 CLI 参数；`niceeval exp foo` 与 Report 的 `--experiment foo` 继续使用同一实验 selector 规则。
 
 目录表示作者允许成员共同比较，不证明它们一定可比。Analysis 另行验证 Eval 总体、evaluation kind、Measure population 与 basis。验证不通过时产生可呈现的 `non-comparable`，不产生排名或散点，也不让整份项目报告失败。
 

--- a/docs/feature/experiments/README.md
+++ b/docs/feature/experiments/README.md
@@ -19,10 +19,26 @@ experiments/  # 怎么跑 —— 运行矩阵:agent × model × attempts over �
 - **experiment 是可签入的运行配置。**
   比一串临时 CLI flag 可复现:`niceeval exp compare` 永远跑同一组对照。
 - **跨 agent / 跨配置对比是一等公民。**
-  每个实验文件声明一个配置；报告只比较 `Sample` 已经选好的 Run 与 Attempt，不在页面打开时另选结果。
+  每个实验文件声明一个配置；报告只在 `Sample` 已经选好的同一实验组内比较，不在页面打开时另选结果。
 
 实验文件改名会改变 `experimentId`。需要采用已有 Attempt 时，使用[实验改名与 Run 采用](rename.md)建立 reference Member；其 Core `accepted` action 与精确引用就是可复核的采用事实。
-  目录只组织源码、生成 id 和支持 CLI 前缀选择。
+  目录组织源码、生成 id、支持 CLI 前缀选择，并且由第一段表达实验组。
+
+## 实验组与可比边界
+
+实验组是 Experiment 的比较准入边界，不是 [Eval Group](../eval-groups/README.md) 的 Sandbox 复用 lane，也不是具名 Experiment 族的作者语法。
+
+```text
+experiments/compare/baseline.ts      -> Experiment compare/baseline  -> named/compare
+experiments/compare/nested/model.ts  -> Experiment compare/nested/model -> named/compare
+experiments/smoke.ts                 -> Experiment smoke             -> singleton/smoke
+```
+
+`named/<segment>` 取 `experimentId` 的第一段；更深的目录只组织成员。根级 Experiment 没有作者声明的同组成员，因此以 `singleton/<experimentId>` 形成自己的单成员组。两种 identity 是判别联合；named `foo` 与根级 Experiment `foo` 不冲突，CLI、route 与机器输出都不接受未带 kind 的 `foo`。
+
+目录表示作者允许成员共同比较，不证明它们一定可比。Analysis 另行验证 Eval 总体、evaluation kind、Measure population 与 basis。验证不通过时产生可呈现的 `non-comparable`，不产生排名或散点，也不让整份项目报告失败。
+
+实验组不写入 Record。历史 Run 从已封存的 `experimentId` 派生组；跨第一段改名后，目标 Run 属于新组，origin Attempt 仍保留自己的历史身份。
 
 ## 与 Record 的边界
 

--- a/docs/feature/experiments/library.md
+++ b/docs/feature/experiments/library.md
@@ -141,14 +141,22 @@ interface ScopedFeedback {
 
 要让运行失败，应抛出 typed error。要改变 Verdict，应形成 assertion 或 Judge 结果；error diagnostic 本身不改变 Verdict。
 
-## 路径只表达身份与选择
+## 路径表达身份、选择与实验组
 
 ```text
 experiments/agents/codex/coding.ts   -> agents/codex/coding
 experiments/agents/claude/coding.ts  -> agents/claude/coding
 ```
 
-路径形成 `experimentId` 并支持前缀选择。它不决定 Record 物理布局，也不成为 Sample 的隐含 selection。
+路径形成 `experimentId` 并支持前缀选择。第一段同时形成具名实验组；无目录段的根级 Experiment 形成单成员组。
+
+```ts
+type ExperimentGroupIdentity =
+  | { readonly kind: "named"; readonly groupId: ExperimentGroupId }
+  | { readonly kind: "singleton"; readonly experimentId: ExperimentId };
+```
+
+实验组不决定 Record 物理布局，也不改变 Sample 的 selection。它只能在已固定 Sample 内形成单调收窄的实验比较范围。
 
 ## 相关阅读
 

--- a/docs/feature/reports/README.md
+++ b/docs/feature/reports/README.md
@@ -28,7 +28,7 @@ Report 有两条明确不同的执行路径。它们共享同一份作者定义�
 
 `show` 不调用参数 Page 的 `enumerate()`，不建立 `ClosedSiteRevision`，也不为未选 route 执行作者 callback。
 
-`project-current` 仍是整个项目的 Sample。只有一个实验组时，标准 Overview 直接从父 Sample 形成该组的 `ExperimentComparisonScope`，不显示组选择器。有多个组时，Overview 列出组，Header 才显示实验组选择。每个组 Page 把唯一 scope 交给 `ExperimentTable` 或 `ExperimentScatter`；任何比较组件都不能跨组。
+`project-current` 仍是整个项目的 Sample。只有一个可比实验范围时，标准 Overview 直接从父 Sample 形成该范围的 `ExperimentComparisonScope`，不显示选择器。有多个范围时，Overview 列出实验，Header 才显示实验选择；它沿真实 Page 链接导航，不新增 CLI 参数。每个 Page 把唯一 scope 交给 `ExperimentTable` 或 `ExperimentScatter`；任何比较组件都不能跨范围。
 `view` 与静态导出则必须完成全站枚举、链接校验、资源闭包和限额检查；它们只从同一个 revision 读取最终 bytes。
 
 [Report 成本投影](cost-projections/README.md) 是完整的成本契约。它只经 `ReportDefinition.pricing` 接入 Report，并以同一只读值暴露为
@@ -85,9 +85,11 @@ view 不注入只在本机有效的作者脚本。
 `MetricValue` 始终保留 `value`、`state`、`samples`、`total`、`issues` 与 `refs`。合法零值不是空值；显示组件不得靠筛选行数
 重写分母或隐藏问题。完整数值语义见[读数与显示语义](calculations.md)。
 
-`show --json` 的内建报告和自定义报告各有固定 schema。内建报告输出 Host-owned 领域数据；自定义报告输出单目标执行 manifest 与
-选中 Page 的已呈现文字，不序列化通用作者树或 site revision。schema、locale、route 选择与 canonical order 由 [CLI](cli.md) 定义。
-内建文档使用 `niceeval.show/v2`：单组默认输出 `experiment-group`，多组 Overview 输出 `groups`，不建立跨组 leaderboard。实验组 Page 的 `comparison` 穷尽 `comparable | non-comparable`。
+`show --json` 的内建报告和自定义报告各有固定 format。内建报告输出 Host-owned 领域数据；自定义报告输出单目标执行 manifest 与
+选中 Page 的已呈现文字，不序列化通用作者树或 site revision。format、locale、route 选择与 canonical order 由 [CLI](cli.md) 定义。
+
+实验索引与组内比较使用 `niceeval.show/v2`。单组默认输出 `experiment-group`，多组 Overview 输出 `groups`，不建立跨组 leaderboard。
+既有 Attempt、Source、Execution 与 Timing 文档继续使用 `niceeval.show/v1`。实验组 Page 的 `comparison` 穷尽 `comparable | non-comparable`。
 
 报告样式只有一个产品 owner：Report CSS 负责 reset、基础排版、theme token 消费和所有报告组件。View shell 只负责浏览器语言切换、
 更新状态与 Host 提示，不重绘 Report 内容。完整边界见 [Architecture](architecture.md#css、theme-与-view-shell)。

--- a/docs/feature/reports/README.md
+++ b/docs/feature/reports/README.md
@@ -90,8 +90,10 @@ view 不注入只在本机有效的作者脚本。
 `show --json` 的内建报告和自定义报告各有固定 format。内建报告输出 Host-owned 领域数据；自定义报告输出单目标执行 manifest 与
 选中 Page 的已呈现文字，不序列化通用作者树或 site revision。format、locale、route 选择与 canonical order 由 [CLI](cli.md) 定义。
 
-实验索引与组内比较使用 `niceeval.show/v2`。单组默认输出 `experiment-group`，多组 Overview 输出 `groups`，不建立跨组 leaderboard。
-既有 Attempt、Source、Execution 与 Timing 文档继续使用 `niceeval.show/v1`。实验组 Page 的 `comparison` 穷尽 `comparable | non-comparable`。
+所有内建 `show --json` Page 使用同一个 `niceeval.show` 文档 format；format 只标识机器文档类型，不承担版本或迁移语义，
+也不随当前 Page 改变。该 API 与生产者同步演进；持久化版本只属于 Record。
+单组默认输出 `experiment-group`，多组 Overview 输出 `groups`，不建立跨组 leaderboard；实验组 Page 的 `comparison` 穷尽
+`comparable | non-comparable`。
 
 报告样式只有一个产品 owner：Report CSS 负责 reset、基础排版、theme token 消费和所有报告组件。View shell 左侧放品牌，中间居中整个
 Page router，右侧放实验与语言两个原生选择器；Page router 无论含一个还是多个 Page 都作为整体居中。Shell 不重绘 Report 内容。

--- a/docs/feature/reports/README.md
+++ b/docs/feature/reports/README.md
@@ -28,7 +28,9 @@ Report 有两条明确不同的执行路径。它们共享同一份作者定义�
 
 `show` 不调用参数 Page 的 `enumerate()`，不建立 `ClosedSiteRevision`，也不为未选 route 执行作者 callback。
 
-`project-current` 仍是整个项目的 Sample。只有一个可比实验范围时，标准 Overview 直接从父 Sample 形成该范围的 `ExperimentComparisonScope`，不显示选择器。有多个范围时，Overview 列出实验，Header 才显示实验选择；它沿真实 Page 链接导航，不新增 CLI 参数。每个 Page 把唯一 scope 交给 `ExperimentTable` 或 `ExperimentScatter`；任何比较组件都不能跨范围。
+`project-current` 仍是整个项目的 Sample。只有一个可比实验范围时，标准 Overview 直接从父 Sample 形成该范围的 `ExperimentComparisonScope`，不显示选择器。有多个范围时，浏览器默认稳定选择第一项，并在 Header 显示实验下拉框；不存在未选择范围的 view Overview。Hero、通知、Summary、图表和 Table 都消费所选范围背后的同一 narrowed Sample。
+
+切换选项沿已闭合 Page 导航，不新增 CLI 参数。`show` 的多组默认输出仍是可复制命令的实验索引。每个 Page 把唯一 scope 交给具名比较组件；任何比较组件都不能跨范围。
 `view` 与静态导出则必须完成全站枚举、链接校验、资源闭包和限额检查；它们只从同一个 revision 读取最终 bytes。
 
 [Report 成本投影](cost-projections/README.md) 是完整的成本契约。它只经 `ReportDefinition.pricing` 接入 Report，并以同一只读值暴露为
@@ -91,8 +93,9 @@ view 不注入只在本机有效的作者脚本。
 实验索引与组内比较使用 `niceeval.show/v2`。单组默认输出 `experiment-group`，多组 Overview 输出 `groups`，不建立跨组 leaderboard。
 既有 Attempt、Source、Execution 与 Timing 文档继续使用 `niceeval.show/v1`。实验组 Page 的 `comparison` 穷尽 `comparable | non-comparable`。
 
-报告样式只有一个产品 owner：Report CSS 负责 reset、基础排版、theme token 消费和所有报告组件。View shell 只负责浏览器语言切换、
-更新状态与 Host 提示，不重绘 Report 内容。完整边界见 [Architecture](architecture.md#css、theme-与-view-shell)。
+报告样式只有一个产品 owner：Report CSS 负责 reset、基础排版、theme token 消费和所有报告组件。View shell 左侧放品牌，中间居中整个
+Page router，右侧放实验与语言两个原生选择器；Page router 无论含一个还是多个 Page 都作为整体居中。Shell 不重绘 Report 内容。
+完整边界见 [Architecture](architecture.md#css、theme-与-view-shell)。
 
 ## 范围与入口
 

--- a/docs/feature/reports/README.md
+++ b/docs/feature/reports/README.md
@@ -27,6 +27,8 @@ Report 有两条明确不同的执行路径。它们共享同一份作者定义�
 ```
 
 `show` 不调用参数 Page 的 `enumerate()`，不建立 `ClosedSiteRevision`，也不为未选 route 执行作者 callback。
+
+`project-current` 仍是整个项目的 Sample。只有一个实验组时，标准 Overview 直接从父 Sample 形成该组的 `ExperimentComparisonScope`，不显示组选择器。有多个组时，Overview 列出组，Header 才显示实验组选择。每个组 Page 把唯一 scope 交给 `ExperimentTable` 或 `ExperimentScatter`；任何比较组件都不能跨组。
 `view` 与静态导出则必须完成全站枚举、链接校验、资源闭包和限额检查；它们只从同一个 revision 读取最终 bytes。
 
 [Report 成本投影](cost-projections/README.md) 是完整的成本契约。它只经 `ReportDefinition.pricing` 接入 Report，并以同一只读值暴露为
@@ -85,6 +87,7 @@ view 不注入只在本机有效的作者脚本。
 
 `show --json` 的内建报告和自定义报告各有固定 schema。内建报告输出 Host-owned 领域数据；自定义报告输出单目标执行 manifest 与
 选中 Page 的已呈现文字，不序列化通用作者树或 site revision。schema、locale、route 选择与 canonical order 由 [CLI](cli.md) 定义。
+内建文档使用 `niceeval.show/v2`：单组默认输出 `experiment-group`，多组 Overview 输出 `groups`，不建立跨组 leaderboard。实验组 Page 的 `comparison` 穷尽 `comparable | non-comparable`。
 
 报告样式只有一个产品 owner：Report CSS 负责 reset、基础排版、theme token 消费和所有报告组件。View shell 只负责浏览器语言切换、
 更新状态与 Host 提示，不重绘 Report 内容。完整边界见 [Architecture](architecture.md#css、theme-与-view-shell)。

--- a/docs/feature/reports/architecture.md
+++ b/docs/feature/reports/architecture.md
@@ -85,8 +85,16 @@ client 先读取两边都存在且 bytes 相同的自身 runtime 文件；只有
 `theme.ts` 只定义 theme token 与 token 值；它不新增 reset、布局 selector 或组件样式。`styles.css` 是 token 的唯一消费者。
 作者通过结构化 `head` 提供的样式只能服务自己的具名内容，不能建立另一套 reset、theme 或 View shell。
 
-View shell 只拥有浏览器语言切换、reload 状态、Host 错误提示和已闭合 Page 的访问入口。固定 Sample 有两个或更多实验组时，选择器才沿作者声明的 `experiment-group` Page 真实链接导航；只有一组时不渲染该选择器。它不读取 Analysis、不在浏览器改变比较范围、
+View shell 只拥有浏览器语言切换、reload 状态、Host 错误提示和已闭合 Page 的访问入口。品牌位于左侧，完整 Page router 作为一个整体
+居中，右侧使用原生 select 承载实验与语言选择；Page router 含一个或多个 Page 时都保持同一位置。
+
+固定 Sample 有两个或更多实验组时，实验选择器默认选中稳定排序的第一个 `experiment-group` Page；根 URL 也进入该 Page，不交付未选择
+范围的 Overview。只有一组时不渲染实验选择器。选择变化只导航到另一个已闭合 Page；无 JavaScript 时由同组真实链接 fallback。
+Shell 不读取 Analysis、不在浏览器计算比较范围、
 不注入第二份产品 CSS，也不重绘已关闭的 Report 内容。
+
+所选逻辑 Attempt 没有 Record 输入时，Report 正文以 `not-recorded` notice 与 partial MetricValue 呈现一次。Host 不再把同一事实重复成
+`analysis-missing — the selected logical Slot has no input value`；带具体语义的附件缺失、无效输入或迁移提示仍保留在数据说明中。
 
 浏览器启用 JavaScript 时，站内参数 Page 的普通详情 href 会渐进增强为 Host modal，并把当前位置写成
 `#/<page-route-prefix>/<key>`。该 hash 可复制、首次打开和刷新后恢复同一详情；Escape、关闭按钮和浏览器返回会关闭 modal 并恢复

--- a/docs/feature/reports/architecture.md
+++ b/docs/feature/reports/architecture.md
@@ -24,6 +24,8 @@ enumerate every Page instance → execute every Page → validate site → Close
 `show` 只执行目标 Page。省略 `--page` 时使用 Report 的默认 route；带 `--page` 时使用精确 route。它不枚举参数 Page，
 不执行其它 Page，也不创建 site revision。
 
+`--group` 是实验组 Page 的具名 target，不是 Sample selector。`show --group` 只执行该组 Page；`view --group` 只设定初始 route，仍枚举并闭合固定 Sample 中的全部组 Page。
+
 `view` 和 `view --out` 都先枚举全部普通 Page 与参数 Page 实例。只有所有页面、route、链接、下载、asset、问题表和预算通过校验，
 Host 才形成一个 revision。view 只托管它；static 只写出它。
 
@@ -83,7 +85,7 @@ client 先读取两边都存在且 bytes 相同的自身 runtime 文件；只有
 `theme.ts` 只定义 theme token 与 token 值；它不新增 reset、布局 selector 或组件样式。`styles.css` 是 token 的唯一消费者。
 作者通过结构化 `head` 提供的样式只能服务自己的具名内容，不能建立另一套 reset、theme 或 View shell。
 
-View shell 只拥有浏览器语言切换、reload 状态、Host 错误提示和访问入口。它不读取 Analysis、不调整报告组件的数据含义、
+View shell 只拥有浏览器语言切换、reload 状态、Host 错误提示和已闭合 Page 的访问入口。固定 Sample 有两个或更多实验组时，选择器才沿作者声明的 `experiment-group` Page 真实链接导航；只有一组时不渲染该选择器。它不读取 Analysis、不在浏览器改变比较范围、
 不注入第二份产品 CSS，也不重绘已关闭的 Report 内容。
 
 浏览器启用 JavaScript 时，站内参数 Page 的普通详情 href 会渐进增强为 Host modal，并把当前位置写成

--- a/docs/feature/reports/architecture.md
+++ b/docs/feature/reports/architecture.md
@@ -24,7 +24,7 @@ enumerate every Page instance → execute every Page → validate site → Close
 `show` 只执行目标 Page。省略 `--page` 时使用 Report 的默认 route；带 `--page` 时使用精确 route。它不枚举参数 Page，
 不执行其它 Page，也不创建 site revision。
 
-`--group` 是实验组 Page 的具名 target，不是 Sample selector。`show --group` 只执行该组 Page；`view --group` 只设定初始 route，仍枚举并闭合固定 Sample 中的全部组 Page。
+`--experiment <selector>` 与 `niceeval exp <selector>` 使用同一实验选择规则并形成固定 Sample；Report 不增加另一套实验组 CLI selector。浏览器 Header 沿已关闭的实验组 Page 链接导航，不重新选择 Sample。
 
 `view` 和 `view --out` 都先枚举全部普通 Page 与参数 Page 实例。只有所有页面、route、链接、下载、asset、问题表和预算通过校验，
 Host 才形成一个 revision。view 只托管它；static 只写出它。
@@ -146,7 +146,7 @@ Page、params、locale 与 theme identity。缓存不保存开放 Scope、callba
 的 route、标题、rendered text、下载摘要和问题表，不含 React tree、site revision、revision identity 或任意作者数据对象。
 其中 rendered text 固定为该 Page 已关闭的英语 80-column text projection；它不随 TTY 或浏览器宽度变化，也不会触发第二次执行。
 
-CLI 固定这些文档的 schema、locale、目标选择和 canonical order；详见 [CLI](cli.md#niceeval-show---json)。机器数据不是组件第三面。
+CLI 固定这些文档的 format、locale、目标选择和 canonical order；详见 [CLI](cli.md#niceeval-show---json)。机器数据不是组件第三面。
 
 ## 仓库 E2E 与候选包 dogfood
 

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -201,7 +201,7 @@ view 在启动 server 前完整构建 `ClosedSiteRevision`。它对每个参数 
 枚举实例，并校验全站路径、链接、download、asset、Source、Diff、问题表、`_niceeval/data/projections.json` 与预算。该文件捕获所有
 显式声明 Page 的 projection closure；浏览器不重新计算成本。
 
-`--page` 只决定浏览器初始打开的已存在 route；不会缩小构建、枚举或验证。Header 的实验选择器沿已关闭的组 Page 链接导航，不增加 CLI selector。浏览器导航、刷新、Source、Trace、Diff 与下载只读取
+`--page` 只决定浏览器初始打开的已存在 route；不会缩小构建、枚举或验证。未给 `--page` 且存在实验组 Page 时，view 默认打开稳定排序的第一组；多组 Header 显示原生实验选择器，单组不显示。每个选项导航到已关闭的完整 scoped Overview，因此 Hero、通知、Summary、图表与 Table 使用同一范围。浏览器导航、刷新、Source、Trace、Diff 与下载只读取
 revision bytes，不执行作者 callback、Analysis 或 Record 读取。
 
 view 监听 Record root、Report module、项目内静态 import、theme 与配置。最新完整构建成功时原子替换 current revision；失败保留

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -66,7 +66,7 @@ key 完全相同。`show` 不调用 `enumerate()`，却要求 `PageLoadContext` 
 
 `standard` 只遇到一个实验组时，Overview 直接呈现该组的比较结果。遇到多个组时，`show` 默认输出实验组索引和可复制的 `niceeval show --group <key>` 命令，不生成跨组 leaderboard。具名组 Page 在唯一 `ExperimentComparisonScope` 内使用 `ExperimentTable` 呈现 Pass Eval 与 Score Eval。Pass Eval 显示通过率，Score Eval 只显示 earned score，不声明满分或百分比；两种题型分面板呈现，不互排。
 
-每个 Experiment 可逐层展开到 Eval 与 Attempt，Attempt locator 链接到同一份 `standard` 显式声明的详情 Page。Analysis 的 `MetricValue` 仍完整保留 state、samples、total、issues 与 refs。结构不可比时，组 Page 显示具名原因、成员、实际 population / basis 与 Evidence，不显示排名或散点。
+每个 Experiment 可逐层展开到 Eval 与 Attempt，Attempt locator 链接到同一份 `standard` 显式声明的详情 Page。Analysis 的 `MetricValue` 仍完整保留 state、samples、total、issues 与 refs。Eval population 不同时，组 Page 显示具名原因、成员与实际 population，不显示排名或散点。
 
 `ExperimentScatter` 使用同一题型判断：通过制画成本 × 通过率，分数制画成本 × 总分；同一实验比较范围同时包含两种题型时分成两张图，
 不把 points 和 ratio 混在同一纵轴。通过率轴以百分比刻度显示，`ratio` 只保留为内部量纲，不进入轴标题或刻度文案。

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -87,7 +87,7 @@ Record 或 Analysis 读取路径。
 
 ```ts
 interface BuiltInShowDocument {
-  readonly format: "niceeval.show/v1" | "niceeval.show/v2";
+  readonly format: "niceeval.show";
   readonly locale: "en";
   readonly selection: ShowSelection;
   readonly report: { readonly token: BuiltInReportToken; readonly identity: ContentAddress };

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -27,6 +27,7 @@ niceeval view [selection] [report options] --out <directory>
 | `--experiment <id>` | 可重复；按完整 ExperimentId 收窄不带 locator 或 `--run` 的项目选择。 |
 | `--report <module>` | 选择内建 Report 或受信任的 Report module。 |
 | `--page <route>` | `show` 的唯一目标 route，或 `view` 的初始浏览 route。 |
+| `--group <key>` | 选择实验组 Page；精确 key 为 `named/<segment>` 或 `singleton/<experiment-id>`。 |
 | `--port <port>` | `view` 监听端口；省略时由操作系统分配空闲端口。 |
 | `--host <address>` | `view` 监听地址；省略时为 `127.0.0.1`。 |
 | `--no-open` | 阻止 `view` 自动打开浏览器。 |
@@ -36,14 +37,16 @@ niceeval view [selection] [report options] --out <directory>
 不带 locator、`--run` 或 `--experiment` 时，命令按当前项目身份形成 Sample。它选择所有匹配的 published Run，不按时间缩成
 一个 Run，也不写回 Record。没有匹配结果仍形成空 Sample；度量用自己的 state、samples、total 与 issues 表示结果。
 
-`--experiment` 不能与 locator 或 `--run` 合用。未知 Run、未知 Experiment、未知 route、参数 route 的非规范 key 和缺少默认 route
-都是用法错误。
+`--experiment` 不能与 locator 或 `--run` 合用。`--group` 是 Page target，不改变 Sample；它可与 `--run` 或 `--experiment` 合用，但不能与 locator、`--page` 或 `--out` 合用。不接受未带 kind 的 `foo`，因为它无法区分 named 与 singleton。
+
+未知 Run、未知 Experiment、未知 route、参数 route 的非规范 key 和缺少默认 route 都是用法错误。目标组不在固定 Sample 中时返回 `report-group-not-in-sample`；自定义 Report 没有声明对应 `groupKind` 的 `experiment-group` Page 时返回 `report-group-page-unavailable`。
 
 ## `niceeval show`
 
 ```sh
 niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527
 niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527 --page /overview
+niceeval show --group named/compare
 niceeval show @1K1P0VJAPVJ12 --page /attempt/1K1P0VJAPVJ12
 ```
 
@@ -61,11 +64,11 @@ key 完全相同。`show` 不调用 `enumerate()`，却要求 `PageLoadContext` 
 `Section` 显示区域框，`Grid` 与 `Table` 显示数据格线；非 TTY 或过窄终端选择 plain projection，组件、数据状态与顺序不变。
 `NO_COLOR` 只禁用颜色，不删除表达组件边界的结构框。`show --json` 的 `renderedText` 始终读取固定 80 列 plain projection，不继承 TTY。
 
-`standard` 的 Overview 使用同一个 `ExperimentTable` 呈现 Pass Eval 与 Score Eval。Pass Eval 显示通过率，Score Eval 只显示
-earned score，不声明满分或百分比；mixed Experiment 同时保留两种子行。每个 Experiment 可逐层展开到 Eval 与 Attempt，Attempt locator
-链接到同一份 `standard` 显式声明的详情 Page。Analysis 的 `MetricValue` 仍完整保留 state、samples、total、issues 与 refs。
+`standard` 只遇到一个实验组时，Overview 直接呈现该组的比较结果。遇到多个组时，`show` 默认输出实验组索引和可复制的 `niceeval show --group <key>` 命令，不生成跨组 leaderboard。具名组 Page 在唯一 `ExperimentComparisonScope` 内使用 `ExperimentTable` 呈现 Pass Eval 与 Score Eval。Pass Eval 显示通过率，Score Eval 只显示 earned score，不声明满分或百分比；两种题型分面板呈现，不互排。
 
-`ExperimentScatter` 使用同一题型判断：通过制画成本 × 通过率，分数制画成本 × 总分；同一 Sample 同时包含两种题型时分成两张图，
+每个 Experiment 可逐层展开到 Eval 与 Attempt，Attempt locator 链接到同一份 `standard` 显式声明的详情 Page。Analysis 的 `MetricValue` 仍完整保留 state、samples、total、issues 与 refs。结构不可比时，组 Page 显示具名原因、成员、实际 population / basis 与 Evidence，不显示排名或散点。
+
+`ExperimentScatter` 使用同一题型判断：通过制画成本 × 通过率，分数制画成本 × 总分；同一实验比较范围同时包含两种题型时分成两张图，
 不把 points 和 ratio 混在同一纵轴。通过率轴以百分比刻度显示，`ratio` 只保留为内部量纲，不进入轴标题或刻度文案。
 
 ### locale
@@ -85,19 +88,38 @@ Record 或 Analysis 读取路径。
 
 ```ts
 interface BuiltInShowDocument {
-  readonly schema: "niceeval.show/v1";
+  readonly schema: "niceeval.show/v2";
   readonly locale: "en";
   readonly selection: ShowSelection;
   readonly report: { readonly token: BuiltInReportToken; readonly identity: ContentAddress };
   readonly page: { readonly route: string; readonly pageId: string; readonly title: LocalizedText };
   readonly data:
-    | { readonly kind: "leaderboard"; readonly rows: JsonValue }
+    | { readonly kind: "groups"; readonly groups: readonly ExperimentGroupSummary[] }
+    | {
+        readonly kind: "experiment-group";
+        readonly group: ExperimentGroupIdentity;
+        readonly comparison:
+          | { readonly state: "comparable"; readonly members: readonly string[]; readonly rows: JsonValue }
+          | { readonly state: "non-comparable"; readonly members: readonly string[]; readonly issues: readonly NonComparableIssue[] };
+      }
     | { readonly kind: "attempt"; readonly evidence: JsonValue; readonly observability: JsonValue; readonly fileChanges: JsonValue }
     | { readonly kind: "source"; readonly sources: JsonValue }
     | { readonly kind: "execution"; readonly execution: JsonValue }
     | { readonly kind: "timing"; readonly timing: JsonValue };
   readonly projections: ReportProjections;
   readonly problems: readonly ReportProblem[];
+}
+```
+
+```ts
+type ExperimentGroupIdentity =
+  | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
+  | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
+
+interface ExperimentGroupSummary {
+  readonly group: ExperimentGroupIdentity;
+  readonly members: readonly string[];
+  readonly href: string;
 }
 ```
 
@@ -124,11 +146,13 @@ interface CustomTargetExecutionManifest {
 }
 ```
 
-`projections` 是两种 v1 文档完全相同的顶层对象。它的 closed Profile、cost entry、target-Page 范围和排除项由
+`projections` 在内建 v2 与自定义 target-execution v1 中是完全相同的顶层对象。它的 closed Profile、cost entry、target-Page 范围和排除项由
 [Report 成本投影 CLI](cost-projections/cli.md) 定义；`report.identity` 标识加载的作者定义，不标识站点版本。
 
 `renderedText` 固定取该 Page 已关闭的英语 text projection，宽度固定为 80 个 display columns。它不读取 TTY 或浏览器宽度，
 也不为 JSON 再次运行组件、执行 Analysis 或读取 Record。
+
+默认 Page 以固定 Sample 中的组数决定关闭数据：恰好一组时产生 `experiment-group`，两组或更多时产生 `groups`。显式 `--group` 总是产生目标组的 `experiment-group`。
 
 `ShowSelection` 是固定 selector 的机器形状：
 
@@ -171,6 +195,7 @@ canonical JSON 的规则固定如下：
 ```sh
 niceeval view --report ./reports/summary.ts --port 4400
 niceeval view --host 192.168.0.199
+niceeval view --group named/compare
 niceeval view --run 01H... --page /attempt/attempt-01h... --no-open
 ```
 
@@ -178,7 +203,7 @@ view 在启动 server 前完整构建 `ClosedSiteRevision`。它对每个参数 
 枚举实例，并校验全站路径、链接、download、asset、Source、Diff、问题表、`_niceeval/data/projections.json` 与预算。该文件捕获所有
 显式声明 Page 的 projection closure；浏览器不重新计算成本。
 
-`--page` 只决定浏览器初始打开的已存在 route；不会缩小构建、枚举或验证。浏览器导航、刷新、Source、Trace、Diff 与下载只读取
+`--page` 或 `--group` 只决定浏览器初始打开的已存在 route；不会缩小构建、枚举或验证。浏览器导航、刷新、Source、Trace、Diff 与下载只读取
 revision bytes，不执行作者 callback、Analysis 或 Record 读取。
 
 view 监听 Record root、Report module、项目内静态 import、theme 与配置。最新完整构建成功时原子替换 current revision；失败保留
@@ -194,7 +219,7 @@ niceeval view --report ./reports/summary.ts --out ./report-site
 niceeval view --run 01H... --out ./shared-site --no-open
 ```
 
-`--out` 不接受 `--page`。它与 view 使用同一完整 SSG 路径，完成全站校验后原样写出 revision 的页面、CSS、reload client、作者 asset、
+`--out` 不接受 `--page` 或 `--group`。它与 view 使用同一完整 SSG 路径，完成全站校验后原样写出 revision 的页面、CSS、reload client、作者 asset、
 下载文件与 `_niceeval/data/projections.json`。该 projections 文件包含全体声明 Page 的 closure，bytes 进入 revision identity。目标目录
 必须不存在；存在时返回 `report-export-target-exists`，Host 不删除或替换其中的文件。
 
@@ -214,6 +239,9 @@ niceeval view --run 01H... --out ./shared-site --no-open
 | `show` 的 Page callback、参数 key 或成员资格失败 | 返回单目标执行错误，不形成 revision。 |
 | 全站 Page、枚举、路径、asset 或预算失败 | view 保留 last-good；static 不创建完整目录。 |
 | MetricValue 是 partial、empty、unsupported 或 failed | 成功呈现状态、issues 与 refs。 |
+| 实验组结构不可比 | 成功呈现 `non-comparable`、成员、原因与 Evidence，不生成排名或散点。 |
+| 比较组件收到多组输入 | 返回 `analysis-comparison-group-mismatch`，不降级成 `non-comparable`。 |
+| `--group` 不在 Sample 中，或 Report 没有组 Page | 分别返回 `report-group-not-in-sample` 或 `report-group-page-unavailable`。 |
 | 未知或非规范 route | 用法错误，说明可用 route 或参数格式。 |
 | 输出目录已存在 | 返回 `report-export-target-exists`，不改动目录。 |
 | 静态写入失败 | 返回 `report-export-write-failed`，不泄露任意系统路径或内部 cause。 |

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -66,7 +66,9 @@ key 完全相同。`show` 不调用 `enumerate()`，却要求 `PageLoadContext` 
 
 `standard` 只遇到一个实验组时，Overview 直接呈现该组的比较结果。遇到多个组时，`show` 默认输出实验组索引和可复制的 `niceeval show --group <key>` 命令，不生成跨组 leaderboard。具名组 Page 在唯一 `ExperimentComparisonScope` 内使用 `ExperimentTable` 呈现 Pass Eval 与 Score Eval。Pass Eval 显示通过率，Score Eval 只显示 earned score，不声明满分或百分比；两种题型分面板呈现，不互排。
 
-每个 Experiment 可逐层展开到 Eval 与 Attempt，Attempt locator 链接到同一份 `standard` 显式声明的详情 Page。Analysis 的 `MetricValue` 仍完整保留 state、samples、total、issues 与 refs。Eval population 不同时，组 Page 显示具名原因、成员与实际 population，不显示排名或散点。
+每个 Experiment 可逐层展开到 Eval 与 Attempt，Attempt locator 链接到同一份 `standard` 显式声明的详情 Page。Analysis 的 `MetricValue` 仍完整保留 state、samples、total、issues 与 refs。
+
+同组实验运行的 Eval ID 集合不同时，组 Page 显示具名原因、成员与实际集合，不显示排名或散点。通过制与分数制可以在同组的独立面板中呈现，不因题型不同而进入这个状态。
 
 `ExperimentScatter` 使用同一题型判断：通过制画成本 × 通过率，分数制画成本 × 总分；同一实验比较范围同时包含两种题型时分成两张图，
 不把 points 和 ratio 混在同一纵轴。通过率轴以百分比刻度显示，`ratio` 只保留为内部量纲，不进入轴标题或刻度文案。

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -101,6 +101,13 @@ interface BuiltInShowDocument {
           | { readonly state: "comparable"; readonly members: readonly string[]; readonly rows: JsonValue }
           | { readonly state: "non-comparable"; readonly members: readonly string[]; readonly issues: readonly NonComparableIssue[] };
       }
+    | {
+        readonly kind: "run-membership";
+        readonly summary: JsonValue;
+        readonly members: JsonValue;
+        readonly errors: JsonValue;
+        readonly evidence: JsonValue;
+      }
     | { readonly kind: "attempt"; readonly evidence: JsonValue; readonly observability: JsonValue; readonly fileChanges: JsonValue }
     | { readonly kind: "source"; readonly sources: JsonValue }
     | { readonly kind: "execution"; readonly execution: JsonValue }
@@ -151,7 +158,9 @@ interface CustomTargetExecutionManifest {
 `renderedText` 固定取该 Page 已关闭的英语 text projection，宽度固定为 80 个 display columns。它不读取 TTY 或浏览器宽度，
 也不为 JSON 再次运行组件、执行 Analysis 或读取 Record。
 
-默认 Page 以固定 Sample 中的组数决定关闭数据：恰好一组时产生 `experiment-group`，两组或更多时产生 `groups`。`--experiment <selector>` 先按 `exp` 的同一规则收窄当前项目；收窄后只有一组时直接产生该组的 `experiment-group`。
+`project-current` 的默认 Page 以固定 Sample 中的组数决定关闭数据：恰好一组时产生 `experiment-group`，两组或更多时产生 `groups`。
+`--experiment <selector>` 先按 `exp` 的同一规则收窄当前项目；收窄后只有一组时直接产生该组的 `experiment-group`。
+一个或多个 `--run` 始终选择 `run-membership` Page；即使这些 Run 只含一个实验组，也不会转成实验比较。
 
 `ShowSelection` 是固定 selector 的机器形状：
 

--- a/docs/feature/reports/cli.md
+++ b/docs/feature/reports/cli.md
@@ -24,10 +24,9 @@ niceeval view [selection] [report options] --out <directory>
 | `--record <root>` | 选择实际 Record root；省略时使用 `<cwd>/.niceeval/record`。 |
 | `@<locator>` | 精确选择一个 immutable Attempt。 |
 | `--run <run-id>` | 可重复；精确选择历史 Run。 |
-| `--experiment <id>` | 可重复；按完整 ExperimentId 收窄不带 locator 或 `--run` 的项目选择。 |
+| `--experiment <selector>` | 可重复；使用与 `niceeval exp <selector>` 相同的实验选择规则收窄当前项目；目录 selector 会选择其下全部 Experiments。 |
 | `--report <module>` | 选择内建 Report 或受信任的 Report module。 |
 | `--page <route>` | `show` 的唯一目标 route，或 `view` 的初始浏览 route。 |
-| `--group <key>` | 选择实验组 Page；精确 key 为 `named/<segment>` 或 `singleton/<experiment-id>`。 |
 | `--port <port>` | `view` 监听端口；省略时由操作系统分配空闲端口。 |
 | `--host <address>` | `view` 监听地址；省略时为 `127.0.0.1`。 |
 | `--no-open` | 阻止 `view` 自动打开浏览器。 |
@@ -37,16 +36,14 @@ niceeval view [selection] [report options] --out <directory>
 不带 locator、`--run` 或 `--experiment` 时，命令按当前项目身份形成 Sample。它选择所有匹配的 published Run，不按时间缩成
 一个 Run，也不写回 Record。没有匹配结果仍形成空 Sample；度量用自己的 state、samples、total 与 issues 表示结果。
 
-`--experiment` 不能与 locator 或 `--run` 合用。`--group` 是 Page target，不改变 Sample；它可与 `--run` 或 `--experiment` 合用，但不能与 locator、`--page` 或 `--out` 合用。不接受未带 kind 的 `foo`，因为它无法区分 named 与 singleton。
-
-未知 Run、未知 Experiment、未知 route、参数 route 的非规范 key 和缺少默认 route 都是用法错误。目标组不在固定 Sample 中时返回 `report-group-not-in-sample`；自定义 Report 没有声明对应 `groupKind` 的 `experiment-group` Page 时返回 `report-group-page-unavailable`。
+`--experiment` 不能与 locator 或 `--run` 合用。它沿用 `exp` 的精确 ID、目录与同目录文件名前缀选择规则；例如 `--experiment classic` 选择 `classic/` 下的整组 Experiments。未知 Run、零命中的 Experiment selector、未知 route、参数 route 的非规范 key 和缺少默认 route 都是用法错误。
 
 ## `niceeval show`
 
 ```sh
 niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527
 niceeval show --run 7b8d2ea4-b840-4870-9840-f85a436a5527 --page /overview
-niceeval show --group named/compare
+niceeval show --experiment compare
 niceeval show @1K1P0VJAPVJ12 --page /attempt/1K1P0VJAPVJ12
 ```
 
@@ -64,7 +61,7 @@ key 完全相同。`show` 不调用 `enumerate()`，却要求 `PageLoadContext` 
 `Section` 显示区域框，`Grid` 与 `Table` 显示数据格线；非 TTY 或过窄终端选择 plain projection，组件、数据状态与顺序不变。
 `NO_COLOR` 只禁用颜色，不删除表达组件边界的结构框。`show --json` 的 `renderedText` 始终读取固定 80 列 plain projection，不继承 TTY。
 
-`standard` 只遇到一个实验组时，Overview 直接呈现该组的比较结果。遇到多个组时，`show` 默认输出实验组索引和可复制的 `niceeval show --group <key>` 命令，不生成跨组 leaderboard。具名组 Page 在唯一 `ExperimentComparisonScope` 内使用 `ExperimentTable` 呈现 Pass Eval 与 Score Eval。Pass Eval 显示通过率，Score Eval 只显示 earned score，不声明满分或百分比；两种题型分面板呈现，不互排。
+`standard` 只遇到一个实验组时，Overview 直接呈现该组的比较结果。遇到多个组时，`show` 默认输出实验索引和可复制的 `niceeval show --experiment <selector>` 命令，不生成跨组 leaderboard，也不引入另一套实验组 CLI 参数。具名组 Page 在唯一 `ExperimentComparisonScope` 内使用 `ExperimentTable` 呈现 Pass Eval 与 Score Eval。Pass Eval 显示通过率，Score Eval 只显示 earned score，不声明满分或百分比；两种题型分面板呈现，不互排。
 
 每个 Experiment 可逐层展开到 Eval 与 Attempt，Attempt locator 链接到同一份 `standard` 显式声明的详情 Page。Analysis 的 `MetricValue` 仍完整保留 state、samples、total、issues 与 refs。
 
@@ -90,7 +87,7 @@ Record 或 Analysis 读取路径。
 
 ```ts
 interface BuiltInShowDocument {
-  readonly schema: "niceeval.show/v2";
+  readonly format: "niceeval.show/v1" | "niceeval.show/v2";
   readonly locale: "en";
   readonly selection: ShowSelection;
   readonly report: { readonly token: BuiltInReportToken; readonly identity: ContentAddress };
@@ -132,7 +129,7 @@ interface ExperimentGroupSummary {
 
 ```ts
 interface CustomTargetExecutionManifest {
-  readonly schema: "niceeval.report-target-execution/v1";
+  readonly format: "niceeval.report-target-execution/v1";
   readonly locale: "en";
   readonly selection: ShowSelection;
   readonly report: { readonly identity: ContentAddress; readonly title: LocalizedText };
@@ -154,7 +151,7 @@ interface CustomTargetExecutionManifest {
 `renderedText` 固定取该 Page 已关闭的英语 text projection，宽度固定为 80 个 display columns。它不读取 TTY 或浏览器宽度，
 也不为 JSON 再次运行组件、执行 Analysis 或读取 Record。
 
-默认 Page 以固定 Sample 中的组数决定关闭数据：恰好一组时产生 `experiment-group`，两组或更多时产生 `groups`。显式 `--group` 总是产生目标组的 `experiment-group`。
+默认 Page 以固定 Sample 中的组数决定关闭数据：恰好一组时产生 `experiment-group`，两组或更多时产生 `groups`。`--experiment <selector>` 先按 `exp` 的同一规则收窄当前项目；收窄后只有一组时直接产生该组的 `experiment-group`。
 
 `ShowSelection` 是固定 selector 的机器形状：
 
@@ -165,10 +162,10 @@ type ShowSelection =
   | { readonly kind: "attempt-locator"; readonly sampleIdentity: ContentAddress; readonly locator: string };
 ```
 
-`selection` 只说明固定 Sample 的选择；`page` 是唯一的 Page 选择，恰好含一个 `route` 与一个 `pageId`。两种 schema 都没有全站
+`selection` 只说明固定 Sample 的选择；`page` 是唯一的 Page 选择，恰好含一个 `route` 与一个 `pageId`。两类机器文档都没有全站
 pages 数组或 site identity。
 
-`ContentAddress` 与 `BuiltInReportToken` 都是非空 string。两种 schema 共用下列问题形状：
+`ContentAddress` 与 `BuiltInReportToken` 都是非空 string。两类机器文档共用下列问题形状：
 
 ```ts
 interface ReportProblem {
@@ -197,7 +194,6 @@ canonical JSON 的规则固定如下：
 ```sh
 niceeval view --report ./reports/summary.ts --port 4400
 niceeval view --host 192.168.0.199
-niceeval view --group named/compare
 niceeval view --run 01H... --page /attempt/attempt-01h... --no-open
 ```
 
@@ -205,7 +201,7 @@ view 在启动 server 前完整构建 `ClosedSiteRevision`。它对每个参数 
 枚举实例，并校验全站路径、链接、download、asset、Source、Diff、问题表、`_niceeval/data/projections.json` 与预算。该文件捕获所有
 显式声明 Page 的 projection closure；浏览器不重新计算成本。
 
-`--page` 或 `--group` 只决定浏览器初始打开的已存在 route；不会缩小构建、枚举或验证。浏览器导航、刷新、Source、Trace、Diff 与下载只读取
+`--page` 只决定浏览器初始打开的已存在 route；不会缩小构建、枚举或验证。Header 的实验选择器沿已关闭的组 Page 链接导航，不增加 CLI selector。浏览器导航、刷新、Source、Trace、Diff 与下载只读取
 revision bytes，不执行作者 callback、Analysis 或 Record 读取。
 
 view 监听 Record root、Report module、项目内静态 import、theme 与配置。最新完整构建成功时原子替换 current revision；失败保留
@@ -221,7 +217,7 @@ niceeval view --report ./reports/summary.ts --out ./report-site
 niceeval view --run 01H... --out ./shared-site --no-open
 ```
 
-`--out` 不接受 `--page` 或 `--group`。它与 view 使用同一完整 SSG 路径，完成全站校验后原样写出 revision 的页面、CSS、reload client、作者 asset、
+`--out` 不接受 `--page`。它与 view 使用同一完整 SSG 路径，完成全站校验后原样写出 revision 的页面、CSS、reload client、作者 asset、
 下载文件与 `_niceeval/data/projections.json`。该 projections 文件包含全体声明 Page 的 closure，bytes 进入 revision identity。目标目录
 必须不存在；存在时返回 `report-export-target-exists`，Host 不删除或替换其中的文件。
 
@@ -243,7 +239,6 @@ niceeval view --run 01H... --out ./shared-site --no-open
 | MetricValue 是 partial、empty、unsupported 或 failed | 成功呈现状态、issues 与 refs。 |
 | 实验组结构不可比 | 成功呈现 `non-comparable`、成员、原因与 Evidence，不生成排名或散点。 |
 | 比较组件收到多组输入 | 返回 `analysis-comparison-group-mismatch`，不降级成 `non-comparable`。 |
-| `--group` 不在 Sample 中，或 Report 没有组 Page | 分别返回 `report-group-not-in-sample` 或 `report-group-page-unavailable`。 |
 | 未知或非规范 route | 用法错误，说明可用 route 或参数格式。 |
 | 输出目录已存在 | 返回 `report-export-target-exists`，不改动目录。 |
 | 静态写入失败 | 返回 `report-export-write-failed`，不泄露任意系统路径或内部 cause。 |

--- a/docs/feature/reports/cost-projections/cli.md
+++ b/docs/feature/reports/cost-projections/cli.md
@@ -33,8 +33,8 @@ openai · Attempt #14  unavailable · pricing information unavailable
 
 ## machine、view 与静态输出
 
-内建与自定义 `show --json` 都使用各自的 v1 schema，并且都在顶层携带相同的 `projections` 对象：
-`{ schema: "niceeval.report-projections/v1", pricingProfile, costs }`。
+内建与自定义 `show --json` 都使用各自的版本化 format，并且都在顶层携带相同的 `projections` 对象：
+`{ format: "niceeval.report-projections/v1", pricingProfile, costs }`。
 
 每个 cost entry 的形状为 `{ page: { pageId, route }, measureId, row: { key, dimensions }, profileIdentity, projection }`。
 `projection` 包含 `{ kind: "declared-rate-card", source, asOf }`、slot-provider ledger、exact aggregate、rational mean 和有限 reasons。

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -210,7 +210,7 @@ type Page<Params extends JsonValue | void = void, Input = Sample> =
     : ParameterizedPage<Extract<Params, JsonValue>, Input>;
 ```
 
-`role.kind: "experiment-group"` 只适用于参数 Page。`groupKind` 固定该 Page 接收 named 或 singleton identity，`load` 再从当前 Sample 形成 `ExperimentComparisonScope`。Host 只为作者显式声明的这类 Page 生成 Header 实验组选择器；当前 Sample 只有一组时不显示选择器，有两组或更多时才显示。未声明该 role 时不补造 Page、route 或选择器。
+`role.kind: "experiment-group"` 只适用于参数 Page。`groupKind` 固定该 Page 接收 named 或 singleton identity，`load` 再从当前 Sample 形成 `ExperimentComparisonScope`。Host 只为作者显式声明的这类 Page 生成 Header 实验选择器；当前 Sample 只有一个可比范围时不显示选择器，有两个或更多时才显示。未声明该 role 时不补造 Page、route 或选择器。
 
 参数 Page 仍只消费一个 canonical key segment。标准 Report 因此显式声明 `path: "/group/named"` 和 `path: "/group/singleton"` 两个 Page，形成 `/group/named/<segment>` 与 `/group/singleton/<experiment-id>`。选择器把两个 Page 的已闭合目标汇总成一个列表；每个选项都是真实 `href`。JavaScript 只渐进增强交互，禁用 JavaScript 与静态导出仍能沿同一链接切换组。
 

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -210,9 +210,11 @@ type Page<Params extends JsonValue | void = void, Input = Sample> =
     : ParameterizedPage<Extract<Params, JsonValue>, Input>;
 ```
 
-`role.kind: "experiment-group"` 只适用于参数 Page。`groupKind` 固定该 Page 接收 named 或 singleton identity，`load` 再从当前 Sample 形成 `ExperimentComparisonScope`。Host 只为作者显式声明的这类 Page 生成 Header 实验选择器；当前 Sample 只有一个可比范围时不显示选择器，有两个或更多时才显示。未声明该 role 时不补造 Page、route 或选择器。
+`role.kind: "experiment-group"` 只适用于参数 Page。`groupKind` 固定该 Page 接收 named 或 singleton identity，`load` 再从当前 Sample 形成 `ExperimentComparisonScope`。Host 只为作者显式声明的这类 Page 生成 Header 实验选择器；当前 Sample 只有一个可比范围时不显示选择器，有两个或更多时才显示，并默认选择稳定排序的第一项。未声明该 role 时不补造 Page、route 或选择器。
 
-参数 Page 仍只消费一个 canonical key segment。标准 Report 因此显式声明 `path: "/group/named"` 和 `path: "/group/singleton"` 两个 Page，形成 `/group/named/<segment>` 与 `/group/singleton/<experiment-id>`。选择器把两个 Page 的已闭合目标汇总成一个列表；每个选项都是真实 `href`。JavaScript 只渐进增强交互，禁用 JavaScript 与静态导出仍能沿同一链接切换组。
+参数 Page 仍只消费一个 canonical key segment。标准 Report 因此显式声明 `path: "/group/named"` 和 `path: "/group/singleton"` 两个 Page，形成 `/group/named/<segment>` 与 `/group/singleton/<experiment-id>`。选择器把两个 Page 的已闭合目标汇总成一个原生 `select`；切换只导航到选项携带的静态 Page URL。禁用 JavaScript 时，Header 提供同一组真实链接作为 fallback，静态导出仍能切换组。
+
+标准实验组 Page 是完整的 scoped Overview，不是只替换 Experiment Table。它把 `ExperimentComparisonScope` 的 backing Sample 显式交给 Hero、`SampleNotices` 与 `SampleSummary`，再把同一 scope 交给 `ExperimentScatter` 和 `ExperimentTable`。因此告警数、Pass rate、Experiments、Evals、Attempts、Eval results、Total cost 与 Run range 都随选择范围变化。
 
 `params.encode()` 产生一个 canonical key segment；`decode()` 只接受同一形式。全站路径调用 `enumerate(sample)` 恰好一次，
 并生成每个返回值。`show --page` 只用 `decode()` 取得已请求 key，不调用 `enumerate()`。

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -188,6 +188,10 @@ interface ParameterizedPage<Params extends JsonValue, Input> {
   readonly path?: string;
   readonly title: LocalizedText;
   readonly navigation: false;
+  readonly role?: {
+    readonly kind: "experiment-group";
+    readonly groupKind: "named" | "singleton";
+  };
   readonly params: PageParams<Params>;
   readonly load: (
     sample: Sample,
@@ -205,6 +209,10 @@ type Page<Params extends JsonValue | void = void, Input = Sample> =
     ? PlainPage<Input>
     : ParameterizedPage<Extract<Params, JsonValue>, Input>;
 ```
+
+`role.kind: "experiment-group"` 只适用于参数 Page。`groupKind` 固定该 Page 接收 named 或 singleton identity，`load` 再从当前 Sample 形成 `ExperimentComparisonScope`。Host 只为作者显式声明的这类 Page 生成 Header 实验组选择器；当前 Sample 只有一组时不显示选择器，有两组或更多时才显示。未声明该 role 时不补造 Page、route 或选择器。
+
+参数 Page 仍只消费一个 canonical key segment。标准 Report 因此显式声明 `path: "/group/named"` 和 `path: "/group/singleton"` 两个 Page，形成 `/group/named/<segment>` 与 `/group/singleton/<experiment-id>`。选择器把两个 Page 的已闭合目标汇总成一个列表；每个选项都是真实 `href`。JavaScript 只渐进增强交互，禁用 JavaScript 与静态导出仍能沿同一链接切换组。
 
 `params.encode()` 产生一个 canonical key segment；`decode()` 只接受同一形式。全站路径调用 `enumerate(sample)` 恰好一次，
 并生成每个返回值。`show --page` 只用 `decode()` 取得已请求 key，不调用 `enumerate()`。
@@ -383,6 +391,8 @@ ledger 与 reason data types 同样仅以 type-only export 提供。精确调用
 `Hero`、`SampleOverview`、`AttemptDetails`、`ExperimentDetails`、`Conversation`、`TurnTrace`、`DiffView`、`SourceView` 与 `Waterfall` 是
 官方组合组件。它们只接收关闭数据，详情 route 一律通过 `attemptDetailTarget()`、`experimentDetailTarget()` 与
 `libraryDetailRoute()` 建立。
+
+`ExperimentTable` 与 `ExperimentScatter` 是具名比较组件。它们只接受 `ExperimentComparisonScope` 或该 scope 产生的同组 branded projection，不接受普通 Sample 或任意 rows。多组输入以 `analysis-comparison-group-mismatch` 失败；单组的 `non-comparable` 闭合原因与 Evidence，不渲染排名或散点。中立 `Table` 与 `Scatter` 仍可显示任意已闭合值，不承担实验组语义。
 
 `AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。展开该行后，`TurnTrace` 以 `Conversation` 的静态因果事件流为账本，加上 turn 时间概览与可关闭的事件 inspector。没有精确 source mapping 的 turn 保留在页面级 `TurnTrace`，不按源码顺序猜测归属；没有 JavaScript 时 inspector 不出现，但完整事件内容仍在正文中。
 

--- a/docs/source-map.md
+++ b/docs/source-map.md
@@ -38,6 +38,7 @@ Verdict、Score 和采用理由由 Assertions、Attempt outcome 与 Member Core 
 | 目标契约 owner | 源码边界 |
 |---|---|
 | [Analysis](feature/analysis/README.md) | `src/analysis/{api,definitions,contracts,host}.ts` 拥有 Population、Dimension、Measure、Relation、Host-issued Sample、`aggregate()` 与 `query()`。 |
+| [实验组与比较范围](feature/analysis/library.md#实验组与比较范围) | `src/analysis/experiment-groups.ts` 从固定 Sample 派生 Experiment Group、签发 `ExperimentComparisonScope` 并闭合结构可比性；`src/report/built-in/standard.tsx` 与 `src/report/host/{from-record,machine,static}.ts` 分别拥有标准组 Page、`show` 组输出与 Header 真实链接。 |
 | [Analysis outputs](feature/analysis/library.md#closedrowssemanticframe-与-domainview) | `src/analysis/` 形成并校验 `ClosedRows`、`SemanticFrame` 与 `DomainView`；`src/report/model/{aggregate,conversions}.ts` 只提供 Report facade 与具名关闭投影，不建立通用作者 semantic model。 |
 | [Reports](feature/reports/README.md) | `src/report/definition/{report,tree}.ts`、`definition/primitives/**`、`components/**`、`model/{aggregate,conversions}.ts` 与 `index.ts` 是作者面：`defineReport({ pages })`、两种 `defineComponent()`、普通 Page 与参数 Page。作者只使用标准 React JSX，不增加专属 JSX 入口。 |
 | [Report 成本投影](feature/reports/cost-projections/README.md) | `src/analysis/{cost,cost-projection,cost-decimal}.ts` 定义 Profile 验证、slot-provider ledger 与闭合 projection；`src/report/{definition/report.ts,execution/machine.ts,host/{machine,show-target,site-runtime}.ts}` 把已签发 projection 纳入 target 或 site 输出，不重新计算。 |

--- a/docs/writing-rules.json
+++ b/docs/writing-rules.json
@@ -113,6 +113,15 @@
     },
     "rejectedCliFlags": [
       {
+        "flag": "--group",
+        "roots": [
+          "docs/feature/reports",
+          "docs-site/zh/reference"
+        ],
+        "use": "使用与 niceeval exp 相同的 --experiment <selector>；浏览器 Header 沿已关闭的实验 Page 链接切换",
+        "why": "实验 selector 已代表用户可运行和可查看的实验范围，另加 group 参数会暴露内部比较 identity，并形成第二套选择语法"
+      },
+      {
         "flag": "--latest",
         "roots": [
           "docs-site/zh"

--- a/e2e/adapter/opencode/evals/skills/status-report.eval.ts
+++ b/e2e/adapter/opencode/evals/skills/status-report.eval.ts
@@ -21,8 +21,8 @@ export default defineEval({
       t.check(installed.exitCode, equals(0));
     });
     const turn = await t.send(
-      `Before writing a status report, inspect only the applicable Skill under ${SKILL_DIR}/; ` +
-        "do not inspect another Skill. " +
+      `Before writing a status report, use OpenCode's native Skill tool to load ${STATUS_SKILL}; ` +
+        "do not read its SKILL.md directly and do not load another Skill. " +
         `Create ${reportPath} saying "all systems nominal" and follow the selected Skill exactly.`,
     );
     await turn.succeeded().orStop();

--- a/e2e/eval/test/assertion-score.test.ts
+++ b/e2e/eval/test/assertion-score.test.ts
@@ -5,17 +5,20 @@ import { only } from "@niceeval/testkit";
 import { expect, test } from "vitest";
 import { evalE2E } from "./context.ts";
 
-interface LeaderboardShow {
-  schema: "niceeval.show/v1";
+interface ExperimentGroupShow {
+  format: "niceeval.show/v2";
   selection: { kind: "project-current"; sampleIdentity: string };
   problems: readonly unknown[];
   data: {
-    kind: "leaderboard";
-    rows: readonly {
-      experiment: string;
-      passRate: null;
-      totalScore: number;
-    }[];
+    kind: "experiment-group";
+    comparison: {
+      state: "comparable";
+      rows: readonly {
+        experiment: string;
+        passRate: null;
+        totalScore: number;
+      }[];
+    };
   };
 }
 
@@ -71,19 +74,22 @@ test("计分 Eval 公开区分 scored、stopped 与 skipped", async () => {
       const shown = await niceeval.run(["show", "--json"]);
       expect(shown.exitCode, shown.diagnostic()).toBe(0);
       expect(evaluations.filter((event) => event.verdict === "failed")).toEqual([]);
-      const document = shown.json<LeaderboardShow>();
+      const document = shown.json<ExperimentGroupShow>();
       expect(document).toMatchObject({
-        schema: "niceeval.show/v1",
+        format: "niceeval.show/v2",
         selection: { kind: "project-current" },
         data: {
-          kind: "leaderboard",
-          rows: [{
-            experiment: "assertion-score",
-            passRate: null,
-          }],
+          kind: "experiment-group",
+          comparison: {
+            state: "comparable",
+            rows: [{
+              experiment: "assertion-score",
+              passRate: null,
+            }],
+          },
         },
       });
-      const [row] = document.data.rows;
+      const [row] = document.data.comparison.rows;
       expect(row).toBeDefined();
       expect(row!.totalScore).toEqual(expect.any(Number));
       expect(document.problems, "scored, stopped, and skipped are known score outcomes").toEqual([]);

--- a/e2e/eval/test/assertion-score.test.ts
+++ b/e2e/eval/test/assertion-score.test.ts
@@ -6,7 +6,7 @@ import { expect, test } from "vitest";
 import { evalE2E } from "./context.ts";
 
 interface ExperimentGroupShow {
-  format: "niceeval.show/v2";
+  format: "niceeval.show";
   selection: { kind: "project-current"; sampleIdentity: string };
   problems: readonly unknown[];
   data: {
@@ -76,7 +76,7 @@ test("计分 Eval 公开区分 scored、stopped 与 skipped", async () => {
       expect(evaluations.filter((event) => event.verdict === "failed")).toEqual([]);
       const document = shown.json<ExperimentGroupShow>();
       expect(document).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         selection: { kind: "project-current" },
         data: {
           kind: "experiment-group",

--- a/e2e/migrate/reports/cost-state.tsx
+++ b/e2e/migrate/reports/cost-state.tsx
@@ -1,6 +1,16 @@
-import { Col, ExperimentScatter, Text, aggregate, costUSD, defineComponent, defineReport } from "niceeval/report";
+import { experimentComparisonScope, experimentGroups } from "niceeval/analysis";
+import {
+  Col,
+  ExperimentScatter,
+  Text,
+  aggregate,
+  costUSD,
+  defineComponent,
+  defineReport,
+  type Sample,
+} from "niceeval/report";
 
-const CostState = defineComponent(async (_props: {}, ctx) => {
+const CostState = defineComponent(async (props: { readonly comparison: ReturnType<typeof experimentComparisonScope> }, ctx) => {
   const [overall] = await aggregate(ctx.scope, {
     by: {},
     values: { cost: costUSD(ctx.report.pricing!) },
@@ -8,10 +18,16 @@ const CostState = defineComponent(async (_props: {}, ctx) => {
   return (
     <Col>
       <Text>{`cost:${overall.cost.state}:${overall.cost.samples}/${overall.cost.total}`}</Text>
-      <ExperimentScatter />
+      <ExperimentScatter comparison={props.comparison} />
     </Col>
   );
 });
+
+function costState(sample: Sample) {
+  const [group] = experimentGroups(sample);
+  if (group === undefined) throw new Error("Migration cost state requires one experiment group");
+  return <CostState comparison={experimentComparisonScope(sample, group.group)} />;
+}
 
 export default defineReport({
   title: "Migration cost state",
@@ -19,6 +35,6 @@ export default defineReport({
     id: "cost-state",
     path: "/cost-state",
     title: "Cost migration state",
-    render: () => <CostState />,
+    render: costState,
   }],
 });

--- a/e2e/migrate/test/handoff.test.ts
+++ b/e2e/migrate/test/handoff.test.ts
@@ -72,10 +72,23 @@ test("Git 保存的 npm 0.13.0 Record 自动迁移后显示同一结果并拒绝
       expect(shown.stderr, shown.diagnostic()).toContain("restore commit");
       const output = shown.json<{
         selection: { runIds: readonly string[] };
-        data: { rows: readonly [{ passRate: { state: string; value: number } }] };
+        data: {
+          kind: "experiment-group";
+          comparison:
+            | {
+                state: "comparable";
+                rows: readonly [{ passRate: { state: string; value: number } }];
+              }
+            | { state: "non-comparable" };
+        };
       }>();
       expect(output.selection.runIds).toEqual([runId]);
-      expect(output.data.rows[0]?.passRate).toMatchObject({ state: "available", value: 1 });
+      expect(output.data.kind).toBe("experiment-group");
+      expect(output.data.comparison.state).toBe("comparable");
+      if (output.data.comparison.state !== "comparable") {
+        throw new Error("the migrated single-Experiment run is not comparable");
+      }
+      expect(output.data.comparison.rows[0]?.passRate).toMatchObject({ state: "available", value: 1 });
 
       const beforeOldWriter = await run(["git", "diff", "--binary", "--", ".niceeval/record"]);
       expect(beforeOldWriter.exitCode, beforeOldWriter.diagnostic()).toBe(0);

--- a/e2e/migrate/test/handoff.test.ts
+++ b/e2e/migrate/test/handoff.test.ts
@@ -73,22 +73,15 @@ test("Git 保存的 npm 0.13.0 Record 自动迁移后显示同一结果并拒绝
       const output = shown.json<{
         selection: { runIds: readonly string[] };
         data: {
-          kind: "experiment-group";
-          comparison:
-            | {
-                state: "comparable";
-                rows: readonly [{ passRate: { state: string; value: number } }];
-              }
-            | { state: "non-comparable" };
+          kind: "run-membership";
+          members: readonly [{ eval: string; locator: string; verdict: string }];
         };
       }>();
       expect(output.selection.runIds).toEqual([runId]);
-      expect(output.data.kind).toBe("experiment-group");
-      expect(output.data.comparison.state).toBe("comparable");
-      if (output.data.comparison.state !== "comparable") {
-        throw new Error("the migrated single-Experiment run is not comparable");
-      }
-      expect(output.data.comparison.rows[0]?.passRate).toMatchObject({ state: "available", value: 1 });
+      expect(output.data.kind).toBe("run-membership");
+      expect(output.data.members).toEqual([
+        expect.objectContaining({ eval: "legacy-handoff", locator: expect.stringMatching(/^@/), verdict: "passed" }),
+      ]);
 
       const beforeOldWriter = await run(["git", "diff", "--binary", "--", ".niceeval/record"]);
       expect(beforeOldWriter.exitCode, beforeOldWriter.diagnostic()).toBe(0);

--- a/e2e/report/experiments/classic/incompatible.ts
+++ b/e2e/report/experiments/classic/incompatible.ts
@@ -1,0 +1,12 @@
+import { defineExperiment } from "niceeval";
+import { classicMemoryAgent } from "../../agents/classic.ts";
+
+export default defineExperiment({
+  description: "classic/incompatible: same author group with a deliberately different Eval population",
+  agent: classicMemoryAgent(),
+  model: "gpt-5.6-luna",
+  evals: ["score"],
+  flags: { memory: "incompatible" },
+  labels: { line: "classic", memory: "incompatible" },
+  attempts: 1,
+});

--- a/e2e/report/reports/classic.tsx
+++ b/e2e/report/reports/classic.tsx
@@ -13,7 +13,9 @@ import {
   defineReport,
   experiment,
   passRate,
+  type Sample,
 } from "niceeval/report";
+import { experimentComparisonScope, experimentGroups } from "niceeval/analysis";
 import {
   standardAttemptPage,
   standardExperimentPage,
@@ -55,7 +57,12 @@ const Leaderboard = defineComponent(async (_props, ctx) => {
   );
 });
 
-function classicOverview() {
+function classicOverview(sample: Sample) {
+  const group = experimentGroups(sample).find((entry) => entry.group.key === "named/classic");
+  if (group === undefined) {
+    throw new Error("Classic comparison fixture requires named/classic");
+  }
+  const comparison = experimentComparisonScope(sample, group.group);
   return (
     <Col>
       <MemoryBenchHero />
@@ -65,10 +72,10 @@ function classicOverview() {
         <Leaderboard />
       </Section>
       <Section title={{ en: "Experiment comparison", "zh-CN": "实验对比" }}>
-        <ExperimentScatter />
+        <ExperimentScatter comparison={comparison} />
       </Section>
       <Section title={{ en: "Experiments", "zh-CN": "实验" }}>
-        <ExperimentTable />
+        <ExperimentTable comparison={comparison} />
       </Section>
     </Col>
   );

--- a/e2e/report/reports/site.tsx
+++ b/e2e/report/reports/site.tsx
@@ -9,7 +9,6 @@ import {
   Grid,
   Link,
   Section,
-  ExperimentScatter,
   SampleSummary,
   Stat,
   Tab,
@@ -169,7 +168,6 @@ export default defineReport({
           <Section title="Fixture overview">
             <Text>{"Report fixture static site"}</Text>
             <SampleSummary />
-            <ExperimentScatter />
             <FixtureSlotCount label="Selected slots" />
             <FixturePassRateState />
             <FixtureMetricRows />

--- a/e2e/report/test/report-execution.test.ts
+++ b/e2e/report/test/report-execution.test.ts
@@ -204,7 +204,7 @@ test("标准 React JSX 的 v0.12 作者 fixture 经安装候选构建完整站�
         const duplicate = await niceeval.run(["show", "--report", `./reports/${module}`, "--json"]);
         expect(duplicate.exitCode, duplicate.diagnostic()).toBe(0);
         expect(duplicate.json<{ format: string; data: { kind: string } }>()).toMatchObject({
-          format: "niceeval.show/v2",
+          format: "niceeval.show",
           data: { kind: "groups" },
         });
       }

--- a/e2e/report/test/report-execution.test.ts
+++ b/e2e/report/test/report-execution.test.ts
@@ -204,8 +204,8 @@ test("标准 React JSX 的 v0.12 作者 fixture 经安装候选构建完整站�
         const duplicate = await niceeval.run(["show", "--report", `./reports/${module}`, "--json"]);
         expect(duplicate.exitCode, duplicate.diagnostic()).toBe(0);
         expect(duplicate.json<{ schema: string; data: { kind: string } }>()).toMatchObject({
-          schema: "niceeval.show/v1",
-          data: { kind: "leaderboard" },
+          schema: "niceeval.show/v2",
+          data: { kind: "groups" },
         });
       }
 
@@ -271,10 +271,10 @@ export default Object.freeze(report);
       const deliberateErrorRows = [...overview.matchAll(/<summary\b[^>]*>[\s\S]*?<\/summary>/g)]
         .map(([summary]) => summary)
         .filter((summary) => summary.includes("deliberate-error"));
-      expect(deliberateErrorRows, "errored attempt rows must be present in both locale surfaces").toHaveLength(2);
-      for (const row of deliberateErrorRows) {
-        expect(row, "an errored attempt keeps the exact cost of completed agent work").toContain("$0.00002");
-      }
+      expect(
+        deliberateErrorRows,
+        "a named Experiment comparison must not pull main's errored row across the group boundary",
+      ).toHaveLength(0);
       expect(overview, "classic overview must not serialize internal attempt evidence into visible text")
         .not.toContain('{"kind":"attempt"');
       expect(overview, "classic overview must link into attempt detail instances")

--- a/e2e/report/test/report-execution.test.ts
+++ b/e2e/report/test/report-execution.test.ts
@@ -115,9 +115,9 @@ test("标准 React JSX 的 v0.12 作者 fixture 经安装候选构建完整站�
       const projected = await niceeval.run(["show", "--report", "./reports/classic.tsx", "--json"]);
       expect(projected.exitCode, projected.diagnostic()).toBe(0);
       const projectionManifest = projected.json<{
-        readonly schema: "niceeval.report-target-execution/v1";
+        readonly format: "niceeval.report-target-execution/v1";
         readonly projections: {
-          readonly schema: "niceeval.report-projections/v1";
+          readonly format: "niceeval.report-projections/v1";
           readonly pricingProfile: {
             readonly currency: string;
             readonly contentIdentity: string;
@@ -137,8 +137,8 @@ test("标准 React JSX 的 v0.12 作者 fixture 经安装候选构建完整站�
           }[];
         };
       }>();
-      expect(projectionManifest.schema).toBe("niceeval.report-target-execution/v1");
-      expect(projectionManifest.projections.schema).toBe("niceeval.report-projections/v1");
+      expect(projectionManifest.format).toBe("niceeval.report-target-execution/v1");
+      expect(projectionManifest.projections.format).toBe("niceeval.report-projections/v1");
       expect(projectionManifest.projections.pricingProfile).toMatchObject({
         currency: "USD",
         provenance: { source: expect.stringMatching(/^NiceEval vendored models\.dev catalog sha256:[a-f0-9]{64}$/) },
@@ -203,8 +203,8 @@ test("标准 React JSX 的 v0.12 作者 fixture 经安装候选构建完整站�
       for (const module of ["duplicate-standard.mjs", "duplicate-standard.cjs"] as const) {
         const duplicate = await niceeval.run(["show", "--report", `./reports/${module}`, "--json"]);
         expect(duplicate.exitCode, duplicate.diagnostic()).toBe(0);
-        expect(duplicate.json<{ schema: string; data: { kind: string } }>()).toMatchObject({
-          schema: "niceeval.show/v2",
+        expect(duplicate.json<{ format: string; data: { kind: string } }>()).toMatchObject({
+          format: "niceeval.show/v2",
           data: { kind: "groups" },
         });
       }

--- a/e2e/report/test/report-export.test.ts
+++ b/e2e/report/test/report-export.test.ts
@@ -80,19 +80,19 @@ test("view --out 导出完整参数化站点并保护已有目标目录", async 
       const projections = JSON.parse(
         await readFile(join(projectRoot, "site-export", manifest.projections), "utf8"),
       ) as {
-        readonly schema: string;
+        readonly format: string;
         readonly pricingProfile: unknown;
         readonly costs: readonly unknown[];
       };
       expect(projections).toMatchObject({
-        schema: "niceeval.report-projections/v1",
+        format: "niceeval.report-projections/v1",
         pricingProfile: {
           contentIdentity: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
           currency: "USD",
           provenance: { kind: "declared-rate-card" },
         },
       });
-      expect(projections.costs).toHaveLength(3);
+      expect(projections.costs).toHaveLength(1);
       const attemptPages = manifest.pages.filter((page) => page.pageId === "attempt");
       const experimentPages = manifest.pages.filter((page) => page.pageId === "experiment");
       expect(attemptPages, "the declared standard Attempt Page must close every included Slot").toHaveLength(

--- a/e2e/report/test/report-project-current.test.ts
+++ b/e2e/report/test/report-project-current.test.ts
@@ -30,7 +30,7 @@ interface ReportProblem {
 }
 
 interface ShowOverview {
-  readonly schema: "niceeval.show/v1";
+  readonly schema: "niceeval.show/v2";
   readonly locale: "en";
   readonly selection:
     | {
@@ -44,7 +44,12 @@ interface ShowOverview {
         readonly runIds: readonly string[];
       };
   readonly page: { readonly route: string; readonly pageId: string };
-  readonly data: { readonly kind: "leaderboard"; readonly rows: readonly LeaderboardRow[] };
+  readonly data:
+    | { readonly kind: "groups"; readonly groups: readonly unknown[] }
+    | {
+        readonly kind: "experiment-group";
+        readonly comparison: { readonly state: string; readonly rows: readonly LeaderboardRow[] };
+      };
   readonly problems: readonly ReportProblem[];
 }
 
@@ -77,25 +82,26 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
         initialRun.diagnostic(),
       );
 
-      const initialShow = await niceeval.run(["show", "--json"]);
+      const initialShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(initialShow.exitCode, initialShow.diagnostic()).toBe(0);
       const initialDocument = initialShow.json<ShowOverview>();
       expect(initialDocument).toMatchObject({
-        schema: "niceeval.show/v1",
+        schema: "niceeval.show/v2",
         locale: "en",
         selection: {
           kind: "project-current",
-          experimentIds: [...PROJECT_EXPERIMENT_IDS],
+          experimentIds: ["source"],
         },
-        page: { route: "/", pageId: "overview" },
-        data: { kind: "leaderboard" },
+        page: { route: "/group/singleton/source", pageId: "group-singleton" },
+        data: { kind: "experiment-group" },
       });
       expect(
         initialDocument.problems,
         "a completed Eval with no Agent send has known zero usage rather than missing input",
       ).toEqual([]);
-      expect(initialDocument.data.rows).toHaveLength(1);
-      expect(initialDocument.data.rows[0]!.passRate).toMatchObject({
+      if (initialDocument.data.kind !== "experiment-group") throw new Error("expected experiment group");
+      expect(initialDocument.data.comparison.rows).toHaveLength(1);
+      expect(initialDocument.data.comparison.rows[0]!.passRate).toMatchObject({
         state: "available",
         samples: 1,
         total: 1,
@@ -112,12 +118,13 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
         ),
       ).toMatchObject({ event: "start", reused: 1 });
 
-      const accumulatedShow = await niceeval.run(["show", "--json"]);
+      const accumulatedShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(accumulatedShow.exitCode, accumulatedShow.diagnostic()).toBe(0);
       const accumulatedDocument = accumulatedShow.json<ShowOverview>();
       expect(accumulatedDocument.selection).toMatchObject({ kind: "project-current" });
-      expect(accumulatedDocument.data.rows).toHaveLength(1);
-      expect(accumulatedDocument.data.rows[0]!.passRate).toMatchObject({
+      if (accumulatedDocument.data.kind !== "experiment-group") throw new Error("expected experiment group");
+      expect(accumulatedDocument.data.comparison.rows).toHaveLength(1);
+      expect(accumulatedDocument.data.comparison.rows[0]!.passRate).toMatchObject({
         state: "available",
         samples: 2,
         total: 2,
@@ -132,26 +139,30 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
         "utf8",
       );
 
-      const staleShow = await niceeval.run(["show", "--json"]);
+      const staleShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(staleShow.exitCode, staleShow.diagnostic()).toBe(0);
       expect(staleShow.json<ShowOverview>()).toMatchObject({
-        schema: "niceeval.show/v1",
+        schema: "niceeval.show/v2",
         selection: { kind: "project-current" },
-        data: { kind: "leaderboard", rows: [] },
+        data: { kind: "groups", groups: [] },
         problems: [],
       });
 
-      const staleHistory = await niceeval.run(["show", "--run", initialRunId, "--json"]);
+      const staleHistory = await niceeval.run([
+        "show", "--run", initialRunId, "--report", "standard", "--group", "singleton/source", "--json",
+      ]);
       expect(staleHistory.exitCode, staleHistory.diagnostic()).toBe(0);
       expect(staleHistory.json<ShowOverview>()).toMatchObject({
-        schema: "niceeval.show/v1",
+        schema: "niceeval.show/v2",
         selection: {
           kind: "explicit-runs",
           runIds: [initialRunId],
         },
-        data: { kind: "leaderboard" },
+        data: { kind: "experiment-group" },
       });
-      expect(staleHistory.json<ShowOverview>().data.rows[0]!.passRate.state).toBe("available");
+      const historyData = staleHistory.json<ShowOverview>().data;
+      if (historyData.kind !== "experiment-group") throw new Error("expected experiment group");
+      expect(historyData.comparison.rows[0]!.passRate.state).toBe("available");
 
       const changedRun = await niceeval.run(["exp", "source", "--json"]);
       expect(changedRun.exitCode, changedRun.diagnostic()).toBe(0);
@@ -171,14 +182,16 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
         ),
       ).toMatchObject({ event: "eval", evalId: "source-snapshot", verdict: "passed" });
 
-      const refreshedShow = await niceeval.run(["show", "--json"]);
+      const refreshedShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(refreshedShow.exitCode, refreshedShow.diagnostic()).toBe(0);
       expect(refreshedShow.json<ShowOverview>()).toMatchObject({
-        schema: "niceeval.show/v1",
+        schema: "niceeval.show/v2",
         selection: { kind: "project-current" },
-        data: { kind: "leaderboard" },
+        data: { kind: "experiment-group" },
       });
-      expect(refreshedShow.json<ShowOverview>().data.rows[0]!.passRate).toMatchObject({
+      const refreshedData = refreshedShow.json<ShowOverview>().data;
+      if (refreshedData.kind !== "experiment-group") throw new Error("expected experiment group");
+      expect(refreshedData.comparison.rows[0]!.passRate).toMatchObject({
         state: "available",
         samples: 1,
         total: 1,

--- a/e2e/report/test/report-project-current.test.ts
+++ b/e2e/report/test/report-project-current.test.ts
@@ -30,7 +30,7 @@ interface ReportProblem {
 }
 
 interface ShowOverview {
-  readonly schema: "niceeval.show/v2";
+  readonly format: "niceeval.show/v2";
   readonly locale: "en";
   readonly selection:
     | {
@@ -86,7 +86,7 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
       expect(initialShow.exitCode, initialShow.diagnostic()).toBe(0);
       const initialDocument = initialShow.json<ShowOverview>();
       expect(initialDocument).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         locale: "en",
         selection: {
           kind: "project-current",
@@ -142,18 +142,18 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
       const staleShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(staleShow.exitCode, staleShow.diagnostic()).toBe(0);
       expect(staleShow.json<ShowOverview>()).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         selection: { kind: "project-current" },
         data: { kind: "groups", groups: [] },
         problems: [],
       });
 
       const staleHistory = await niceeval.run([
-        "show", "--run", initialRunId, "--report", "standard", "--group", "singleton/source", "--json",
+        "show", "--run", initialRunId, "--report", "standard", "--json",
       ]);
       expect(staleHistory.exitCode, staleHistory.diagnostic()).toBe(0);
       expect(staleHistory.json<ShowOverview>()).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         selection: {
           kind: "explicit-runs",
           runIds: [initialRunId],
@@ -185,7 +185,7 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
       const refreshedShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(refreshedShow.exitCode, refreshedShow.diagnostic()).toBe(0);
       expect(refreshedShow.json<ShowOverview>()).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         selection: { kind: "project-current" },
         data: { kind: "experiment-group" },
       });

--- a/e2e/report/test/report-project-current.test.ts
+++ b/e2e/report/test/report-project-current.test.ts
@@ -30,7 +30,7 @@ interface ReportProblem {
 }
 
 interface ShowOverview {
-  readonly format: "niceeval.show/v2";
+  readonly format: "niceeval.show";
   readonly locale: "en";
   readonly selection:
     | {
@@ -86,7 +86,7 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
       expect(initialShow.exitCode, initialShow.diagnostic()).toBe(0);
       const initialDocument = initialShow.json<ShowOverview>();
       expect(initialDocument).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         locale: "en",
         selection: {
           kind: "project-current",
@@ -142,22 +142,30 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
       const staleShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(staleShow.exitCode, staleShow.diagnostic()).toBe(0);
       expect(staleShow.json<ShowOverview>()).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         selection: { kind: "project-current" },
         data: { kind: "groups", groups: [] },
         problems: [],
       });
 
       const staleHistory = await niceeval.run([
-        "show", "--run", initialRunId, "--report", "standard", "--json",
+        "show",
+        "--run",
+        initialRunId,
+        "--report",
+        "standard",
+        "--page",
+        "/group/singleton/source",
+        "--json",
       ]);
       expect(staleHistory.exitCode, staleHistory.diagnostic()).toBe(0);
       expect(staleHistory.json<ShowOverview>()).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         selection: {
           kind: "explicit-runs",
           runIds: [initialRunId],
         },
+        page: { route: "/group/singleton/source", pageId: "group-singleton" },
         data: { kind: "experiment-group" },
       });
       const historyData = staleHistory.json<ShowOverview>().data;
@@ -185,7 +193,7 @@ test("项目未变时复用结果，Eval 源码变化后重新执行并读回新
       const refreshedShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
       expect(refreshedShow.exitCode, refreshedShow.diagnostic()).toBe(0);
       expect(refreshedShow.json<ShowOverview>()).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         selection: { kind: "project-current" },
         data: { kind: "experiment-group" },
       });

--- a/e2e/report/test/report-show.test.ts
+++ b/e2e/report/test/report-show.test.ts
@@ -31,7 +31,7 @@ interface ReportProjections {
 
 /** The documented built-in machine document (docs/feature/reports/cli.md). */
 interface BuiltInShowDocument {
-  readonly format: "niceeval.show/v1" | "niceeval.show/v2";
+  readonly format: "niceeval.show";
   readonly locale: "en";
   readonly selection:
     | {
@@ -70,6 +70,18 @@ interface BuiltInShowDocument {
         readonly comparison:
           | { readonly state: "comparable"; readonly members: readonly string[]; readonly rows: readonly unknown[] }
           | { readonly state: "non-comparable"; readonly members: readonly string[]; readonly issues: readonly { readonly reason: string }[] };
+      }
+    | {
+        readonly kind: "run-membership";
+        readonly summary: unknown;
+        readonly members: readonly {
+          readonly experiment: string;
+          readonly selectedRun: string;
+          readonly locator: string | null;
+          readonly verdict: string | null;
+        }[];
+        readonly errors: readonly unknown[];
+        readonly evidence: unknown;
       }
     | {
         readonly kind: "attempt";
@@ -153,7 +165,7 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以实�
       expect(singleJson.exitCode, singleJson.diagnostic()).toBe(0);
       const singleDocument = singleJson.json<BuiltInShowDocument>();
       expect(singleDocument).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         locale: "en",
         selection: {
           kind: "project-current",
@@ -182,7 +194,7 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以实�
       expect(indexJson.exitCode, indexJson.diagnostic()).toBe(0);
       const indexDocument = indexJson.json<BuiltInShowDocument>();
       expect(indexDocument).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         page: { route: "/", pageId: "overview" },
         data: {
           kind: "groups",
@@ -204,7 +216,7 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以实�
       const selected = await niceeval.run(["show", "--experiment", "main", "--json"]);
       expect(selected.exitCode, selected.diagnostic()).toBe(0);
       expect(selected.json<BuiltInShowDocument>()).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         page: { route: "/group/singleton/main", pageId: "group-singleton" },
         data: {
           kind: "experiment-group",
@@ -230,7 +242,7 @@ test("show 保留 named identity，并把同组不同 Eval population 闭合为 
       const shown = await niceeval.run(["show", "--experiment", "classic", "--json"]);
       expect(shown.exitCode, shown.diagnostic()).toBe(0);
       expect(shown.json<BuiltInShowDocument>()).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         page: { route: "/group/named/classic", pageId: "group-named" },
         data: {
           kind: "experiment-group",
@@ -263,7 +275,7 @@ test("show 对 immutable Attempt 交付精确 evidence JSON", async () => {
       expect(attempt.exitCode, attempt.diagnostic()).toBe(0);
       const document = attempt.json<BuiltInShowDocument>();
       expect(document).toMatchObject({
-        format: "niceeval.show/v1",
+        format: "niceeval.show",
         locale: "en",
         selection: { kind: "attempt-locator", locator: failed.locator },
         page: { route: "/", pageId: "attempt-overview", title: "Attempt overview" },
@@ -301,23 +313,31 @@ test("show --run 保留 deterministic classic World 的历史 Run 与 Attempt �
       expect(historical.exitCode, historical.diagnostic()).toBe(0);
       const document = historical.json<BuiltInShowDocument>();
       expect(document).toMatchObject({
-        format: "niceeval.show/v2",
+        format: "niceeval.show",
         locale: "en",
         selection: {
           kind: "explicit-runs",
           runIds: [...historyRunIds].sort(),
         },
-        page: { route: "/group/named/classic", pageId: "group-named" },
+        page: { route: "/", pageId: "run-membership" },
         data: {
-          kind: "experiment-group",
-          group: { kind: "named", groupId: "classic", key: "named/classic" },
-          comparison: {
-            state: "comparable",
-            members: ["classic/baseline", "classic/memory-a", "classic/memory-b"],
-          },
+          kind: "run-membership",
+          errors: [],
         },
       });
-      expectCanonicalProblemTable(document.problems, "group-named");
+      if (document.data.kind !== "run-membership") throw new Error("expected run membership");
+      expect(document.data.members.map((member) => member.selectedRun)).toEqual(
+        expect.arrayContaining(historyRunIds),
+      );
+      expect(document.data.members.map((member) => member.experiment)).toEqual(
+        expect.arrayContaining(["classic/baseline", "classic/memory-a", "classic/memory-b"]),
+      );
+      const includedMembers = document.data.members.filter((member) => member.locator !== null);
+      expect(includedMembers.map((member) => member.selectedRun)).toEqual(
+        expect.arrayContaining(historyRunIds),
+      );
+      expect(includedMembers.every((member) => member.verdict !== null)).toBe(true);
+      expectCanonicalProblemTable(document.problems, "run-membership");
       expectBuiltInPricingProfile(document.projections);
       expect(document.projections.costs).toEqual([]);
     },

--- a/e2e/report/test/report-show.test.ts
+++ b/e2e/report/test/report-show.test.ts
@@ -31,7 +31,7 @@ interface ReportProjections {
 
 /** The documented built-in machine document (docs/feature/reports/cli.md). */
 interface BuiltInShowDocument {
-  readonly schema: "niceeval.show/v1";
+  readonly schema: "niceeval.show/v2";
   readonly locale: "en";
   readonly selection:
     | {
@@ -52,7 +52,25 @@ interface BuiltInShowDocument {
   readonly report: { readonly token: string; readonly identity: string };
   readonly page: { readonly route: string; readonly pageId: string; readonly title: string | Record<string, string> };
   readonly data:
-    | { readonly kind: "leaderboard"; readonly rows: readonly unknown[] }
+    | {
+        readonly kind: "groups";
+        readonly groups: readonly {
+          readonly group:
+            | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
+            | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
+          readonly members: readonly string[];
+          readonly href: string;
+        }[];
+      }
+    | {
+        readonly kind: "experiment-group";
+        readonly group:
+          | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
+          | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
+        readonly comparison:
+          | { readonly state: "comparable"; readonly members: readonly string[]; readonly rows: readonly unknown[] }
+          | { readonly state: "non-comparable"; readonly members: readonly string[]; readonly issues: readonly { readonly reason: string }[] };
+      }
     | {
         readonly kind: "attempt";
         readonly evidence: unknown;
@@ -110,7 +128,7 @@ function expectBuiltInPricingProfile(projections: ReportProjections): void {
   });
 }
 
-test("show 将固定 execution 的文本和单目标机器文档交付给调用方", async () => {
+test("show 对单组默认直达 comparison，对多组默认列索引并以 --group 精确读取", async () => {
   await reportE2E.case(
     "show-overview",
     { artifacts: reportCaseArtifacts() },
@@ -126,37 +144,109 @@ test("show 将固定 execution 的文本和单目标机器文档交付给调用�
         ["tool-call", "passed"],
       ]);
 
-      const text = await niceeval.run(["show"]);
+      const text = await niceeval.run(["show", "--experiment", "main"]);
       expect(text.exitCode, text.diagnostic()).toBe(0);
-      expect(text.stdout).toContain("NiceEval overview");
+      expect(text.stdout).toContain("Experiment comparison");
       expect(text.stdout).toContain("main");
 
-      const json = await niceeval.run(["show", "--json"]);
-      expect(json.exitCode, json.diagnostic()).toBe(0);
-      const document = json.json<BuiltInShowDocument>();
-      expect(document).toMatchObject({
-        schema: "niceeval.show/v1",
+      const singleJson = await niceeval.run(["show", "--experiment", "main", "--json"]);
+      expect(singleJson.exitCode, singleJson.diagnostic()).toBe(0);
+      const singleDocument = singleJson.json<BuiltInShowDocument>();
+      expect(singleDocument).toMatchObject({
+        schema: "niceeval.show/v2",
         locale: "en",
         selection: {
           kind: "project-current",
-          experimentIds: ["classic/baseline", "classic/memory-a", "classic/memory-b", "main", "source"],
+          experimentIds: ["main"],
         },
-        page: { route: "/", pageId: "overview" },
+        page: { route: "/group/singleton/main", pageId: "group-singleton" },
+        data: {
+          kind: "experiment-group",
+          group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
+          comparison: { state: "comparable", members: ["main"] },
+        },
       });
-      expectCanonicalProblemTable(document.problems, "overview");
-      expect(document.selection.sampleIdentity).toEqual(expect.any(String));
-      expect(document.report.token).toEqual(expect.any(String));
-      expect(document.report.identity).toEqual(expect.any(String));
-      expect(document.data.kind).toBe("leaderboard");
-      if (document.data.kind !== "leaderboard") throw new Error("Expected leaderboard data");
-      const mainRow = only(
-        document.data.rows as readonly Record<string, unknown>[],
-        (row) => row.experiment === "main",
-        JSON.stringify(document.data),
-      );
-      expect(mainRow).toMatchObject({ evaluationKind: "mixed", totalScore: 7, passRate: null });
-      expectBuiltInPricingProfile(document.projections);
-      expect(document.projections.costs).toEqual([]);
+      expectCanonicalProblemTable(singleDocument.problems, "group-singleton");
+      expectBuiltInPricingProfile(singleDocument.projections);
+
+      const sourceRun = await niceeval.run(["exp", "source", "--rerun", "all", "--json"]);
+      expect(sourceRun.exitCode, sourceRun.diagnostic()).toBe(0);
+
+      const indexText = await niceeval.run(["show"]);
+      expect(indexText.exitCode, indexText.diagnostic()).toBe(0);
+      expect(indexText.stdout).toContain("niceeval show --group 'singleton/main'");
+      expect(indexText.stdout).toContain("niceeval show --group 'singleton/source'");
+      expect(indexText.stdout).not.toContain("Experiment comparison");
+
+      const indexJson = await niceeval.run(["show", "--json"]);
+      expect(indexJson.exitCode, indexJson.diagnostic()).toBe(0);
+      const indexDocument = indexJson.json<BuiltInShowDocument>();
+      expect(indexDocument).toMatchObject({
+        schema: "niceeval.show/v2",
+        page: { route: "/", pageId: "overview" },
+        data: {
+          kind: "groups",
+          groups: [
+            {
+              group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
+              members: ["main"],
+              href: "/group/singleton/main",
+            },
+            {
+              group: { kind: "singleton", experimentId: "source", key: "singleton/source" },
+              members: ["source"],
+              href: "/group/singleton/source",
+            },
+          ],
+        },
+      });
+
+      const selected = await niceeval.run(["show", "--group", "singleton/main", "--json"]);
+      expect(selected.exitCode, selected.diagnostic()).toBe(0);
+      expect(selected.json<BuiltInShowDocument>()).toMatchObject({
+        schema: "niceeval.show/v2",
+        page: { route: "/group/singleton/main", pageId: "group-singleton" },
+        data: {
+          kind: "experiment-group",
+          group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
+          comparison: { state: "comparable", members: ["main"] },
+        },
+      });
+
+      const narrowed = await niceeval.run([
+        "show", "--experiment", "main", "--group", "singleton/source", "--json",
+      ]);
+      expect(narrowed.exitCode, narrowed.diagnostic()).not.toBe(0);
+      expect(narrowed.stderr).toContain("report-group-not-in-sample");
+    },
+  );
+});
+
+test("show 保留 named identity，并把同组不同 Eval population 闭合为 non-comparable", async () => {
+  await reportE2E.case(
+    "show-named-group-comparison",
+    { artifacts: reportCaseArtifacts() },
+    async ({ commands: { niceeval } }) => {
+      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/incompatible"] as const) {
+        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
+        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
+      }
+
+      const shown = await niceeval.run(["show", "--group", "named/classic", "--json"]);
+      expect(shown.exitCode, shown.diagnostic()).toBe(0);
+      expect(shown.json<BuiltInShowDocument>()).toMatchObject({
+        schema: "niceeval.show/v2",
+        page: { route: "/group/named/classic", pageId: "group-named" },
+        data: {
+          kind: "experiment-group",
+          group: { kind: "named", groupId: "classic", key: "named/classic" },
+          comparison: {
+            state: "non-comparable",
+            members: ["classic/baseline", "classic/incompatible", "classic/memory-a"],
+            issues: [{ reason: "eval-population-mismatch" }],
+          },
+        },
+      });
     },
   );
 });
@@ -178,7 +268,7 @@ test("show 对 immutable Attempt 交付精确 evidence JSON", async () => {
       expect(attempt.exitCode, attempt.diagnostic()).toBe(0);
       const document = attempt.json<BuiltInShowDocument>();
       expect(document).toMatchObject({
-        schema: "niceeval.show/v1",
+        schema: "niceeval.show/v2",
         locale: "en",
         selection: { kind: "attempt-locator", locator: failed.locator },
         page: { route: "/", pageId: "attempt-overview", title: "Attempt overview" },
@@ -216,7 +306,7 @@ test("show --run 保留 deterministic classic World 的历史 Run 与 Attempt �
       expect(historical.exitCode, historical.diagnostic()).toBe(0);
       const document = historical.json<BuiltInShowDocument>();
       expect(document).toMatchObject({
-        schema: "niceeval.show/v1",
+        schema: "niceeval.show/v2",
         locale: "en",
         selection: {
           kind: "explicit-runs",
@@ -241,7 +331,7 @@ test("show 在 pipe 与真实 PTY 中保留独立、可读的公开文本", asyn
 
       const piped = await niceeval.run(["show"]);
       expect(piped.exitCode, piped.diagnostic()).toBe(0);
-      expect(piped.stdout).toContain("NiceEval overview");
+      expect(piped.stdout).toContain("Experiment comparison");
       expect(piped.stdout).toContain("main");
       expect(piped.stdout).not.toMatch(/[╭╮╰╯├┤]/u);
 
@@ -257,7 +347,7 @@ test("show 在 pipe 与真实 PTY 中保留独立、可读的公开文本", asyn
       );
       expect(terminal.exitCode, terminal.diagnostic()).toBe(0);
       const visible = stripVTControlCharacters(terminal.stdout);
-      expect(visible).toContain("NiceEval overview");
+      expect(visible).toContain("Experiment comparison");
       expect(visible).toContain("main");
       expect(visible).toMatch(/^╭.*╮$/mu);
       expect(visible).toMatch(/^╰.*╯$/mu);
@@ -290,7 +380,7 @@ test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execu
       expect(shown.stdout).toContain("Diff detail");
       const unwrapped = shown.stdout.replace(/\s+/gu, " ");
       expect(unwrapped).toContain("Total known cost");
-      expect(unwrapped).toContain("costUSD");
+      expect(unwrapped).toContain("experiment main source");
 
       const json = await niceeval.run(
         ["show", "--report", "./reports/site.tsx", "--json"],
@@ -303,7 +393,14 @@ test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execu
         locale: "en",
         selection: {
           kind: "project-current",
-          experimentIds: ["classic/baseline", "classic/memory-a", "classic/memory-b", "main", "source"],
+          experimentIds: [
+            "classic/baseline",
+            "classic/incompatible",
+            "classic/memory-a",
+            "classic/memory-b",
+            "main",
+            "source",
+          ],
         },
         report: { title: "Report fixture" },
         page: {
@@ -318,10 +415,8 @@ test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execu
       expect(manifest.report.identity).toEqual(expect.any(String));
       expect(manifest.selection.sampleIdentity).toEqual(expect.any(String));
       expectBuiltInPricingProfile(manifest.projections);
-      expect(manifest.projections.costs).toHaveLength(3);
+      expect(manifest.projections.costs).toHaveLength(1);
       expect(manifest.projections.costs.map((entry) => entry.page)).toEqual([
-        { pageId: "overview", route: "/" },
-        { pageId: "overview", route: "/" },
         { pageId: "overview", route: "/" },
       ]);
     },

--- a/e2e/report/test/report-show.test.ts
+++ b/e2e/report/test/report-show.test.ts
@@ -18,7 +18,7 @@ interface ReportProblem {
 }
 
 interface ReportProjections {
-  readonly schema: "niceeval.report-projections/v1";
+  readonly format: "niceeval.report-projections/v1";
   readonly pricingProfile: Record<string, unknown> | null;
   readonly costs: readonly {
     readonly page: { readonly pageId: string; readonly route: string };
@@ -31,7 +31,7 @@ interface ReportProjections {
 
 /** The documented built-in machine document (docs/feature/reports/cli.md). */
 interface BuiltInShowDocument {
-  readonly schema: "niceeval.show/v2";
+  readonly format: "niceeval.show/v1" | "niceeval.show/v2";
   readonly locale: "en";
   readonly selection:
     | {
@@ -83,7 +83,7 @@ interface BuiltInShowDocument {
 
 /** The documented custom single-target manifest (docs/feature/reports/cli.md). */
 interface CustomTargetExecutionManifest {
-  readonly schema: "niceeval.report-target-execution/v1";
+  readonly format: "niceeval.report-target-execution/v1";
   readonly locale: "en";
   readonly selection: { readonly kind: "project-current"; readonly sampleIdentity: string; readonly experimentIds: readonly string[] };
   readonly report: { readonly identity: string; readonly title: string | Record<string, string> };
@@ -119,7 +119,7 @@ function expectCanonicalProblemTable(problems: readonly ReportProblem[], pageId:
 
 function expectBuiltInPricingProfile(projections: ReportProjections): void {
   expect(projections).toMatchObject({
-    schema: "niceeval.report-projections/v1",
+    format: "niceeval.report-projections/v1",
     pricingProfile: {
       contentIdentity: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
       currency: "USD",
@@ -128,7 +128,7 @@ function expectBuiltInPricingProfile(projections: ReportProjections): void {
   });
 }
 
-test("show 对单组默认直达 comparison，对多组默认列索引并以 --group 精确读取", async () => {
+test("show 对单组默认直达 comparison，对多组默认列索引并以实验选择精确读取", async () => {
   await reportE2E.case(
     "show-overview",
     { artifacts: reportCaseArtifacts() },
@@ -153,7 +153,7 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以 --g
       expect(singleJson.exitCode, singleJson.diagnostic()).toBe(0);
       const singleDocument = singleJson.json<BuiltInShowDocument>();
       expect(singleDocument).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         locale: "en",
         selection: {
           kind: "project-current",
@@ -174,15 +174,15 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以 --g
 
       const indexText = await niceeval.run(["show"]);
       expect(indexText.exitCode, indexText.diagnostic()).toBe(0);
-      expect(indexText.stdout).toContain("niceeval show --group 'singleton/main'");
-      expect(indexText.stdout).toContain("niceeval show --group 'singleton/source'");
+      expect(indexText.stdout).toContain("niceeval show --experiment 'main'");
+      expect(indexText.stdout).toContain("niceeval show --experiment 'source'");
       expect(indexText.stdout).not.toContain("Experiment comparison");
 
       const indexJson = await niceeval.run(["show", "--json"]);
       expect(indexJson.exitCode, indexJson.diagnostic()).toBe(0);
       const indexDocument = indexJson.json<BuiltInShowDocument>();
       expect(indexDocument).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         page: { route: "/", pageId: "overview" },
         data: {
           kind: "groups",
@@ -201,10 +201,10 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以 --g
         },
       });
 
-      const selected = await niceeval.run(["show", "--group", "singleton/main", "--json"]);
+      const selected = await niceeval.run(["show", "--experiment", "main", "--json"]);
       expect(selected.exitCode, selected.diagnostic()).toBe(0);
       expect(selected.json<BuiltInShowDocument>()).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         page: { route: "/group/singleton/main", pageId: "group-singleton" },
         data: {
           kind: "experiment-group",
@@ -213,11 +213,6 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以 --g
         },
       });
 
-      const narrowed = await niceeval.run([
-        "show", "--experiment", "main", "--group", "singleton/source", "--json",
-      ]);
-      expect(narrowed.exitCode, narrowed.diagnostic()).not.toBe(0);
-      expect(narrowed.stderr).toContain("report-group-not-in-sample");
     },
   );
 });
@@ -232,10 +227,10 @@ test("show 保留 named identity，并把同组不同 Eval population 闭合为 
         expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
       }
 
-      const shown = await niceeval.run(["show", "--group", "named/classic", "--json"]);
+      const shown = await niceeval.run(["show", "--experiment", "classic", "--json"]);
       expect(shown.exitCode, shown.diagnostic()).toBe(0);
       expect(shown.json<BuiltInShowDocument>()).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         page: { route: "/group/named/classic", pageId: "group-named" },
         data: {
           kind: "experiment-group",
@@ -268,7 +263,7 @@ test("show 对 immutable Attempt 交付精确 evidence JSON", async () => {
       expect(attempt.exitCode, attempt.diagnostic()).toBe(0);
       const document = attempt.json<BuiltInShowDocument>();
       expect(document).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v1",
         locale: "en",
         selection: { kind: "attempt-locator", locator: failed.locator },
         page: { route: "/", pageId: "attempt-overview", title: "Attempt overview" },
@@ -306,7 +301,7 @@ test("show --run 保留 deterministic classic World 的历史 Run 与 Attempt �
       expect(historical.exitCode, historical.diagnostic()).toBe(0);
       const document = historical.json<BuiltInShowDocument>();
       expect(document).toMatchObject({
-        schema: "niceeval.show/v2",
+        format: "niceeval.show/v2",
         locale: "en",
         selection: {
           kind: "explicit-runs",
@@ -389,7 +384,7 @@ test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execu
       expect(json.exitCode, json.diagnostic()).toBe(0);
       const manifest = json.json<CustomTargetExecutionManifest>();
       expect(manifest).toMatchObject({
-        schema: "niceeval.report-target-execution/v1",
+        format: "niceeval.report-target-execution/v1",
         locale: "en",
         selection: {
           kind: "project-current",
@@ -449,7 +444,7 @@ test("参数化 show 按规范 key 读取详情页，并对非成员 key 返回�
       expect(detail.exitCode, detail.diagnostic()).toBe(0);
       const detailManifest = detail.json<CustomTargetExecutionManifest>();
       expect(detailManifest).toMatchObject({
-        schema: "niceeval.report-target-execution/v1",
+        format: "niceeval.report-target-execution/v1",
         page: {
           route: `/slot/${slotKey}`,
           pageId: "slot",

--- a/e2e/report/test/report-show.test.ts
+++ b/e2e/report/test/report-show.test.ts
@@ -307,9 +307,17 @@ test("show --run 保留 deterministic classic World 的历史 Run 与 Attempt �
           kind: "explicit-runs",
           runIds: [...historyRunIds].sort(),
         },
-        page: { route: "/", pageId: "run-membership" },
+        page: { route: "/group/named/classic", pageId: "group-named" },
+        data: {
+          kind: "experiment-group",
+          group: { kind: "named", groupId: "classic", key: "named/classic" },
+          comparison: {
+            state: "comparable",
+            members: ["classic/baseline", "classic/memory-a", "classic/memory-b"],
+          },
+        },
       });
-      expectCanonicalProblemTable(document.problems, "run-membership");
+      expectCanonicalProblemTable(document.problems, "group-named");
       expectBuiltInPricingProfile(document.projections);
       expect(document.projections.costs).toEqual([]);
     },

--- a/e2e/report/test/report-source.test.ts
+++ b/e2e/report/test/report-source.test.ts
@@ -14,7 +14,7 @@ interface ExpEvent {
 }
 
 interface SourceShowManifest {
-  readonly schema: "niceeval.report-target-execution/v1";
+  readonly format: "niceeval.report-target-execution/v1";
   readonly locale: "en";
   readonly page: {
     readonly route: string;
@@ -76,7 +76,7 @@ test("选中的 Source Page 从本轮 Record 呈现入口与导入断言快照",
       expect(json.stdout).not.toContain("sources.json");
       const document = json.json<SourceShowManifest>();
       expect(document).toMatchObject({
-        schema: "niceeval.report-target-execution/v1",
+        format: "niceeval.report-target-execution/v1",
         locale: "en",
         page: {
           route: "/source",

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -235,7 +235,7 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
 
         // A fixed Sample with one named Experiment Group goes straight to its
         // comparison and does not waste Header space on a one-option selector.
-        await expect(page.getByRole("navigation", { name: "Experiment groups" })).toHaveCount(0);
+        await expect(page.getByRole("navigation", { name: "Experiments" })).toHaveCount(0);
 
         const passChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
         await expect(passChart).toHaveCount(1);
@@ -247,7 +247,7 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
 
         const mixedRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
         expect(mixedRun.expReceipt(), mixedRun.diagnostic()).toMatchObject({ completion: "completed" });
-        const groupNavigation = page.getByRole("navigation", { name: "Experiment groups" });
+        const groupNavigation = page.getByRole("navigation", { name: "Experiments" });
         await expect(groupNavigation).toBeVisible({ timeout: 15_000 });
         const classicGroup = groupNavigation.getByRole("link", { name: "classic" });
         const mainGroup = groupNavigation.getByRole("link", { name: "main" });
@@ -265,7 +265,7 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         try {
           const staticPage = await offline.newPage();
           await staticPage.goto(pathToFileURL(join(projectRoot, "group-static", "index.html")).href);
-          const staticGroups = staticPage.getByRole("navigation", { name: "Experiment groups" });
+          const staticGroups = staticPage.getByRole("navigation", { name: "Experiments" });
           await expect(staticGroups.getByRole("link", { name: "classic" }))
             .toHaveAttribute("href", "group/named/classic/index.html");
           await staticGroups.getByRole("link", { name: "classic" }).click();

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -204,14 +204,11 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
   await reportE2E.case(
     "browser-default-classic-surface",
     { artifacts: reportCaseArtifacts() },
-    async ({ commands: { niceeval } }) => {
+    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
       for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/memory-b"] as const) {
         const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
         expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
       }
-      const mixedRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
-      expect(mixedRun.expReceipt(), mixedRun.diagnostic()).toMatchObject({ completion: "completed" });
-
       const view = niceeval.start(
         [
           "view",
@@ -236,15 +233,49 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         await page.goto(origin!);
         await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
 
+        // A fixed Sample with one named Experiment Group goes straight to its
+        // comparison and does not waste Header space on a one-option selector.
+        await expect(page.getByRole("navigation", { name: "Experiment groups" })).toHaveCount(0);
+
         const passChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
         await expect(passChart).toHaveCount(1);
         await expect(passChart).toContainText("classic/memory-a");
         await expect(passChart).toContainText("100%");
         await expect(passChart).not.toContainText("ratio");
         const scoreChart = page.locator('svg[aria-label="costUSD × totalScore"]').filter({ visible: true });
-        await expect(scoreChart).toHaveCount(1);
-        await expect(scoreChart).toContainText("main");
+        await expect(scoreChart).toHaveCount(0);
 
+        const mixedRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
+        expect(mixedRun.expReceipt(), mixedRun.diagnostic()).toMatchObject({ completion: "completed" });
+        const groupNavigation = page.getByRole("navigation", { name: "Experiment groups" });
+        await expect(groupNavigation).toBeVisible({ timeout: 15_000 });
+        const classicGroup = groupNavigation.getByRole("link", { name: "classic" });
+        const mainGroup = groupNavigation.getByRole("link", { name: "main" });
+        await expect(classicGroup).toHaveAttribute("href", "group/named/classic/index.html");
+        await expect(mainGroup).toHaveAttribute("href", "group/singleton/main/index.html");
+        await classicGroup.click();
+        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
+        const selectedGroupChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
+        await expect(selectedGroupChart).toContainText("classic/memory-a");
+        await expect(selectedGroupChart).not.toContainText("main");
+
+        const exported = await niceeval.run(["view", "--out", "group-static", "--no-open"]);
+        expect(exported.exitCode, exported.diagnostic()).toBe(0);
+        const offline = await browser.newContext({ javaScriptEnabled: false });
+        try {
+          const staticPage = await offline.newPage();
+          await staticPage.goto(pathToFileURL(join(projectRoot, "group-static", "index.html")).href);
+          const staticGroups = staticPage.getByRole("navigation", { name: "Experiment groups" });
+          await expect(staticGroups.getByRole("link", { name: "classic" }))
+            .toHaveAttribute("href", "group/named/classic/index.html");
+          await staticGroups.getByRole("link", { name: "classic" }).click();
+          await expect(staticPage).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
+          const staticGroupChart = staticPage.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
+          await expect(staticGroupChart).toContainText("classic/memory-a");
+          await expect(staticGroupChart).not.toContainText("main");
+        } finally {
+          await offline.close();
+        }
         const filter = page.getByRole("searchbox").filter({ visible: true });
         await expect(filter).toHaveCount(1);
         await expect(filter).toBeVisible();
@@ -381,7 +412,7 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         await expect(page.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
         await expect(page.getByText(/^source · execution · timing(?: · diff)?$/).filter({ visible: true })).toBeVisible();
 
-        await page.goto(origin!);
+        await page.goto(new URL("group/named/classic/index.html", origin!).href);
         const scatter = page.getByRole("img", { name: "costUSD × passRate" }).filter({ visible: true });
         await expect(scatter).toHaveCount(1);
         await expect(scatter).toContainText("classic/memory-a");

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -235,7 +235,7 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
 
         // A fixed Sample with one named Experiment Group goes straight to its
         // comparison and does not waste Header space on a one-option selector.
-        await expect(page.getByRole("navigation", { name: "Experiments" })).toHaveCount(0);
+        await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);
 
         const passChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
         await expect(passChart).toHaveCount(1);
@@ -247,13 +247,26 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
 
         const mixedRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
         expect(mixedRun.expReceipt(), mixedRun.diagnostic()).toMatchObject({ completion: "completed" });
-        const groupNavigation = page.getByRole("navigation", { name: "Experiments" });
-        await expect(groupNavigation).toBeVisible({ timeout: 15_000 });
-        const classicGroup = groupNavigation.getByRole("link", { name: "classic" });
-        const mainGroup = groupNavigation.getByRole("link", { name: "main" });
-        await expect(classicGroup).toHaveAttribute("href", "group/named/classic/index.html");
-        await expect(mainGroup).toHaveAttribute("href", "group/singleton/main/index.html");
-        await classicGroup.click();
+        const experimentSelector = page.getByRole("combobox", { name: "Experiments" });
+        await expect(experimentSelector).toBeVisible({ timeout: 15_000 });
+        await expect(experimentSelector.getByRole("option")).toHaveText(["classic", "main"]);
+        await expect(experimentSelector.locator("option:checked")).toHaveText("classic");
+
+        // Opening the site root never exposes an unselected project-wide
+        // overview: the first stable Experiment Group is the current value.
+        await page.goto(origin!);
+        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
+        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
+        const classicExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
+        await expect(classicExperimentCount.locator(".niceeval-stat-value")).toHaveText("3");
+
+        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "main" });
+        await expect(page).toHaveURL(new RegExp("/group/singleton/main/index\\.html$"));
+        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
+        const mainExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
+        await expect(mainExperimentCount.locator(".niceeval-stat-value")).toHaveText("1");
+
+        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "classic" });
         await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
         const selectedGroupChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
         await expect(selectedGroupChart).toContainText("classic/memory-a");
@@ -416,12 +429,19 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         const scatter = page.getByRole("img", { name: "costUSD × passRate" }).filter({ visible: true });
         await expect(scatter).toHaveCount(1);
         await expect(scatter).toContainText("classic/memory-a");
-        const zhButton = page.getByRole("button", { name: "中文" }).filter({ visible: true });
-        await expect(zhButton).toHaveCount(1);
-        await expect(zhButton).toBeVisible();
-        await zhButton.click();
+        const pageRouter = page.getByRole("navigation", { name: "Report pages" });
+        const pageRouterBox = await pageRouter.boundingBox();
+        const viewport = page.viewportSize();
+        expect(pageRouterBox, "the whole Page router must have a visible layout box").not.toBeNull();
+        expect(viewport, "the browser fixture must expose its viewport").not.toBeNull();
+        expect(Math.abs(pageRouterBox!.x + pageRouterBox!.width / 2 - viewport!.width / 2))
+          .toBeLessThanOrEqual(1);
+        const languageSelector = page.getByRole("combobox", { name: "Language" });
+        await expect(languageSelector).toBeVisible();
+        await expect(languageSelector.getByRole("option")).toHaveText(["EN", "中文"]);
+        await languageSelector.selectOption("zh-CN");
         await expect(page.getByText("总览", { exact: true })).toBeVisible();
-        await expect(zhButton).toHaveAttribute("aria-pressed", "true");
+        await expect(languageSelector).toHaveValue("zh-CN");
       } finally {
         await page.close();
       }

--- a/e2e/runner/test/accept-reanchor.test.ts
+++ b/e2e/runner/test/accept-reanchor.test.ts
@@ -37,7 +37,7 @@ interface DryPlan {
 }
 
 interface ExperimentGroupShow {
-  format: "niceeval.show/v2";
+  format: "niceeval.show";
   selection:
     | { kind: "explicit-runs"; sampleIdentity: string; runIds: readonly string[] }
     | { kind: "project-current"; sampleIdentity: string; experimentIds: readonly string[] };
@@ -124,12 +124,14 @@ test("审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 ver
       acceptedRunId,
       "--report",
       "standard",
+      "--page",
+      "/group/singleton/accept",
       "--json",
     ]);
     expect(acceptedCurrent.exitCode, acceptedCurrent.diagnostic()).toBe(0);
     const acceptedShow = acceptedCurrent.json<ExperimentGroupShow>();
     expect(acceptedShow).toMatchObject({
-      format: "niceeval.show/v2",
+      format: "niceeval.show",
       selection: { kind: "explicit-runs", runIds: [acceptedRunId] },
       data: {
         kind: "experiment-group",
@@ -152,7 +154,7 @@ test("审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 ver
     expect(projectCurrent.exitCode, projectCurrent.diagnostic()).toBe(0);
     const projectCurrentShow = projectCurrent.json<ExperimentGroupShow>();
     expect(projectCurrentShow).toMatchObject({
-      format: "niceeval.show/v2",
+      format: "niceeval.show",
       selection: { kind: "project-current" },
       data: {
         kind: "experiment-group",

--- a/e2e/runner/test/accept-reanchor.test.ts
+++ b/e2e/runner/test/accept-reanchor.test.ts
@@ -36,23 +36,26 @@ interface DryPlan {
   matrix: DryTarget[];
 }
 
-interface LeaderboardShow {
-  schema: "niceeval.show/v1";
+interface ExperimentGroupShow {
+  format: "niceeval.show/v2";
   selection:
     | { kind: "explicit-runs"; sampleIdentity: string; runIds: readonly string[] }
     | { kind: "project-current"; sampleIdentity: string; experimentIds: readonly string[] };
   data: {
-    kind: "leaderboard";
-    rows: readonly {
-      experiment: string;
-      passRate: {
-        state: string;
-        value: number | null;
-        samples: number;
-        total: number;
-        refs: readonly { identity: { kind: "attempt"; locator: string } }[];
-      };
-    }[];
+    kind: "experiment-group";
+    comparison: {
+      state: "comparable";
+      rows: readonly {
+        experiment: string;
+        passRate: {
+          state: string;
+          value: number | null;
+          samples: number;
+          total: number;
+          refs: readonly { identity: { kind: "attempt"; locator: string } }[];
+        };
+      }[];
+    };
   };
 }
 
@@ -115,41 +118,54 @@ test("审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 ver
     // the immutable source Attempt identity instead of manufacturing an Attempt.
     expect(newLocator).toBe(oldLocator);
 
-    const acceptedCurrent = await niceeval.run(["show", "--run", acceptedRunId, "--json"]);
+    const acceptedCurrent = await niceeval.run([
+      "show",
+      "--run",
+      acceptedRunId,
+      "--report",
+      "standard",
+      "--json",
+    ]);
     expect(acceptedCurrent.exitCode, acceptedCurrent.diagnostic()).toBe(0);
-    const acceptedShow = acceptedCurrent.json<LeaderboardShow>();
+    const acceptedShow = acceptedCurrent.json<ExperimentGroupShow>();
     expect(acceptedShow).toMatchObject({
-      schema: "niceeval.show/v1",
+      format: "niceeval.show/v2",
       selection: { kind: "explicit-runs", runIds: [acceptedRunId] },
       data: {
-        kind: "leaderboard",
-        rows: [{
-          experiment: "accept",
-          passRate: { state: "available", value: 1, samples: 1, total: 1 },
-        }],
+        kind: "experiment-group",
+        comparison: {
+          state: "comparable",
+          rows: [{
+            experiment: "accept",
+            passRate: { state: "available", value: 1, samples: 1, total: 1 },
+          }],
+        },
       },
     });
-    expect(acceptedShow.data.rows[0]!.passRate.refs).toEqual([
+    expect(acceptedShow.data.comparison.rows[0]!.passRate.refs).toEqual([
       { identity: { kind: "attempt", locator: oldLocator } },
     ]);
 
     // Explicit --run proves the durable reference, while the default read proves
     // accept used the same current target identity as project-current planning.
-    const projectCurrent = await niceeval.run(["show", "--json"]);
+    const projectCurrent = await niceeval.run(["show", "--experiment", "accept", "--json"]);
     expect(projectCurrent.exitCode, projectCurrent.diagnostic()).toBe(0);
-    const projectCurrentShow = projectCurrent.json<LeaderboardShow>();
+    const projectCurrentShow = projectCurrent.json<ExperimentGroupShow>();
     expect(projectCurrentShow).toMatchObject({
-      schema: "niceeval.show/v1",
+      format: "niceeval.show/v2",
       selection: { kind: "project-current" },
       data: {
-        kind: "leaderboard",
-        rows: [{
-          experiment: "accept",
-          passRate: { state: "available", value: 1, samples: 1, total: 1 },
-        }],
+        kind: "experiment-group",
+        comparison: {
+          state: "comparable",
+          rows: [{
+            experiment: "accept",
+            passRate: { state: "available", value: 1, samples: 1, total: 1 },
+          }],
+        },
       },
     });
-    expect(projectCurrentShow.data.rows[0]!.passRate.refs).toEqual([
+    expect(projectCurrentShow.data.comparison.rows[0]!.passRate.refs).toEqual([
       { identity: { kind: "attempt", locator: oldLocator } },
     ]);
 

--- a/e2e/runner/test/shared-state-lifecycle.scenarios.ts
+++ b/e2e/runner/test/shared-state-lifecycle.scenarios.ts
@@ -20,6 +20,8 @@ async function appearsWithin(path: string, timeoutMs: number, label: string): Pr
   ).then(() => true).catch(() => false);
 }
 
+const REUSABLE_SANDBOX_READY_TIMEOUT_MS = 60_000;
+
 function ownerTokenFromPublicRecoveryInspection(stderr: string): string {
   const match = stderr.match(/owner token:\s*(\S+)/u);
   expect(match, stderr).not.toBeNull();
@@ -94,7 +96,11 @@ test("复用的同一物理 Sandbox 完成 Sandbox lifecycle/finalizer scope 和
               const secondAttempt = join(barrierRoot, "pool-first-attempt-2");
               return await exists(firstAttempt) && await exists(secondAttempt) ? true : undefined;
             },
-            { timeoutMs: 45_000, intervalMs: 20, label: "two attempts use the reusable Sandbox" },
+            {
+              timeoutMs: REUSABLE_SANDBOX_READY_TIMEOUT_MS,
+              intervalMs: 20,
+              label: "two attempts use the reusable Sandbox",
+            },
           );
           const [firstSandbox, secondSandbox] = await Promise.all([
             (await import("node:fs/promises")).readFile(join(barrierRoot, "pool-first-attempt-1"), "utf8"),
@@ -105,7 +111,11 @@ test("复用的同一物理 Sandbox 完成 Sandbox lifecycle/finalizer scope 和
 
           await pollUntil(
             async () => (await exists(join(barrierRoot, "sandbox-lifecycle-scope-started"))) || undefined,
-            { timeoutMs: 45_000, intervalMs: 20, label: "Sandbox lifecycle/finalizer scope starts after the last Attempt" },
+            {
+              timeoutMs: REUSABLE_SANDBOX_READY_TIMEOUT_MS,
+              intervalMs: 20,
+              label: "Sandbox lifecycle/finalizer scope starts after the last Attempt",
+            },
           );
           second = niceeval.start(["exp", "shared-state-pool-second", "--rerun", "all", "--json"], {
             env: {

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -34,5 +34,8 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "npm:@typescript/typescript6@6.0.2"
+  },
+  "dependencies": {
+    "effect": "3.22.1"
   }
 }

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -4,6 +4,7 @@ export * from "./live-exp-retry.js";
 export * from "./process-lifecycle.js";
 export * from "./show-timing.js";
 export * from "./show-attempt-diagnostics.js";
+export * from "./show-schema.js";
 export * from "./primitives.js";
 export * from "./temp.js";
 export * from "./project-copy.js";

--- a/packages/testkit/src/show-attempt-diagnostics.ts
+++ b/packages/testkit/src/show-attempt-diagnostics.ts
@@ -35,8 +35,8 @@ function string(value: unknown, path: string, receipt: ProcessReceipt): string {
 /** Strictly read stable diagnostic facts from public `niceeval show @locator --json`. */
 export function decodeShowAttemptDiagnostics(receipt: ProcessReceipt): readonly ShowAttemptDiagnostic[] {
   const document = record(receipt.json<unknown>(), "$", receipt);
-  if (string(document.schema, "$.schema", receipt) !== "niceeval.show/v1") {
-    throw new Error(`decodeShowAttemptDiagnostics(): $.schema is not niceeval.show/v1\n\n${receipt.diagnostic()}`);
+  if (string(document.format, "$.format", receipt) !== "niceeval.show/v1") {
+    throw new Error(`decodeShowAttemptDiagnostics(): $.format is not niceeval.show/v1\n\n${receipt.diagnostic()}`);
   }
   const data = record(document.data, "$.data", receipt);
   if (string(data.kind, "$.data.kind", receipt) !== "attempt") {

--- a/packages/testkit/src/show-attempt-diagnostics.ts
+++ b/packages/testkit/src/show-attempt-diagnostics.ts
@@ -1,73 +1,70 @@
+import { Schema } from "effect";
 import type { ProcessReceipt } from "./process.js";
+import {
+  decodeShowSchema,
+  NonEmptyStringSchema,
+  ShowAttemptEnvelopeFields,
+} from "./show-schema.js";
 
-export interface ShowAttemptDiagnostic {
-  readonly code: string;
-  readonly kind: string;
-  readonly phase: string;
-  readonly summary: string;
-}
+const ShowAttemptDiagnosticOutputSchema = Schema.Struct({
+  code: NonEmptyStringSchema,
+  kind: NonEmptyStringSchema,
+  phase: NonEmptyStringSchema,
+  summary: Schema.String,
+});
 
-interface UnknownRecord {
-  readonly [key: string]: unknown;
-}
+const ShowAttemptDiagnosticSchema = Schema.Struct({
+  ...ShowAttemptDiagnosticOutputSchema.fields,
+  diagnosticId: NonEmptyStringSchema,
+  causes: Schema.Array(Schema.Unknown),
+  redaction: Schema.Unknown,
+  sourceFrame: Schema.Unknown,
+});
 
-function record(value: unknown, path: string, receipt: ProcessReceipt): UnknownRecord {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error(`decodeShowAttemptDiagnostics(): ${path} is not an object\n\n${receipt.diagnostic()}`);
-  }
-  return value as UnknownRecord;
-}
+const ShowAttemptDiagnosticsDocumentSchema = Schema.Struct({
+  ...ShowAttemptEnvelopeFields,
+  data: Schema.Struct({
+    kind: Schema.Literal("attempt"),
+    evidence: Schema.Unknown,
+    observability: Schema.Struct({
+      kind: Schema.Literal("domain-view"),
+      identity: Schema.Unknown,
+      refs: Schema.Array(Schema.Unknown),
+      issues: Schema.Array(Schema.Unknown),
+      view: Schema.Literal("attempt-observability"),
+      entries: Schema.Tuple(Schema.Struct({
+        attempt: Schema.Unknown,
+        state: Schema.Literal("available"),
+        view: Schema.Literal("attempt-observability"),
+        detail: Schema.Struct({
+          conversation: Schema.Unknown,
+          commands: Schema.Unknown,
+          usage: Schema.Unknown,
+          timing: Schema.Unknown,
+          diagnostics: Schema.Struct({
+            collection: Schema.Unknown,
+            diagnostics: Schema.Array(ShowAttemptDiagnosticSchema),
+          }),
+        }),
+      })),
+    }),
+    fileChanges: Schema.Unknown,
+  }),
+});
 
-function array(value: unknown, path: string, receipt: ProcessReceipt): readonly unknown[] {
-  if (!Array.isArray(value)) {
-    throw new Error(`decodeShowAttemptDiagnostics(): ${path} is not an array\n\n${receipt.diagnostic()}`);
-  }
-  return value;
-}
-
-function string(value: unknown, path: string, receipt: ProcessReceipt): string {
-  if (typeof value !== "string") {
-    throw new Error(`decodeShowAttemptDiagnostics(): ${path} is not a string\n\n${receipt.diagnostic()}`);
-  }
-  return value;
-}
+export type ShowAttemptDiagnostic = Schema.Schema.Type<typeof ShowAttemptDiagnosticOutputSchema>;
 
 /** Strictly read stable diagnostic facts from public `niceeval show @locator --json`. */
 export function decodeShowAttemptDiagnostics(receipt: ProcessReceipt): readonly ShowAttemptDiagnostic[] {
-  const document = record(receipt.json<unknown>(), "$", receipt);
-  if (string(document.format, "$.format", receipt) !== "niceeval.show/v1") {
-    throw new Error(`decodeShowAttemptDiagnostics(): $.format is not niceeval.show/v1\n\n${receipt.diagnostic()}`);
-  }
-  const data = record(document.data, "$.data", receipt);
-  if (string(data.kind, "$.data.kind", receipt) !== "attempt") {
-    throw new Error(`decodeShowAttemptDiagnostics(): $.data.kind is not attempt\n\n${receipt.diagnostic()}`);
-  }
-  const observability = record(data.observability, "$.data.observability", receipt);
-  const entries = array(observability.entries, "$.data.observability.entries", receipt);
-  if (entries.length !== 1) {
-    throw new Error(`decodeShowAttemptDiagnostics(): expected one observability entry, got ${entries.length}\n\n${receipt.diagnostic()}`);
-  }
-  const entry = record(entries[0], "$.data.observability.entries[0]", receipt);
-  if (string(entry.state, "$.data.observability.entries[0].state", receipt) !== "available") {
-    throw new Error(`decodeShowAttemptDiagnostics(): observability entry is not available\n\n${receipt.diagnostic()}`);
-  }
-  const detail = record(entry.detail, "$.data.observability.entries[0].detail", receipt);
-  const diagnostics = record(detail.diagnostics, "$.data.observability.entries[0].detail.diagnostics", receipt);
-  return array(
-    diagnostics.diagnostics,
-    "$.data.observability.entries[0].detail.diagnostics.diagnostics",
+  const document = decodeShowSchema(
+    ShowAttemptDiagnosticsDocumentSchema,
     receipt,
-  ).map((value, index) => {
-    const diagnostic = record(
-      value,
-      `$.data.observability.entries[0].detail.diagnostics.diagnostics[${index}]`,
-      receipt,
-    );
-    return {
-      code: string(diagnostic.code, `diagnostics[${index}].code`, receipt),
-      kind: string(diagnostic.kind, `diagnostics[${index}].kind`, receipt),
-      phase: string(diagnostic.phase, `diagnostics[${index}].phase`, receipt),
-      summary: string(diagnostic.summary, `diagnostics[${index}].summary`, receipt),
-    };
-  });
+    "decodeShowAttemptDiagnostics()",
+  );
+  return document.data.observability.entries[0].detail.diagnostics.diagnostics.map((diagnostic) => ({
+    code: diagnostic.code,
+    kind: diagnostic.kind,
+    phase: diagnostic.phase,
+    summary: diagnostic.summary,
+  }));
 }

--- a/packages/testkit/src/show-schema.ts
+++ b/packages/testkit/src/show-schema.ts
@@ -1,0 +1,73 @@
+import { Either, Schema } from "effect";
+import type { ProcessReceipt } from "./process.js";
+
+export const ShowExactParseOptions = Object.freeze({
+  errors: "all" as const,
+  onExcessProperty: "error" as const,
+});
+
+export const NonEmptyStringSchema = Schema.String.pipe(
+  Schema.filter((value) => value.length > 0, {
+    identifier: "ShowNonEmptyString",
+    description: "a non-empty string",
+  }),
+);
+
+export const CanonicalAttemptLocatorSchema = Schema.String.pipe(
+  Schema.filter((value) => /^@1[0-9A-HJKMNP-TV-Z]{12}$/.test(value), {
+    identifier: "CanonicalAttemptLocator",
+    description: "a canonical NiceEval Attempt locator",
+  }),
+);
+
+const LocalizedTextSchema = Schema.Union(
+  Schema.String,
+  Schema.Record({ key: NonEmptyStringSchema, value: Schema.String }).pipe(
+    Schema.filter((value) => Object.keys(value).length > 0, {
+      identifier: "ShowLocalizedText",
+      description: "a non-empty localized text map",
+    }),
+  ),
+);
+
+const ShowProblemSchema = Schema.Struct({
+  code: NonEmptyStringSchema,
+  path: Schema.Array(NonEmptyStringSchema),
+  refs: Schema.Array(NonEmptyStringSchema),
+  summary: Schema.optional(NonEmptyStringSchema),
+});
+
+export const ShowAttemptEnvelopeFields = Object.freeze({
+  format: Schema.Literal("niceeval.show"),
+  locale: Schema.Literal("en"),
+  selection: Schema.Struct({
+    kind: Schema.Literal("attempt-locator"),
+    sampleIdentity: NonEmptyStringSchema,
+    locator: CanonicalAttemptLocatorSchema,
+  }),
+  report: Schema.Struct({
+    token: NonEmptyStringSchema,
+    identity: NonEmptyStringSchema,
+  }),
+  page: Schema.Struct({
+    route: NonEmptyStringSchema,
+    pageId: NonEmptyStringSchema,
+    title: LocalizedTextSchema,
+  }),
+  projections: Schema.Struct({
+    format: Schema.Literal("niceeval.report-projections/v1"),
+    pricingProfile: Schema.Unknown,
+    costs: Schema.Array(Schema.Unknown),
+  }),
+  problems: Schema.Array(ShowProblemSchema),
+});
+
+export function decodeShowSchema<A, I>(
+  schema: Schema.Schema<A, I>,
+  receipt: ProcessReceipt,
+  label: string,
+): A {
+  const decoded = Schema.decodeUnknownEither(schema, ShowExactParseOptions)(receipt.json<unknown>());
+  if (Either.isRight(decoded)) return decoded.right;
+  throw new Error(`${label}: invalid niceeval.show document\n${String(decoded.left)}\n\n${receipt.diagnostic()}`);
+}

--- a/packages/testkit/src/show-timing.ts
+++ b/packages/testkit/src/show-timing.ts
@@ -43,7 +43,7 @@ export type ShowTimingEntry =
     };
 
 export interface ShowTimingDocument {
-  readonly schema: "niceeval.show/v1";
+  readonly format: "niceeval.show/v1";
   readonly locale: "en";
   readonly selection: {
     readonly kind: "attempt-locator";
@@ -64,7 +64,7 @@ export interface ShowTimingDocument {
     readonly timing: readonly ShowTimingEntry[];
   };
   readonly projections: {
-    readonly schema: "niceeval.report-projections/v1";
+    readonly format: "niceeval.report-projections/v1";
     readonly pricingProfile: unknown;
     readonly costs: readonly unknown[];
   };
@@ -86,9 +86,9 @@ export function decodeShowTiming(receipt: ProcessReceipt): ShowTimingDocument {
     "problems",
     "projections",
     "report",
-    "schema",
+    "format",
     "selection",
-  ]) || value.schema !== "niceeval.show/v1" || value.locale !== "en") {
+  ]) || value.format !== "niceeval.show/v1" || value.locale !== "en") {
     return invalid(receipt, "document must be the exact niceeval.show/v1 envelope");
   }
   const selection = value.selection;
@@ -138,8 +138,8 @@ function isLocalizedText(value: unknown): value is ShowTimingDocument["page"]["t
 }
 
 function isProjections(value: unknown): value is ShowTimingDocument["projections"] {
-  return isRecord(value) && hasExactKeys(value, ["costs", "pricingProfile", "schema"]) &&
-    value.schema === "niceeval.report-projections/v1" && Array.isArray(value.costs);
+  return isRecord(value) && hasExactKeys(value, ["costs", "format", "pricingProfile"]) &&
+    value.format === "niceeval.report-projections/v1" && Array.isArray(value.costs);
 }
 
 function isProblems(value: unknown): value is ShowTimingDocument["problems"] {

--- a/packages/testkit/src/show-timing.ts
+++ b/packages/testkit/src/show-timing.ts
@@ -1,249 +1,53 @@
+import { Schema } from "effect";
 import type { ProcessReceipt } from "./process.js";
+import {
+  CanonicalAttemptLocatorSchema,
+  decodeShowSchema,
+  ShowAttemptEnvelopeFields,
+} from "./show-schema.js";
 
-export interface ShowTimingInterval {
-  readonly intervalId: string;
-  readonly phase: string;
-  readonly label: string;
-  readonly startOffsetMs: number;
-  readonly durationMs: number;
-  readonly parentIntervalId: string | null;
-  readonly outcome: "completed" | "failed" | "cancelled" | "interrupted" | "unknown";
-}
+const NonNegativeSafeIntegerSchema = Schema.JsonNumber.pipe(
+  Schema.filter((value) => Number.isSafeInteger(value) && value >= 0, {
+    identifier: "ShowNonNegativeSafeInteger",
+    description: "a non-negative safe integer",
+  }),
+);
 
-export interface ShowTimingDetail {
-  readonly collection: {
-    readonly state: "complete" | "partial";
-    readonly limitations: readonly unknown[];
-  };
-  readonly intervals: readonly ShowTimingInterval[];
-}
+const PositiveSafeIntegerSchema = Schema.JsonNumber.pipe(
+  Schema.filter((value) => Number.isSafeInteger(value) && value > 0, {
+    identifier: "ShowPositiveSafeInteger",
+    description: "a positive safe integer",
+  }),
+);
 
-export interface ShowTimingAttempt {
-  readonly kind: "attempt";
-  readonly locator: string;
-  readonly originRunId: string;
-}
-
-export type ShowTimingEntry =
-  | {
-      readonly attempt: ShowTimingAttempt;
-      readonly state: "available";
-      readonly timing: ShowTimingDetail;
-    }
-  | {
-      readonly attempt: ShowTimingAttempt;
-      readonly state: "not-recorded" | "unsupported" | "invalid";
-      readonly view: "attempt-observability";
-    }
-  | {
-      readonly attempt: ShowTimingAttempt;
-      readonly state: "failed";
-      readonly view: "attempt-observability";
-      readonly detail: string;
-    };
-
-export interface ShowTimingDocument {
-  readonly format: "niceeval.show/v1";
-  readonly locale: "en";
-  readonly selection: {
-    readonly kind: "attempt-locator";
-    readonly sampleIdentity: string;
-    readonly locator: string;
-  };
-  readonly report: {
-    readonly token: string;
-    readonly identity: string;
-  };
-  readonly page: {
-    readonly route: string;
-    readonly pageId: string;
-    readonly title: string | Readonly<Record<string, string>>;
-  };
-  readonly data: {
-    readonly kind: "timing";
-    readonly timing: readonly ShowTimingEntry[];
-  };
-  readonly projections: {
-    readonly format: "niceeval.report-projections/v1";
-    readonly pricingProfile: unknown;
-    readonly costs: readonly unknown[];
-  };
-  readonly problems: readonly {
-    readonly code: string;
-    readonly path: readonly string[];
-    readonly refs: readonly string[];
-    readonly summary?: string;
-  }[];
-}
-
-/** Strictly decode the public timing facts and their `niceeval.show/v1` envelope. */
-export function decodeShowTiming(receipt: ProcessReceipt): ShowTimingDocument {
-  const value = receipt.json<unknown>();
-  if (!isRecord(value) || !hasExactKeys(value, [
-    "data",
-    "locale",
-    "page",
-    "problems",
-    "projections",
-    "report",
-    "format",
-    "selection",
-  ]) || value.format !== "niceeval.show/v1" || value.locale !== "en") {
-    return invalid(receipt, "document must be the exact niceeval.show/v1 envelope");
-  }
-  const selection = value.selection;
-  if (!isAttemptSelection(selection)) {
-    return invalid(receipt, "selection must be one canonical attempt-locator");
-  }
-  if (!isReport(value.report) || !isPage(value.page) ||
-    !isProjections(value.projections) || !isProblems(value.problems)) {
-    return invalid(receipt, "report, page, projections, or problems envelope is invalid");
-  }
-  if (!isRecord(value.data) || !hasExactKeys(value.data, ["kind", "timing"]) ||
-    value.data.kind !== "timing" || !Array.isArray(value.data.timing)) {
-    return invalid(receipt, "data must be a timing document");
-  }
-  for (let index = 0; index < value.data.timing.length; index++) {
-    if (!isTimingEntry(value.data.timing[index])) {
-      return invalid(receipt, `data.timing[${index}] is invalid`);
-    }
-  }
-  if (value.data.timing.length === 0 ||
-    value.data.timing.some((entry) => entry.attempt.locator !== selection.locator)) {
-    return invalid(receipt, "timing entries must belong to the selected Attempt locator");
-  }
-  return value as unknown as ShowTimingDocument;
-}
-
-function isAttemptSelection(value: unknown): value is ShowTimingDocument["selection"] {
-  return isRecord(value) && hasExactKeys(value, ["kind", "locator", "sampleIdentity"]) &&
-    value.kind === "attempt-locator" && isCanonicalLocator(value.locator) &&
-    isNonEmptyString(value.sampleIdentity);
-}
-
-function isReport(value: unknown): value is ShowTimingDocument["report"] {
-  return isRecord(value) && hasExactKeys(value, ["identity", "token"]) &&
-    isNonEmptyString(value.identity) && isNonEmptyString(value.token);
-}
-
-function isPage(value: unknown): value is ShowTimingDocument["page"] {
-  return isRecord(value) && hasExactKeys(value, ["pageId", "route", "title"]) &&
-    isNonEmptyString(value.pageId) && isNonEmptyString(value.route) && isLocalizedText(value.title);
-}
-
-function isLocalizedText(value: unknown): value is ShowTimingDocument["page"]["title"] {
-  if (typeof value === "string") return true;
-  return isRecord(value) && Object.keys(value).length > 0 &&
-    Object.entries(value).every(([locale, text]) => locale.length > 0 && typeof text === "string");
-}
-
-function isProjections(value: unknown): value is ShowTimingDocument["projections"] {
-  return isRecord(value) && hasExactKeys(value, ["costs", "format", "pricingProfile"]) &&
-    value.format === "niceeval.report-projections/v1" && Array.isArray(value.costs);
-}
-
-function isProblems(value: unknown): value is ShowTimingDocument["problems"] {
-  return Array.isArray(value) && value.every((problem) => {
-    if (!isRecord(problem)) return false;
-    const keys = problem.summary === undefined
-      ? ["code", "path", "refs"]
-      : ["code", "path", "refs", "summary"];
-    return hasExactKeys(problem, keys) && isNonEmptyString(problem.code) &&
-      isStringArray(problem.path) && isStringArray(problem.refs) &&
-      (problem.summary === undefined || isNonEmptyString(problem.summary));
-  });
-}
-
-function isStringArray(value: unknown): value is readonly string[] {
-  return Array.isArray(value) && value.every(isNonEmptyString);
-}
-
-function isTimingEntry(value: unknown): value is ShowTimingEntry {
-  if (!isRecord(value) || !isAttempt(value.attempt)) return false;
-  if (value.state === "available") {
-    return hasExactKeys(value, ["attempt", "state", "timing"]) && isTimingDetail(value.timing);
-  }
-  if (value.state === "failed") {
-    return hasExactKeys(value, ["attempt", "detail", "state", "view"]) &&
-      value.view === "attempt-observability" && typeof value.detail === "string";
-  }
-  return hasExactKeys(value, ["attempt", "state", "view"]) &&
-    value.view === "attempt-observability" &&
-    (value.state === "not-recorded" || value.state === "unsupported" || value.state === "invalid");
-}
-
-function isAttempt(value: unknown): value is ShowTimingAttempt {
-  return isRecord(value) &&
-    hasExactKeys(value, ["kind", "locator", "originRunId"]) &&
-    value.kind === "attempt" &&
-    isCanonicalLocator(value.locator) &&
-    typeof value.originRunId === "string" && isPortableSegment(value.originRunId);
-}
-
-function isCanonicalLocator(value: unknown): value is string {
-  return typeof value === "string" && /^@1[0-9A-HJKMNP-TV-Z]{12}$/.test(value);
-}
+const SafeIdentifierSchema = Schema.String.pipe(
+  Schema.filter((value) => /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(value), {
+    identifier: "ShowSafeIdentifier",
+    description: "a safe timing identifier",
+  }),
+);
 
 const PORTABLE_SEGMENT_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,253}[A-Za-z0-9])?$/;
 const WINDOWS_RESERVED_SEGMENT_PATTERN = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i;
+const PortableSegmentSchema = Schema.String.pipe(
+  Schema.filter(
+    (value) => PORTABLE_SEGMENT_PATTERN.test(value) && !WINDOWS_RESERVED_SEGMENT_PATTERN.test(value),
+    {
+      identifier: "ShowPortableSegment",
+      description: "a portable non-reserved path segment",
+    },
+  ),
+);
 
-function isPortableSegment(value: string): boolean {
-  return PORTABLE_SEGMENT_PATTERN.test(value) && !WINDOWS_RESERVED_SEGMENT_PATTERN.test(value);
-}
-
-function isTimingDetail(value: unknown): value is ShowTimingDetail {
-  if (!isRecord(value) || !hasExactKeys(value, ["collection", "intervals"])) return false;
-  if (!isTimingCollectionState(value.collection) || !Array.isArray(value.intervals)) return false;
-  if (!value.intervals.every(isTimingInterval)) return false;
-  return hasCanonicalTimingIntervals(value.collection.state, value.intervals);
-}
-
-function isTimingInterval(value: unknown): value is ShowTimingInterval {
-  if (!isRecord(value) || !hasExactKeys(value, [
-    "durationMs",
-    "intervalId",
-    "label",
-    "outcome",
-    "parentIntervalId",
-    "phase",
-    "startOffsetMs",
-  ])) return false;
-  if (
-    !isSafeIdentifier(value.intervalId) ||
-    !isAttemptTimingPhase(value.phase) ||
-    !isSafeIdentifier(value.label) ||
-    !isNonNegativeSafeInteger(value.startOffsetMs) ||
-    !isNonNegativeSafeInteger(value.durationMs) ||
-    (value.parentIntervalId !== null && !isSafeIdentifier(value.parentIntervalId))
-  ) return false;
-  return value.outcome === "completed" ||
-    value.outcome === "failed" ||
-    value.outcome === "cancelled" ||
-    value.outcome === "interrupted" ||
-    value.outcome === "unknown";
-}
-
-const ATTEMPT_TIMING_PHASES = new Set([
-  "attempt.setup",
-  "sandbox.prepare",
-  "agent.ensure",
-  "eval.run",
-  "agent.send",
-  "sandbox.command",
-  "assertion.evaluate",
-  "verdict.fold",
-  "attempt.teardown",
-]);
-
-const OBSERVABILITY_TARGETS = new Set([
+const CollectionTargetSchema = Schema.Literal(
   "conversation",
   "command",
   "usage",
   "timing",
   "diagnostic",
-]);
+);
 
-const OBSERVABILITY_STAGES = new Set([
+const CollectionStageSchema = Schema.Literal(
   "adapter",
   "command-capture",
   "usage-capture",
@@ -251,46 +55,139 @@ const OBSERVABILITY_STAGES = new Set([
   "diagnostic-capture",
   "attempt-finalizer",
   "run-teardown",
-]);
+);
 
-function isTimingCollectionState(value: unknown): value is ShowTimingDetail["collection"] {
-  if (!isRecord(value) || !hasExactKeys(value, ["limitations", "state"]) ||
-    !Array.isArray(value.limitations)) return false;
-  if (value.state === "complete") return value.limitations.length === 0;
-  return value.state === "partial" && value.limitations.length > 0 &&
-    value.limitations.every(isObservabilityLimitation);
-}
+const ObservabilityLimitationSchema = Schema.Union(
+  Schema.Struct({
+    code: Schema.Literal("capture-failed", "capture-interrupted"),
+    stage: CollectionStageSchema,
+    target: CollectionTargetSchema,
+  }),
+  Schema.Struct({
+    code: Schema.Literal("collection-cap-reached", "unsupported-input"),
+    omittedAtLeast: PositiveSafeIntegerSchema,
+    target: CollectionTargetSchema,
+  }),
+  Schema.Struct({
+    code: Schema.Literal("text-truncated", "redacted"),
+    replacementOrOmittedCount: PositiveSafeIntegerSchema,
+    target: CollectionTargetSchema,
+  }),
+  Schema.Struct({
+    code: Schema.Literal("stream-truncated"),
+    commandId: SafeIdentifierSchema,
+    omittedBytes: PositiveSafeIntegerSchema,
+    retainedBytes: NonNegativeSafeIntegerSchema,
+    stream: Schema.Literal("stdout", "stderr"),
+  }),
+  Schema.Struct({
+    code: Schema.Literal("invalid-utf8-replaced", "unsafe-control-stripped"),
+    commandId: SafeIdentifierSchema,
+    count: PositiveSafeIntegerSchema,
+    stream: Schema.Literal("stdout", "stderr"),
+  }),
+);
 
-function isObservabilityLimitation(value: unknown): boolean {
-  if (!isRecord(value) || typeof value.code !== "string") return false;
-  if (value.code === "capture-failed" || value.code === "capture-interrupted") {
-    return hasExactKeys(value, ["code", "stage", "target"]) &&
-      typeof value.stage === "string" && OBSERVABILITY_STAGES.has(value.stage) &&
-      typeof value.target === "string" && OBSERVABILITY_TARGETS.has(value.target);
-  }
-  if (value.code === "collection-cap-reached" || value.code === "unsupported-input") {
-    return hasExactKeys(value, ["code", "omittedAtLeast", "target"]) &&
-      isPositiveSafeInteger(value.omittedAtLeast) &&
-      typeof value.target === "string" && OBSERVABILITY_TARGETS.has(value.target);
-  }
-  if (value.code === "text-truncated" || value.code === "redacted") {
-    return hasExactKeys(value, ["code", "replacementOrOmittedCount", "target"]) &&
-      isPositiveSafeInteger(value.replacementOrOmittedCount) &&
-      typeof value.target === "string" && OBSERVABILITY_TARGETS.has(value.target);
-  }
-  if (value.code === "stream-truncated") {
-    return hasExactKeys(value, ["code", "commandId", "omittedBytes", "retainedBytes", "stream"]) &&
-      isSafeIdentifier(value.commandId) &&
-      (value.stream === "stdout" || value.stream === "stderr") &&
-      isNonNegativeSafeInteger(value.retainedBytes) && isPositiveSafeInteger(value.omittedBytes);
-  }
-  if (value.code === "invalid-utf8-replaced" || value.code === "unsafe-control-stripped") {
-    return hasExactKeys(value, ["code", "commandId", "count", "stream"]) &&
-      isSafeIdentifier(value.commandId) &&
-      (value.stream === "stdout" || value.stream === "stderr") &&
-      isPositiveSafeInteger(value.count);
-  }
-  return false;
+const TimingCollectionSchema = Schema.Union(
+  Schema.Struct({
+    state: Schema.Literal("complete"),
+    limitations: Schema.Tuple(),
+  }),
+  Schema.Struct({
+    state: Schema.Literal("partial"),
+    limitations: Schema.NonEmptyArray(ObservabilityLimitationSchema),
+  }),
+);
+
+const ShowTimingIntervalSchema = Schema.Struct({
+  intervalId: SafeIdentifierSchema,
+  phase: Schema.Literal(
+    "attempt.setup",
+    "sandbox.prepare",
+    "agent.ensure",
+    "eval.run",
+    "agent.send",
+    "sandbox.command",
+    "assertion.evaluate",
+    "verdict.fold",
+    "attempt.teardown",
+  ),
+  label: SafeIdentifierSchema,
+  startOffsetMs: NonNegativeSafeIntegerSchema,
+  durationMs: NonNegativeSafeIntegerSchema,
+  parentIntervalId: Schema.NullOr(SafeIdentifierSchema),
+  outcome: Schema.Literal("completed", "failed", "cancelled", "interrupted", "unknown"),
+});
+
+export type ShowTimingInterval = Schema.Schema.Type<typeof ShowTimingIntervalSchema>;
+
+const ShowTimingDetailSchema = Schema.Struct({
+  collection: TimingCollectionSchema,
+  intervals: Schema.Array(ShowTimingIntervalSchema),
+}).pipe(
+  Schema.filter(
+    (detail) => hasCanonicalTimingIntervals(detail.collection.state, detail.intervals),
+    {
+      identifier: "CanonicalShowTimingDetail",
+      description: "canonical, bounded and acyclic timing intervals",
+    },
+  ),
+);
+
+export type ShowTimingDetail = Schema.Schema.Type<typeof ShowTimingDetailSchema>;
+
+const ShowTimingAttemptSchema = Schema.Struct({
+  kind: Schema.Literal("attempt"),
+  locator: CanonicalAttemptLocatorSchema,
+  originRunId: PortableSegmentSchema,
+});
+
+export type ShowTimingAttempt = Schema.Schema.Type<typeof ShowTimingAttemptSchema>;
+
+const ShowTimingEntrySchema = Schema.Union(
+  Schema.Struct({
+    attempt: ShowTimingAttemptSchema,
+    state: Schema.Literal("available"),
+    timing: ShowTimingDetailSchema,
+  }),
+  Schema.Struct({
+    attempt: ShowTimingAttemptSchema,
+    state: Schema.Literal("not-recorded", "unsupported", "invalid"),
+    view: Schema.Literal("attempt-observability"),
+  }),
+  Schema.Struct({
+    attempt: ShowTimingAttemptSchema,
+    state: Schema.Literal("failed"),
+    view: Schema.Literal("attempt-observability"),
+    detail: Schema.String,
+  }),
+);
+
+export type ShowTimingEntry = Schema.Schema.Type<typeof ShowTimingEntrySchema>;
+
+const ShowTimingDocumentSchema = Schema.Struct({
+  ...ShowAttemptEnvelopeFields,
+  data: Schema.Struct({
+    kind: Schema.Literal("timing"),
+    timing: Schema.NonEmptyArray(ShowTimingEntrySchema),
+  }),
+}).pipe(
+  Schema.filter(
+    (document) => document.data.timing.every(
+      (entry) => entry.attempt.locator === document.selection.locator,
+    ),
+    {
+      identifier: "SelectedShowTimingDocument",
+      description: "timing entries belonging to the selected Attempt locator",
+    },
+  ),
+);
+
+export type ShowTimingDocument = Schema.Schema.Type<typeof ShowTimingDocumentSchema>;
+
+/** Decode the public timing facts through the current unversioned show API. */
+export function decodeShowTiming(receipt: ProcessReceipt): ShowTimingDocument {
+  return decodeShowSchema(ShowTimingDocumentSchema, receipt, "decodeShowTiming()");
 }
 
 function hasCanonicalTimingIntervals(
@@ -325,38 +222,4 @@ function hasCanonicalTimingIntervals(
     }
   }
   return collectionState !== "complete" || intervals.every((interval) => interval.outcome !== "unknown");
-}
-
-function isAttemptTimingPhase(value: unknown): value is ShowTimingInterval["phase"] {
-  return typeof value === "string" && ATTEMPT_TIMING_PHASES.has(value);
-}
-
-function isSafeIdentifier(value: unknown): value is string {
-  return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(value);
-}
-
-function isPositiveSafeInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
-}
-
-function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
-  const actual = Object.keys(value).sort();
-  const expected = [...keys].sort();
-  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
-}
-
-function isNonNegativeSafeInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
-}
-
-function invalid(receipt: ProcessReceipt, reason: string): never {
-  throw new Error(`decodeShowTiming(): ${reason}\n\n${receipt.diagnostic()}`);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/testkit:
+    dependencies:
+      effect:
+        specifier: 3.22.1
+        version: 3.22.1
     devDependencies:
       '@types/node':
         specifier: ^24.0.0

--- a/src/analysis/contracts.ts
+++ b/src/analysis/contracts.ts
@@ -227,13 +227,7 @@ export type ExperimentGroupIdentity =
   | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
   | { readonly kind: "singleton"; readonly experimentId: ExperimentId; readonly key: `singleton/${string}` };
 
-export type NonComparableReason =
-  | "eval-population-mismatch"
-  | "evaluation-kind-mismatch"
-  | "population-unavailable"
-  | "measure-population-mismatch"
-  | "measure-basis-mismatch"
-  | "measure-basis-unavailable";
+export type NonComparableReason = "eval-population-mismatch";
 
 export interface NonComparableIssue {
   readonly reason: NonComparableReason;

--- a/src/analysis/contracts.ts
+++ b/src/analysis/contracts.ts
@@ -223,6 +223,52 @@ export interface Sample {
   readonly [sampleCapabilityTypeId]: true;
 }
 
+export type ExperimentGroupIdentity =
+  | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
+  | { readonly kind: "singleton"; readonly experimentId: ExperimentId; readonly key: `singleton/${string}` };
+
+export type NonComparableReason =
+  | "eval-population-mismatch"
+  | "evaluation-kind-mismatch"
+  | "population-unavailable"
+  | "measure-population-mismatch"
+  | "measure-basis-mismatch"
+  | "measure-basis-unavailable";
+
+export interface NonComparableIssue {
+  readonly reason: NonComparableReason;
+  readonly members: readonly ExperimentId[];
+  readonly actual: readonly {
+    readonly member: ExperimentId;
+    readonly population: JsonValue | null;
+    readonly basis: JsonValue | null;
+  }[];
+  readonly refs: readonly EvidenceRef[];
+  readonly params: Readonly<Record<string, JsonValue>>;
+}
+
+export type ExperimentComparisonState =
+  | { readonly state: "comparable"; readonly members: readonly ExperimentId[] }
+  | {
+      readonly state: "non-comparable";
+      readonly members: readonly ExperimentId[];
+      readonly issues: readonly NonComparableIssue[];
+    };
+
+const experimentComparisonScopeTypeId: unique symbol = Symbol("niceeval.analysis.ExperimentComparisonScope");
+
+/** Analysis-issued comparison capability; the backing Sample remains private. */
+export interface ExperimentComparisonScope {
+  readonly group: ExperimentGroupIdentity;
+  readonly comparison: ExperimentComparisonState;
+  readonly [experimentComparisonScopeTypeId]: true;
+}
+
+export interface AnalysisComparisonGroupMismatchError {
+  readonly code: "analysis-comparison-group-mismatch";
+  readonly groups: readonly ExperimentGroupIdentity[];
+}
+
 export interface SampleSelector {
   readonly runIds?: readonly RunId[];
   readonly slotIds?: readonly SlotId[];

--- a/src/analysis/experiment-groups.ts
+++ b/src/analysis/experiment-groups.ts
@@ -1,0 +1,113 @@
+import type {
+  ExperimentComparisonScope,
+  ExperimentComparisonState,
+  ExperimentGroupIdentity,
+  ExperimentId,
+  JsonValue,
+  NonComparableIssue,
+  Sample,
+} from "./contracts.ts";
+import { narrowSample } from "../sample/capability.ts";
+import { experimentGroupOf } from "../shared/aggregate.ts";
+
+const scopeBrand: unique symbol = Symbol("niceeval.analysis.ExperimentComparisonScope.runtime");
+const scopeSamples = new WeakMap<ExperimentComparisonScope, Sample>();
+
+export interface ExperimentGroupSummary {
+  readonly group: ExperimentGroupIdentity;
+  readonly members: readonly ExperimentId[];
+}
+
+export function experimentGroups(sample: Sample): readonly ExperimentGroupSummary[] {
+  const experiments = new Map<string, ExperimentId>();
+  const selectedRuns = new Set(sample.snapshot.selection.selectedRunIds.map(String));
+  for (const run of sample.snapshot.runs) {
+    if (!selectedRuns.has(String(run.runId))) continue;
+    experiments.set(String(run.experimentId), run.experimentId);
+  }
+  const byGroup = new Map<string, { group: ExperimentGroupIdentity; members: Map<string, ExperimentId> }>();
+  for (const experimentId of experiments.values()) {
+    const derived = experimentGroupOf(String(experimentId));
+    const group = derived.kind === "named"
+      ? Object.freeze({ kind: "named" as const, groupId: derived.groupId, key: derived.key })
+      : Object.freeze({ kind: "singleton" as const, experimentId, key: derived.key });
+    const entry = byGroup.get(group.key) ?? { group, members: new Map<string, ExperimentId>() };
+    entry.members.set(String(experimentId), experimentId);
+    byGroup.set(group.key, entry);
+  }
+  return Object.freeze([...byGroup.values()]
+    .sort((left, right) => compareUtf8(left.group.key, right.group.key))
+    .map((entry) => Object.freeze({
+      group: entry.group,
+      members: Object.freeze([...entry.members.values()].sort((left, right) => compareUtf8(String(left), String(right)))),
+    })));
+}
+
+export function experimentComparisonScope(
+  sample: Sample,
+  group: ExperimentGroupIdentity,
+): ExperimentComparisonScope {
+  const summary = experimentGroups(sample).find((candidate) => candidate.group.key === group.key);
+  if (summary === undefined || !sameGroup(summary.group, group)) {
+    throw Object.freeze({ code: "analysis-comparison-group-not-found" as const, group });
+  }
+  const memberSet = new Set(summary.members.map(String));
+  const runIds = sample.snapshot.runs
+    .filter((run) => memberSet.has(String(run.experimentId)))
+    .map((run) => run.runId);
+  const narrowed = narrowSample(sample, { runIds });
+  const comparison = comparisonState(narrowed, summary.members);
+  const scope = Object.freeze({
+    group: summary.group,
+    comparison,
+    [scopeBrand]: true as const,
+  }) as unknown as ExperimentComparisonScope;
+  scopeSamples.set(scope, narrowed);
+  return scope;
+}
+
+/** @internal Used only by named comparison components. */
+export function sampleForExperimentComparisonScope(scope: ExperimentComparisonScope): Sample {
+  const sample = scopeSamples.get(scope);
+  if (sample === undefined) {
+    throw Object.freeze({
+      code: "analysis-comparison-group-mismatch" as const,
+      groups: Object.freeze([scope?.group].filter((value): value is ExperimentGroupIdentity => value !== undefined)),
+    });
+  }
+  return sample;
+}
+
+function comparisonState(sample: Sample, members: readonly ExperimentId[]): ExperimentComparisonState {
+  const populations = members.map((member) => {
+    const values = [...new Set(sample.snapshot.slots
+      .filter((slot) => slot.state !== "excluded" && String(slot.experimentId) === String(member))
+      .map((slot) => String(slot.evalId)))]
+      .sort(compareUtf8);
+    return Object.freeze({ member, population: Object.freeze(values) });
+  });
+  const reference = JSON.stringify(populations[0]?.population ?? []);
+  if (populations.every((entry) => JSON.stringify(entry.population) === reference)) {
+    return Object.freeze({ state: "comparable" as const, members });
+  }
+  const issue: NonComparableIssue = Object.freeze({
+    reason: "eval-population-mismatch" as const,
+    members,
+    actual: Object.freeze(populations.map((entry) => Object.freeze({
+      member: entry.member,
+      population: entry.population as JsonValue,
+      basis: null,
+    }))),
+    refs: Object.freeze([]),
+    params: Object.freeze({ expected: populations[0]?.population as JsonValue ?? [] }),
+  });
+  return Object.freeze({ state: "non-comparable" as const, members, issues: Object.freeze([issue]) });
+}
+
+function sameGroup(left: ExperimentGroupIdentity, right: ExperimentGroupIdentity): boolean {
+  return left.kind === right.kind && left.key === right.key;
+}
+
+function compareUtf8(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left), Buffer.from(right));
+}

--- a/src/analysis/index.ts
+++ b/src/analysis/index.ts
@@ -48,6 +48,11 @@ export {
   narrowSample,
 } from "../sample/capability.ts";
 
+export {
+  experimentComparisonScope,
+  experimentGroups,
+} from "./experiment-groups.ts";
+
 export type {
   AggregateRequest,
   AggregateRow,
@@ -194,11 +199,16 @@ export type {
   EvidenceIdentity,
   EvidenceRef,
   ExperimentId,
+  ExperimentComparisonScope,
+  ExperimentComparisonState,
+  ExperimentGroupIdentity,
   JsonValue,
   MeasureFormat,
   MetricBasis,
   MetricState,
   MetricValue,
+  NonComparableIssue,
+  NonComparableReason,
   PopulationIdentity,
   ProducerIdentity,
   RunId,
@@ -209,5 +219,7 @@ export type {
   SampleSnapshotCodecError,
   SlotId,
 } from "./contracts.ts";
+
+export type { ExperimentGroupSummary } from "./experiment-groups.ts";
 
 export { ExperimentIdSchema } from "../record/codec/identifiers.ts";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -330,6 +330,8 @@ export interface Flags {
   run?: string[];
   report?: string;
   page?: string;
+  /** `show` / `view`：选择固定 Sample 中一个 Experiment Group Page。 */
+  group?: string;
   theme?: string;
   /** `sandbox list` 专用:核对强杀路径留下的无主实例。 */
   orphans: boolean;
@@ -424,6 +426,8 @@ const FLAG_OPTIONS = {
   theme: { type: "string" },
   /** `show` / `view` 命令专用:选择报告的初始页;`show` 渲染该页并在尾部附其余页索引,`view` 以它作初始路由。未命中的页 id 按用法错误退出并列出可用页 id。 */
   page: { type: "string" },
+  /** `show` / `view`：精确选择 `named/<key>` 或 `singleton/<experiment-id>` Experiment Group。 */
+  group: { type: "string" },
   /** `exp` 命令专用:补齐被强杀打断的实验级 teardown——只对选中的实验各执行一次 teardown(新进程语义),不派发 attempt、不跑 setup;没有遗留登记也照常执行。与 eval 前缀位置参数组合是用法错误。 */
   teardown: { type: "boolean" },
   /** `exp --teardown` 专用:显式恢复一个永不自动接管的 sharedState lease；必须同时提供 --owner-token、--confirm-owner-terminated 和 --confirm-remote-quiesced。 */
@@ -644,6 +648,7 @@ function parseArgs(argv: string[]): ParsedCliArgs {
     run: values.run as string[] | undefined,
     report: values.report as string | undefined,
     page: values.page as string | undefined,
+    group: values.group as string | undefined,
     theme: values.theme as string | undefined,
     orphans: values.orphans === true,
     teardown: values.teardown === true,
@@ -2549,6 +2554,7 @@ interface ReportCliRequest {
   readonly reportSelection: ReportSelection;
   readonly themeSelection: ThemeSelection;
   readonly page?: string;
+  readonly group?: string;
 }
 
 /** Resolve the CLI's one portable Record target without treating `.niceeval` as Record data. */
@@ -2585,7 +2591,16 @@ function parseReportCliRequest(input: {
 
   const { root, rootPath } = parseActualRecordRoot(input.cwd, input.flags.record);
 
-  const page = parseReportRoute(input.flags.page);
+  if (input.flags.group !== undefined && input.flags.page !== undefined) {
+    throw usageError("--group cannot be combined with --page.\n");
+  }
+  const group = parseExperimentGroupTarget(input.flags.group);
+  const page = group === undefined
+    ? parseReportRoute(input.flags.page)
+    : `/group/${group}`;
+  if (group !== undefined && input.positionals.length > 0) {
+    throw usageError("--group cannot be combined with an Attempt locator.\n");
+  }
   const evidenceReports = [
     input.flags.source !== undefined ? "--source" : undefined,
     input.flags.execution ? "--execution" : undefined,
@@ -2743,6 +2758,7 @@ function parseReportCliRequest(input: {
     reportSelection: report,
     themeSelection: theme,
     ...(page === undefined ? {} : { page }),
+    ...(group === undefined ? {} : { group }),
   });
 }
 
@@ -2811,6 +2827,15 @@ function parseReportRoute(value: string | undefined): string | undefined {
     throw usageError(`Invalid --page route "${value}": ${issue.reason}.\n`);
   }
   return value;
+}
+
+function parseExperimentGroupTarget(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const match = /^(named|singleton)\/([a-z0-9][a-z0-9._~-]*)$/u.exec(value);
+  if (match === null) {
+    throw usageError(`Invalid --group "${value}"; expected named/<key> or singleton/<experiment-id>.\n`);
+  }
+  return `${match[1]}/${match[2]}`;
 }
 
 function reportSelection(cwd: string, value: string | undefined): ReportSelection {
@@ -3133,15 +3158,31 @@ function finiteNumberProperty(value: unknown, key: string): number | undefined {
 function requireKnownReportPage(
   revision: ClosedSiteRevision,
   page: string | undefined,
+  group?: string,
 ): Effect.Effect<void, CliUsageError> {
   const routes = closedSiteRevisionData(revision).routes;
   if (page === undefined || routes.includes(page)) {
     return Effect.void;
   }
+  if (group !== undefined) {
+    return Effect.fail(usageError(`report-group-not-in-sample: ${group}\n`));
+  }
   const available = [...routes].sort().join(", ");
   return Effect.fail(usageError(
     `Unknown Report route "${page}". Available routes: ${available || "none"}.\n`,
   ));
+}
+
+function requireGroupPageAvailable(
+  report: ReportDefinition,
+  group: string | undefined,
+): Effect.Effect<void, CliUsageError> {
+  if (group === undefined) return Effect.void;
+  const groupKind = group.startsWith("named/") ? "named" : "singleton";
+  if (report.pages.some((page) => "role" in page && page.role?.kind === "experiment-group" && page.role.groupKind === groupKind)) {
+    return Effect.void;
+  }
+  return Effect.fail(usageError(`report-group-page-unavailable: ${group}\n`));
 }
 
 const cliReportConsole = Object.freeze({
@@ -3283,6 +3324,7 @@ function runShowCommand(
       "Load project, config, Report, and Theme",
       loadCliReportInputs(request),
     );
+    yield* requireGroupPageAvailable(inputs.report, request.group);
     const textProjection = flags.json
       ? undefined
       : panelCapabilityOf({
@@ -3338,6 +3380,9 @@ function runViewCommand(
       if (flags.port !== undefined || flags.host !== undefined || flags.open === true) {
         return yield* Effect.fail(usageError("view --out does not start a server; remove --port, --host, and --open.\n"));
       }
+      if (request.group !== undefined) {
+        return yield* Effect.fail(usageError("view --out does not accept --group.\n"));
+      }
       if (request.page !== undefined) {
         return yield* Effect.fail(usageError("view --out does not accept --page.\n"));
       }
@@ -3360,10 +3405,11 @@ function runViewCommand(
       "Load project, config, Report, and Theme",
       loadCliReportInputs(request),
     );
+    yield* requireGroupPageAvailable(initialInputs.report, request.group);
     const initial = yield* buildCliReportSite(request, initialInputs).pipe(
       Effect.provideService(ReportHostProgressObserver, makeCliReportProgress(request.rootPath, progress)),
     );
-    yield* requireKnownReportPage(initial, request.page);
+    yield* requireKnownReportPage(initial, request.page, request.group);
     const buildCache = yield* makeReportViewBuildCache(
       request,
       initialInputs,
@@ -3469,7 +3515,7 @@ function rebuildReportView(request: ReportCliRequest, cache: ReportViewBuildCach
         themeIdentity,
       });
     }
-    yield* requireKnownReportPage(revision, request.page);
+    yield* requireKnownReportPage(revision, request.page, request.group);
     cache.revision = revision;
     cache.pageBytes = pageBytes;
     cache.watchInputs = inputs.watchInputs;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -330,8 +330,6 @@ export interface Flags {
   run?: string[];
   report?: string;
   page?: string;
-  /** `show` / `view`：选择固定 Sample 中一个 Experiment Group Page。 */
-  group?: string;
   theme?: string;
   /** `sandbox list` 专用:核对强杀路径留下的无主实例。 */
   orphans: boolean;
@@ -426,8 +424,6 @@ const FLAG_OPTIONS = {
   theme: { type: "string" },
   /** `show` / `view` 命令专用:选择报告的初始页;`show` 渲染该页并在尾部附其余页索引,`view` 以它作初始路由。未命中的页 id 按用法错误退出并列出可用页 id。 */
   page: { type: "string" },
-  /** `show` / `view`：精确选择 `named/<key>` 或 `singleton/<experiment-id>` Experiment Group。 */
-  group: { type: "string" },
   /** `exp` 命令专用:补齐被强杀打断的实验级 teardown——只对选中的实验各执行一次 teardown(新进程语义),不派发 attempt、不跑 setup;没有遗留登记也照常执行。与 eval 前缀位置参数组合是用法错误。 */
   teardown: { type: "boolean" },
   /** `exp --teardown` 专用:显式恢复一个永不自动接管的 sharedState lease；必须同时提供 --owner-token、--confirm-owner-terminated 和 --confirm-remote-quiesced。 */
@@ -648,7 +644,6 @@ function parseArgs(argv: string[]): ParsedCliArgs {
     run: values.run as string[] | undefined,
     report: values.report as string | undefined,
     page: values.page as string | undefined,
-    group: values.group as string | undefined,
     theme: values.theme as string | undefined,
     orphans: values.orphans === true,
     teardown: values.teardown === true,
@@ -2545,7 +2540,7 @@ interface ReportCliRequest {
     }
     | {
       readonly kind: "project-current";
-      readonly experimentIds?: readonly ExperimentId[];
+      readonly experimentSelectors?: readonly string[];
     }
     | {
       readonly kind: "attempt";
@@ -2554,7 +2549,6 @@ interface ReportCliRequest {
   readonly reportSelection: ReportSelection;
   readonly themeSelection: ThemeSelection;
   readonly page?: string;
-  readonly group?: string;
 }
 
 /** Resolve the CLI's one portable Record target without treating `.niceeval` as Record data. */
@@ -2591,16 +2585,7 @@ function parseReportCliRequest(input: {
 
   const { root, rootPath } = parseActualRecordRoot(input.cwd, input.flags.record);
 
-  if (input.flags.group !== undefined && input.flags.page !== undefined) {
-    throw usageError("--group cannot be combined with --page.\n");
-  }
-  const group = parseExperimentGroupTarget(input.flags.group);
-  const page = group === undefined
-    ? parseReportRoute(input.flags.page)
-    : `/group/${group}`;
-  if (group !== undefined && input.positionals.length > 0) {
-    throw usageError("--group cannot be combined with an Attempt locator.\n");
-  }
+  const page = parseReportRoute(input.flags.page);
   const evidenceReports = [
     input.flags.source !== undefined ? "--source" : undefined,
     input.flags.execution ? "--execution" : undefined,
@@ -2746,7 +2731,7 @@ function parseReportCliRequest(input: {
         kind: "project-current" as const,
         ...(input.flags.experiment === undefined
           ? {}
-          : { experimentIds: uniqueExactExperimentIds(input.flags.experiment) }),
+          : { experimentSelectors: uniqueExperimentSelectors(input.flags.experiment) }),
       });
 
   return Object.freeze({
@@ -2758,7 +2743,6 @@ function parseReportCliRequest(input: {
     reportSelection: report,
     themeSelection: theme,
     ...(page === undefined ? {} : { page }),
-    ...(group === undefined ? {} : { group }),
   });
 }
 
@@ -2829,15 +2813,6 @@ function parseReportRoute(value: string | undefined): string | undefined {
   return value;
 }
 
-function parseExperimentGroupTarget(value: string | undefined): string | undefined {
-  if (value === undefined) return undefined;
-  const match = /^(named|singleton)\/([a-z0-9][a-z0-9._~-]*)$/u.exec(value);
-  if (match === null) {
-    throw usageError(`Invalid --group "${value}"; expected named/<key> or singleton/<experiment-id>.\n`);
-  }
-  return `${match[1]}/${match[2]}`;
-}
-
 function reportSelection(cwd: string, value: string | undefined): ReportSelection {
   if (value === undefined) return Object.freeze({ kind: "config" as const });
   if (value === "standard") return Object.freeze({ kind: "built-in" as const, name: "standard" as const });
@@ -2891,13 +2866,13 @@ function uniqueExactRunIds(values: readonly string[]): readonly RunId[] {
   return Object.freeze(result);
 }
 
-function uniqueExactExperimentIds(values: readonly string[]): readonly ExperimentId[] {
-  const result: ExperimentId[] = [];
+function uniqueExperimentSelectors(values: readonly string[]): readonly string[] {
+  const result: string[] = [];
   const seen = new Set<string>();
   for (const value of values) {
     const decoded = Schema.decodeUnknownEither(ExperimentIdSchema)(value);
     if (Either.isLeft(decoded)) {
-      throw usageError(`Invalid --experiment value "${value}": expected one exact ExperimentId.\n`);
+      throw usageError(`Invalid --experiment value "${value}": expected an Experiment selector.\n`);
     }
     if (!seen.has(decoded.right)) {
       seen.add(decoded.right);
@@ -2905,6 +2880,13 @@ function uniqueExactExperimentIds(values: readonly string[]): readonly Experimen
     }
   }
   return Object.freeze(result);
+}
+
+function selectedExperimentIds(
+  slots: readonly import("./analysis/contracts.ts").AnalysisCurrentSlotIdentity[],
+): readonly ExperimentId[] {
+  return Object.freeze([...new Set(slots.map((slot) => slot.experimentId))]
+    .sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right))));
 }
 
 /** Current Record locators use the strict scheme-1 short alias. */
@@ -2939,9 +2921,9 @@ function loadCliReportInputs(request: ReportCliRequest): Effect.Effect<LoadedCli
   return Effect.gen(function* () {
     const projectCurrent = request.target.kind === "project-current"
       ? yield* cliEffect("load current project target", loadProjectCurrent(request.cwd, {
-          ...(request.target.experimentIds === undefined
+          ...(request.target.experimentSelectors === undefined
             ? {}
-            : { experiments: request.target.experimentIds }),
+            : { experiments: request.target.experimentSelectors }),
           freshImport: true,
         }))
       : undefined;
@@ -2960,8 +2942,8 @@ function loadCliReportInputs(request: ReportCliRequest): Effect.Effect<LoadedCli
       : Object.freeze({
           policy: "project-current" as const,
           currentSlots: projectCurrent.currentSlots,
-          ...(request.target.kind === "project-current" && request.target.experimentIds !== undefined
-            ? { experimentIds: request.target.experimentIds }
+          ...(request.target.kind === "project-current" && request.target.experimentSelectors !== undefined
+            ? { experimentIds: selectedExperimentIds(projectCurrent.currentSlots) }
             : {}),
         });
     const sourceWatchInputs = uniqueWatchInputs([
@@ -3178,31 +3160,15 @@ function finiteNumberProperty(value: unknown, key: string): number | undefined {
 function requireKnownReportPage(
   revision: ClosedSiteRevision,
   page: string | undefined,
-  group?: string,
 ): Effect.Effect<void, CliUsageError> {
   const routes = closedSiteRevisionData(revision).routes;
   if (page === undefined || routes.includes(page)) {
     return Effect.void;
   }
-  if (group !== undefined) {
-    return Effect.fail(usageError(`report-group-not-in-sample: ${group}\n`));
-  }
   const available = [...routes].sort().join(", ");
   return Effect.fail(usageError(
     `Unknown Report route "${page}". Available routes: ${available || "none"}.\n`,
   ));
-}
-
-function requireGroupPageAvailable(
-  report: ReportDefinition,
-  group: string | undefined,
-): Effect.Effect<void, CliUsageError> {
-  if (group === undefined) return Effect.void;
-  const groupKind = group.startsWith("named/") ? "named" : "singleton";
-  if (report.pages.some((page) => "role" in page && page.role?.kind === "experiment-group" && page.role.groupKind === groupKind)) {
-    return Effect.void;
-  }
-  return Effect.fail(usageError(`report-group-page-unavailable: ${group}\n`));
 }
 
 const cliReportConsole = Object.freeze({
@@ -3344,7 +3310,6 @@ function runShowCommand(
       "Load project, config, Report, and Theme",
       loadCliReportInputs(request),
     );
-    yield* requireGroupPageAvailable(inputs.report, request.group);
     const textProjection = flags.json
       ? undefined
       : panelCapabilityOf({
@@ -3400,9 +3365,6 @@ function runViewCommand(
       if (flags.port !== undefined || flags.host !== undefined || flags.open === true) {
         return yield* Effect.fail(usageError("view --out does not start a server; remove --port, --host, and --open.\n"));
       }
-      if (request.group !== undefined) {
-        return yield* Effect.fail(usageError("view --out does not accept --group.\n"));
-      }
       if (request.page !== undefined) {
         return yield* Effect.fail(usageError("view --out does not accept --page.\n"));
       }
@@ -3425,11 +3387,10 @@ function runViewCommand(
       "Load project, config, Report, and Theme",
       loadCliReportInputs(request),
     );
-    yield* requireGroupPageAvailable(initialInputs.report, request.group);
     const initial = yield* buildCliReportSite(request, initialInputs).pipe(
       Effect.provideService(ReportHostProgressObserver, makeCliReportProgress(request.rootPath, progress)),
     );
-    yield* requireKnownReportPage(initial, request.page, request.group);
+    yield* requireKnownReportPage(initial, request.page);
     const buildCache = yield* makeReportViewBuildCache(
       request,
       initialInputs,
@@ -3535,7 +3496,7 @@ function rebuildReportView(request: ReportCliRequest, cache: ReportViewBuildCach
         themeIdentity,
       });
     }
-    yield* requireKnownReportPage(revision, request.page, request.group);
+    yield* requireKnownReportPage(revision, request.page);
     cache.revision = revision;
     cache.pageBytes = pageBytes;
     cache.watchInputs = inputs.watchInputs;

--- a/src/report/assets/styles.css
+++ b/src/report/assets/styles.css
@@ -2456,9 +2456,9 @@ html.niceeval-view-document body {
   position: sticky;
   top: 0;
   z-index: 10;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
-  justify-content: space-between;
   gap: 28px;
 }
 
@@ -2470,11 +2470,26 @@ html.niceeval-view-document body {
 
 .niceeval-view-brand {
   display: flex;
+  justify-self: start;
   flex: 0 0 auto;
   align-items: baseline;
   gap: 12px;
   font-size: 20px;
   font-weight: 690;
+}
+
+.niceeval-view-pages {
+  display: flex;
+  min-width: 0;
+  justify-self: center;
+}
+
+.niceeval-view-controls {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-self: end;
+  gap: 12px;
 }
 
 .niceeval-view-mark {
@@ -2516,40 +2531,42 @@ html.niceeval-view-document body {
 
 .niceeval-view-nav a[aria-current="page"] { font-weight: 560; }
 
-.niceeval-view-locale {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  overflow: hidden;
-  border: 1px solid var(--niceeval-color-border, #262626);
-  border-radius: var(--niceeval-radius, 0);
-  background: var(--niceeval-color-surface, #0b0b0b);
+.niceeval-view-experiment {
+  min-width: 0;
+  color: var(--niceeval-color-text-secondary, #a1a1aa);
+  font-size: 12px;
 }
 
-.niceeval-view-locale button {
-  height: 30px;
-  min-width: 44px;
-  border: 0;
-  border-right: 1px solid var(--niceeval-color-border, #262626);
-  padding: 0;
-  color: var(--niceeval-color-text-secondary, #a1a1aa);
-  background: transparent;
+.niceeval-view-experiment label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.niceeval-view-experiment select,
+.niceeval-view-language select {
+  min-width: 132px;
+  height: 32px;
+  border: 1px solid var(--niceeval-color-border, #262626);
+  border-radius: var(--niceeval-radius, 0);
+  padding: 0 28px 0 10px;
+  color: var(--niceeval-color-text, #ededed);
+  background: var(--niceeval-color-surface, #0b0b0b);
   font: inherit;
-  font-size: 12px;
-  line-height: 1;
+  font-size: 14px;
   cursor: pointer;
 }
 
-.niceeval-view-locale button:last-child { border-right: 0; }
-.niceeval-view-locale button:hover { color: var(--niceeval-color-text, #ededed); }
-.niceeval-view-locale button.is-active {
-  color: var(--niceeval-color-text, #ededed);
-  background: var(--niceeval-color-surface-subtle, #111111);
-  font-weight: 620;
+.niceeval-view-language {
+  display: block;
+  flex: 0 0 auto;
 }
 
+.niceeval-view-language select { min-width: 76px; }
+
 .niceeval-view-nav a:focus-visible,
-.niceeval-view-locale button:focus-visible,
+.niceeval-view-experiment select:focus-visible,
+.niceeval-view-language select:focus-visible,
 .niceeval-view-brand:focus-visible {
   outline: 1px solid var(--niceeval-color-focus, #cbd6dc);
   outline-offset: 2px;
@@ -2665,14 +2682,21 @@ html.niceeval-view-document body {
 [data-niceeval-locale][hidden] { display: none !important; }
 
 @media (max-width: 760px) {
-  .niceeval-view-shell { padding: 0 20px; }
-  .niceeval-view-nav { display: none; }
-  .niceeval-view-locale button { min-width: 40px; }
+  .niceeval-view-shell {
+    grid-template-columns: auto minmax(0, 1fr);
+    padding: 0 20px;
+  }
+  .niceeval-view-pages { display: none; }
+  .niceeval-view-controls { grid-column: 2; }
+  .niceeval-view-experiment noscript .niceeval-view-nav { display: none; }
+  .niceeval-view-experiment label > span { display: none; }
+  .niceeval-view-experiment select { min-width: 108px; }
+  .niceeval-view-language select { min-width: 68px; }
   .niceeval-view-main { width: min(calc(100vw - 28px), 1120px); padding-top: 42px; }
 }
 
 @media print {
   .niceeval-view-shell { position: static; }
-  .niceeval-view-locale { display: none; }
+  .niceeval-view-controls { display: none; }
   .niceeval-view-main { width: auto; padding: 0; }
 }

--- a/src/report/built-in/run-membership-overview.ts
+++ b/src/report/built-in/run-membership-overview.ts
@@ -26,6 +26,12 @@ import {
   builtInMachineProducerIds,
   defineBuiltInReport,
 } from "./machine.ts";
+import {
+  standardAttemptPage,
+  standardExperimentPage,
+  standardNamedGroupPage,
+  standardSingletonGroupPage,
+} from "./standard.tsx";
 
 interface RunMembershipPageInput {
   readonly hero: HeroData;
@@ -199,7 +205,13 @@ const runMembershipPage = {
 export function runMembershipOverviewReport() {
   return defineBuiltInReport(builtInMachineProducerIds.runMembershipOverview, {
     title: "Run results",
-    pages: [runMembershipPage],
+    pages: [
+      runMembershipPage,
+      standardNamedGroupPage,
+      standardSingletonGroupPage,
+      standardAttemptPage,
+      standardExperimentPage,
+    ],
   });
 }
 

--- a/src/report/built-in/run-membership-overview.ts
+++ b/src/report/built-in/run-membership-overview.ts
@@ -33,12 +33,28 @@ import {
   standardSingletonGroupPage,
 } from "./standard.tsx";
 
-interface RunMembershipPageInput {
+export interface RunMembershipPageInput {
   readonly hero: HeroData;
   readonly summary: BuiltInSummaryRows;
   readonly members: readonly MembershipRow[];
   readonly errors: readonly RunErrorRow[];
   readonly evidence: Awaited<ReturnType<typeof toAttemptEvidence>>;
+}
+
+/** Closes the data shared by the Human Page and its Host-owned machine producer. */
+export async function loadRunMembershipPageInput(sample: Sample): Promise<RunMembershipPageInput> {
+  const [summary, evidence, diagnostics] = await Promise.all([
+    loadBuiltInSummaryRows(sample),
+    toAttemptEvidence(sample),
+    query(sample, { kind: "domain-view", view: runDiagnosticsView }),
+  ]);
+  return Object.freeze({
+    hero: heroData(sample.snapshot),
+    summary,
+    members: membershipRows(sample.snapshot, diagnostics, evidence),
+    errors: runErrorRows(diagnostics),
+    evidence,
+  });
 }
 
 function heroData(snapshot: SampleSnapshot): HeroData {
@@ -184,20 +200,7 @@ const runMembershipPage = {
   id: "run-membership",
   path: "/",
   title: "Run results",
-  load: async (sample: Sample): Promise<RunMembershipPageInput> => {
-    const [summary, evidence, diagnostics] = await Promise.all([
-      loadBuiltInSummaryRows(sample),
-      toAttemptEvidence(sample),
-      query(sample, { kind: "domain-view", view: runDiagnosticsView }),
-    ]);
-    return Object.freeze({
-      hero: heroData(sample.snapshot),
-      summary,
-      members: membershipRows(sample.snapshot, diagnostics, evidence),
-      errors: runErrorRows(diagnostics),
-      evidence,
-    });
-  },
+  load: loadRunMembershipPageInput,
   render: (input: RunMembershipPageInput) => jsx(RunMembershipResultView, input),
 } satisfies Page<void, RunMembershipPageInput>;
 

--- a/src/report/built-in/standard.tsx
+++ b/src/report/built-in/standard.tsx
@@ -123,7 +123,7 @@ function standardOverview(sample: Sample) {
       <SampleNotices />
       <SampleSummary />
       {only === undefined ? (
-        <Section title={{ en: "Experiment groups", "zh-CN": "实验组" }}>
+        <Section title={{ en: "Experiments", "zh-CN": "实验" }}>
           <Col>
             {groups.map((entry) => (
               <Link

--- a/src/report/built-in/standard.tsx
+++ b/src/report/built-in/standard.tsx
@@ -7,15 +7,22 @@
  */
 
 import type {
+  ExperimentComparisonScope,
+  ExperimentGroupIdentity,
   ExperimentId,
   Sample,
   SampleSnapshot,
 } from "../../analysis/index.ts";
+import {
+  experimentComparisonScope,
+  experimentGroups,
+} from "../../analysis/index.ts";
 import type {
   Page,
   PageEvidence,
+  PageParams,
 } from "../definition/report.ts";
-import { Col, Section } from "../definition/primitives.tsx";
+import { Col, Link, Section, Text } from "../definition/primitives.tsx";
 import { defineComponent } from "../definition/tree.ts";
 import { AttemptDetails } from "../components/attempt-detail/index.tsx";
 import { ExperimentTable } from "../components/entity-lists/index.tsx";
@@ -94,27 +101,44 @@ function membershipRows(
     })));
 }
 
-const StandardExperimentResults = defineComponent(async (_props, context) => {
-  const rows = await experimentListData(context.scope, context.report.pricing);
+const StandardExperimentResults = defineComponent<{ readonly comparison: ExperimentComparisonScope }>(async (props) => {
   return (
     <Col>
       <Section title={{ en: "Experiment comparison", "zh-CN": "实验对比" }}>
-        <ExperimentScatter rows={rows} />
+        <ExperimentScatter comparison={props.comparison} />
       </Section>
       <Section title={{ en: "Experiments", "zh-CN": "实验" }}>
-        <ExperimentTable rows={rows} />
+        <ExperimentTable comparison={props.comparison} />
       </Section>
     </Col>
   );
 });
 
-function standardOverview() {
+function standardOverview(sample: Sample) {
+  const groups = experimentGroups(sample);
+  const only = groups.length === 1 ? groups[0] : undefined;
   return (
     <Col>
       <Hero />
       <SampleNotices />
       <SampleSummary />
-      <StandardExperimentResults />
+      {only === undefined ? (
+        <Section title={{ en: "Experiment groups", "zh-CN": "实验组" }}>
+          <Col>
+            {groups.map((entry) => (
+              <Link
+                key={entry.group.key}
+                target={{
+                  page: entry.group.kind === "named" ? "group-named" : "group-singleton",
+                  params: entry.group,
+                }}
+              >
+                {entry.group.kind === "named" ? entry.group.groupId : String(entry.group.experimentId)}
+              </Link>
+            ))}
+          </Col>
+        </Section>
+      ) : <StandardExperimentResults comparison={experimentComparisonScope(sample, only.group)} />}
     </Col>
   );
 }
@@ -126,6 +150,81 @@ export const standardOverviewPage = {
   title: { en: "Overview", "zh-CN": "总览" },
   render: standardOverview,
 } satisfies Page;
+
+type NamedGroupParams = {
+  readonly kind: "named";
+  readonly groupId: string;
+  readonly key: `named/${string}`;
+};
+type SingletonGroupParams = {
+  readonly kind: "singleton";
+  readonly experimentId: ExperimentId;
+  readonly key: `singleton/${string}`;
+};
+
+const namedGroupParams: PageParams<NamedGroupParams> = Object.freeze({
+  encode: (params: NamedGroupParams) => params.groupId,
+  decode: (key: string) => {
+    if (!/^[a-z0-9][a-z0-9._~-]*$/u.test(key)) throw new TypeError("named Experiment Group key is not canonical");
+    return Object.freeze({ kind: "named" as const, groupId: key, key: `named/${key}` as const });
+  },
+  enumerate: (sample: Sample) => experimentGroups(sample)
+    .filter((entry): entry is typeof entry & { readonly group: NamedGroupParams } => entry.group.kind === "named")
+    .map((entry) => entry.group),
+});
+
+const singletonGroupParams: PageParams<SingletonGroupParams> = Object.freeze({
+  encode: (params: SingletonGroupParams) => String(params.experimentId),
+  decode: (key: string) => {
+    if (!/^[a-z0-9][a-z0-9._~-]*$/u.test(key)) throw new TypeError("singleton Experiment Group key is not canonical");
+    return Object.freeze({
+      kind: "singleton" as const,
+      experimentId: key as ExperimentId,
+      key: `singleton/${key}` as const,
+    });
+  },
+  enumerate: (sample: Sample) => experimentGroups(sample)
+    .filter((entry): entry is typeof entry & { readonly group: SingletonGroupParams } => entry.group.kind === "singleton")
+    .map((entry) => entry.group),
+});
+
+function standardGroupPage<Params extends import("../../analysis/index.ts").JsonValue>(input: {
+  readonly id: string;
+  readonly path: string;
+  readonly groupKind: "named" | "singleton";
+  readonly params: PageParams<Params>;
+}): Page<Params, ExperimentComparisonScope> {
+  return {
+    id: input.id,
+    path: input.path,
+    title: { en: "Experiment group", "zh-CN": "实验组" },
+    navigation: false as const,
+    role: { kind: "experiment-group" as const, groupKind: input.groupKind },
+    params: input.params,
+    load: (sample: Sample, params: Params) =>
+      experimentComparisonScope(sample, params as ExperimentGroupIdentity),
+    render: (comparison: ExperimentComparisonScope) => (
+      <Col>
+        <Text>{comparison.group.key}</Text>
+        <StandardExperimentResults comparison={comparison} />
+      </Col>
+    ),
+  } as unknown as Page<Params, ExperimentComparisonScope>;
+}
+
+export const standardNamedGroupPage = standardGroupPage({
+  id: "group-named",
+  path: "/group/named",
+  groupKind: "named",
+  params: namedGroupParams,
+});
+
+export const standardSingletonGroupPage = standardGroupPage({
+  id: "group-singleton",
+  path: "/group/singleton",
+  groupKind: "singleton",
+  params: singletonGroupParams,
+});
 
 /** One standard detail Page for one already-selected Attempt. */
 export const standardAttemptPage = {
@@ -176,6 +275,8 @@ export const standard = defineBuiltInReport(builtInMachineProducerIds.standard, 
   title: "NiceEval overview",
   pages: [
     standardOverviewPage,
+    standardNamedGroupPage,
+    standardSingletonGroupPage,
     standardAttemptPage,
     standardExperimentPage,
   ],

--- a/src/report/built-in/standard.tsx
+++ b/src/report/built-in/standard.tsx
@@ -17,12 +17,13 @@ import {
   experimentComparisonScope,
   experimentGroups,
 } from "../../analysis/index.ts";
+import { sampleForExperimentComparisonScope } from "../../analysis/experiment-groups.ts";
 import type {
   Page,
   PageEvidence,
   PageParams,
 } from "../definition/report.ts";
-import { Col, Link, Section, Text } from "../definition/primitives.tsx";
+import { Col, Link, Section } from "../definition/primitives.tsx";
 import { defineComponent } from "../definition/tree.ts";
 import { AttemptDetails } from "../components/attempt-detail/index.tsx";
 import { ExperimentTable } from "../components/entity-lists/index.tsx";
@@ -114,31 +115,44 @@ const StandardExperimentResults = defineComponent<{ readonly comparison: Experim
   );
 });
 
+const StandardExperimentOverview = defineComponent<{ readonly comparison: ExperimentComparisonScope }>((props) => {
+  const sample = sampleForExperimentComparisonScope(props.comparison);
+  return (
+    <Col>
+      <Hero input={sample} />
+      <SampleNotices input={sample} />
+      <SampleSummary input={sample} />
+      <StandardExperimentResults comparison={props.comparison} />
+    </Col>
+  );
+});
+
 function standardOverview(sample: Sample) {
   const groups = experimentGroups(sample);
   const only = groups.length === 1 ? groups[0] : undefined;
+  if (only !== undefined) {
+    return <StandardExperimentOverview comparison={experimentComparisonScope(sample, only.group)} />;
+  }
   return (
     <Col>
       <Hero />
       <SampleNotices />
       <SampleSummary />
-      {only === undefined ? (
-        <Section title={{ en: "Experiments", "zh-CN": "实验" }}>
-          <Col>
-            {groups.map((entry) => (
-              <Link
-                key={entry.group.key}
-                target={{
-                  page: entry.group.kind === "named" ? "group-named" : "group-singleton",
-                  params: entry.group,
-                }}
-              >
-                {entry.group.kind === "named" ? entry.group.groupId : String(entry.group.experimentId)}
-              </Link>
-            ))}
-          </Col>
-        </Section>
-      ) : <StandardExperimentResults comparison={experimentComparisonScope(sample, only.group)} />}
+      <Section title={{ en: "Experiments", "zh-CN": "实验" }}>
+        <Col>
+          {groups.map((entry) => (
+            <Link
+              key={entry.group.key}
+              target={{
+                page: entry.group.kind === "named" ? "group-named" : "group-singleton",
+                params: entry.group,
+              }}
+            >
+              {entry.group.kind === "named" ? entry.group.groupId : String(entry.group.experimentId)}
+            </Link>
+          ))}
+        </Col>
+      </Section>
     </Col>
   );
 }
@@ -204,10 +218,7 @@ function standardGroupPage<Params extends import("../../analysis/index.ts").Json
     load: (sample: Sample, params: Params) =>
       experimentComparisonScope(sample, params as ExperimentGroupIdentity),
     render: (comparison: ExperimentComparisonScope) => (
-      <Col>
-        <Text>{comparison.group.key}</Text>
-        <StandardExperimentResults comparison={comparison} />
-      </Col>
+      <StandardExperimentOverview comparison={comparison} />
     ),
   } as unknown as Page<Params, ExperimentComparisonScope>;
 }

--- a/src/report/components/entity-lists/index.tsx
+++ b/src/report/components/entity-lists/index.tsx
@@ -2,9 +2,10 @@
 // 列表本体是中立 Table 原语(TableContentView);语义全部住在 compute.ts 与
 // content.ts 的投影层,docs/feature/reports/library.md。
 
-import type { Sample } from "../../../analysis/index.ts";
+import type { ExperimentComparisonScope, Sample } from "../../../analysis/index.ts";
+import { sampleForExperimentComparisonScope } from "../../../analysis/experiment-groups.ts";
 import { defineComponent } from "../../definition/tree.ts";
-import { TableContentView } from "../../definition/primitives.tsx";
+import { TableContentView, Text } from "../../definition/primitives.tsx";
 import type { ReportLocale } from "../../model/locale.ts";
 import {
   attemptListData,
@@ -83,10 +84,7 @@ export const AttemptList = defineComponent<AttemptListProps>(async (props, ctx) 
 AttemptList.displayName = "AttemptList";
 
 export interface ExperimentTableProps {
-  /** 显式 Sample;省略时用当前组合上下文的 `ctx.scope`。 */
-  readonly input?: Sample;
-  /** 已闭合的行;省略时按 `input` 计算。 */
-  readonly rows?: readonly ExperimentListItem[];
+  readonly comparison: ExperimentComparisonScope;
   /** 显示排序列;省略时按列表自身题型选择 passRate 或 totalScore。 */
   readonly sort?: string;
   readonly searchable?: boolean;
@@ -95,8 +93,13 @@ export interface ExperimentTableProps {
 }
 
 export const ExperimentTable = defineComponent<ExperimentTableProps>(async (props, ctx) => {
-  const sample = props.input ?? ctx.scope;
-  const rows = props.rows ?? await experimentListData(sample, ctx.report.pricing);
+  if (props.comparison.comparison.state === "non-comparable") {
+    return <Text className={props.className}>
+      {props.comparison.comparison.issues.map((issue) => issue.reason).join(", ")}
+    </Text>;
+  }
+  const sample = sampleForExperimentComparisonScope(props.comparison);
+  const rows = await experimentListData(sample, ctx.report.pricing);
   const composition = experimentListEvaluationKindComposition(
     rows.map((row) => ({ evaluationKind: row.evaluationKind, attempts: row.evalRows.length })),
   );

--- a/src/report/components/summaries/index.tsx
+++ b/src/report/components/summaries/index.tsx
@@ -1,6 +1,7 @@
 /** Official summary components over a fixed Sample and closed Analysis rows. */
 
-import type { ExperimentId, MetricValue, Sample } from "../../../analysis/index.ts";
+import type { ExperimentComparisonScope, ExperimentId, MetricValue, Sample } from "../../../analysis/index.ts";
+import { sampleForExperimentComparisonScope } from "../../../analysis/experiment-groups.ts";
 import { defineComponent } from "../../definition/tree.ts";
 import {
   Chart,
@@ -36,7 +37,6 @@ import {
   type SummarySeries,
 } from "./compute.ts";
 import type { Dataset, DatasetField } from "../../model/types.ts";
-import type { ExperimentListItem } from "../entity-lists/compute.ts";
 
 export { StabilityOverview } from "./stability-overview.tsx";
 export type { StabilityOverviewProps } from "./stability-overview.tsx";
@@ -94,16 +94,13 @@ export const SampleSummary = defineComponent<SampleSummaryProps>(async (props, c
 SampleSummary.displayName = "SampleSummary";
 
 export interface ExperimentScatterProps {
-  /** Explicit fixed Sample; omitted means the resolving component's `ctx.scope`. */
-  readonly input?: Sample;
+  readonly comparison: ExperimentComparisonScope;
   /** The closed Run-context dimension used to split experiment points. */
   readonly series?: SummarySeries;
   /** Connect points from the same series; defaults on for the conventional `line` label. */
   readonly connect?: boolean;
   /** Overrides the library's default Experiment detail target for each point. */
   readonly pointTarget?: (point: ChartTargetPoint) => ReportTarget | undefined;
-  /** Closed Experiment facts; the standard Report shares these with ExperimentTable. */
-  readonly rows?: readonly ExperimentListItem[];
   readonly locale?: ReportLocale;
   readonly className?: string;
 }
@@ -125,10 +122,18 @@ export const ExperimentScatter = defineComponent<ExperimentScatterProps>(async (
       </Col>
     );
   }
-  const data = await experimentScatterData(props.input ?? ctx.scope, {
+  if (props.comparison.comparison.state === "non-comparable") {
+    return (
+      <Col className={joinClassNames("niceeval-experiment-scatter", props.className)}>
+        <Text className="niceeval-experiment-scatter-note">
+          {props.comparison.comparison.issues.map((issue) => issue.reason).join(", ")}
+        </Text>
+      </Col>
+    );
+  }
+  const data = await experimentScatterData(sampleForExperimentComparisonScope(props.comparison), {
     series: props.series,
     connect: props.connect,
-    experiments: props.rows,
   }, pricing);
   if (data.points.length > 0 && data.points.every((point) => point.costUSD.state === "migration-required")) {
     return (
@@ -185,13 +190,12 @@ export interface SampleOverviewProps extends ExperimentScatterProps {}
 /** The conventional summary + comparison composition. */
 export const SampleOverview = defineComponent<SampleOverviewProps>((props) => (
   <Col className={props.className}>
-    <SampleSummary input={props.input} locale={props.locale} />
+    <SampleSummary input={sampleForExperimentComparisonScope(props.comparison)} locale={props.locale} />
     <ExperimentScatter
-      input={props.input}
+      comparison={props.comparison}
       series={props.series}
       connect={props.connect}
       pointTarget={props.pointTarget}
-      rows={props.rows}
       locale={props.locale}
     />
   </Col>

--- a/src/report/definition/report.ts
+++ b/src/report/definition/report.ts
@@ -171,6 +171,10 @@ export interface ParameterizedPage<Params extends JsonValue, Input> {
   readonly path?: string;
   readonly title: LocalizedText;
   readonly navigation: false;
+  readonly role?: {
+    readonly kind: "experiment-group";
+    readonly groupKind: "named" | "singleton";
+  };
   readonly params: PageParams<Params>;
   readonly load: PageLoad<Params, Input>;
   readonly render: PageRender<Input>;
@@ -201,6 +205,10 @@ interface NormalizedParameterizedPage<
   readonly path: string;
   readonly title: LocalizedText;
   readonly navigation: false;
+  readonly role?: {
+    readonly kind: "experiment-group";
+    readonly groupKind: "named" | "singleton";
+  };
   readonly params: PageParams<Params>;
   readonly load: PageLoad<Params, Input>;
   readonly render: PageRender<Input>;
@@ -524,7 +532,9 @@ function isFrozenNormalizedPage(value: unknown): value is NormalizedPage {
   }
   if (Object.hasOwn(value, "params")) {
     return value.navigation === false && typeof value.load === "function" &&
-      hasExactOwnDataFields(value, ["id", "path", "title", "navigation", "params", "load", "render"]) &&
+      (hasExactOwnDataFields(value, ["id", "path", "title", "navigation", "params", "load", "render"]) ||
+        hasExactOwnDataFields(value, ["id", "path", "title", "navigation", "role", "params", "load", "render"])) &&
+      (!Object.hasOwn(value, "role") || isExperimentGroupRole(value.role)) &&
       isFrozenPageParams(value.params);
   }
   const valid = hasExactOwnDataFields(value, ["id", "path", "title", "navigation", "render"]) ||
@@ -632,10 +642,10 @@ function normalizePage(value: unknown, index: number): NormalizedPage {
   assertOnlyFields(
     fields,
     parameterized
-      ? ["id", "path", "title", "navigation", "params", "load", "render"]
+      ? ["id", "path", "title", "navigation", "role", "params", "load", "render"]
       : ["id", "path", "title", "navigation", "load", "render"],
     label,
-    parameterized ? ["path"] : ["path", "navigation", "load"],
+    parameterized ? ["path", "role"] : ["path", "navigation", "load"],
   );
   const id = normalizePageId(fields.get("id"), label);
   const path = fields.has("path") && fields.get("path") !== undefined
@@ -650,11 +660,13 @@ function normalizePage(value: unknown, index: number): NormalizedPage {
     }
     const params = normalizePageParams(fields.get("params"), `${label}.params`);
     const load = requireFunction(fields.get("load"), `${label}.load`);
+    const role = fields.has("role") ? normalizeExperimentGroupRole(fields.get("role"), `${label}.role`) : undefined;
     return Object.freeze({
       id,
       path,
       title,
       navigation: false as const,
+      ...(role === undefined ? {} : { role }),
       params,
       load: load as PageLoad<JsonValue, unknown>,
       render: render as PageRender<unknown>,
@@ -677,6 +689,27 @@ function normalizePage(value: unknown, index: number): NormalizedPage {
     ...(load === undefined ? {} : { load: load as PageLoad<void, unknown> }),
     render: render as PageRender<unknown>,
   }) as NormalizedPlainPage<unknown>;
+}
+
+function normalizeExperimentGroupRole(value: unknown, label: string): NonNullable<NormalizedParameterizedPage["role"]> {
+  const fields = ownFields(value, label);
+  assertOnlyFields(fields, ["kind", "groupKind"], label);
+  if (fields.get("kind") !== "experiment-group" ||
+    (fields.get("groupKind") !== "named" && fields.get("groupKind") !== "singleton")) {
+    throw new TypeError(`${label} must declare experiment-group and named/singleton`);
+  }
+  return Object.freeze({
+    kind: "experiment-group" as const,
+    groupKind: fields.get("groupKind") as "named" | "singleton",
+  });
+}
+
+function isExperimentGroupRole(value: unknown): value is NonNullable<NormalizedParameterizedPage["role"]> {
+  try {
+    return normalizeExperimentGroupRole(value, "Report page role") !== undefined;
+  } catch {
+    return false;
+  }
 }
 
 function derivePagePath(id: string): string {

--- a/src/report/execution/machine.ts
+++ b/src/report/execution/machine.ts
@@ -19,7 +19,7 @@ import { resolvedPageText } from "../runtime/text.ts";
 export type ContentAddress = string;
 
 /** The exact machine schemas in docs/feature/reports/cli.md. */
-export const BUILT_IN_SHOW_SCHEMA = "niceeval.show/v1";
+export const BUILT_IN_SHOW_SCHEMA = "niceeval.show/v2";
 export const CUSTOM_TARGET_EXECUTION_SCHEMA = "niceeval.report-target-execution/v1";
 export const REPORT_PROJECTIONS_SCHEMA = "niceeval.report-projections/v1";
 
@@ -58,7 +58,8 @@ export interface ReportProblem {
  * not a generic component/HTML/text reverse-engineering format.
  */
 export type BuiltInShowData =
-  | { readonly kind: "leaderboard"; readonly rows: JsonValue }
+  | { readonly kind: "groups"; readonly groups: JsonValue }
+  | { readonly kind: "experiment-group"; readonly group: JsonValue; readonly comparison: JsonValue }
   | {
       readonly kind: "attempt";
       readonly evidence: JsonValue;
@@ -653,9 +654,16 @@ function freezeBuiltInData(value: BuiltInShowData): BuiltInShowData {
   // The selected registry producer owns their stable identities and must close
   // them in the canonical order defined for that domain before returning.
   switch (value.kind) {
-    case "leaderboard":
-      assertExactFields(value, ["kind", "rows"], "leaderboard show data");
-      return Object.freeze({ kind: "leaderboard" as const, rows: closeMachineJson(value.rows) });
+    case "groups":
+      assertExactFields(value, ["kind", "groups"], "groups show data");
+      return Object.freeze({ kind: "groups" as const, groups: closeMachineJson(value.groups) });
+    case "experiment-group":
+      assertExactFields(value, ["kind", "group", "comparison"], "experiment-group show data");
+      return Object.freeze({
+        kind: "experiment-group" as const,
+        group: closeMachineJson(value.group),
+        comparison: closeMachineJson(value.comparison),
+      });
     case "attempt":
       assertExactFields(value, ["kind", "evidence", "observability", "fileChanges"], "attempt show data");
       return Object.freeze({

--- a/src/report/execution/machine.ts
+++ b/src/report/execution/machine.ts
@@ -19,8 +19,7 @@ import { resolvedPageText } from "../runtime/text.ts";
 export type ContentAddress = string;
 
 /** The exact regenerable machine formats in docs/feature/reports/cli.md. */
-export const BUILT_IN_SHOW_FORMAT_V1 = "niceeval.show/v1";
-export const BUILT_IN_SHOW_FORMAT_V2 = "niceeval.show/v2";
+export const BUILT_IN_SHOW_FORMAT = "niceeval.show";
 export const CUSTOM_TARGET_EXECUTION_FORMAT = "niceeval.report-target-execution/v1";
 export const REPORT_PROJECTIONS_FORMAT = "niceeval.report-projections/v1";
 
@@ -79,7 +78,7 @@ export type BuiltInShowData =
   | { readonly kind: "timing"; readonly timing: JsonValue };
 
 export interface BuiltInShowDocument {
-  readonly format: typeof BUILT_IN_SHOW_FORMAT_V1 | typeof BUILT_IN_SHOW_FORMAT_V2;
+  readonly format: typeof BUILT_IN_SHOW_FORMAT;
   readonly locale: "en";
   readonly selection: ShowSelection;
   readonly report: {
@@ -536,7 +535,7 @@ export function builtInShowDocument(input: {
   readonly problems?: readonly ReportProblem[];
 }): BuiltInShowDocument {
   return Object.freeze({
-    format: builtInShowFormat(input.data),
+    format: BUILT_IN_SHOW_FORMAT,
     locale: "en" as const,
     selection: freezeSelection(input.selection),
     report: Object.freeze({
@@ -705,14 +704,6 @@ function freezeBuiltInData(value: BuiltInShowData): BuiltInShowData {
     default:
       throw new TypeError("built-in show data kind is not declared by the show format");
   }
-}
-
-function builtInShowFormat(
-  data: BuiltInShowData,
-): typeof BUILT_IN_SHOW_FORMAT_V1 | typeof BUILT_IN_SHOW_FORMAT_V2 {
-  return data.kind === "groups" || data.kind === "experiment-group"
-    ? BUILT_IN_SHOW_FORMAT_V2
-    : BUILT_IN_SHOW_FORMAT_V1;
 }
 
 /** Re-closes a ReportProjections value: validates format, dedupes, and canonically sorts. */

--- a/src/report/execution/machine.ts
+++ b/src/report/execution/machine.ts
@@ -18,10 +18,11 @@ import { resolvedPageText } from "../runtime/text.ts";
 /** Content-addressed identities are opaque, printable strings at this boundary. */
 export type ContentAddress = string;
 
-/** The exact machine schemas in docs/feature/reports/cli.md. */
-export const BUILT_IN_SHOW_SCHEMA = "niceeval.show/v2";
-export const CUSTOM_TARGET_EXECUTION_SCHEMA = "niceeval.report-target-execution/v1";
-export const REPORT_PROJECTIONS_SCHEMA = "niceeval.report-projections/v1";
+/** The exact regenerable machine formats in docs/feature/reports/cli.md. */
+export const BUILT_IN_SHOW_FORMAT_V1 = "niceeval.show/v1";
+export const BUILT_IN_SHOW_FORMAT_V2 = "niceeval.show/v2";
+export const CUSTOM_TARGET_EXECUTION_FORMAT = "niceeval.report-target-execution/v1";
+export const REPORT_PROJECTIONS_FORMAT = "niceeval.report-projections/v1";
 
 export type BuiltInReportToken = string;
 
@@ -71,7 +72,7 @@ export type BuiltInShowData =
   | { readonly kind: "timing"; readonly timing: JsonValue };
 
 export interface BuiltInShowDocument {
-  readonly schema: typeof BUILT_IN_SHOW_SCHEMA;
+  readonly format: typeof BUILT_IN_SHOW_FORMAT_V1 | typeof BUILT_IN_SHOW_FORMAT_V2;
   readonly locale: "en";
   readonly selection: ShowSelection;
   readonly report: {
@@ -89,12 +90,12 @@ export interface BuiltInShowDocument {
 }
 
 /**
- * The custom schema is a single target execution manifest, never a revision.
+ * The custom format is a single target execution manifest, never a revision.
  * It contains only the selected Page's closed English text—not a React tree,
  * HTML body, site identity, Sample capability, Record payload, or raw bytes.
  */
 export interface CustomTargetExecutionManifest {
-  readonly schema: typeof CUSTOM_TARGET_EXECUTION_SCHEMA;
+  readonly format: typeof CUSTOM_TARGET_EXECUTION_FORMAT;
   readonly locale: "en";
   readonly selection: ShowSelection;
   readonly report: {
@@ -142,7 +143,7 @@ export interface ReportProjectionCost {
  * dimensions or projections at one canonical capture key are a build failure.
  */
 export interface ReportProjections {
-  readonly schema: typeof REPORT_PROJECTIONS_SCHEMA;
+  readonly format: typeof REPORT_PROJECTIONS_FORMAT;
   readonly pricingProfile: JsonValue | null;
   readonly costs: readonly ReportProjectionCost[];
 }
@@ -242,7 +243,7 @@ export function buildReportProjections(input: {
     compareUtf8(left.profileIdentity, right.profileIdentity)
   ));
   return Object.freeze({
-    schema: REPORT_PROJECTIONS_SCHEMA,
+    format: REPORT_PROJECTIONS_FORMAT,
     pricingProfile,
     costs,
   });
@@ -528,7 +529,7 @@ export function builtInShowDocument(input: {
   readonly problems?: readonly ReportProblem[];
 }): BuiltInShowDocument {
   return Object.freeze({
-    schema: BUILT_IN_SHOW_SCHEMA,
+    format: builtInShowFormat(input.data),
     locale: "en" as const,
     selection: freezeSelection(input.selection),
     report: Object.freeze({
@@ -563,7 +564,7 @@ export function customTargetExecutionManifest(input: {
     throw new TypeError("the selected Page lacks a closed English text projection at the requested width");
   }
   return Object.freeze({
-    schema: CUSTOM_TARGET_EXECUTION_SCHEMA,
+    format: CUSTOM_TARGET_EXECUTION_FORMAT,
     locale: "en" as const,
     selection: freezeSelection(input.selection),
     report: Object.freeze({
@@ -682,13 +683,21 @@ function freezeBuiltInData(value: BuiltInShowData): BuiltInShowData {
       assertExactFields(value, ["kind", "timing"], "timing show data");
       return Object.freeze({ kind: "timing" as const, timing: closeMachineJson(value.timing) });
     default:
-      throw new TypeError("built-in show data kind is not declared by the show schema");
+      throw new TypeError("built-in show data kind is not declared by the show format");
   }
 }
 
-/** Re-closes a ReportProjections value: validates schema, dedupes, and canonically sorts. */
+function builtInShowFormat(
+  data: BuiltInShowData,
+): typeof BUILT_IN_SHOW_FORMAT_V1 | typeof BUILT_IN_SHOW_FORMAT_V2 {
+  return data.kind === "groups" || data.kind === "experiment-group"
+    ? BUILT_IN_SHOW_FORMAT_V2
+    : BUILT_IN_SHOW_FORMAT_V1;
+}
+
+/** Re-closes a ReportProjections value: validates format, dedupes, and canonically sorts. */
 function freezeProjections(value: ReportProjections): ReportProjections {
-  if (!isPlainRecord(value) || value.schema !== REPORT_PROJECTIONS_SCHEMA) {
+  if (!isPlainRecord(value) || value.format !== REPORT_PROJECTIONS_FORMAT) {
     throw new TypeError("projections must be a niceeval.report-projections/v1 value");
   }
   return buildReportProjections({

--- a/src/report/execution/machine.ts
+++ b/src/report/execution/machine.ts
@@ -62,6 +62,13 @@ export type BuiltInShowData =
   | { readonly kind: "groups"; readonly groups: JsonValue }
   | { readonly kind: "experiment-group"; readonly group: JsonValue; readonly comparison: JsonValue }
   | {
+      readonly kind: "run-membership";
+      readonly summary: JsonValue;
+      readonly members: JsonValue;
+      readonly errors: JsonValue;
+      readonly evidence: JsonValue;
+    }
+  | {
       readonly kind: "attempt";
       readonly evidence: JsonValue;
       readonly observability: JsonValue;
@@ -664,6 +671,19 @@ function freezeBuiltInData(value: BuiltInShowData): BuiltInShowData {
         kind: "experiment-group" as const,
         group: closeMachineJson(value.group),
         comparison: closeMachineJson(value.comparison),
+      });
+    case "run-membership":
+      assertExactFields(
+        value,
+        ["kind", "summary", "members", "errors", "evidence"],
+        "run-membership show data",
+      );
+      return Object.freeze({
+        kind: "run-membership" as const,
+        summary: closeMachineJson(value.summary),
+        members: closeMachineJson(value.members),
+        errors: closeMachineJson(value.errors),
+        evidence: closeMachineJson(value.evidence),
       });
     case "attempt":
       assertExactFields(value, ["kind", "evidence", "observability", "fileChanges"], "attempt show data");

--- a/src/report/host/execute.ts
+++ b/src/report/host/execute.ts
@@ -705,7 +705,7 @@ function commandForTarget(pages: readonly ReportPageDefinition[], target: Report
   const page = pages.find((candidate) => candidate.id === target.page);
   if (page?.params !== undefined && page.role?.kind === "experiment-group") {
     const key = route.slice(page.path.length + 1);
-    return `niceeval show --group ${shellQuote(`${page.role.groupKind}/${key}`)}`;
+    return `niceeval show --experiment ${shellQuote(key)}`;
   }
   return `niceeval show --page ${shellQuote(route)}`;
 }

--- a/src/report/host/execute.ts
+++ b/src/report/host/execute.ts
@@ -128,6 +128,10 @@ export interface ClosedTargetExecution {
 export interface ClosedSitePage {
   readonly page: ResolvedPage;
   readonly navigation: boolean;
+  readonly role?: {
+    readonly kind: "experiment-group";
+    readonly groupKind: "named" | "singleton";
+  };
 }
 
 /** Host-private complete page closure used only while forming a revision. */
@@ -287,7 +291,7 @@ export function executeReportSite(input: {
               },
               capturePage: (capture) => capturedProjectionCosts(capture, route, definition.id),
             });
-            yield* addSitePage(pages, routeOwners, page, false);
+            yield* addSitePage(pages, routeOwners, page, false, definition.role);
             yield* registerProjectionCosts(pricingProfile, projectionCosts, pageCosts);
             siteProblems.push(...analysisProblems(issues, page.target.pageId));
             yield* checkBuildBudgets(input.budget);
@@ -557,6 +561,7 @@ function addSitePage(
   routeOwners: Map<string, string>,
   page: ResolvedPage,
   navigation: boolean,
+  role?: ClosedSitePage["role"],
 ): Effect.Effect<void, ReportSiteRouteConflict | ReportBuildBudgetExceeded> {
   const owner = routeOwners.get(page.target.route);
   if (owner !== undefined) {
@@ -570,7 +575,7 @@ function addSitePage(
     return Effect.fail(reportBuildBudgetExceeded("pages", REPORT_PAGES_MAX, pages.length + 1));
   }
   routeOwners.set(page.target.route, page.target.pageId);
-  pages.push(Object.freeze({ page, navigation }));
+  pages.push(Object.freeze({ page, navigation, ...(role === undefined ? {} : { role }) }));
   return Effect.void;
 }
 
@@ -696,7 +701,13 @@ function relativeHref(sourceFile: string, targetFile: string): string {
 
 function commandForTarget(pages: readonly ReportPageDefinition[], target: ReportTarget): string | undefined {
   const route = routeForTarget(pages, target);
-  return route === undefined ? undefined : `niceeval show --page ${shellQuote(route)}`;
+  if (route === undefined) return undefined;
+  const page = pages.find((candidate) => candidate.id === target.page);
+  if (page?.params !== undefined && page.role?.kind === "experiment-group") {
+    const key = route.slice(page.path.length + 1);
+    return `niceeval show --group ${shellQuote(`${page.role.groupKind}/${key}`)}`;
+  }
+  return `niceeval show --page ${shellQuote(route)}`;
 }
 
 function shellQuote(value: string): string {

--- a/src/report/host/from-record.ts
+++ b/src/report/host/from-record.ts
@@ -208,7 +208,7 @@ function showSelectionFromRecord(input: SelectionTarget & {
     const sample = yield* openSelectionSample(input.root, input.selection);
     const report = input.report ?? defaultReportForSelection(input.selection);
     const selection = showSelectionForRequest(sample, input.selection);
-    const implicitRoute = input.route === undefined
+    const implicitRoute = input.route === undefined && input.selection.policy !== "explicit-runs"
       ? singleExperimentGroupRoute(report, sample)
       : undefined;
     return yield* presentShowTarget({

--- a/src/report/host/from-record.ts
+++ b/src/report/host/from-record.ts
@@ -10,6 +10,7 @@ import type {
   JsonValue,
   Sample,
 } from "../../analysis/index.ts";
+import { experimentGroups } from "../../analysis/index.ts";
 import type { RecordCoordination } from "../../coordination/record-leases.ts";
 import { recordHost } from "../../record/host/runtime.ts";
 import type { RecordRoot } from "../../record/platform/root.ts";
@@ -207,15 +208,25 @@ function showSelectionFromRecord(input: SelectionTarget & {
     const sample = yield* openSelectionSample(input.root, input.selection);
     const report = input.report ?? defaultReportForSelection(input.selection);
     const selection = showSelectionForRequest(sample, input.selection);
+    const groups = report === standard ? experimentGroups(sample) : [];
+    const implicitRoute = input.route === undefined && groups.length === 1
+      ? groupRoute(groups[0]!.group)
+      : undefined;
     return yield* presentShowTarget({
       sample,
       report,
       selection,
-      ...(input.route === undefined ? {} : { route: input.route }),
+      ...(input.route === undefined && implicitRoute === undefined ? {} : { route: input.route ?? implicitRoute }),
       ...(input.textProjection === undefined ? {} : { textProjection: input.textProjection }),
       format: input.format ?? "text",
     });
   }));
+}
+
+function groupRoute(group: import("../../analysis/index.ts").ExperimentGroupIdentity): string {
+  return group.kind === "named"
+    ? `/group/named/${group.groupId}`
+    : `/group/singleton/${String(group.experimentId)}`;
 }
 
 function showAttemptFromRecord(input: AttemptTarget & {

--- a/src/report/host/from-record.ts
+++ b/src/report/host/from-record.ts
@@ -208,9 +208,8 @@ function showSelectionFromRecord(input: SelectionTarget & {
     const sample = yield* openSelectionSample(input.root, input.selection);
     const report = input.report ?? defaultReportForSelection(input.selection);
     const selection = showSelectionForRequest(sample, input.selection);
-    const groups = report === standard ? experimentGroups(sample) : [];
-    const implicitRoute = input.route === undefined && groups.length === 1
-      ? groupRoute(groups[0]!.group)
+    const implicitRoute = input.route === undefined
+      ? singleExperimentGroupRoute(report, sample)
       : undefined;
     return yield* presentShowTarget({
       sample,
@@ -221,6 +220,18 @@ function showSelectionFromRecord(input: SelectionTarget & {
       format: input.format ?? "text",
     });
   }));
+}
+
+function singleExperimentGroupRoute(report: ReportDefinition, sample: Sample): string | undefined {
+  const groups = experimentGroups(sample);
+  if (groups.length !== 1) return undefined;
+  const group = groups[0]!.group;
+  const declaresGroupPage = report.pages.some((page) =>
+    "role" in page
+    && page.role?.kind === "experiment-group"
+    && page.role.groupKind === group.kind
+  );
+  return declaresGroupPage ? groupRoute(group) : undefined;
 }
 
 function groupRoute(group: import("../../analysis/index.ts").ExperimentGroupIdentity): string {

--- a/src/report/host/machine.ts
+++ b/src/report/host/machine.ts
@@ -3,11 +3,14 @@ import { Effect } from "effect";
 import {
   attemptEvidenceView,
   attemptObservabilityView,
+  experimentComparisonScope,
+  experimentGroups,
   fileChangesView,
   query,
   sourcesView,
   type Sample,
 } from "../../analysis/index.ts";
+import { sampleForExperimentComparisonScope } from "../../analysis/experiment-groups.ts";
 import { builtInMachineProducerIds } from "../built-in/machine.ts";
 import { loadBuiltInExperimentRows } from "../built-in/analysis-values.ts";
 import {
@@ -23,9 +26,40 @@ export interface BuiltInMachineProductionFailed {
   readonly reason: string;
 }
 
-const leaderboard = producer(async (sample) => {
-  const rows = [...await loadBuiltInExperimentRows(sample)].sort((left, right) => compareUtf8(left.key, right.key));
-  return Object.freeze({ kind: "leaderboard" as const, rows: closeMachineJson(rows) });
+const groups = producer(async (sample) => {
+  const entries = experimentGroups(sample).map((entry) => Object.freeze({
+    group: entry.group,
+    members: entry.members,
+    href: `/group/${entry.group.kind}/${entry.group.kind === "named" ? entry.group.groupId : String(entry.group.experimentId)}`,
+  }));
+  return Object.freeze({ kind: "groups" as const, groups: closeMachineJson(entries) });
+});
+
+const experimentGroup = producer(async (sample, _locator, route) => {
+  const match = /^\/group\/(named|singleton)\/([^/]+)$/u.exec(route);
+  if (match === null) throw new TypeError("Experiment Group route is invalid");
+  const kind = match[1]!;
+  const key = decodeURIComponent(match[2]!);
+  const summary = experimentGroups(sample).find((entry) =>
+    entry.group.kind === kind && (kind === "named"
+      ? entry.group.kind === "named" && entry.group.groupId === key
+      : entry.group.kind === "singleton" && String(entry.group.experimentId) === key));
+  if (summary === undefined) {
+    throw Object.freeze({ code: "report-group-not-in-sample" as const, group: `${kind}/${key}` });
+  }
+  const scope = experimentComparisonScope(sample, summary.group);
+  const comparison = scope.comparison.state === "comparable"
+    ? Object.freeze({
+        state: "comparable" as const,
+        members: scope.comparison.members,
+        rows: await loadBuiltInExperimentRows(sampleForExperimentComparisonScope(scope)),
+      })
+    : scope.comparison;
+  return Object.freeze({
+    kind: "experiment-group" as const,
+    group: closeMachineJson(summary.group),
+    comparison: closeMachineJson(comparison),
+  });
 });
 
 const attempt = producer(async (sample, locator) => {
@@ -79,13 +113,16 @@ const standard: BuiltInMachineProducer<BuiltInMachineProductionFailed, never> = 
     case "attempt":
     case "attempt-overview":
       return attempt(input);
+    case "group-named":
+    case "group-singleton":
+      return experimentGroup(input);
     default:
-      return leaderboard(input);
+      return groups(input);
   }
 };
 
 const producers = new Map<string, BuiltInMachineProducer<BuiltInMachineProductionFailed, never>>([
-  [builtInMachineProducerIds.runMembershipOverview, leaderboard],
+  [builtInMachineProducerIds.runMembershipOverview, groups],
   [builtInMachineProducerIds.attemptOverview, attempt],
   [builtInMachineProducerIds.executionEvidence, execution],
   [builtInMachineProducerIds.timingEvidence, timing],
@@ -102,6 +139,7 @@ function producer(
   build: (
     sample: Sample,
     locator: import("../../attempt-locator.ts").AttemptLocator | undefined,
+    route: string,
   ) => Promise<BuiltInShowData>,
 ): BuiltInMachineProducer<BuiltInMachineProductionFailed, never> {
   return (input) => Effect.tryPromise({
@@ -110,6 +148,7 @@ function producer(
       input.selection.kind === "attempt-locator"
         ? input.selection.locator as import("../../attempt-locator.ts").AttemptLocator
         : undefined,
+      input.route,
     ),
     catch: (cause): BuiltInMachineProductionFailed => Object.freeze({
       code: "report-built-in-machine-production-failed" as const,
@@ -124,7 +163,8 @@ function producerIdForInput(pageId: string): string {
 }
 
 function boundedReason(cause: unknown): string {
-  const value = cause instanceof Error ? cause.message : String(cause);
+  const value = cause instanceof Error ? cause.message
+    : typeof cause === "object" && cause !== null ? JSON.stringify(cause) : String(cause);
   return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ").slice(0, 512).trim() || "machine producer failed";
 }
 

--- a/src/report/host/machine.ts
+++ b/src/report/host/machine.ts
@@ -13,6 +13,7 @@ import {
 import { sampleForExperimentComparisonScope } from "../../analysis/experiment-groups.ts";
 import { builtInMachineProducerIds } from "../built-in/machine.ts";
 import { loadBuiltInExperimentRows } from "../built-in/analysis-values.ts";
+import { loadRunMembershipPageInput } from "../built-in/run-membership-overview.ts";
 import {
   closeMachineJson,
   type BuiltInMachineProducer,
@@ -59,6 +60,17 @@ const experimentGroup = producer(async (sample, _locator, route) => {
     kind: "experiment-group" as const,
     group: closeMachineJson(summary.group),
     comparison: closeMachineJson(comparison),
+  });
+});
+
+const runMembership = producer(async (sample) => {
+  const result = await loadRunMembershipPageInput(sample);
+  return Object.freeze({
+    kind: "run-membership" as const,
+    summary: closeMachineJson(result.summary),
+    members: closeMachineJson(result.members),
+    errors: closeMachineJson(result.errors),
+    evidence: closeMachineJson(result.evidence),
   });
 });
 
@@ -122,7 +134,7 @@ const standard: BuiltInMachineProducer<BuiltInMachineProductionFailed, never> = 
 };
 
 const producers = new Map<string, BuiltInMachineProducer<BuiltInMachineProductionFailed, never>>([
-  [builtInMachineProducerIds.runMembershipOverview, standard],
+  [builtInMachineProducerIds.runMembershipOverview, runMembership],
   [builtInMachineProducerIds.attemptOverview, attempt],
   [builtInMachineProducerIds.executionEvidence, execution],
   [builtInMachineProducerIds.timingEvidence, timing],

--- a/src/report/host/machine.ts
+++ b/src/report/host/machine.ts
@@ -122,7 +122,7 @@ const standard: BuiltInMachineProducer<BuiltInMachineProductionFailed, never> = 
 };
 
 const producers = new Map<string, BuiltInMachineProducer<BuiltInMachineProductionFailed, never>>([
-  [builtInMachineProducerIds.runMembershipOverview, groups],
+  [builtInMachineProducerIds.runMembershipOverview, standard],
   [builtInMachineProducerIds.attemptOverview, attempt],
   [builtInMachineProducerIds.executionEvidence, execution],
   [builtInMachineProducerIds.timingEvidence, timing],

--- a/src/report/host/site-runtime.ts
+++ b/src/report/host/site-runtime.ts
@@ -8,7 +8,7 @@ export const REPORT_LOCALE_RUNTIME = `(() => {
   "use strict";
   const locales = ["en", "zh-CN"];
   const views = Array.from(document.querySelectorAll("[data-niceeval-locale]"));
-  const buttons = Array.from(document.querySelectorAll("[data-niceeval-locale-button]"));
+  const selectors = Array.from(document.querySelectorAll("[data-niceeval-locale-select]"));
   if (views.length === 0) return;
   const stored = () => {
     try {
@@ -23,19 +23,20 @@ export const REPORT_LOCALE_RUNTIME = `(() => {
   const select = (locale, persist) => {
     if (!locales.includes(locale)) return;
     for (const view of views) view.hidden = view.dataset.niceevalLocale !== locale;
-    for (const button of buttons) {
-      const active = button.dataset.niceevalLocaleButton === locale;
-      button.setAttribute("aria-pressed", String(active));
-      button.classList.toggle("is-active", active);
-    }
+    for (const selector of selectors) selector.value = locale;
     document.documentElement.lang = locale;
     const title = document.documentElement.getAttribute("data-niceeval-title-" + locale.toLowerCase());
     if (title !== null) document.title = title;
     if (!persist) return;
     try { localStorage.setItem("niceeval:view:locale", locale); } catch {}
   };
-  for (const button of buttons) {
-    button.addEventListener("click", () => select(button.dataset.niceevalLocaleButton, true));
+  for (const selector of selectors) {
+    selector.addEventListener("change", () => select(selector.value, true));
+  }
+  for (const experiment of document.querySelectorAll("[data-niceeval-experiment-select]")) {
+    experiment.addEventListener("change", () => {
+      if (experiment.value) location.href = experiment.value;
+    });
   }
   select(stored() || preferred(), false);
 })();`;

--- a/src/report/host/static.ts
+++ b/src/report/host/static.ts
@@ -617,7 +617,7 @@ function renderExperimentGroupNavigation(
     return `<li><a href="${escapeAttribute(href)}"${current}>${escapeText(label)}</a></li>`;
   });
   const hidden = locale === "zh-CN" ? " hidden" : "";
-  const label = locale === "zh-CN" ? "实验组" : "Experiment groups";
+  const label = locale === "zh-CN" ? "实验" : "Experiments";
   return `<nav class="niceeval-view-nav" data-niceeval-locale="${locale}" aria-label="${label}"${hidden}><ul>${items.join("")}</ul></nav>`;
 }
 

--- a/src/report/host/static.ts
+++ b/src/report/host/static.ts
@@ -597,7 +597,7 @@ function renderPage(site: ClosedReportSite, entry: ClosedSitePage, paramRoutes: 
     ? ""
     : ` data-niceeval-param-routes="${escapeAttribute(paramRoutes.join(" "))}"`;
   const siteRootHref = relativeHref(output, "index.html");
-  return `<!doctype html><html class="niceeval-view-document" lang="en" data-niceeval-title-en="${escapeAttribute(titleEn)}" data-niceeval-title-zh-cn="${escapeAttribute(titleZh)}" data-niceeval-site-root="${escapeAttribute(siteRootHref)}"${paramRoutesAttr}><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeText(titleEn)}</title><link rel="stylesheet" href="${escapeAttribute(stylesheetHref)}"><link rel="stylesheet" href="${escapeAttribute(themeHref)}">${authorHead}${rendererAssets}<script src="${escapeAttribute(runtimeHref)}" defer></script></head><body><header class="niceeval-view-shell"><a class="niceeval-view-brand" href="${escapeAttribute(NICEEVAL_BRAND_HREF)}" target="_blank" rel="noopener"><span class="niceeval-view-mark" aria-hidden="true"></span><span>NiceEval</span></a><nav class="niceeval-view-nav" data-niceeval-locale="en" aria-label="Report pages">${navigationEn}</nav><nav class="niceeval-view-nav" data-niceeval-locale="zh-CN" aria-label="报告页面" hidden>${navigationZh}</nav>${groupsEn}${groupsZh}<div class="niceeval-view-locale" aria-label="Language"><button class="is-active" type="button" data-niceeval-locale-button="en" aria-pressed="true">EN</button><button type="button" data-niceeval-locale-button="zh-CN" aria-pressed="false">中文</button></div></header><main class="niceeval-view-main"><div class="niceeval-view-report-slot" data-niceeval-locale="en" data-page-id="${escapeAttribute(page.target.pageId)}">${bodyEn}${problemsEn}</div><div class="niceeval-view-report-slot" data-niceeval-locale="zh-CN" data-page-id="${escapeAttribute(page.target.pageId)}" hidden>${bodyZh}${problemsZh}</div><noscript><p class="niceeval-view-noscript">This report remains readable without JavaScript; language selection is unavailable.</p></noscript></main></body></html>`;
+  return `<!doctype html><html class="niceeval-view-document" lang="en" data-niceeval-title-en="${escapeAttribute(titleEn)}" data-niceeval-title-zh-cn="${escapeAttribute(titleZh)}" data-niceeval-site-root="${escapeAttribute(siteRootHref)}"${paramRoutesAttr}><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeText(titleEn)}</title><link rel="stylesheet" href="${escapeAttribute(stylesheetHref)}"><link rel="stylesheet" href="${escapeAttribute(themeHref)}">${authorHead}${rendererAssets}<script src="${escapeAttribute(runtimeHref)}" defer></script></head><body><header class="niceeval-view-shell"><a class="niceeval-view-brand" href="${escapeAttribute(NICEEVAL_BRAND_HREF)}" target="_blank" rel="noopener"><span class="niceeval-view-mark" aria-hidden="true"></span><span>NiceEval</span></a><div class="niceeval-view-pages"><nav class="niceeval-view-nav" data-niceeval-locale="en" aria-label="Report pages">${navigationEn}</nav><nav class="niceeval-view-nav" data-niceeval-locale="zh-CN" aria-label="报告页面" hidden>${navigationZh}</nav></div><div class="niceeval-view-controls">${groupsEn}${groupsZh}<label class="niceeval-view-language"><select aria-label="Language" data-niceeval-locale-select><option value="en">EN</option><option value="zh-CN">中文</option></select></label></div></header><main class="niceeval-view-main"><div class="niceeval-view-report-slot" data-niceeval-locale="en" data-page-id="${escapeAttribute(page.target.pageId)}">${bodyEn}${problemsEn}</div><div class="niceeval-view-report-slot" data-niceeval-locale="zh-CN" data-page-id="${escapeAttribute(page.target.pageId)}" hidden>${bodyZh}${problemsZh}</div><noscript><p class="niceeval-view-noscript">This report remains readable without JavaScript; language selection is unavailable.</p></noscript></main></body></html>`;
 }
 
 function renderExperimentGroupNavigation(
@@ -608,7 +608,15 @@ function renderExperimentGroupNavigation(
 ): string {
   const groups = pages.filter((entry) => entry.role?.kind === "experiment-group").sort(compareSitePages);
   if (groups.length < 2) return "";
-  const items = groups.map(({ page }) => {
+  const options = groups.map(({ page }) => {
+    const current = page.target.route === currentRoute ? " selected" : "";
+    const href = relativeHref(sourceFile, staticPathForRoute(page.target.route).posix);
+    const params = page.target.params as Record<string, unknown> | undefined;
+    const label = typeof params?.groupId === "string" ? params.groupId
+      : typeof params?.experimentId === "string" ? params.experimentId : page.target.route;
+    return `<option value="${escapeAttribute(href)}"${current}>${escapeText(label)}</option>`;
+  });
+  const links = groups.map(({ page }) => {
     const current = page.target.route === currentRoute ? " aria-current=\"page\"" : "";
     const href = relativeHref(sourceFile, staticPathForRoute(page.target.route).posix);
     const params = page.target.params as Record<string, unknown> | undefined;
@@ -618,7 +626,7 @@ function renderExperimentGroupNavigation(
   });
   const hidden = locale === "zh-CN" ? " hidden" : "";
   const label = locale === "zh-CN" ? "实验" : "Experiments";
-  return `<nav class="niceeval-view-nav" data-niceeval-locale="${locale}" aria-label="${label}"${hidden}><ul>${items.join("")}</ul></nav>`;
+  return `<div class="niceeval-view-experiment" data-niceeval-locale="${locale}"${hidden}><label><span>${label}</span><select aria-label="${label}" data-niceeval-experiment-select>${options.join("")}</select></label><noscript><nav class="niceeval-view-nav" aria-label="${label}"><ul>${links.join("")}</ul></nav></noscript></div>`;
 }
 
 function renderNavigation(
@@ -627,20 +635,35 @@ function renderNavigation(
   sourceFile: string,
   locale: string,
 ): string {
+  const groups = pages.filter((entry) => entry.role?.kind === "experiment-group").sort(compareSitePages);
+  const groupRoutes = new Set(groups.map((entry) => entry.page.target.route));
+  const selectedGroupRoute = groupRoutes.has(currentRoute) ? currentRoute : groups[0]?.page.target.route;
   const items = pages.filter((entry) => entry.navigation).sort(compareSitePages).map(({ page }) => {
-    const current = page.target.route === currentRoute ? " aria-current=\"page\"" : "";
-    const href = relativeHref(sourceFile, staticPathForRoute(page.target.route).posix);
+    const targetRoute = page.target.route === "/" && selectedGroupRoute !== undefined
+      ? selectedGroupRoute
+      : page.target.route;
+    const current = page.target.route === currentRoute || (page.target.route === "/" && groupRoutes.has(currentRoute))
+      ? " aria-current=\"page\""
+      : "";
+    const href = relativeHref(sourceFile, staticPathForRoute(targetRoute).posix);
     return `<li><a href="${escapeAttribute(href)}"${current}>${escapeText(resolveLocalizedText(page.title, locale))}</a></li>`;
   });
   return `<ul>${items.join("")}</ul>`;
 }
 
 function renderProblems(problems: readonly ReportProblem[], locale: string): string {
-  if (problems.length === 0) return "";
+  const visible = problems.filter((problem) => !isGenericMissingSlotProblem(problem));
+  if (visible.length === 0) return "";
   const title = locale === "zh-CN" ? "数据说明" : "Data notes";
-  return `<aside class="niceeval-view-problems"><h2>${title}</h2><ul>${problems.map((problem) =>
+  return `<aside class="niceeval-view-problems"><h2>${title}</h2><ul>${visible.map((problem) =>
     `<li><code>${escapeText(problem.code)}</code>${problem.summary === undefined ? "" : ` — ${escapeText(problem.summary)}`}</li>`
   ).join("")}</ul></aside>`;
+}
+
+function isGenericMissingSlotProblem(problem: ReportProblem): boolean {
+  return problem.code === "analysis-missing" &&
+    problem.refs.length === 0 &&
+    problem.summary === "the selected logical Slot has no input value";
 }
 
 function projection(page: ResolvedPage, locale: string): string {
@@ -760,9 +783,13 @@ function inlineThemeStyles(theme: ThemeDefinition): string {
   }).join("\n");
 }
 
-/** Uses show's first navigable Page, then the first closed route as a fallback. */
+/** A grouped site always opens a concrete comparison; other sites use their first navigable Page. */
 function defaultRouteForSite(site: ClosedReportSite): string | undefined {
-  return site.pages.find((entry) => entry.navigation)?.page.target.route ?? site.pages[0]?.page.target.route;
+  return [...site.pages]
+    .filter((entry) => entry.role?.kind === "experiment-group")
+    .sort(compareSitePages)[0]?.page.target.route
+    ?? site.pages.find((entry) => entry.navigation)?.page.target.route
+    ?? site.pages[0]?.page.target.route;
 }
 
 function closedProblemsFromFiles(files: readonly ClosedSiteFile[]): readonly ReportProblem[] {

--- a/src/report/host/static.ts
+++ b/src/report/host/static.ts
@@ -559,6 +559,7 @@ function buildSiteFiles(site: ClosedReportSite, theme: ThemeDefinition): readonl
 function parameterizedRoutePrefixes(site: ClosedReportSite): readonly string[] {
   const prefixes = new Set<string>();
   for (const entry of site.pages) {
+    if (entry.role?.kind === "experiment-group") continue;
     if (entry.page.target.params === undefined) continue;
     const route = entry.page.target.route;
     const cut = route.lastIndexOf("/");
@@ -585,6 +586,8 @@ function renderPage(site: ClosedReportSite, entry: ClosedSitePage, paramRoutes: 
   const bodyZh = projection(page, "zh-CN");
   const navigationEn = renderNavigation(site.pages, page.target.route, output, "en");
   const navigationZh = renderNavigation(site.pages, page.target.route, output, "zh-CN");
+  const groupsEn = renderExperimentGroupNavigation(site.pages, page.target.route, output, "en");
+  const groupsZh = renderExperimentGroupNavigation(site.pages, page.target.route, output, "zh-CN");
   const pageProblems = site.problems.filter((problem) =>
     problem.path.length === 0 || (problem.path[0] === "page" && problem.path[1] === page.target.pageId)
   );
@@ -594,7 +597,28 @@ function renderPage(site: ClosedReportSite, entry: ClosedSitePage, paramRoutes: 
     ? ""
     : ` data-niceeval-param-routes="${escapeAttribute(paramRoutes.join(" "))}"`;
   const siteRootHref = relativeHref(output, "index.html");
-  return `<!doctype html><html class="niceeval-view-document" lang="en" data-niceeval-title-en="${escapeAttribute(titleEn)}" data-niceeval-title-zh-cn="${escapeAttribute(titleZh)}" data-niceeval-site-root="${escapeAttribute(siteRootHref)}"${paramRoutesAttr}><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeText(titleEn)}</title><link rel="stylesheet" href="${escapeAttribute(stylesheetHref)}"><link rel="stylesheet" href="${escapeAttribute(themeHref)}">${authorHead}${rendererAssets}<script src="${escapeAttribute(runtimeHref)}" defer></script></head><body><header class="niceeval-view-shell"><a class="niceeval-view-brand" href="${escapeAttribute(NICEEVAL_BRAND_HREF)}" target="_blank" rel="noopener"><span class="niceeval-view-mark" aria-hidden="true"></span><span>NiceEval</span></a><nav class="niceeval-view-nav" data-niceeval-locale="en" aria-label="Report pages">${navigationEn}</nav><nav class="niceeval-view-nav" data-niceeval-locale="zh-CN" aria-label="报告页面" hidden>${navigationZh}</nav><div class="niceeval-view-locale" aria-label="Language"><button class="is-active" type="button" data-niceeval-locale-button="en" aria-pressed="true">EN</button><button type="button" data-niceeval-locale-button="zh-CN" aria-pressed="false">中文</button></div></header><main class="niceeval-view-main"><div class="niceeval-view-report-slot" data-niceeval-locale="en" data-page-id="${escapeAttribute(page.target.pageId)}">${bodyEn}${problemsEn}</div><div class="niceeval-view-report-slot" data-niceeval-locale="zh-CN" data-page-id="${escapeAttribute(page.target.pageId)}" hidden>${bodyZh}${problemsZh}</div><noscript><p class="niceeval-view-noscript">This report remains readable without JavaScript; language selection is unavailable.</p></noscript></main></body></html>`;
+  return `<!doctype html><html class="niceeval-view-document" lang="en" data-niceeval-title-en="${escapeAttribute(titleEn)}" data-niceeval-title-zh-cn="${escapeAttribute(titleZh)}" data-niceeval-site-root="${escapeAttribute(siteRootHref)}"${paramRoutesAttr}><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeText(titleEn)}</title><link rel="stylesheet" href="${escapeAttribute(stylesheetHref)}"><link rel="stylesheet" href="${escapeAttribute(themeHref)}">${authorHead}${rendererAssets}<script src="${escapeAttribute(runtimeHref)}" defer></script></head><body><header class="niceeval-view-shell"><a class="niceeval-view-brand" href="${escapeAttribute(NICEEVAL_BRAND_HREF)}" target="_blank" rel="noopener"><span class="niceeval-view-mark" aria-hidden="true"></span><span>NiceEval</span></a><nav class="niceeval-view-nav" data-niceeval-locale="en" aria-label="Report pages">${navigationEn}</nav><nav class="niceeval-view-nav" data-niceeval-locale="zh-CN" aria-label="报告页面" hidden>${navigationZh}</nav>${groupsEn}${groupsZh}<div class="niceeval-view-locale" aria-label="Language"><button class="is-active" type="button" data-niceeval-locale-button="en" aria-pressed="true">EN</button><button type="button" data-niceeval-locale-button="zh-CN" aria-pressed="false">中文</button></div></header><main class="niceeval-view-main"><div class="niceeval-view-report-slot" data-niceeval-locale="en" data-page-id="${escapeAttribute(page.target.pageId)}">${bodyEn}${problemsEn}</div><div class="niceeval-view-report-slot" data-niceeval-locale="zh-CN" data-page-id="${escapeAttribute(page.target.pageId)}" hidden>${bodyZh}${problemsZh}</div><noscript><p class="niceeval-view-noscript">This report remains readable without JavaScript; language selection is unavailable.</p></noscript></main></body></html>`;
+}
+
+function renderExperimentGroupNavigation(
+  pages: readonly ClosedSitePage[],
+  currentRoute: string,
+  sourceFile: string,
+  locale: string,
+): string {
+  const groups = pages.filter((entry) => entry.role?.kind === "experiment-group").sort(compareSitePages);
+  if (groups.length < 2) return "";
+  const items = groups.map(({ page }) => {
+    const current = page.target.route === currentRoute ? " aria-current=\"page\"" : "";
+    const href = relativeHref(sourceFile, staticPathForRoute(page.target.route).posix);
+    const params = page.target.params as Record<string, unknown> | undefined;
+    const label = typeof params?.groupId === "string" ? params.groupId
+      : typeof params?.experimentId === "string" ? params.experimentId : page.target.route;
+    return `<li><a href="${escapeAttribute(href)}"${current}>${escapeText(label)}</a></li>`;
+  });
+  const hidden = locale === "zh-CN" ? " hidden" : "";
+  const label = locale === "zh-CN" ? "实验组" : "Experiment groups";
+  return `<nav class="niceeval-view-nav" data-niceeval-locale="${locale}" aria-label="${label}"${hidden}><ul>${items.join("")}</ul></nav>`;
 }
 
 function renderNavigation(

--- a/src/runner/project-current.ts
+++ b/src/runner/project-current.ts
@@ -21,6 +21,7 @@ import type { ProjectCurrentTarget } from "./project-target.ts";
 import type { SandboxRunPlanningError } from "./sandbox-selection.ts";
 import { resolveAttemptTimeout, resolveRunTimeout } from "./timeout.ts";
 import type { AgentRun, Config } from "./types.ts";
+import { matchExperimentSelector } from "../shared/aggregate.ts";
 
 export interface LoadProjectCurrentOptions {
   experiments?: string | readonly string[];
@@ -73,18 +74,22 @@ export function loadProjectCurrent(
     const selectors = options.experiments === undefined
       ? []
       : Array.isArray(options.experiments) ? options.experiments : [options.experiments];
-    const availableIds = new Set(experiments.map((entry) => entry.id));
+    const availableExperimentIds = experiments.map((entry) => entry.id);
+    const availableIds = new Set(availableExperimentIds);
+    const selectedIds = new Set<string>();
     for (const selector of selectors) {
-      if (!availableIds.has(selector)) {
+      const matches = matchExperimentSelector(availableExperimentIds, selector);
+      if (matches.length === 0) {
         return yield* Effect.fail(new ProjectCurrentLoadError({
           stage: "selection",
           message: `Unknown current project Experiment ${JSON.stringify(selector)}.`,
         }));
       }
+      for (const match of matches) selectedIds.add(match);
     }
-    const selectedIds = selectors.length === 0
-      ? availableIds
-      : new Set(selectors);
+    if (selectors.length === 0) {
+      for (const id of availableIds) selectedIds.add(id);
+    }
     if (selectedIds.size === 0) {
       return yield* Effect.fail(new ProjectCurrentLoadError({
         stage: "selection",

--- a/src/shared/aggregate.ts
+++ b/src/shared/aggregate.ts
@@ -34,14 +34,29 @@ export function displayExperimentName(id: string | undefined): string | undefine
   return id.split("/").filter(Boolean).at(-1) ?? id;
 }
 
+export type ExperimentGroupIdentityValue =
+  | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
+  | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
+
 /**
- * 实验 id 的组推导:去掉末段的目录前缀("compare/bub-low" → "compare");
- * 无 "/" 的顶层实验不属于任何组,返回 undefined。view 实验列表分组与自定义报告
- * 的分组用同一份,两边的「组」永远指同一个东西。
+ * The sole Experiment Group derivation. A named group is always the first
+ * ExperimentId segment; a root Experiment is its own singleton group.
  */
-export function experimentGroupOf(experimentId: string): string | undefined {
-  if (!experimentId.includes("/")) return undefined;
-  return experimentId.split("/").slice(0, -1).join("/");
+export function experimentGroupOf(experimentId: string): ExperimentGroupIdentityValue {
+  const slash = experimentId.indexOf("/");
+  if (slash === -1) {
+    return Object.freeze({
+      kind: "singleton" as const,
+      experimentId,
+      key: `singleton/${experimentId}` as const,
+    });
+  }
+  const groupId = experimentId.slice(0, slash);
+  return Object.freeze({
+    kind: "named" as const,
+    groupId,
+    key: `named/${groupId}` as const,
+  });
 }
 
 /**

--- a/src/view/server.ts
+++ b/src/view/server.ts
@@ -700,6 +700,12 @@ function siteFileForPath(pathname: string, site: ClosedSiteRevision): SitePathLo
   const exact = requested === "" ? "index.html" : requested;
   const revision = closedSiteRevisionData(site);
   const files = revision.files;
+  if (requested === "" && revision.defaultRoute !== undefined && revision.defaultRoute !== "/") {
+    const entryFile = staticPageFileForRoute(revision.defaultRoute);
+    if (files.some((file) => file.path === entryFile)) {
+      return Object.freeze({ state: "redirect" as const, location: revision.defaultRoute });
+    }
+  }
   const direct = files.find((file) => file.path === exact);
   if (direct !== undefined) return Object.freeze({ state: "file" as const, file: direct });
 


### PR DESCRIPTION
## Problem

`project-current` 同时有 `classic/*` 与根级 `main` 时，旧 Report 会错误地跨组比较。现在单组直接展示，多组先选范围再组内比较。

## Use cases

### Case: 单组直接查看实验比较

#### Starting state

`project-current` 中只选择根级实验 `main`。

#### Action

```sh
niceeval show --experiment main
```

#### Result

```text
Experiment comparison
Experiments
main
```

`show` 直接进入 `singleton/main`；单组 view 不显示一项式实验选择器。

### Case: 多组项目先列组，再查看 classic

#### Starting state

`project-current` 同时包含 `classic/baseline`、`classic/memory-a` 与根级 `main`。

#### Action

```sh
niceeval show
```

#### Result

```text
Experiments
niceeval show --experiment 'classic'
niceeval show --experiment 'main'
```

接着运行：

```sh
niceeval show --experiment classic
```

```text
Experiment comparison
classic/baseline
classic/memory-a
```

结果不含 `main`。view 默认选中 `classic`；切到 `main` 后整页收窄，静态页保留 fallback 链接。

### Case: 同组实验运行的 Eval 集合不同

#### Starting state

`classic/baseline` 与 `classic/memory-a` 运行 `classic/*` 的八个通过制 Eval 和 `source-snapshot`；`classic/incompatible` 只运行分数制 Eval `score`。这里的差异是 Eval ID 集合，不是通过制与分数制本身不能共存。

#### Action

```sh
niceeval show --experiment classic --json
```

#### Result

```json
{
  "format": "niceeval.show",
  "data": {
    "kind": "experiment-group",
    "group": { "kind": "named", "groupId": "classic", "key": "named/classic" },
    "comparison": {
      "state": "non-comparable",
      "members": ["classic/baseline", "classic/incompatible", "classic/memory-a"],
      "issues": [{ "reason": "eval-population-mismatch" }]
    }
  }
}
```

命令成功关闭不可比状态，但不产生排名或散点。

## Public API

### Added

#### Case: 从固定 Sample 签发组内比较范围

##### Before

```tsx
import { experimentComparisonScope, experimentGroups } from "niceeval/analysis";
```

```text
Module 'niceeval/analysis' has no exported member 'experimentGroups'.
```

##### After

```tsx
import { experimentComparisonScope, experimentGroups } from "niceeval/analysis";
import { ExperimentTable } from "niceeval/report";

const [entry] = experimentGroups(sample);
const comparison = experimentComparisonScope(sample, entry.group);
return <ExperimentTable comparison={comparison} />;
```

```text
Experiments
classic/baseline
classic/memory-a
```

##### User impact

比较只能来自一个实验组。

#### Case: 自定义 Report 声明实验组 Page

##### Before

```tsx
{
  id: "group-named",
  path: "/group/named",
  navigation: false,
  role: { kind: "experiment-group", groupKind: "named" },
  params,
  load,
  render,
}
```

```text
Report Page contains unsupported field "role".
```

##### After

```tsx
{
  id: "group-named",
  path: "/group/named",
  title: "Experiment group",
  navigation: false,
  role: { kind: "experiment-group", groupKind: "named" },
  params,
  load: (sample, group) => experimentComparisonScope(sample, group),
  render: (comparison) => <ExperimentTable comparison={comparison} />,
}
```

```text
Experiments select: classic
```

##### User impact

Host 为组 Page 建立选择器。

## CLI

### Changed

#### Case: `show --experiment` 选择一个实验目录

##### Before

```sh
niceeval show --experiment classic --json
```

```text
No experiments matched selector "classic".
exit 1
```

##### After

```sh
niceeval show --experiment classic --json
```

```json
{
  "format": "niceeval.show",
  "data": {
    "kind": "experiment-group",
    "group": { "kind": "named", "groupId": "classic", "key": "named/classic" }
  }
}
```

##### User impact

`show --experiment` 复用 `niceeval exp <selector>` 的规则，不增加组参数。

#### Case: 多组项目运行默认 `show --json`

##### Before

```sh
niceeval show --json
```

```json
{
  "format": "niceeval.show",
  "data": { "kind": "leaderboard", "rows": ["classic/baseline", "main"] }
}
```

##### After

```sh
niceeval show --json
```

```json
{
  "format": "niceeval.show",
  "data": {
    "kind": "groups",
    "groups": [
      { "group": { "key": "named/classic" }, "members": ["classic/baseline", "classic/memory-a"] },
      { "group": { "key": "singleton/main" }, "members": ["main"] }
    ]
  }
}
```

##### User impact

自动化按 v2 的 `data.kind` 分支；默认输出不建立跨组 leaderboard。

#### Case: `show --run` 保持 Run 级详情

##### Before

```sh
niceeval show --run <run-id>
```

```text
Experiment comparison
```

##### After

```sh
niceeval show --run <run-id>
```

```text
Run results
Run errors
using result @18NG6D8XYR4NV
```

##### User impact

单 Run 不再被误当成单实验组；JSON 使用 `data.kind: "run-membership"`。

## Report components

### Changed

#### Case: `ExperimentTable` 与 `ExperimentScatter` 接受比较范围

##### Before

```tsx
<ExperimentTable rows={rows} />
<ExperimentScatter rows={rows} />
```

```text
Experiment comparison
classic/baseline
main
```

##### After

```tsx
const comparison = experimentComparisonScope(sample, classic.group);

<ExperimentTable comparison={comparison} />
<ExperimentScatter comparison={comparison} />
```

```text
Experiment comparison
classic/baseline
classic/memory-a
```

##### User impact

比较组件只接受组内范围。

#### Case: 标准 Report 在多组 Sample 中导航

##### Before

```sh
niceeval view --host 127.0.0.1 --port 4400 --no-open
```

```text
Experiment comparison
classic/memory-a
main
```

##### After

```sh
niceeval view --host 127.0.0.1 --port 4400 --no-open
```

```text
                           Overview
Experiments [classic ▾]                 Language [EN ▾]
NiceEval overview
Experiments 3
4 selected slot(s) were not recorded.
(no internal analysis-missing note)
```

##### User impact

多组 view 默认选中一组并收窄整页；缺席值只显示 not-recorded。

## Observable behavior and data contracts

### Changed

#### Case: 内建 `show --json` 文档

##### Before

```json
{ "format": "niceeval.show", "data": { "kind": "leaderboard", "rows": [] } }
```

##### After

```json
{ "format": "niceeval.show", "data": { "kind": "groups", "groups": [] } }
```

或单组：

```json
{
  "format": "niceeval.show",
  "data": {
    "kind": "experiment-group",
    "group": { "kind": "singleton", "experimentId": "main", "key": "singleton/main" },
    "comparison": { "state": "comparable", "members": ["main"], "rows": [] }
  }
}
```

##### User impact

只改变即时输出，不修改 Record。

## Terminology

### Added terms

#### Case: 实验组（Experiment Group）

##### Before

```md
实验目录只用于组织文件。
```

##### After

```md
实验组是 Experiment 的比较准入边界；第一段目录形成具名组，根级 Experiment 形成单成员组。
```

见 [`docs/concepts.md`](https://github.com/NiceEval/NiceEval/blob/exp-group/docs/concepts.md#实验与评估结构)。

#### Case: 实验比较范围（ExperimentComparisonScope）

##### Before

```md
Report 直接把 Sample 交给实验比较组件。
```

##### After

```md
Analysis 从固定 Sample 为一个实验组签发 ExperimentComparisonScope。
```

见 [`docs/concepts.md`](https://github.com/NiceEval/NiceEval/blob/exp-group/docs/concepts.md#report-与-analysis)。

### Removed terms

None

## Tests

### `e2e/report/experiments/classic/incompatible.ts`

- Purpose: feature
- Protects: 不同 Eval 集合 fixture。
- Runs: 安装候选后运行 exp。
- Asserts: expected Evals 只有 score。

```tsx
import { defineExperiment } from "niceeval";
import { classicMemoryAgent } from "../../agents/classic.ts";

export default defineExperiment({
  description: "classic/incompatible: same author group with a deliberately different Eval population",
  agent: classicMemoryAgent(),
  model: "gpt-5.6-luna",
  evals: ["score"],
  flags: { memory: "incompatible" },
  labels: { line: "classic", memory: "incompatible" },
  attempts: 1,
});
```

### `e2e/report/reports/classic.tsx`

- Purpose: feature + regression
- Protects: classic scope 不吸入 main。
- Runs: 加载 Report 并导出。
- Asserts: 表与散点只含 classic。

```tsx
import {
  Bars,
  Col,
  ExperimentScatter,
  ExperimentTable,
  Hero,
  SampleNotices,
  SampleSummary,
  Section,
  aggregate,
  costUSD,
  defineComponent,
  defineReport,
  experiment,
  passRate,
  type Sample,
} from "niceeval/report";
import { experimentComparisonScope, experimentGroups } from "niceeval/analysis";
import {
  standardAttemptPage,
  standardExperimentPage,
} from "niceeval/report/built-in";

const logo = `data:image/svg+xml,${encodeURIComponent(
  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#1f6feb"/><text x="32" y="40" text-anchor="middle" font-size="22" fill="white" font-family="sans-serif">MB</text></svg>',
)}`;

const MemoryBenchHero = defineComponent(() => (
  <Hero
    title="MemoryBench Classic"
    logo={{ src: logo, alt: "MemoryBench Classic" }}
    description="Deterministic 0.12 classic report: Hero, SampleSummary, leaderboard Bars, ExperimentScatter, and ExperimentTable."
    links={[{ label: "NiceEval", href: "https://github.com/NiceEval/NiceEval" }]}
  />
));

const Leaderboard = defineComponent(async (_props, ctx) => {
  const pricing = ctx.report.pricing;
  const leaderboard = await aggregate(ctx.scope, {
    by: { experiment },
    values: pricing === null
      ? { passRate }
      : { passRate, costUSD: costUSD(pricing) },
  });
  const ranked = [...leaderboard].toSorted(
    (a, b) => (b.passRate.value ?? Number.NEGATIVE_INFINITY) - (a.passRate.value ?? Number.NEGATIVE_INFINITY),
  );

  return (
    <Bars
      points={ranked}
      x="experiment"
      y="passRate"
      sort={{ field: "passRate", direction: "desc" }}
      layout="horizontal"
    />
  );
});

function classicOverview(sample: Sample) {
  const group = experimentGroups(sample).find((entry) => entry.group.key === "named/classic");
  if (group === undefined) {
    throw new Error("Classic comparison fixture requires named/classic");
  }
  const comparison = experimentComparisonScope(sample, group.group);
  return (
    <Col>
      <MemoryBenchHero />
      <SampleNotices />
      <SampleSummary />
      <Section title={{ en: "Leaderboard", "zh-CN": "排行榜" }}>
        <Leaderboard />
      </Section>
      <Section title={{ en: "Experiment comparison", "zh-CN": "实验对比" }}>
        <ExperimentScatter comparison={comparison} />
      </Section>
      <Section title={{ en: "Experiments", "zh-CN": "实验" }}>
        <ExperimentTable comparison={comparison} />
      </Section>
    </Col>
  );
}

export default defineReport({
  title: { en: "MemoryBench Classic", "zh-CN": "MemoryBench Classic" },
  head: [
    {
      tag: "meta",
      attrs: {
        name: "description",
        content: "Deterministic installed-candidate Report author fixture.",
      },
    },
    ...(process.env.NICEEVAL_E2E_AUTHOR_HEAD === "1"
      ? [{
          tag: "script" as const,
          attrs: {
            src: "https://example.test/report-author-fixture.js",
            crossorigin: "anonymous",
          },
        }]
      : []),
  ],
  pages: [
    {
      id: "overview",
      title: { en: "Overview", "zh-CN": "总览" },
      render: classicOverview,
    },
    standardAttemptPage,
    standardExperimentPage,
  ],
});
```

### `e2e/report/reports/site.tsx`

- Purpose: feature + regression
- Protects: 无 role 不补造组页面。
- Runs: 执行 show、view、export。
- Asserts: 中立页面仍可渲染。

```tsx
// The representative Report fixture for the final v0.12 contract. It uses only
// the documented public author surface: standard React JSX (react/jsx-runtime),
// defineReport with ordinary and parameterized Pages, both defineComponent
// forms, aggregate() with complete MetricValues, and closed DomainViews. The
// tests seal two runs: `main` (four logical
// slots, including failures that make passRate partial) and `source` (captured
// Source evidence); the Diff page also proves honest `not-recorded` handling.
import {
  Grid,
  Link,
  Section,
  SampleSummary,
  Stat,
  Tab,
  Table,
  Tabs,
  Text,
  aggregate,
  defineComponent,
  defineReport,
  durationMs,
  experiment,
// … omitted: file=e2e/report/reports/site.tsx; before=import { attemptDetailTarget, defineReport } from "niceeval/report";; after=export default defineReport({; reason=unchanged fixture components and helpers
    </Section>
  ),
};

export default defineReport({
  title: "Report fixture",
  pages: [
    {
      id: "overview",
      path: "/",
      title: "Report fixture",
      render: (sample: Sample) => (
        <Grid>
          <Section title="Fixture overview">
            <Text>{"Report fixture static site"}</Text>
            <SampleSummary />
            <FixtureSlotCount label="Selected slots" />
            <FixturePassRateState />
            <FixtureMetricRows />
          </Section>
          <Section title="Fixture model scores">
            <Table rows={fixtureChartPoints} columns={["model", "score"]} />
          </Section>
          {siteCopyBlock()}
          <Tabs>
            <Tab title="Fixture overview">
// … omitted: file=e2e/report/reports/site.tsx; before=          </Section>; after=      {; reason=unchanged remaining fixture pages
```

### `e2e/report/test/report-execution.test.ts`

- Purpose: feature + regression
- Protects: 执行与导出遵守组边界。
- Runs: 运行 show、loader、export。
- Asserts: v2 groups；classic 无 main。

```tsx
// … omitted: file=e2e/report/test/report-execution.test.ts; before=import { expect, test } from "vitest";; after=      // carrying executable producer callbacks across the package boundary.; reason=unchanged test setup and earlier assertions
      // carrying executable producer callbacks across the package boundary.
      const duplicateModules = join(projectRoot, "reports", "node_modules");
      await mkdir(duplicateModules, { recursive: true });
      await cp(
        join(projectRoot, "node_modules", "niceeval"),
        join(duplicateModules, "niceeval-duplicate"),
        { recursive: true, dereference: true },
      );
      await writeFile(
        join(projectRoot, "reports", "duplicate-standard.mjs"),
        'export { standard as default } from "niceeval-duplicate/report/built-in";\n',
        "utf8",
      );
      await writeFile(
        join(projectRoot, "reports", "duplicate-standard.cjs"),
        'module.exports = require("niceeval-duplicate/report/built-in").standard;\n',
        "utf8",
      );
      for (const module of ["duplicate-standard.mjs", "duplicate-standard.cjs"] as const) {
        const duplicate = await niceeval.run(["show", "--report", `./reports/${module}`, "--json"]);
        expect(duplicate.exitCode, duplicate.diagnostic()).toBe(0);
        expect(duplicate.json<{ format: string; data: { kind: string } }>()).toMatchObject({
          format: "niceeval.show",
          data: { kind: "groups" },
        });
      }

      // A globally recognizable Symbol is not enough: the loader accepts only
      // defineReport's frozen v2 normalized shape and rejects v1 outright.
      await writeFile(
        join(projectRoot, "reports", "forged-report-v2.mjs"),
        `const report = {
  kind: "report",
  pricing: null,
  head: [],
  pages: [{ id: "overview", path: "/", title: "forged", navigation: true, render: () => null }],
// … omitted: file=e2e/report/test/report-execution.test.ts; before=        pages: [{; after=        "classic-export",; reason=unchanged forged-report rejection and export setup
        "classic-export",
        "--no-open",
      ]);
      expect(exported.exitCode, exported.diagnostic()).toBe(0);

      const overview = await readFile(join(projectRoot, "classic-export", "overview", "index.html"), "utf8");
      for (const marker of [
        "Deterministic 0.12 classic report:",
        "Eval results",
        "Total cost",
        "Run range",
        "Leaderboard",
        "Experiment comparison",
        "Experiments",
      ] as const) {
        expect(overview, `classic overview marker ${JSON.stringify(marker)}`).toContain(marker);
      }
      expect(overview, "classic Hero external link must be an anchor")
        .toMatch(/<a\b[^>]*\bhref="https:\/\/github\.com\/NiceEval\/NiceEval"/);
      expect(overview, "classic hierarchy must keep native disclosure semantics")
        .toMatch(/<details\b[\s\S]*<summary\b/);
      const deliberateErrorRows = [...overview.matchAll(/<summary\b[^>]*>[\s\S]*?<\/summary>/g)]
        .map(([summary]) => summary)
        .filter((summary) => summary.includes("deliberate-error"));
      expect(
        deliberateErrorRows,
        "a named Experiment comparison must not pull main's errored row across the group boundary",
      ).toHaveLength(0);
      expect(overview, "classic overview must not serialize internal attempt evidence into visible text")
        .not.toContain('{"kind":"attempt"');
      expect(overview, "classic overview must link into attempt detail instances")
        .toMatch(/<a\b[^>]*\bhref="[^"]*\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}\/index\.html"/);
      expect(overview, "classic overview must link into experiment detail instances")
        .toMatch(/<a\b[^>]*\bhref="[^"]*\/experiment\/e1[a-f0-9]{24}\/index\.html"/);
    },
  );
});
```

### `e2e/report/test/report-project-current.test.ts`

- Purpose: feature + regression
- Protects: project-current 与收窄规则。
- Runs: 运行 exp 与 show。
- Asserts: 组、历史与分母正确。

```tsx
// owner: docs/engineering/testing/e2e/report.md#report-project-current
// regression: 052b13bb (design: memory/current-result-single-state-ruling.md)
// rerun: pnpm e2e --repo report -- --run test/report-project-current.test.ts

import { only, type ExpEvent } from "@niceeval/testkit";
import { readFile, writeFile } from "node:fs/promises";
import { join } from "node:path";
import { expect, test } from "vitest";
import { reportCaseArtifacts, reportE2E } from "./support.ts";

interface MetricValueJson {
  readonly value: number | null;
  readonly state: string;
  readonly samples: number;
  readonly total: number;
  readonly issues: readonly unknown[];
  readonly refs: readonly unknown[];
}

interface LeaderboardRow {
  readonly key: string;
  readonly passRate: MetricValueJson;
}

interface ReportProblem {
  readonly code: string;
  readonly path: readonly string[];
  readonly refs: readonly string[];
  readonly summary?: string;
}

interface ShowOverview {
  readonly format: "niceeval.show";
  readonly locale: "en";
  readonly selection:
    | {
        readonly kind: "project-current";
        readonly sampleIdentity: string;
        readonly experimentIds: readonly string[];
      }
    | {
        readonly kind: "explicit-runs";
        readonly sampleIdentity: string;
        readonly runIds: readonly string[];
      };
  readonly page: { readonly route: string; readonly pageId: string };
  readonly data:
    | { readonly kind: "groups"; readonly groups: readonly unknown[] }
    | {
        readonly kind: "experiment-group";
        readonly comparison: { readonly state: string; readonly rows: readonly LeaderboardRow[] };
      };
  readonly problems: readonly ReportProblem[];
}

const PROJECT_EXPERIMENT_IDS = [
  "classic/baseline",
  "classic/memory-a",
  "classic/memory-b",
  "main",
  "source",
] as const;

test("项目未变时复用结果，Eval 源码变化后重新执行并读回新结果", async () => {
  await reportE2E.case(
    "project-current",
    { artifacts: reportCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      const initialRun = await niceeval.run(["exp", "source", "--rerun", "all", "--json"]);
      expect(initialRun.exitCode, initialRun.diagnostic()).toBe(0);
      expect(initialRun.expReceipt()).toMatchObject({ completion: "completed" });
      expect(
        only(
          initialRun.expEvalEvents(),
          (event) => event.evalId === "source-snapshot",
          initialRun.diagnostic(),
        ),
      ).toMatchObject({ event: "eval", evalId: "source-snapshot", verdict: "passed" });
      const initialRunId = only(
        initialRun.expReceipt().runIds,
        () => true,
        initialRun.diagnostic(),
      );

      const initialShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
      expect(initialShow.exitCode, initialShow.diagnostic()).toBe(0);
      const initialDocument = initialShow.json<ShowOverview>();
      expect(initialDocument).toMatchObject({
        format: "niceeval.show",
        locale: "en",
        selection: {
          kind: "project-current",
          experimentIds: ["source"],
        },
        page: { route: "/group/singleton/source", pageId: "group-singleton" },
        data: { kind: "experiment-group" },
      });
      expect(
        initialDocument.problems,
        "a completed Eval with no Agent send has known zero usage rather than missing input",
      ).toEqual([]);
      if (initialDocument.data.kind !== "experiment-group") throw new Error("expected experiment group");
      expect(initialDocument.data.comparison.rows).toHaveLength(1);
      expect(initialDocument.data.comparison.rows[0]!.passRate).toMatchObject({
        state: "available",
        samples: 1,
        total: 1,
      });

      const unchangedRun = await niceeval.run(["exp", "source", "--json"]);
      expect(unchangedRun.exitCode, unchangedRun.diagnostic()).toBe(0);
      expect(unchangedRun.expReceipt()).toMatchObject({ completion: "completed" });
      expect(
        only(
          unchangedRun.ndjson<ExpEvent>(),
          (event) => event.event === "start",
          unchangedRun.diagnostic(),
        ),
      ).toMatchObject({ event: "start", reused: 1 });

      const accumulatedShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
      expect(accumulatedShow.exitCode, accumulatedShow.diagnostic()).toBe(0);
      const accumulatedDocument = accumulatedShow.json<ShowOverview>();
      expect(accumulatedDocument.selection).toMatchObject({ kind: "project-current" });
      if (accumulatedDocument.data.kind !== "experiment-group") throw new Error("expected experiment group");
      expect(accumulatedDocument.data.comparison.rows).toHaveLength(1);
      expect(accumulatedDocument.data.comparison.rows[0]!.passRate).toMatchObject({
        state: "available",
        samples: 2,
        total: 2,
      });

      const evalPath = join(projectRoot, "evals", "source-snapshot.eval.ts");
      const evalSource = await readFile(evalPath, "utf8");
      expect(evalSource).toContain("ENTRY_SNAPSHOT_BEFORE");
      await writeFile(
        evalPath,
        evalSource.replace("ENTRY_SNAPSHOT_BEFORE", "ENTRY_SNAPSHOT_AFTER"),
        "utf8",
      );

      const staleShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
      expect(staleShow.exitCode, staleShow.diagnostic()).toBe(0);
      expect(staleShow.json<ShowOverview>()).toMatchObject({
        format: "niceeval.show",
        selection: { kind: "project-current" },
        data: { kind: "groups", groups: [] },
        problems: [],
      });

      const staleHistory = await niceeval.run([
        "show",
        "--run",
        initialRunId,
        "--report",
        "standard",
        "--page",
        "/group/singleton/source",
        "--json",
      ]);
      expect(staleHistory.exitCode, staleHistory.diagnostic()).toBe(0);
      expect(staleHistory.json<ShowOverview>()).toMatchObject({
        format: "niceeval.show",
        selection: {
          kind: "explicit-runs",
          runIds: [initialRunId],
        },
        page: { route: "/group/singleton/source", pageId: "group-singleton" },
        data: { kind: "experiment-group" },
      });
      const historyData = staleHistory.json<ShowOverview>().data;
      if (historyData.kind !== "experiment-group") throw new Error("expected experiment group");
      expect(historyData.comparison.rows[0]!.passRate.state).toBe("available");

      const changedRun = await niceeval.run(["exp", "source", "--json"]);
      expect(changedRun.exitCode, changedRun.diagnostic()).toBe(0);
      expect(changedRun.expReceipt()).toMatchObject({ completion: "completed" });
      expect(
        only(
          changedRun.ndjson<ExpEvent>(),
          (event) => event.event === "start",
          changedRun.diagnostic(),
        ),
      ).toMatchObject({ event: "start", reused: 0 });
      expect(
        only(
          changedRun.expEvalEvents(),
          (event) => event.evalId === "source-snapshot",
          changedRun.diagnostic(),
        ),
      ).toMatchObject({ event: "eval", evalId: "source-snapshot", verdict: "passed" });

      const refreshedShow = await niceeval.run(["show", "--experiment", "source", "--json"]);
      expect(refreshedShow.exitCode, refreshedShow.diagnostic()).toBe(0);
      expect(refreshedShow.json<ShowOverview>()).toMatchObject({
        format: "niceeval.show",
        selection: { kind: "project-current" },
        data: { kind: "experiment-group" },
      });
      const refreshedData = refreshedShow.json<ShowOverview>().data;
      if (refreshedData.kind !== "experiment-group") throw new Error("expected experiment group");
      expect(refreshedData.comparison.rows[0]!.passRate).toMatchObject({
        state: "available",
        samples: 1,
        total: 1,
      });

      const removedLatest = await niceeval.run(["show", "--latest"]);
      expect(removedLatest.exitCode, removedLatest.diagnostic()).not.toBe(0);
      expect(removedLatest.stderr).toContain("Unknown option '--latest'");
    },
  );
});
```

### `e2e/report/test/report-show.test.ts`

- Purpose: feature + regression
- Protects: 单组、多组、Run membership 与不可比输出。
- Runs: 运行 exp 与 show。
- Asserts: 无版本 identity、成员与 mismatch。

```tsx
// owner: docs/engineering/testing/e2e/report.md#report-show-json
// rerun: pnpm e2e --repo report -- --run test/report-show.test.ts

import { only } from "@niceeval/testkit";
import { stripVTControlCharacters } from "node:util";
import { expect, test } from "vitest";
import {
  reportCaseArtifacts,
  reportE2E,
  runReportPty,
} from "./support.ts";

interface ReportProblem {
  readonly code: string;
  readonly path: readonly string[];
  readonly refs: readonly string[];
  readonly summary?: string;
}

interface ReportProjections {
  readonly format: "niceeval.report-projections/v1";
  readonly pricingProfile: Record<string, unknown> | null;
  readonly costs: readonly {
    readonly page: { readonly pageId: string; readonly route: string };
    readonly measureId: string;
    readonly row: { readonly key: string; readonly dimensions: Record<string, unknown> };
    readonly profileIdentity: string;
    readonly projection: Record<string, unknown>;
  }[];
}

/** The documented built-in machine document (docs/feature/reports/cli.md). */
interface BuiltInShowDocument {
  readonly format: "niceeval.show";
  readonly locale: "en";
  readonly selection:
    | {
        readonly kind: "project-current";
        readonly sampleIdentity: string;
        readonly experimentIds: readonly string[];
      }
    | {
        readonly kind: "explicit-runs";
        readonly sampleIdentity: string;
        readonly runIds: readonly string[];
      }
    | {
        readonly kind: "attempt-locator";
        readonly sampleIdentity: string;
        readonly locator: string;
      };
  readonly report: { readonly token: string; readonly identity: string };
  readonly page: { readonly route: string; readonly pageId: string; readonly title: string | Record<string, string> };
  readonly data:
    | {
        readonly kind: "groups";
        readonly groups: readonly {
          readonly group:
            | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
            | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
          readonly members: readonly string[];
          readonly href: string;
        }[];
      }
    | {
        readonly kind: "experiment-group";
        readonly group:
          | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
          | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
        readonly comparison:
          | { readonly state: "comparable"; readonly members: readonly string[]; readonly rows: readonly unknown[] }
          | { readonly state: "non-comparable"; readonly members: readonly string[]; readonly issues: readonly { readonly reason: string }[] };
      }
    | {
        readonly kind: "run-membership";
        readonly summary: unknown;
        readonly members: readonly {
          readonly experiment: string;
          readonly selectedRun: string;
          readonly locator: string | null;
          readonly verdict: string | null;
        }[];
        readonly errors: readonly unknown[];
        readonly evidence: unknown;
      }
    | {
        readonly kind: "attempt";
        readonly evidence: unknown;
        readonly observability: unknown;
      readonly fileChanges: unknown;
    };
  readonly projections: ReportProjections;
  readonly problems: readonly ReportProblem[];
}

/** The documented custom single-target manifest (docs/feature/reports/cli.md). */
interface CustomTargetExecutionManifest {
  readonly format: "niceeval.report-target-execution/v1";
  readonly locale: "en";
  readonly selection: { readonly kind: "project-current"; readonly sampleIdentity: string; readonly experimentIds: readonly string[] };
  readonly report: { readonly identity: string; readonly title: string | Record<string, string> };
  readonly page: {
    readonly route: string;
    readonly pageId: string;
    readonly title: string | Record<string, string>;
    readonly renderedText: string;
  };
  readonly downloads: readonly { readonly path: string; readonly mediaType: string; readonly bytes: number }[];
  readonly projections: ReportProjections;
  readonly problems: readonly ReportProblem[];
}

function expectCanonicalProblemTable(problems: readonly ReportProblem[], pageId: string): void {
  for (const problem of problems) {
    expect(problem).toMatchObject({
      code: expect.any(String),
      path: ["page", pageId],
      refs: expect.any(Array),
    });
    expect(problem.refs).toEqual([...new Set(problem.refs)].sort());
    if (problem.summary !== undefined) expect(problem.summary).toEqual(expect.any(String));
  }
  const keys = problems.map((problem) => JSON.stringify([
    problem.code,
    problem.path,
    problem.refs,
    problem.summary ?? "",
  ]));
  expect(keys).toEqual([...keys].sort());
}

function expectBuiltInPricingProfile(projections: ReportProjections): void {
  expect(projections).toMatchObject({
    format: "niceeval.report-projections/v1",
    pricingProfile: {
      contentIdentity: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
      currency: "USD",
      provenance: { kind: "declared-rate-card" },
    },
  });
}

test("show 对单组默认直达 comparison，对多组默认列索引并以实验选择精确读取", async () => {
  await reportE2E.case(
    "show-overview",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.exitCode, run.diagnostic()).not.toBe(0);
      expect(run.expReceipt()).toMatchObject({ completion: "completed" });
      const evals = run.expEvalEvents();
      expect(evals.map((event) => [event.evalId, event.verdict]).sort()).toEqual([
        ["deliberate-error", "errored"],
        ["deliberate-fail", "failed"],
        ["score", "passed"],
        ["tool-call", "passed"],
      ]);

      const text = await niceeval.run(["show", "--experiment", "main"]);
      expect(text.exitCode, text.diagnostic()).toBe(0);
      expect(text.stdout).toContain("Experiment comparison");
      expect(text.stdout).toContain("main");

      const singleJson = await niceeval.run(["show", "--experiment", "main", "--json"]);
      expect(singleJson.exitCode, singleJson.diagnostic()).toBe(0);
      const singleDocument = singleJson.json<BuiltInShowDocument>();
      expect(singleDocument).toMatchObject({
        format: "niceeval.show",
        locale: "en",
        selection: {
          kind: "project-current",
          experimentIds: ["main"],
        },
        page: { route: "/group/singleton/main", pageId: "group-singleton" },
        data: {
          kind: "experiment-group",
          group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
          comparison: { state: "comparable", members: ["main"] },
        },
      });
      expectCanonicalProblemTable(singleDocument.problems, "group-singleton");
      expectBuiltInPricingProfile(singleDocument.projections);

      const sourceRun = await niceeval.run(["exp", "source", "--rerun", "all", "--json"]);
      expect(sourceRun.exitCode, sourceRun.diagnostic()).toBe(0);

      const indexText = await niceeval.run(["show"]);
      expect(indexText.exitCode, indexText.diagnostic()).toBe(0);
      expect(indexText.stdout).toContain("niceeval show --experiment 'main'");
      expect(indexText.stdout).toContain("niceeval show --experiment 'source'");
      expect(indexText.stdout).not.toContain("Experiment comparison");

      const indexJson = await niceeval.run(["show", "--json"]);
      expect(indexJson.exitCode, indexJson.diagnostic()).toBe(0);
      const indexDocument = indexJson.json<BuiltInShowDocument>();
      expect(indexDocument).toMatchObject({
        format: "niceeval.show",
        page: { route: "/", pageId: "overview" },
        data: {
          kind: "groups",
          groups: [
            {
              group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
              members: ["main"],
              href: "/group/singleton/main",
            },
            {
              group: { kind: "singleton", experimentId: "source", key: "singleton/source" },
              members: ["source"],
              href: "/group/singleton/source",
            },
          ],
        },
      });

      const selected = await niceeval.run(["show", "--experiment", "main", "--json"]);
      expect(selected.exitCode, selected.diagnostic()).toBe(0);
      expect(selected.json<BuiltInShowDocument>()).toMatchObject({
        format: "niceeval.show",
        page: { route: "/group/singleton/main", pageId: "group-singleton" },
        data: {
          kind: "experiment-group",
          group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
          comparison: { state: "comparable", members: ["main"] },
        },
      });

    },
  );
});

test("show 保留 named identity，并把同组不同 Eval population 闭合为 non-comparable", async () => {
  await reportE2E.case(
    "show-named-group-comparison",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/incompatible"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }

      const shown = await niceeval.run(["show", "--experiment", "classic", "--json"]);
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      expect(shown.json<BuiltInShowDocument>()).toMatchObject({
        format: "niceeval.show",
        page: { route: "/group/named/classic", pageId: "group-named" },
        data: {
          kind: "experiment-group",
          group: { kind: "named", groupId: "classic", key: "named/classic" },
          comparison: {
            state: "non-comparable",
            members: ["classic/baseline", "classic/incompatible", "classic/memory-a"],
            issues: [{ reason: "eval-population-mismatch" }],
          },
        },
      });
    },
  );
});

test("show 对 immutable Attempt 交付精确 evidence JSON", async () => {
  await reportE2E.case(
    "show-attempt-json",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.exitCode, run.diagnostic()).not.toBe(0);
      const failed = only(
        run.expEvalEvents(),
        (event) => event.evalId === "deliberate-fail",
        run.diagnostic(),
      );

      const attempt = await niceeval.run(["show", failed.locator, "--json"]);
      expect(attempt.exitCode, attempt.diagnostic()).toBe(0);
      const document = attempt.json<BuiltInShowDocument>();
      expect(document).toMatchObject({
        format: "niceeval.show",
        locale: "en",
        selection: { kind: "attempt-locator", locator: failed.locator },
        page: { route: "/", pageId: "attempt-overview", title: "Attempt overview" },
      });
      expectCanonicalProblemTable(document.problems, "attempt-overview");
      expect(document.data.kind).toBe("attempt");
      expectBuiltInPricingProfile(document.projections);
      expect(document.projections.costs).toEqual([]);

      const payload = JSON.stringify(document.data);
      expect(payload).toContain(failed.locator);
      expect(payload).toContain("mismatched");
    },
  );
});

test("show --run 保留 deterministic classic World 的历史 Run 与 Attempt 身份", async () => {
  await reportE2E.case(
    "show-classic-world",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const historyRunIds: string[] = [];
      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/memory-b", "classic/baseline"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
        const runId = only(run.expReceipt().runIds, () => true, run.diagnostic());
        historyRunIds.push(runId);
      }

      const historical = await niceeval.run([
        "show",
        ...historyRunIds.flatMap((runId) => ["--run", runId]),
        "--json",
      ]);
      expect(historical.exitCode, historical.diagnostic()).toBe(0);
      const document = historical.json<BuiltInShowDocument>();
      expect(document).toMatchObject({
        format: "niceeval.show",
        locale: "en",
        selection: {
          kind: "explicit-runs",
          runIds: [...historyRunIds].sort(),
        },
        page: { route: "/", pageId: "run-membership" },
        data: {
          kind: "run-membership",
          errors: [],
        },
      });
      if (document.data.kind !== "run-membership") throw new Error("expected run membership");
      expect(document.data.members.map((member) => member.selectedRun)).toEqual(
        expect.arrayContaining(historyRunIds),
      );
      expect(document.data.members.map((member) => member.experiment)).toEqual(
        expect.arrayContaining(["classic/baseline", "classic/memory-a", "classic/memory-b"]),
      );
      const includedMembers = document.data.members.filter((member) => member.locator !== null);
      expect(includedMembers.map((member) => member.selectedRun)).toEqual(
        expect.arrayContaining(historyRunIds),
      );
      expect(includedMembers.every((member) => member.verdict !== null)).toBe(true);
      expectCanonicalProblemTable(document.problems, "run-membership");
      expectBuiltInPricingProfile(document.projections);
      expect(document.projections.costs).toEqual([]);
    },
  );
});

test("show 在 pipe 与真实 PTY 中保留独立、可读的公开文本", async () => {
  await reportE2E.case(
    "show-pty",
    { artifacts: reportCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });

      const piped = await niceeval.run(["show"]);
      expect(piped.exitCode, piped.diagnostic()).toBe(0);
      expect(piped.stdout).toContain("Experiment comparison");
      expect(piped.stdout).toContain("main");
      expect(piped.stdout).not.toMatch(/[╭╮╰╯├┤]/u);

      const terminal = await runReportPty(
        ["show"],
        {
          columns: 120,
          rows: 40,
          cwd: projectRoot,
          env: { TERM: "dumb", NO_COLOR: "1", FORCE_COLOR: undefined },
          timeoutMs: 60_000,
        },
      );
      expect(terminal.exitCode, terminal.diagnostic()).toBe(0);
      const visible = stripVTControlCharacters(terminal.stdout);
      expect(visible).toContain("Experiment comparison");
      expect(visible).toContain("main");
      expect(visible).toMatch(/^╭.*╮$/mu);
      expect(visible).toMatch(/^╰.*╯$/mu);
    },
  );
});

test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execution manifest", async () => {
  await reportE2E.case(
    "show-custom-fixture",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      for (const experimentId of ["main", "source"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }

      // This makes the unrelated parameter Page's enumerate() fail. A target
      // show must still succeed because only view/static build the whole site.
      const targetOnlyEnv = { NICEEVAL_E2E_FAIL_UNRELATED_ENUMERATE: "1" };

      const shown = await niceeval.run(
        ["show", "--report", "./reports/site.tsx"],
        { env: targetOnlyEnv },
      );
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      expect(shown.stdout).toContain("Report fixture static");
      expect(shown.stdout).toMatch(/Fixture pass rate is\s+partial \(\d+\/\d+\)/);
      expect(shown.stdout).toContain("Source detail");
      expect(shown.stdout).toContain("Diff detail");
      const json = await niceeval.run(
        ["show", "--report", "./reports/site.tsx", "--json"],
        { env: targetOnlyEnv },
      );
      expect(json.exitCode, json.diagnostic()).toBe(0);
      const manifest = json.json<CustomTargetExecutionManifest>();
      expect(manifest).toMatchObject({
        format: "niceeval.report-target-execution/v1",
        locale: "en",
        selection: {
          kind: "project-current",
          experimentIds: [
            "classic/baseline",
            "classic/incompatible",
            "classic/memory-a",
            "classic/memory-b",
            "main",
            "source",
          ],
        },
        report: { title: "Report fixture" },
        page: {
          route: "/",
          pageId: "overview",
          title: "Report fixture",
          renderedText: expect.stringContaining("Report fixture static"),
        },
        downloads: [],
      });
      expectCanonicalProblemTable(manifest.problems, "overview");
      expect(manifest.report.identity).toEqual(expect.any(String));
      expect(manifest.selection.sampleIdentity).toEqual(expect.any(String));
      expectBuiltInPricingProfile(manifest.projections);
      expect(manifest.projections.costs).toHaveLength(1);
      expect(manifest.projections.costs.map((entry) => entry.page)).toEqual([
        { pageId: "overview", route: "/" },
      ]);
    },
  );
});

test("参数化 show 按规范 key 读取详情页，并对非成员 key 返回单目标错误", async () => {
  await reportE2E.case(
    "show-parameterized",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });

      const json = await niceeval.run(["show", "--report", "./reports/site.tsx", "--json"]);
      expect(json.exitCode, json.diagnostic()).toBe(0);
      const manifest = json.json<CustomTargetExecutionManifest>();
      const slotId = /Slot detail (slot-[a-zA-Z0-9_-]+)/.exec(manifest.page.renderedText);
      expect(slotId, "the overview must expose at least one slot detail target").not.toBeNull();
      const slotKey = slotId![1];

      const detail = await niceeval.run([
        "show",
        "--report",
        "./reports/site.tsx",
        "--page",
        `/slot/${slotKey}`,
        "--json",
      ]);
      expect(detail.exitCode, detail.diagnostic()).toBe(0);
      const detailManifest = detail.json<CustomTargetExecutionManifest>();
      expect(detailManifest).toMatchObject({
        format: "niceeval.report-target-execution/v1",
        page: {
          route: `/slot/${slotKey}`,
          pageId: "slot",
          renderedText: expect.stringContaining(`Slot fixture detail ${slotKey}`),
        },
        problems: [],
      });
      expect(detailManifest.downloads, "a single target carries only its own downloads").toEqual([]);
      expect(detailManifest.projections.costs, "show carries only the selected Page capture").toEqual([]);

      const missing = await niceeval.run([
        "show",
        "--report",
        "./reports/site.tsx",
        "--page",
        "/slot/not-a-member-slot",
      ]);
      expect(missing.exitCode, missing.diagnostic()).not.toBe(0);
      expect(missing.stdout, missing.diagnostic()).not.toContain("Slot fixture detail");
    },
  );
});
```

### `e2e/migrate/test/handoff.test.ts`

- Purpose: regression
- Protects: 旧历史 Run 保持 Run 级结果。
- Runs: 旧 producer 写入后运行 show。
- Asserts: run-membership 成员与 verdict 正确。

```tsx
// owner: docs/engineering/testing/e2e/migrate.md#observability-v1-to-v2

import { readFileSync, renameSync, writeFileSync } from "node:fs";
import { join } from "node:path";
import { expect, test } from "vitest";
import { attestLegacyProducer, commitRecord, e2e } from "./support.ts";

test("Git 保存的 npm 0.13.0 Record 自动迁移后显示同一结果并拒绝旧 writer", async () => {
  await e2e.case(
    "observability-v1-auto-migrate",
    { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
    async ({ paths, commands: { candidate, legacyProducer }, run }) => {
// … omitted: file=e2e/migrate/test/handoff.test.ts; before=    async ({ paths, commands: { candidate, legacyProducer }, run }) => {; after=      const unsaved = await candidate.run(["show", "--run", runId, "--json"]);; reason=unchanged legacy producer setup
      const unsaved = await candidate.run(["show", "--run", runId, "--json"]);
      expect(unsaved.exitCode, unsaved.diagnostic()).toBe(1);
      expect(unsaved.stderr, unsaved.diagnostic()).toContain("record-auto-migration-git-save-required");
      expect(unsaved.stderr, unsaved.diagnostic()).toContain("git add");
      expect(unsaved.stdout, unsaved.diagnostic()).not.toContain('"selection"');

      await commitRecord(run, "record: save npm 0.13.0 run");

      const shown = await candidate.run(["show", "--run", runId, "--json"]);
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      expect(shown.stderr, shown.diagnostic()).toContain("Record automatically migrated");
      expect(shown.stderr, shown.diagnostic()).toContain("restore commit");
      const output = shown.json<{
        selection: { runIds: readonly string[] };
        data: {
          kind: "run-membership";
          members: readonly [{ eval: string; locator: string; verdict: string }];
        };
      }>();
      expect(output.selection.runIds).toEqual([runId]);
      expect(output.data.kind).toBe("run-membership");
      expect(output.data.members).toEqual([
        expect.objectContaining({ eval: "legacy-handoff", locator: expect.stringMatching(/^@/), verdict: "passed" }),
      ]);

      const beforeOldWriter = await run(["git", "diff", "--binary", "--", ".niceeval/record"]);
      expect(beforeOldWriter.exitCode, beforeOldWriter.diagnostic()).toBe(0);
      const beforeOldWriterStatus = await run([
        "git", "status", "--porcelain=v1", "--untracked-files=all", "--", ".niceeval/record",
      ]);
      expect(beforeOldWriterStatus.exitCode, beforeOldWriterStatus.diagnostic()).toBe(0);
// … omitted: file=e2e/migrate/test/handoff.test.ts; before=      expect(output.data.comparison.rows[0]?.passRate).toMatchObject({ state: "available", value: 1 });; after=      expect(afterOldWriterStatus.stdout).toBe(beforeOldWriterStatus.stdout);; reason=unchanged old-writer rejection verification
  );
});
```

### `e2e/report/test/report.browser.spec.ts`

- Purpose: feature + regression
- Protects: view 有所选组与居中 router。
- Runs: 启动 view、切换 select、导出。
- Asserts: scoped Overview、中心、语言与 no-JS。

```tsx
// … omitted: file=e2e/report/test/report.browser.spec.ts; before=import { expect, test } from "@playwright/test";; after=test("零配置 view 使用经典报告完成筛选、原生展开、详情下钻与语言切换", async ({ browser }) => {; reason=unchanged static-site owner and browser helpers
test("零配置 view 使用经典报告完成筛选、原生展开、详情下钻与语言切换", async ({ browser }) => {
  test.setTimeout(180_000);

  await reportE2E.case(
    "browser-default-classic-surface",
    { artifacts: reportCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/memory-b"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const view = niceeval.start(
        [
          "view",
          "--host",
          "127.0.0.1",
          "--port",
          "0",
          "--no-open",
        ],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000,
        label: "classic surface view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "classic surface view readiness");

      const page = await browser.newPage();
      try {
        await page.goto(origin!);
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();

        // A fixed Sample with one named Experiment Group goes straight to its
        // comparison and does not waste Header space on a one-option selector.
        await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);

        const passChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
        await expect(passChart).toHaveCount(1);
        await expect(passChart).toContainText("classic/memory-a");
        await expect(passChart).toContainText("100%");
        await expect(passChart).not.toContainText("ratio");
        const scoreChart = page.locator('svg[aria-label="costUSD × totalScore"]').filter({ visible: true });
        await expect(scoreChart).toHaveCount(0);

        const mixedRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
        expect(mixedRun.expReceipt(), mixedRun.diagnostic()).toMatchObject({ completion: "completed" });
        const experimentSelector = page.getByRole("combobox", { name: "Experiments" });
        await expect(experimentSelector).toBeVisible({ timeout: 15_000 });
        await expect(experimentSelector.getByRole("option")).toHaveText(["classic", "main"]);
        await expect(experimentSelector.locator("option:checked")).toHaveText("classic");

        // Opening the site root never exposes an unselected project-wide
        // overview: the first stable Experiment Group is the current value.
        await page.goto(origin!);
        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const classicExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
        await expect(classicExperimentCount.locator(".niceeval-stat-value")).toHaveText("3");

        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "main" });
        await expect(page).toHaveURL(new RegExp("/group/singleton/main/index\\.html$"));
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const mainExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
        await expect(mainExperimentCount.locator(".niceeval-stat-value")).toHaveText("1");

        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "classic" });
        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
        const selectedGroupChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
        await expect(selectedGroupChart).toContainText("classic/memory-a");
        await expect(selectedGroupChart).not.toContainText("main");

        const exported = await niceeval.run(["view", "--out", "group-static", "--no-open"]);
        expect(exported.exitCode, exported.diagnostic()).toBe(0);
        const offline = await browser.newContext({ javaScriptEnabled: false });
        try {
          const staticPage = await offline.newPage();
          await staticPage.goto(pathToFileURL(join(projectRoot, "group-static", "index.html")).href);
          const staticGroups = staticPage.getByRole("navigation", { name: "Experiments" });
          await expect(staticGroups.getByRole("link", { name: "classic" }))
            .toHaveAttribute("href", "group/named/classic/index.html");
          await staticGroups.getByRole("link", { name: "classic" }).click();
          await expect(staticPage).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
          const staticGroupChart = staticPage.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
          await expect(staticGroupChart).toContainText("classic/memory-a");
          await expect(staticGroupChart).not.toContainText("main");
        } finally {
          await offline.close();
        }
        const filter = page.getByRole("searchbox").filter({ visible: true });
        await expect(filter).toHaveCount(1);
        await expect(filter).toBeVisible();
        const experimentTable = filter.locator("..").getByRole("table");
        await expect(experimentTable).toHaveCount(1);
        await filter.fill("classic/memory-a");
        const memoryA = experimentTable.locator("summary").filter({
          hasText: "classic/memory-a",
        }).filter({ visible: true });
        await expect(memoryA).toHaveCount(1);
        await expect(memoryA).toBeVisible();
        const baseline = experimentTable.locator("summary").filter({
          hasText: "classic/baseline",
        }).filter({ visible: true });
        await expect(baseline).toHaveCount(0);
        await filter.fill("");

        const group = experimentTable.locator("details").filter({
          hasText: "classic/memory-a",
        }).filter({ visible: true });
        await expect(group).toHaveCount(1);
        await expect(group).toBeVisible();
        const groupSummary = group.locator(":scope > summary");
        await groupSummary.focus();
        await groupSummary.press("Space");
        await expect(group).toHaveAttribute("open", "");

        const evalGroupSummary = group.locator("summary").filter({
          hasText: "classic (8 evals)",
        }).filter({ visible: true });
        await expect(evalGroupSummary).toHaveCount(1);
        const evalGroup = evalGroupSummary.locator("..");
        await expect(evalGroup).toHaveCount(1);
        await expect(evalGroup).toBeVisible();
        await evalGroupSummary.focus();
        await evalGroupSummary.press("Space");
        await expect(evalGroup).toHaveAttribute("open", "");

        const evalRowSummary = evalGroup.locator("summary").filter({
          hasText: "recall-constraint",
        }).filter({ visible: true });
        await expect(evalRowSummary).toHaveCount(1);
        const evalRow = evalRowSummary.locator("..");
        await expect(evalRow).toHaveCount(1);
        await evalRowSummary.focus();
        await evalRowSummary.press("Space");
        await expect(evalRow).toHaveAttribute("open", "");

        const attemptLink = evalRow.getByRole("link").filter({
          visible: true,
        });
        await expect(attemptLink).toHaveCount(1);
        await expect(attemptLink).toBeVisible();
        const href = await attemptLink.getAttribute("href");
        if (href === null) throw new Error("an expanded attempt row has no detail href");
        const detail = new URL(href, page.url());
        expect(detail.pathname).toMatch(/^\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}\/index\.html$/);

        // The JavaScript enhancement opens the Host-owned detail dialog around
        // the same href instead of leaving the overview page.
        await attemptLink.click();
        const dialog = page.getByRole("dialog");
        await expect(dialog).toBeVisible();
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await expect(dialog.getByText(/^source · execution · timing(?: · diff)?$/).filter({ visible: true })).toBeVisible();
        await expect(dialog.getByText("Assessment evidence", { exact: true })).toHaveCount(0);
        await expect(dialog.getByText(/^\{\"groupPath\":/)).toHaveCount(0);
        const sendLine = dialog.locator("details.niceeval-source-line--send").filter({ visible: true });
        await expect(sendLine).toHaveCount(1);
        await expect(sendLine).not.toHaveAttribute("open", "");
        await sendLine.locator(":scope > summary").click();
        await expect(sendLine).toHaveAttribute("open", "");
        await expect(sendLine.getByText("Duration", { exact: true })).toBeVisible();
        await expect(sendLine.getByText("Turns", { exact: true })).toBeVisible();
        await expect(sendLine.getByText("Calls", { exact: true })).toBeVisible();
        await expect(sendLine.locator(".niceeval-conversation-turn-head")).toBeVisible();
        const trace = sendLine.locator("[data-niceeval-turn-trace]");
        const traceRows = trace.locator("[data-niceeval-trace-event]");
        const firstTraceRow = traceRows.nth(0);
        const secondTraceRow = traceRows.nth(1);
        const thirdTraceRow = traceRows.nth(2);
        const firstTraceEvidence = firstTraceRow.locator("[data-niceeval-trace-evidence]");
        const secondTraceEvidence = secondTraceRow.locator("[data-niceeval-trace-evidence]");
        const thirdTraceEvidence = thirdTraceRow.locator("[data-niceeval-trace-evidence]");
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await firstTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).toHaveAttribute("open", "");
        await expect(firstTraceRow.locator("[data-niceeval-trace-select]")).toHaveAttribute("aria-expanded", "true");
        await secondTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await expect(secondTraceEvidence).toHaveAttribute("open", "");
        await expect(secondTraceEvidence.locator("[data-tool-evidence-kind='command']")).toBeVisible();
        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").textContent()).toBe(
          "printf 'classic/recall-constraint: recalled=true\\n' > memory-note.txt",
        );
        await thirdTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(secondTraceEvidence).not.toHaveAttribute("open", "");
        await expect(thirdTraceEvidence).toHaveAttribute("open", "");
        await expect(thirdTraceRow.locator(".niceeval-trace-event-summary")).toHaveText("command_execution result");
        await expect(thirdTraceEvidence.locator("[data-tool-evidence-kind='terminal']")).toBeVisible();
        await expect(thirdTraceEvidence.getByText("Exit 0", { exact: true })).toBeVisible();
        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(0).textContent()).toBe(
          "wrote memory-note.txt\nclassic/recall-constraint: recalled=true\n",
        );
        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(1).textContent()).toBe(
          '{\n  "written": true,\n  "recalled": true\n}',
        );
        await thirdTraceEvidence.getByRole("tab", { name: "Raw" }).click();
        await expect(thirdTraceEvidence.getByRole("tab", { name: "Raw" })).toHaveAttribute("aria-selected", "true");
        await expect(thirdTraceEvidence.locator("[data-niceeval-trace-evidence-panel='raw']")).toBeVisible();
        expect(await thirdTraceEvidence.locator(".niceeval-trace-evidence-raw").textContent()).toBe(
          '{"output":"wrote memory-note.txt\\nclassic/recall-constraint: recalled=true\\n","exit_code":0,"written":true,"recalled":true}',
        );
        const deepLink = page.url();
        expect(new URL(deepLink).hash).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);
        await page.keyboard.press("Escape");
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("");

        // The legacy URL contract survives the new closed-site host: opening
        // its hash directly restores the same dialog, and reload keeps it.
        await page.goto(deepLink);
        await expect(dialog).toBeVisible();
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await page.reload();
        expect(page.url()).toBe(deepLink);
        await expect(dialog).toBeVisible();
        await page.goBack();
        await expect(dialog).not.toBeVisible();

        // The href stays a real standalone route: direct navigation reads the
        // same closed detail document.
        await page.goto(detail.href);
        await expect(page.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await expect(page.getByText(/^source · execution · timing(?: · diff)?$/).filter({ visible: true })).toBeVisible();

        await page.goto(new URL("group/named/classic/index.html", origin!).href);
        const scatter = page.getByRole("img", { name: "costUSD × passRate" }).filter({ visible: true });
        await expect(scatter).toHaveCount(1);
        await expect(scatter).toContainText("classic/memory-a");
        const pageRouter = page.getByRole("navigation", { name: "Report pages" });
        const pageRouterBox = await pageRouter.boundingBox();
        const viewport = page.viewportSize();
        expect(pageRouterBox, "the whole Page router must have a visible layout box").not.toBeNull();
        expect(viewport, "the browser fixture must expose its viewport").not.toBeNull();
        expect(Math.abs(pageRouterBox!.x + pageRouterBox!.width / 2 - viewport!.width / 2))
          .toBeLessThanOrEqual(1);
        const languageSelector = page.getByRole("combobox", { name: "Language" });
        await expect(languageSelector).toBeVisible();
        await expect(languageSelector.getByRole("option")).toHaveText(["EN", "中文"]);
        await languageSelector.selectOption("zh-CN");
        await expect(page.getByText("总览", { exact: true })).toBeVisible();
        await expect(languageSelector).toHaveValue("zh-CN");
      } finally {
        await page.close();
      }
    },
  );
});

async function expectSameBody(staticUrl: URL, liveUrl: URL): Promise<void> {
  const expected = await readFile(fileURLToPath(staticUrl));
  const response = await fetch(liveUrl);
  expect(response.status, `${liveUrl} should serve the exported body`).toBe(200);
  // Headers and a view-only refresh transport are intentionally outside this
  // oracle; the publicly delivered bytes must still be identical.
  expect(Buffer.from(await response.arrayBuffer()), `${liveUrl} body`).toEqual(expected);
}

function detailKind(label: string): DetailKind {
  const matched = /^(Source|Diff|Slot) detail(?: |$)/.exec(label);
```

### Verification receipt

- Candidate: final tarball SHA-256 `85483c6fd709aca2b3840cce69f066d6f5077b759081ef240d9ea45cc86154c8`
- Red: 旧候选在 CI CLI Repo 稳定失败 3 条 `show --run` 公开结果。
- Green: Report Repo Vitest 12/12、Playwright 2/2；Eval 6/6；Adapter local-protocol 5/5；Runner 相关 owner 2/2。
- Repeatability: Report browser、show --run 与 Migrate handoff takeover 矩阵全部通过。
- Fixed conditions: `origin/main@42437566`、锁文件、Chromium。
- Unit count: `not applicable — no Unit changed`
