### PR TITLE
ci: 缩短依赖安装与打包等待时间

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   package:
     name: Typecheck and docs lint
@@ -13,17 +17,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - name: Set up pnpm and Node
+        uses: pnpm/setup@v1
         with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # Typecheck/lint only need the dependency graph. Root prepare builds the
+        # publishable package and would add ~22s without being consumed here.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Typecheck
         run: pnpm run typecheck
@@ -38,19 +42,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      # mint CLI 要 LTS Node；这个 job 与 package job 并行，慢在拉 mint@latest 上，
-      # 不拖住代码侧反馈。
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      # mint CLI 要 LTS Node；这个 job 与 package job 并行，不拖住代码侧反馈。
+      - name: Set up pnpm and Node
+        uses: pnpm/setup@v1
         with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # Mint 不进根 devDependencies，避免所有非文档 job 都安装它的大依赖树。
+      # npx 环境按精确 CLI 版本单独缓存；lint:docs-site 先预热，
+      # 再并发 validate/links。
+      - name: Restore Mint CLI cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.npm/_npx
+          key: mint-cli-${{ runner.os }}-${{ runner.arch }}-node24-4.2.812
 
       - name: Lint docs-site and validate with mint
         run: pnpm run lint:docs-site

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,9 @@ jobs:
           install: false
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # `pnpm e2e pack` below invokes `pnpm pack`, whose prepare lifecycle
+        # builds dist/ and INDEX.md. Do not perform the same build during install.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Resolve lane and environment
         id: lane

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,9 @@ name: Release
 # 集合通过闸门后，才发布同一份 tgz。不要求 main 预先提交版本号变更。
 #
 # 前置:在仓库 Settings → Secrets → Actions 配好 NPM_TOKEN(npm automation token)。
-# 包大部分发 TypeScript 源码(package.json files: src + bin,消费侧用 tsx 加载,无 build 步骤);
-# 唯一例外是 src/report/**(报告 web 面用到 JSX,tsx 的 JSX 编译按调用进程 cwd 找 tsconfig,
-# niceeval 被 link 消费时会退化成 classic JSX、产物引用未定义的全局 React)—— 这部分改发预编译
-# ESM(`pnpm run build:report` 产出 dist/report/**,tsconfig.report-build.json),不受消费方
-# cwd/tsconfig 影响。`pnpm install` / `pnpm pack` 会经 prepare 生命周期触发这一步；
-# 下面的 Build 仍显式跑一遍，方便 CI 失败时定位，也让 Typecheck 针对真实构建
-# 产物跑。最后的 `npm publish <tgz>` 不再重建或重新 pack。
+# 根 install 只准备工具依赖，不触发 prepare。后面的 `pnpm pack` 是唯一构建点：
+# prepare 生成 dist/** 与随包 INDEX.md，再把精确 tgz 交给 release E2E。最后的
+# `npm publish <tgz>` 发布同一份已验证制品，不再重建或重新 pack。
 
 on:
   push:
@@ -50,15 +46,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - name: Set up pnpm and Node
+        uses: pnpm/setup@v1
         with:
-          node-version: 24
-          cache: pnpm
-          registry-url: "https://registry.npmjs.org"
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Apply release version
         id: version
@@ -80,17 +73,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm run build:report
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Typecheck
         run: pnpm run typecheck
 
       # 发版闸门只看包自身对不对:类型检查 + docs/memory 守护。docs-site 的 mint 校验
       # (lint:docs-site)不进这条链——文档站单独部署,一条断链不该拦住 npm publish;
-      # 随包 INDEX.md 的生成失败由 prepare 里的 build:index 直接报错。
+      # 随包 INDEX.md 的生成失败由 pack 里的 prepare/build:index 直接报错。
       - name: Lint docs
         run: pnpm run lint:docs
 
@@ -169,15 +159,13 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - name: Set up pnpm and Node
+        uses: pnpm/setup@v1
         with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
           cache-dependency-path: ${{ steps.dependency-cache.outputs.paths }}
+          install: false
 
       - name: Install orchestrator dependencies
         # release candidate 已由 prepare-release 从同一 checkout 构建；matrix 只安装
@@ -361,17 +349,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - name: Set up pnpm and Node
+        uses: pnpm/setup@v1
         with:
-          node-version: 24
-          cache: pnpm
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install verifier dependencies
-        run: pnpm install --frozen-lockfile
+        # verify-release only executes the checked-out verifier; it does not
+        # consume root dist/ or INDEX.md.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Download exact release candidate and plan
         uses: actions/download-artifact@v8

