### PR TITLE
fix(report): 精简未封口 Run 警告与成本摘要

### DIFF
--- a/docs/feature/record/README.md
+++ b/docs/feature/record/README.md
@@ -35,8 +35,8 @@ Record
       └─ own blobs（只属于这一 owner 和 family）
 ```
 
-缺少 `complete`，或该路径不是零字节普通文件的 Run directory，不是 Record 事实。reader 不读取、不展示也不沿用它，只返回
-`incomplete-run` warning；用户可以用 `niceeval clean` 删除。
+缺少 `complete`，或该路径不是零字节普通文件的 Run directory，不是 Record 事实。reader 不读取、不展示也不沿用它；这类正常的
+writer residue 只留给 maintenance 检查，不进入 Analysis 或 Report warning。用户可以用 `niceeval clean` 删除。
 
 Record Core（核心身份）只保存完整 `attemptId`。面向人的 locator 是上层确定性别名：`@1` 加
 `SHA-256(AttemptId UTF-8)` 前 60 bit 的 12 位大写 Crockford 编码。它不写入 Core，也不触发迁移。

--- a/docs/feature/record/architecture.md
+++ b/docs/feature/record/architecture.md
@@ -54,8 +54,8 @@ record/
 事实是否存在。
 
 `complete` 是零字节普通文件，也是排他创建的唯一发布信号。writer 在它之前关闭并 flush 本 Run 的每份文件和目录；
-它之后永不修改这个 Run。缺少它，或该路径为非空文件、目录、symlink 等其它形态的 Run 不进入选择、Sample 或 reuse，并产生
-`incomplete-run` warning。
+它之后永不修改这个 Run。缺少它，或该路径为非空文件、目录、symlink 等其它形态的 Run 不进入选择、Sample 或 reuse。
+reader 保留 `incomplete-run` maintenance warning 供 `clean` 检查，但 Analysis 与 Report 不把正常 residue 当成用户数据问题。
 
 ## NiceEval 内部的 Effect Schema 作者模型
 

--- a/docs/feature/record/cli.md
+++ b/docs/feature/record/cli.md
@@ -149,7 +149,7 @@ preflight 失败或 sentinel 创建失败都发生在首个 portable write 前�
 | `record-maintenance-busy` | maintenance 与 reader/writer/clean 冲突 | 关闭占用命令后重试 |
 | `record-migration-plan-stale` / `record-migration-git-restore-required` | apply 前计划或 Git 状态已变化，尚未写 portable byte | 保留当前编辑，重新检查并形成新计划；不要执行旧计划的 restore |
 | `record-migration-recovery-required` | sentinel 已创建，迁移写入或最终校验失败 | 仅在 `restoreSafe` 证明成立时按命令恢复；否则先人工检查并保留并发编辑 |
-| `incomplete-run` | Run 缺少规范的零字节普通文件 `complete` | 有效 Run 继续可用；用 `niceeval clean` 检查 |
+| `incomplete-run` | Run 缺少规范的零字节普通文件 `complete` | 普通 `show` 不提示；用 `niceeval clean` 检查 |
 | `not-recorded` | 已封口 owner 没有请求的 fixed family | 让 query 按其 missing policy 处理 |
 | `unsupported-format` | root/Core/family 是 future、unknown 或无完整 chain | 使用写出该格式的 NiceEval；不会形成部分 ordinary session |
 | `invalid` | envelope、payload、ref 或 closure 无效 | 检查该 family；其它有效事实继续可用 |

--- a/docs/feature/record/use-case/发布完整运行.md
+++ b/docs/feature/record/use-case/发布完整运行.md
@@ -100,8 +100,8 @@ Run 目录与 `runs/` 父目录。此后没有可失败的业务步骤。
 ## 5. 失败、中断与重新读取
 
 `complete` 前发生 typed failure、defect、interruption 或进程退出时，session 进入 `failed`。目录留在
-`runs/<RunId>/`，但不属于 Record；reader 忽略它并给出 `incomplete-run` warning。Scope finalizer 只释放
-lease 和 handle，不自动删除目录。
+`runs/<RunId>/`，但不属于 Record；reader 忽略它，并只向 maintenance 保留 `incomplete-run` warning，不进入
+Analysis 或 Report warning。Scope finalizer 只释放 lease 和 handle，不自动删除目录。
 
 用户可明确运行：
 

--- a/docs/feature/reports/cost-projections/cli.md
+++ b/docs/feature/reports/cost-projections/cli.md
@@ -13,6 +13,10 @@ Sample、Profile 和关闭投影。
 
 ## 人类输出
 
+摘要中的成本 KPI 只显示闭合金额，例如 `USD 32.414359`。`partial` 的缺失 slot 由同层 `not-recorded`
+warning 解释，不在 KPI 格里重复 Profile、provenance、coverage 和每个 reason。完整 ledger 仍在成本组件与 machine
+projection 中可用。
+
 成本组件显示 USD、Profile content identity、declared-rate-card provenance、`available` / `partial` / `unavailable` 状态、total、mean
 和每条 Attempt 的 Provider 计价状态。它不会以一个 basis 标签替代 ledger。
 

--- a/e2e/report/test/report-show.test.ts
+++ b/e2e/report/test/report-show.test.ts
@@ -288,9 +288,6 @@ test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execu
       expect(shown.stdout).toMatch(/Fixture pass rate is\s+partial \(\d+\/\d+\)/);
       expect(shown.stdout).toContain("Source detail");
       expect(shown.stdout).toContain("Diff detail");
-      const unwrapped = shown.stdout.replace(/\s+/gu, " ");
-      expect(unwrapped).toContain("Total known cost");
-      expect(unwrapped).toContain("costUSD");
 
       const json = await niceeval.run(
         ["show", "--report", "./reports/site.tsx", "--json"],

--- a/src/report/model/pricing.ts
+++ b/src/report/model/pricing.ts
@@ -75,19 +75,10 @@ export function formatCostProjectionCellText(
   if (projection.state === "unavailable" || projection.combined === null) {
     return Object.freeze({
       text: localeText(locale, "costProjection.unavailable"),
-      detail: formatCostProjectionCellDetail(cell, locale),
     });
   }
-  const parts = [
-    `${knownValueLabel(projection, locale)} ${moneyText(projection.combined)}`,
-    localeText(locale, `costProjection.basis.${projection.basis}`),
-  ];
-  if (projection.state === "partial") {
-    parts.push(localeText(locale, "costProjection.state.partial"));
-  }
   return Object.freeze({
-    text: parts.join(" · "),
-    detail: formatCostProjectionCellDetail(cell, locale),
+    text: moneyText(projection.combined),
   });
 }
 

--- a/src/sample/analysis.ts
+++ b/src/sample/analysis.ts
@@ -309,13 +309,9 @@ function selectionSummary(
   selection: RecordSelection,
 ): AnalysisSelectionSummary {
   const selectedRunIds = uniqueSorted(selection.runRefs.map((ref) => ref.runId));
-  const problems = normalizedSelectionProblems([
-    ...selection.problems,
-    ...selection.warnings.map((warning): AnalysisSelectionProblem => Object.freeze({
-      code: "incomplete-run" as const,
-      runId: warning.runId,
-    })),
-  ]);
+  // Unpublished Run directories are normal writer residue. Record keeps the
+  // warning for maintenance, but it is not a problem with the selected Sample.
+  const problems = normalizedSelectionProblems(selection.problems);
   if (request.policy === "explicit-runs") {
     return Object.freeze({
       policy: "explicit-runs" as const,


### PR DESCRIPTION
## Problem

- User goal: 在大型 Record 上快速阅读真正需要处理的警告与摘要数字。
- Current limitation: 普通 `niceeval show` 会把正常的未封口 Run residue 逐条列为 warning，并把成本 Profile、provenance、coverage 与每个缺失原因全部塞进 `Total cost` 单元格。
- Required capability: 将 maintenance 诊断留在 Record/`clean` 边界，并让摘要成本只呈现 Analysis 已闭合的金额。
- User outcome: `show` 保留 `not-recorded` 等数据问题，同时以单行金额呈现总成本，不再输出几十条无行动价值的 residue 说明。

## Use cases

### `阅读当前评估概览`

- Coverage: `happy path | lifecycle`
- Starting point: 项目已有已封口 Run、未封口 writer residue，以及部分未记录 slot。
- Copyable usage or trigger: `pnpm exec niceeval show`
- Observable result or diagnostic: 普通概览不列出 `incomplete-run`；`not-recorded` 仍作为 warning；`Total cost` 显示为 `USD 32.414359` 这样的单行金额。
- Contract: `docs/feature/record/use-case/发布完整运行.md`

## CLI

### Changed

#### Case: `niceeval show` 忽略正常的未封口 Run residue

- Before usage or result: `pnpm exec niceeval show` 为每个缺少 `complete` 的 Run 输出一条 `incomplete-run` warning。
- After usage or result: 同一命令忽略这些未发布目录；显式维护仍使用 `niceeval clean` 检查。
- User impact: 人类输出与 machine Sample identity 不再被正常 writer residue 放大；Record reader、发布边界和清理流程不变。

#### Case: `niceeval show` 紧凑呈现总成本

- Before usage or result: `Total cost` 单元格同时展开金额、Pricing Profile、rate-card provenance、coverage 和每个缺失 reason。
- After usage or result: 同一单元格只显示闭合金额，例如 `USD 0.00004`；`not-recorded` 继续由同层 warning 解释。
- User impact: 摘要表保持可扫读；完整成本 ledger 和 machine projection 仍可用于审计。

## Report components

### Changed

#### Case: `SampleSummary` 的成本 KPI

- Before usage or result: `<SampleSummary />` 的 text face 在金额下方重复完整 projection detail。
- After usage or result: `<SampleSummary />` 的 text face 只渲染 projection 的 canonical `currency amount`。
- User impact: Report 作者无需迁移；reader 获得紧凑摘要，详细成本组件和 JSON 数据不变。

## Terminology

### Added terms

None

### Removed terms

None

## Tests

### `e2e/report/test/report-show.test.ts`

- Purpose: `feature`
- Protects: 自定义 Report 的 human/JSON `show` 只执行目标 Page，且 JSON 保持 target-execution manifest。
- Runs: 通过安装后的 candidate 执行 `niceeval exp main/source`、human `niceeval show --report` 与 JSON `niceeval show --report --json`。
- Asserts: 目标页面文本、选择身份、问题表、内建 Pricing Profile 和三个目标页面成本 projection 保持一致；不再把旧的冗长成本 text copy 当成该 owner 的职责。

```ts
// … omitted: file=e2e/report/test/report-show.test.ts; before=// rerun: pnpm e2e --repo report -- --run test/report-show.test.ts; after=test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execution manifest", async () => {; reason=unrelated imports, helpers, and preceding owners
test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execution manifest", async () => {
  await reportE2E.case(
    "show-custom-fixture",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      for (const experimentId of ["main", "source"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }

      // This makes the unrelated parameter Page's enumerate() fail. A target
      // show must still succeed because only view/static build the whole site.
      const targetOnlyEnv = { NICEEVAL_E2E_FAIL_UNRELATED_ENUMERATE: "1" };

      const shown = await niceeval.run(
        ["show", "--report", "./reports/site.tsx"],
        { env: targetOnlyEnv },
      );
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      expect(shown.stdout).toContain("Report fixture static");
      expect(shown.stdout).toMatch(/Fixture pass rate is\s+partial \(\d+\/\d+\)/);
      expect(shown.stdout).toContain("Source detail");
      expect(shown.stdout).toContain("Diff detail");

      const json = await niceeval.run(
        ["show", "--report", "./reports/site.tsx", "--json"],
        { env: targetOnlyEnv },
      );
      expect(json.exitCode, json.diagnostic()).toBe(0);
      const manifest = json.json<CustomTargetExecutionManifest>();
      expect(manifest).toMatchObject({
        schema: "niceeval.report-target-execution/v1",
        locale: "en",
        selection: {
          kind: "project-current",
          experimentIds: ["classic/baseline", "classic/memory-a", "classic/memory-b", "main", "source"],
        },
        report: { title: "Report fixture" },
        page: {
          route: "/",
          pageId: "overview",
          title: "Report fixture",
          renderedText: expect.stringContaining("Report fixture static"),
        },
        downloads: [],
      });
      expectCanonicalProblemTable(manifest.problems, "overview");
      expect(manifest.report.identity).toEqual(expect.any(String));
      expect(manifest.selection.sampleIdentity).toEqual(expect.any(String));
      expectBuiltInPricingProfile(manifest.projections);
      expect(manifest.projections.costs).toHaveLength(3);
      expect(manifest.projections.costs.map((entry) => entry.page)).toEqual([
        { pageId: "overview", route: "/" },
        { pageId: "overview", route: "/" },
        { pageId: "overview", route: "/" },
      ]);
    },
  );
});
// … omitted: file=e2e/report/test/report-show.test.ts; before=expect(manifest.projections.costs.map((entry) => entry.page)).toEqual([; after=test("参数化 show 按规范 key 读取详情页，并对非成员 key 返回单目标错误", async () => {; reason=remaining unrelated owners
```

### Verification receipt

- Candidate: Git `742489c3b3018683587b3db46c7f10fd0afb103c`; tarball SHA-256 `a0c1ac4d20345f458d07722f9526c7f95a171dc944336e91afcd85756f38989a`
- Green: `pnpm e2e takeover --candidate artifacts/niceeval-candidate.tgz --repo report --artifact-root artifacts/e2e/takeover-report-show -- --run test/report-show.test.ts -t '自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execution manifest'`
- Repeatability: 三个全新副本各通过一次；同一安装副本连续通过两次；Report repo 默认并行 suite、2 个 Chromium Journey 与单目标复验全部通过，cleanup 终态通过。
- Fixed conditions: checkout `742489c3` 等价源码、Effect `3.22.1`、锁文件固定、Report fixture 固定、无真实 Provider。
- Unit count: `not applicable — no Unit changed`

### Deliberately not automated

- Case: 普通 `show` 不提示未封口 Run residue。
- Public action: 用 candidate 在 NiceEval-Eval Record 的隔离副本运行 `niceeval show`。
- Observation: 原有 19 条 `incomplete-run` warning 消失；Record 未迁移、未修改。
- Remaining risk: 这是产品反馈取舍，不新增回归 owner；底层 `clean` 行为由既有 Record 测试继续负责。

- Case: 成本摘要只显示闭合金额。
- Public action: 在隔离 Report consumer 执行 `niceeval exp main/source` 后运行 `niceeval show`。
- Observation: `Total cost` 显示 `USD 0.00004`，不再展开 Profile、provenance、coverage 或 reason。
- Remaining risk: 这是产品呈现设计修正，不新增按历史输出命名的回归 case；完整 projection 的既有 machine owner 保持覆盖。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789804676&installation_model_id=431746&pr_number=72&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F72&signature=3cc4f25f46f7ff569c9e89d8175276fce9856e1891b5a5a486784236a0b86a78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->