### PR TITLE
fix(report): 让计分实验散点显示总分

### DIFF
--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -265,6 +265,11 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
         const mainExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
         await expect(mainExperimentCount.locator(".niceeval-stat-value")).toHaveText("1");
+        const mainPassChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
+        await expect(mainPassChart).toHaveCount(0);
+        const mainScoreChart = page.locator('svg[aria-label="costUSD × totalScore"]').filter({ visible: true });
+        await expect(mainScoreChart).toHaveCount(1);
+        await expect(mainScoreChart).toContainText("Total score");
 
         await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "classic" });
         await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));

--- a/src/report/components/summaries/index.tsx
+++ b/src/report/components/summaries/index.tsx
@@ -36,6 +36,7 @@ import {
   type ExperimentScatterPoint,
   type SummarySeries,
 } from "./compute.ts";
+import { experimentListData } from "../entity-lists/compute.ts";
 import type { Dataset, DatasetField } from "../../model/types.ts";
 
 export { StabilityOverview } from "./stability-overview.tsx";
@@ -131,9 +132,12 @@ export const ExperimentScatter = defineComponent<ExperimentScatterProps>(async (
       </Col>
     );
   }
-  const data = await experimentScatterData(sampleForExperimentComparisonScope(props.comparison), {
+  const sample = sampleForExperimentComparisonScope(props.comparison);
+  const experiments = await experimentListData(sample, pricing);
+  const data = await experimentScatterData(sample, {
     series: props.series,
     connect: props.connect,
+    experiments,
   }, pricing);
   if (data.points.length > 0 && data.points.every((point) => point.costUSD.state === "migration-required")) {
     return (


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 9c858a344a4862bafb31391b36c83c0f0b1e9ca5
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: b04d6e540611793b8a5b248c7f2757d71160fb2e
-->

## Problem

- User goal: 在同一个报告中直接比较通过制与计分制实验的正确主读数。
- Current limitation: `ExperimentScatter` 没有收到已闭合的实验题型事实，计分制或 mixed 实验会回退成通过制并画出通过率。
- Required capability: 散点图与实验表复用同一份 `evaluationKind` 和 `totalScore`，避免各自推断题型。
- User outcome: 通过制实验继续显示成本 × 通过率，包含 Score Eval 的实验显示成本 × 总分。

## Use cases

### Case: 在默认报告中比较 pass 与 score 实验

#### Starting state

```text
一个通过制实验组，以及一个同时包含 defineEval() 与 defineScoreEval() 的实验。
```

#### Action

```sh
pnpm exec niceeval view --no-open
```

#### Result

```text
通过制实验组：Cost × Pass rate
包含 Score Eval 的实验：Cost × Total score
```

报告读者不再看到与实验表“Total score”冲突的 100% 通过率散点；现有通过制图表保持原样。

## Report components

### Changed

#### Case: `ExperimentScatter` 按实验题型选择纵轴

##### Before

```tsx
<ExperimentScatter comparison={comparison} />
```

```text
包含 Score Eval 的实验仍渲染 Cost × Pass rate。
```

##### After

```tsx
<ExperimentScatter comparison={comparison} />
```

```text
Pass-only 实验渲染 Cost × Pass rate；包含 Score Eval 的实验渲染 Cost × Total score。
```

##### User impact

调用方式不变；报告中的散点图与实验表现在使用相同的主指标。

## Tests

### `e2e/report/test/report.browser.spec.ts`

- Purpose: bug regression
- Protects: 默认报告必须为包含 Score Eval 的实验显示总分散点，不能静默回退成通过率。
- Runs: 通过安装后的候选执行真实 Experiment，启动 `niceeval view`，再用 Chromium 从实验选择器进入 pass-only 与 mixed 页面。
- Asserts: pass-only 页面存在通过率图且没有总分图；mixed 页面不存在通过率图，并存在带 `Total score` 文案的唯一总分图。

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `bug regression`
- Protects: 默认报告必须为包含 Score Eval 的实验显示总分散点，不能静默回退成通过率。
- Runs: 通过安装后的候选执行真实 Experiment，启动 niceeval view，再用 Chromium 从实验选择器进入 pass-only 与 mixed 页面。
- Asserts: pass-only 页面存在通过率图且没有总分图；mixed 页面不存在通过率图，并存在带 Total score 文案的唯一总分图。

```ts
// owner: docs/engineering/testing/e2e/report.md#report-browser-journey
// rerun: pnpm e2e --repo report -- --run test/report.browser.spec.ts
//
// The Journey uses only the installed candidate CLI, exported files, real HTTP,
// href navigation, and browser-visible content. It deliberately
// does not inspect renderer classes, layout, paint, CSS selectors, or Record files.

import { pollUntil, waitForOutput } from "@niceeval/testkit";
import { readFile, writeFile } from "node:fs/promises";
import { join } from "node:path";
import { fileURLToPath, pathToFileURL } from "node:url";
import { expect, test } from "@playwright/test";
import { reportCaseArtifacts, reportE2E } from "./support.ts";

type DetailKind = "Source" | "Diff" | "Slot";

test("静态站与 view 对同一用户路由交付相同字节，且离线无 JavaScript 仍可浏览", async ({ browser }) => {
  test.setTimeout(120_000);

  await reportE2E.case(
    "browser-static-site",
    { artifacts: reportCaseArtifacts(["site-export"]) },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      const mainRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(mainRun.expReceipt(), mainRun.diagnostic()).toMatchObject({ completion: "completed" });
      const sourceRun = await niceeval.run(["exp", "source", "--rerun", "all", "--json"]);
      expect(sourceRun.expReceipt(), sourceRun.diagnostic()).toMatchObject({ completion: "completed" });
      const slotCount = mainRun.expEvalEvents().length + sourceRun.expEvalEvents().length;
      expect(slotCount, mainRun.diagnostic()).toBeGreaterThan(0);

      const exported = await niceeval.run([
        "view",
        "--report",
        "./reports/site.tsx",
        "--out",
        "site-export",
        "--no-open",
      ]);
      expect(exported.exitCode, exported.diagnostic()).toBe(0);

      const view = niceeval.start(
        [
          "view",
          "--report",
          "./reports/site.tsx",
          "--host",
          "127.0.0.1",
          "--port",
          "0",
          "--no-open",
        ],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000,
        label: "static-equivalent view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "static-equivalent view readiness");

      const staticRoot = pathToFileURL(join(projectRoot, "site-export", "index.html"));
      await expectSameBody(staticRoot, new URL(origin!));

      const offline = await browser.newContext({ javaScriptEnabled: false });
      try {
        await offline.setOffline(true);
        const page = await offline.newPage();
        await page.goto(staticRoot.href);
        await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
        const staticSiteText = visibleText(page, "Report fixture static site");
        await expect(staticSiteText).toHaveCount(1);
        await expect(staticSiteText).toBeVisible();
        const overviewTabText = visibleText(page, "Fixture overview tab content");
        await expect(overviewTabText).toHaveCount(1);
        await expect(overviewTabText).toBeVisible();
        // Native disclosure: only the first tab is open without JavaScript.
        const fixtureDetailsTab = page.locator("details").filter({
          hasText: "Fixture details tab content",
        }).filter({ visible: true });
        await expect(fixtureDetailsTab).toHaveCount(1);
        await expect(visibleText(page, "Fixture details tab content")).toHaveCount(0);
        await fixtureDetailsTab.locator(":scope > summary").click();
        await expect(fixtureDetailsTab).toHaveAttribute("open", "");
        const expandedDetailsText = visibleText(page, "Fixture details tab content");
        await expect(expandedDetailsText).toHaveCount(1);
        await expect(expandedDetailsText).toBeVisible();

        const detailLinks = await Promise.all(
          (await page.getByRole("link", { name: /^(?:Source|Diff) detail$|^Slot detail / }).all()).map(async (link) => {
            const href = await link.getAttribute("href");
            if (href === null) throw new Error("a visible static detail link has no href");
            return { href, label: await link.innerText() };
          }),
        );
        expect(detailLinks.filter(({ label }) => detailKind(label) === "Slot")).toHaveLength(slotCount);
        expect([...new Set(detailLinks.map(({ label }) => detailKind(label)))].sort()).toEqual(
          ["Diff", "Slot", "Source"],
        );

        for (const detail of detailLinks) {
          const kind = detailKind(detail.label);
          const staticUrl = new URL(detail.href, staticRoot);
          const liveUrl = new URL(detail.href, origin!);
          await expectSameBody(staticUrl, liveUrl);

          // The href is a shareable exported location, not an in-memory router state.
          await page.goto(staticUrl.href);
          const heading = kind === "Slot"
            ? page.getByRole("heading", { name: /^Slot fixture detail slot-/ })
            : page.getByRole("heading", { name: new RegExp(`^${kind} fixture detail$`) });
          await expect(heading).toBeVisible();
          const sharedUrl = page.url();
          await page.reload();
          expect(page.url()).toBe(sharedUrl);
          await expect(heading).toBeVisible();
        }

      } finally {
        await offline.close();
      }

      // A static page must remain complete even if a view-only refresh or host-data
      // probe is unavailable. This context leaves JavaScript enabled and fails every
      // HTTP transport before opening the exported file, without naming a host route.
      const blockedTransport = await browser.newContext();
      try {
        await blockedTransport.route(/^https?:\/\//, (route) => route.abort("failed"));
        const page = await blockedTransport.newPage();
        await page.goto(staticRoot.href);
        await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
      } finally {
        await blockedTransport.close();
      }

      // Open the JavaScript-enhanced live page before changing its watched
      // static import. The user does not reload: a successful new revision must
      // reach the already-open page through the host-owned refresh behavior.
      const liveBrowser = await browser.newContext();
      try {
        const page = await liveBrowser.newPage();
        await page.goto(origin!);
        const slotDetail = page.getByRole("link", { name: /^Slot detail / }).first().filter({ visible: true });
        await expect(slotDetail).toBeVisible();
        await slotDetail.click();
        const dialog = page.getByRole("dialog");
        await expect(dialog).toBeVisible();
        await expect(dialog.getByRole("heading", { name: /^Slot fixture detail slot-/ })).toBeVisible();
        const nestedSource = dialog.getByRole("link", { name: "Source from slot detail" });
        const sourceUrl = new URL("/source/index.html", origin!).href;
        // This is a relative href in the fetched slot document. The dialog
        // must preserve that detail document as the base before insertion.
        await expect(nestedSource).toHaveAttribute("href", sourceUrl);
        await Promise.all([
          page.waitForURL(sourceUrl),
          nestedSource.click(),
        ]);
        await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();

        await page.goto(origin!);
        const initialCopy = visibleText(page, "niceeval report fixture copy text");
        await expect(initialCopy).toHaveCount(1);
        await expect(initialCopy).toBeVisible();
        const overviewTab = page.locator("details").filter({
          hasText: "Fixture overview tab content",
        }).filter({ visible: true });
        const detailsTab = page.locator("details").filter({
          hasText: "Fixture details tab content",
        }).filter({ visible: true });
        await expect(overviewTab).toHaveCount(1);
        await expect(overviewTab).toHaveAttribute("open", "");
        await expect(detailsTab).toHaveCount(1);
        await expect(detailsTab).not.toHaveAttribute("open", "");
        await detailsTab.locator(":scope > summary").click();
        await expect(detailsTab).toHaveAttribute("open", "");
        await expect(overviewTab).not.toHaveAttribute("open", "");
        const selectedDetailsText = visibleText(page, "Fixture details tab content");
        await expect(selectedDetailsText).toHaveCount(1);
        await expect(selectedDetailsText).toBeVisible();
        await expect(visibleText(page, "Fixture overview tab content")).toHaveCount(0);

        const componentPath = join(projectRoot, "reports", "site-copy-block.tsx");
        const component = await readFile(componentPath, "utf8");
        const refreshedMarker = "live view refresh marker 981";
        const refreshedComponent = component.replace("niceeval report fixture copy text", refreshedMarker);
        if (refreshedComponent === component) {
          throw new Error("the watched Report component no longer contains its refresh marker");
        }
        await writeFile(componentPath, refreshedComponent, "utf8");

        const refreshedCopy = visibleText(page, refreshedMarker);
        await expect(refreshedCopy).toHaveCount(1, { timeout: 15_000 });
        await expect(refreshedCopy).toBeVisible();
      } finally {
        await liveBrowser.close();
      }
    },
  );
});

test("零配置 view 使用经典报告完成筛选、原生展开、详情下钻与语言切换", async ({ browser }) => {
  test.setTimeout(180_000);

  await reportE2E.case(
    "browser-default-classic-surface",
    { artifacts: reportCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/memory-b"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const view = niceeval.start(
        [
          "view",
          "--host",
          "127.0.0.1",
          "--port",
          "0",
          "--no-open",
        ],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000,
        label: "classic surface view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "classic surface view readiness");

      const page = await browser.newPage();
      try {
        await page.goto(origin!);
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();

        // A fixed Sample with one named Experiment Group goes straight to its
        // comparison and does not waste Header space on a one-option selector.
        await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);

        const passChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
        await expect(passChart).toHaveCount(1);
        await expect(passChart).toContainText("classic/memory-a");
        await expect(passChart).toContainText("100%");
        await expect(passChart).not.toContainText("ratio");
        const scoreChart = page.locator('svg[aria-label="costUSD × totalScore"]').filter({ visible: true });
        await expect(scoreChart).toHaveCount(0);

        const mixedRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
        expect(mixedRun.expReceipt(), mixedRun.diagnostic()).toMatchObject({ completion: "completed" });
        const experimentSelector = page.getByRole("combobox", { name: "Experiments" });
        await expect(experimentSelector).toBeVisible({ timeout: 15_000 });
        await expect(experimentSelector.getByRole("option")).toHaveText(["classic", "main"]);
        await expect(experimentSelector.locator("option:checked")).toHaveText("classic");

        // Opening the site root never exposes an unselected project-wide
        // overview: the first stable Experiment Group is the current value.
        await page.goto(origin!);
        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const classicExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
        await expect(classicExperimentCount.locator(".niceeval-stat-value")).toHaveText("3");

        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "main" });
        await expect(page).toHaveURL(new RegExp("/group/singleton/main/index\\.html$"));
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const mainExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
        await expect(mainExperimentCount.locator(".niceeval-stat-value")).toHaveText("1");
        const mainPassChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
        await expect(mainPassChart).toHaveCount(0);
        const mainScoreChart = page.locator('svg[aria-label="costUSD × totalScore"]').filter({ visible: true });
        await expect(mainScoreChart).toHaveCount(1);
        await expect(mainScoreChart).toContainText("Total score");

        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "classic" });
        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
        const selectedGroupChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
        await expect(selectedGroupChart).toContainText("classic/memory-a");
        await expect(selectedGroupChart).not.toContainText("main");

        const exported = await niceeval.run(["view", "--out", "group-static", "--no-open"]);
        expect(exported.exitCode, exported.diagnostic()).toBe(0);
        const offline = await browser.newContext({ javaScriptEnabled: false });
        try {
          const staticPage = await offline.newPage();
          await staticPage.goto(pathToFileURL(join(projectRoot, "group-static", "index.html")).href);
          const staticGroups = staticPage.getByRole("navigation", { name: "Experiments" });
          await expect(staticGroups.getByRole("link", { name: "classic" }))
            .toHaveAttribute("href", "group/named/classic/index.html");
          await staticGroups.getByRole("link", { name: "classic" }).click();
          await expect(staticPage).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
          const staticGroupChart = staticPage.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
          await expect(staticGroupChart).toContainText("classic/memory-a");
          await expect(staticGroupChart).not.toContainText("main");
        } finally {
          await offline.close();
        }
        const filter = page.getByRole("searchbox").filter({ visible: true });
        await expect(filter).toHaveCount(1);
        await expect(filter).toBeVisible();
        const experimentTable = filter.locator("..").getByRole("table");
        await expect(experimentTable).toHaveCount(1);
        await filter.fill("classic/memory-a");
        const memoryA = experimentTable.locator("summary").filter({
          hasText: "classic/memory-a",
        }).filter({ visible: true });
        await expect(memoryA).toHaveCount(1);
        await expect(memoryA).toBeVisible();
        const baseline = experimentTable.locator("summary").filter({
          hasText: "classic/baseline",
        }).filter({ visible: true });
        await expect(baseline).toHaveCount(0);
        await filter.fill("");

        const group = experimentTable.locator("details").filter({
          hasText: "classic/memory-a",
        }).filter({ visible: true });
        await expect(group).toHaveCount(1);
        await expect(group).toBeVisible();
        const groupSummary = group.locator(":scope > summary");
        await groupSummary.focus();
        await groupSummary.press("Space");
        await expect(group).toHaveAttribute("open", "");

        const evalGroupSummary = group.locator("summary").filter({
          hasText: "classic (8 evals)",
        }).filter({ visible: true });
        await expect(evalGroupSummary).toHaveCount(1);
        const evalGroup = evalGroupSummary.locator("..");
        await expect(evalGroup).toHaveCount(1);
        await expect(evalGroup).toBeVisible();
        await evalGroupSummary.focus();
        await evalGroupSummary.press("Space");
        await expect(evalGroup).toHaveAttribute("open", "");

        const evalRowSummary = evalGroup.locator("summary").filter({
          hasText: "recall-constraint",
        }).filter({ visible: true });
        await expect(evalRowSummary).toHaveCount(1);
        const evalRow = evalRowSummary.locator("..");
        await expect(evalRow).toHaveCount(1);
        await evalRowSummary.focus();
        await evalRowSummary.press("Space");
        await expect(evalRow).toHaveAttribute("open", "");

        const attemptLink = evalRow.getByRole("link").filter({
          visible: true,
        });
        await expect(attemptLink).toHaveCount(1);
        await expect(attemptLink).toBeVisible();
        const href = await attemptLink.getAttribute("href");
        if (href === null) throw new Error("an expanded attempt row has no detail href");
        const detail = new URL(href, page.url());
        expect(detail.pathname).toMatch(/^\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}\/index\.html$/);

        // The JavaScript enhancement opens the Host-owned detail dialog around
        // the same href instead of leaving the overview page.
        await attemptLink.click();
        const dialog = page.getByRole("dialog");
        await expect(dialog).toBeVisible();
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await expect(dialog.getByText(/^source · execution · timing(?: · diff)?$/).filter({ visible: true })).toBeVisible();
        await expect(dialog.getByText("Assessment evidence", { exact: true })).toHaveCount(0);
        await expect(dialog.getByText(/^\{\"groupPath\":/)).toHaveCount(0);
        const sendLine = dialog.locator("details.niceeval-source-line--send").filter({ visible: true });
        await expect(sendLine).toHaveCount(1);
        await expect(sendLine).not.toHaveAttribute("open", "");
        await sendLine.locator(":scope > summary").click();
        await expect(sendLine).toHaveAttribute("open", "");
        await expect(sendLine.getByText("Duration", { exact: true })).toBeVisible();
        await expect(sendLine.getByText("Turns", { exact: true })).toBeVisible();
        await expect(sendLine.getByText("Calls", { exact: true })).toBeVisible();
        await expect(sendLine.locator(".niceeval-conversation-turn-head")).toBeVisible();
        const trace = sendLine.locator("[data-niceeval-turn-trace]");
        const traceRows = trace.locator("[data-niceeval-trace-event]");
        const firstTraceRow = traceRows.nth(0);
        const secondTraceRow = traceRows.nth(1);
        const thirdTraceRow = traceRows.nth(2);
        const firstTraceEvidence = firstTraceRow.locator("[data-niceeval-trace-evidence]");
        const secondTraceEvidence = secondTraceRow.locator("[data-niceeval-trace-evidence]");
        const thirdTraceEvidence = thirdTraceRow.locator("[data-niceeval-trace-evidence]");
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await firstTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).toHaveAttribute("open", "");
        await expect(firstTraceRow.locator("[data-niceeval-trace-select]")).toHaveAttribute("aria-expanded", "true");
        await secondTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await expect(secondTraceEvidence).toHaveAttribute("open", "");
        await expect(secondTraceEvidence.locator("[data-tool-evidence-kind='command']")).toBeVisible();
        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").textContent()).toBe(
          "printf 'classic/recall-constraint: recalled=true\\n' > memory-note.txt",
        );
        await thirdTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(secondTraceEvidence).not.toHaveAttribute("open", "");
        await expect(thirdTraceEvidence).toHaveAttribute("open", "");
        await expect(thirdTraceRow.locator(".niceeval-trace-event-summary")).toHaveText("command_execution result");
        await expect(thirdTraceEvidence.locator("[data-tool-evidence-kind='terminal']")).toBeVisible();
        await expect(thirdTraceEvidence.getByText("Exit 0", { exact: true })).toBeVisible();
        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(0).textContent()).toBe(
          "wrote memory-note.txt\nclassic/recall-constraint: recalled=true\n",
        );
        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(1).textContent()).toBe(
          '{\n  "written": true,\n  "recalled": true\n}',
        );
        await thirdTraceEvidence.getByRole("tab", { name: "Raw" }).click();
        await expect(thirdTraceEvidence.getByRole("tab", { name: "Raw" })).toHaveAttribute("aria-selected", "true");
        await expect(thirdTraceEvidence.locator("[data-niceeval-trace-evidence-panel='raw']")).toBeVisible();
        expect(await thirdTraceEvidence.locator(".niceeval-trace-evidence-raw").textContent()).toBe(
          '{"output":"wrote memory-note.txt\\nclassic/recall-constraint: recalled=true\\n","exit_code":0,"written":true,"recalled":true}',
        );
        const deepLink = page.url();
        expect(new URL(deepLink).hash).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);
        await page.keyboard.press("Escape");
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("");

        // The legacy URL contract survives the new closed-site host: opening
        // its hash directly restores the same dialog, and reload keeps it.
        await page.goto(deepLink);
        await expect(dialog).toBeVisible();
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await page.reload();
        expect(page.url()).toBe(deepLink);
        await expect(dialog).toBeVisible();
        await page.goBack();
        await expect(dialog).not.toBeVisible();

        // Assertion source-line details use one display contract across a
        // matched built-in assertion, a nested scoped matcher mismatch, and a
        // direct value mismatch. The Report projects sealed diagnostic facts;
        // it never dumps the matcher tree as user-facing JSON.
        await page.goto(origin!);
        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "main" });
        await expect(page).toHaveURL(new RegExp("/group/singleton/main/index\\.html$"));
        const mainFilter = page.getByRole("searchbox").filter({ visible: true });
        await mainFilter.fill("deliberate-fail");
        const mainTable = mainFilter.locator("..").getByRole("table");
        const mainSummary = mainTable.locator("summary").filter({
          has: page.getByText("main", { exact: true }),
        }).filter({ visible: true });
        await expect(mainSummary).toHaveCount(1);
        await expect(mainSummary).toBeVisible();
        const mainGroup = mainSummary.locator("..");
        await mainSummary.click();
        await expect(mainGroup).toHaveAttribute("open", "");
        const failedEvalSummary = mainGroup.locator("summary").filter({
          has: page.getByText("deliberate-fail", { exact: true }),
        }).filter({ visible: true });
        await expect(failedEvalSummary).toHaveCount(1);
        await expect(failedEvalSummary).toBeVisible();
        const failedEval = failedEvalSummary.locator("..");
        await failedEvalSummary.click();
        await expect(failedEval).toHaveAttribute("open", "");
        await mainFilter.fill("");
        const failedAttemptLink = failedEval.getByRole("link").filter({ visible: true });
        await expect(failedAttemptLink).toHaveCount(1);
        await failedAttemptLink.click();
        await expect(dialog).toBeVisible();

        const matchedAssertion = dialog.locator("details").filter({ hasText: "Turn completed · soft passed" });
        await expect(matchedAssertion).toHaveCount(1);
        await matchedAssertion.locator(":scope > summary").click();
        await expect(matchedAssertion.getByText("Turn completed · soft passed", { exact: true })).toBeVisible();

        const nestedMismatch = dialog.locator("details").filter({
          hasText: "No private source access · gate failed",
        });
        await expect(nestedMismatch).toHaveCount(1);
        if (await nestedMismatch.getAttribute("open") === null) {
          await nestedMismatch.locator(":scope > summary").click();
        }
        await expect(nestedMismatch.getByText("reason: condition-not-met", { exact: false })).toBeVisible();
        await expect(nestedMismatch.getByText(
          "notCalledTool(toolMatch(input=referencesAnyPath(3 paths))) observed a matching tool",
          { exact: false },
        )).toBeVisible();
        await expect(nestedMismatch.getByText("received: 1 definite match", { exact: false })).toBeVisible();
        await expect(nestedMismatch.getByText("location: tool occurrence", { exact: false })).toBeVisible();
        await expect(nestedMismatch.getByText(/^diagnostic: \{"children"/)).toHaveCount(0);

        const valueMismatch = dialog.locator("details").filter({ hasText: "Expected fixture value · gate failed" });
        await expect(valueMismatch).toHaveCount(1);
        if (await valueMismatch.getAttribute("open") === null) {
          await valueMismatch.locator(":scope > summary").click();
        }
        await expect(valueMismatch.getByText("includes(\"expected fixture value\") did not find the literal text", {
          exact: false,
        })).toBeVisible();
        await expect(valueMismatch.getByText("expected: \"expected fixture value\"", { exact: false })).toBeVisible();
        await expect(valueMismatch.getByText(/^diagnostic: \{/)).toHaveCount(0);
        await page.keyboard.press("Escape");
        await expect(dialog).not.toBeVisible();

        // The href stays a real standalone route: direct navigation reads the
        // same closed detail document.
        await page.goto(detail.href);
        await expect(page.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await expect(page.getByText(/^source · execution · timing(?: · diff)?$/).filter({ visible: true })).toBeVisible();

        await page.goto(new URL("group/named/classic/index.html", origin!).href);
        const scatter = page.getByRole("img", { name: "costUSD × passRate" }).filter({ visible: true });
        await expect(scatter).toHaveCount(1);
        await expect(scatter).toContainText("classic/memory-a");
        const pageRouter = page.getByRole("navigation", { name: "Report pages" });
        const pageRouterBox = await pageRouter.boundingBox();
        const viewport = page.viewportSize();
        expect(pageRouterBox, "the whole Page router must have a visible layout box").not.toBeNull();
        expect(viewport, "the browser fixture must expose its viewport").not.toBeNull();
        expect(Math.abs(pageRouterBox!.x + pageRouterBox!.width / 2 - viewport!.width / 2))
          .toBeLessThanOrEqual(1);
        const languageSelector = page.getByRole("combobox", { name: "Language" });
        await expect(languageSelector).toBeVisible();
        await expect(languageSelector.getByRole("option")).toHaveText(["EN", "中文"]);
        await languageSelector.selectOption("zh-CN");
        await expect(page.getByText("总览", { exact: true })).toBeVisible();
        await expect(languageSelector).toHaveValue("zh-CN");
      } finally {
        await page.close();
      }
    },
  );
});

async function expectSameBody(staticUrl: URL, liveUrl: URL): Promise<void> {
  const expected = await readFile(fileURLToPath(staticUrl));
  const response = await fetch(liveUrl);
  expect(response.status, `${liveUrl} should serve the exported body`).toBe(200);
  // Headers and a view-only refresh transport are intentionally outside this
  // oracle; the publicly delivered bytes must still be identical.
  expect(Buffer.from(await response.arrayBuffer()), `${liveUrl} body`).toEqual(expected);
}

function detailKind(label: string): DetailKind {
  const matched = /^(Source|Diff|Slot) detail(?: |$)/.exec(label);
  if (matched === null) throw new Error(`unexpected static detail link label: ${JSON.stringify(label)}`);
  return matched[1] as DetailKind;
}

async function waitForHttp(origin: string, label: string): Promise<void> {
  await pollUntil(
    async () => {
      try {
        return (await fetch(origin)).status === 200 ? true : undefined;
      } catch {
        return undefined;
      }
    },
    { timeoutMs: 15_000, intervalMs: 100, label },
  );
}

function visibleText(page: import("@playwright/test").Page, text: string) {
  return page.getByText(text, { exact: true }).filter({ visible: true });
}
```

### Verification receipt

- Candidate: checkout `9c858a344a4862bafb31391b36c83c0f0b1e9ca5` + source snapshot `983d5193625a0bfbcb94b81c034ae20e949108e95bf98710e5e9da1c2cf26415`（同一源码已提交为 `b04d6e54`）；NiceEval tarball SHA-256 `93146f617106e56c027bc6671ee6cbb1457363032d860caa8ba604e7b51ac58d`
- Red: 修复前候选 SHA-256 `f48b497480da93b5f64e9d71f30f27dfe8dfc6e51f014034d8b70b99b0af4cb3`；浏览器切到 `main` 后 `costUSD × passRate` 数量为 1，期望为 0，最早在公开 view DOM 断言失败。
- Green: `pnpm e2e run --candidate <candidate.tgz> --repo report -- --run test/report.browser.spec.ts -g "零配置 view 使用经典报告完成筛选、原生展开、详情下钻与语言切换"`；1 passed。
- Repeatability: `pnpm e2e takeover --candidate <candidate.tgz> --repo report -- --run test/report.browser.spec.ts -g "零配置 view 使用经典报告完成筛选、原生展开、详情下钻与语言切换"`；3 个隔离副本、同副本连续 2 次、默认并行全 Repo 与目标单项全部通过，所有 cleanup 正常。
- Fixed conditions: checkout `9c858a344a4862bafb31391b36c83c0f0b1e9ca5` + dirty source snapshot `983d5193625a0bfbcb94b81c034ae20e949108e95bf98710e5e9da1c2cf26415`；签入 lockfile；确定性 Direct Agent fixture；Playwright Chromium 1.61.1；无 provider 调用。
- Unit count: `not applicable — no Unit changed`；另运行 `pnpm typecheck`，通过。