--- a/package.json
+++ b/package.json
@@ -228,10 +228,10 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit && tsc -p docs/feature/assertions/reference/tsconfig.json",
-    "lint": "concurrently --names vitest,validate,links \"pnpm run lint:vitest\" \"pnpm run docs:validate\" \"pnpm run docs:links\"",
+    "lint": "pnpm run docs:mint && concurrently --names vitest,validate,links \"pnpm run lint:vitest\" \"pnpm run docs:validate\" \"pnpm run docs:links\"",
     "lint:vitest": "vitest run --project lint-docs --project lint-docs-site",
     "lint:docs": "vitest run --project lint-docs",
-    "lint:docs-site": "vitest run --project lint-docs-site && pnpm run docs:validate && pnpm run docs:links",
+    "lint:docs-site": "pnpm run docs:mint && concurrently --names vitest,validate,links \"vitest run --project lint-docs-site\" \"pnpm run docs:validate\" \"pnpm run docs:links\"",
     "niceeval": "node bin/niceeval.js",
     "e2e": "tsx e2e/scripts/cli.ts",
     "gen:diff-code": "tsx scripts/gen-diff-code.ts",
@@ -245,8 +245,9 @@
     "site:dev": "cd site && node scripts/dev.mjs",
     "site:build": "cd site && next build && cd .. && tsx scripts/submit-indexnow.ts",
     "docs:dev": "node scripts/docs-dev.mjs",
-    "docs:validate": "cd docs-site && npx --yes mint@latest validate",
-    "docs:links": "cd docs-site && npx --yes mint@latest broken-links --check-anchors --check-redirects"
+    "docs:mint": "cd docs-site && npx --yes mint@4.2.812 --version",
+    "docs:validate": "cd docs-site && npx --yes mint@4.2.812 validate",
+    "docs:links": "cd docs-site && npx --yes mint@4.2.812 broken-links --check-anchors --check-redirects"
   },
   "dependencies": {
     "@effect/platform-node": "0.108.1",


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 4ec1e6ec21e20be640ba4bc4358a0b1048e2696b
templateSha256: 87433db508780cfb62cc4227c5163773d56362459f95172000e28ac9bc70919f
head: 7a474e7788311b1b5c5c7ecc7fb4fecddc384e0c
-->

## Problem

- User goal: 维护者希望在不减少验收范围的前提下，尽快拿到 CI、E2E 与发版闸门的结果。
- Current limitation: 验证 job 的 `pnpm install` 会触发根 `prepare`，E2E pack 又构建一次，Release prepare 更会重复构建三次；Mint 检查还会串行下载和执行。
- Required capability: 验证型 install 必须跳过 lifecycle，只让生成精确 candidate 的 `pnpm pack` 构建一次；pnpm store 按根与 scenario lockfile 组合缓存，Mint CLI 按精确版本独立缓存并预热。
- User outcome: PR 的新提交会取消旧 CI，文档检查并发执行，E2E 与 Release 仍验证并发布同一份由 `prepare` 现场生成的 tgz。

## Package scripts

### Added

#### Case: `pnpm docs:mint`

##### Before

```sh
pnpm run docs:mint
```

```text
ERR_PNPM_NO_SCRIPT Missing script: docs:mint
```

##### After

```sh
pnpm run docs:mint
```

```text
Mint CLI 4.2.812 is resolved into the npx cache and the command exits 0.
```

##### User impact

本地与 CI 先准备同一个精确 Mint CLI，再并发运行站点构建校验和断链检查，避免 `latest` 漂移和并发安装竞态。

### Changed

#### Case: `pnpm lint` 与 `pnpm lint:docs-site`

##### Before

```sh
pnpm lint
pnpm run lint:docs-site
```

```text
pnpm lint: Vitest, mint validate, and mint broken-links start concurrently with mint@latest.
pnpm lint:docs-site: Vitest, mint validate, and mint broken-links run sequentially.
```

##### After

```sh
pnpm lint
pnpm run lint:docs-site
```

```text
Both commands warm mint@4.2.812 once, then run Vitest, validate, and broken-links concurrently.
```

##### User impact

贡献者仍使用原有 lint 入口，但文档站检查的并发形状一致；CI 另外缓存 `~/.npm/_npx`，热缓存时无需重复下载 Mint 依赖树。

## Terminology

### Added terms

None.

### Removed terms

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789814782&installation_model_id=431746&pr_number=74&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F74&signature=6cbe7731c2684028c702b31f073860afdd382fdb2d8f9517fb1ed9a9201fa35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
