### PR TITLE
fix(report): 明确展示未计分断言结果

### DIFF
--- a/docs/engineering/testing/e2e/report.md
+++ b/docs/engineering/testing/e2e/report.md
@@ -159,4 +159,5 @@ niceeval view --report <fixture> --no-open
 
 `report.browser.spec.ts` 通过真实 href、HTTP、可访问身份、可见内容和断网禁用 JavaScript 的 route 阅读验证浏览器 Journey。
 经典旅程通过真实浏览器完成筛选、原生 `details` 展开、Attempt href 下钻与中文切换。它只锁 role、text、href 和
-原生标签语义，不锁 CSS class、像素或精确颜色。
+原生标签语义，不锁 CSS class、像素或精确颜色。Assertion 展开同时守住 record-only 的 `recorded` 状态，以及
+`notCalledTool` 零命中或决定性命中的人读诊断。

--- a/docs/feature/assertions/library/display.md
+++ b/docs/feature/assertions/library/display.md
@@ -12,7 +12,9 @@ Pass Eval 的区块顺序是 Execution、Verdict、检查项。Score Eval 的区
 
 每条 Assertion 显示其 display、sealed result、coverage、limitations 与有界的 subject／evidence preview。criterion 可解释时显示 criterion 说明；unknown 或 invalid criterion 只影响该 entry，并明确显示 `unsupported` 或 `invalid`。
 
-未配置 points 的 Assertion 显示 `recorded`，不显示 `+0`。配置 points 的 entry 显示 points、其 sealed evaluation 与实际 contribution。entry 的 points 不是 max、百分比或 Evaluation kind。
+未配置 points 且没有失败 gate 的 Assertion 以 `recorded passed`、`recorded failed` 或 `recorded unavailable` 显示，不补 `+0`。失败 gate 仍显示 `gate failed`。配置 points 的 entry 显示 points、sealed evaluation 与实际 contribution。entry 的 points 不是 max、百分比或 Evaluation kind。
+
+`notCalledTool` matched 时，展开区显示期望零命中与 `0 definite matches`。mismatched 时显示实际命中数、决定结果的 tool occurrence，以及命中输入内的位置。诊断采样或截断不能删除 sealed result 与决定性见证。
 
 Assertions display 不携带 source path、origin source snapshot 或跨 family blob ref。需要源码导航时，Analysis 的 source-navigation DomainView 组合 Assertions payload 内的 `sourceSites` 与 origin Sources snapshot。
 没有对应 row 或 Sources 无法形成可用值时，entry 位置显示 `unmapped`，不能猜测当前 worktree。`.orStop()` 已执行的位置可由 role 为 `stop` 的 source site 显示，不能由未保存的控制流推断。

--- a/e2e/report/evals/deliberate-fail.eval.ts
+++ b/e2e/report/evals/deliberate-fail.eval.ts
@@ -12,6 +12,17 @@ export default defineEval({
     turn.notCalledTool(
       toolMatch({ input: referencesAnyPath(["report-notes.txt", "evals", "agents"]) }),
     ).label("No private source access");
+    turn.notCalledTool(
+      toolMatch({
+        input: referencesAnyPath([
+          "package.json",
+          "AGENTS.md",
+          "CLAUDE.md",
+          "INIT.md",
+          "node_modules/niceeval",
+        ]),
+      }),
+    ).label("No project guidance access");
     t.check("actual fixture value", includes("expected fixture value"))
       .label("Expected fixture value");
   },

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -1,4 +1,5 @@
 // owner: docs/engineering/testing/e2e/report.md#report-browser-journey
+// regression: memory/record-only-assertions-labeled-soft.md
 // rerun: pnpm e2e --repo report -- --run test/report.browser.spec.ts
 //
 // The Journey uses only the installed candidate CLI, exported files, real HTTP,
@@ -420,9 +421,10 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         await expect(dialog).not.toBeVisible();
 
         // Assertion source-line details use one display contract across a
-        // matched built-in assertion, a nested scoped matcher mismatch, and a
-        // direct value mismatch. The Report projects sealed diagnostic facts;
-        // it never dumps the matcher tree as user-facing JSON.
+        // matched built-in assertions, a nested scoped matcher mismatch, and
+        // a direct value mismatch. Record-only checks say `recorded`; scoped
+        // matchers expose the decisive count/witness without dumping their
+        // matcher tree as user-facing JSON.
         await page.goto(origin!);
         await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "main" });
         await expect(page).toHaveURL(new RegExp("/group/singleton/main/index\\.html$"));
@@ -451,10 +453,26 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         await failedAttemptLink.click();
         await expect(dialog).toBeVisible();
 
-        const matchedAssertion = dialog.locator("details").filter({ hasText: "Turn completed · soft passed" });
+        const matchedAssertion = dialog.locator("details").filter({ hasText: "Turn completed · recorded passed" });
         await expect(matchedAssertion).toHaveCount(1);
         await matchedAssertion.locator(":scope > summary").click();
-        await expect(matchedAssertion.getByText("Turn completed · soft passed", { exact: true })).toBeVisible();
+        await expect(matchedAssertion.getByText("Turn completed · recorded passed", { exact: true })).toBeVisible();
+
+        const absentToolAssertion = dialog.locator("details").filter({
+          hasText: "No project guidance access · recorded passed",
+        });
+        await expect(absentToolAssertion).toHaveCount(1);
+        await absentToolAssertion.locator(":scope > summary").click();
+        await expect(absentToolAssertion.getByText(
+          "notCalledTool(toolMatch(input=referencesAnyPath(5 paths))) observed no matching tool",
+          { exact: false },
+        )).toBeVisible();
+        await expect(absentToolAssertion.getByText(
+          "expected: no toolMatch(input=referencesAnyPath(5 paths))",
+          { exact: false },
+        )).toBeVisible();
+        await expect(absentToolAssertion.getByText("received: 0 definite matches", { exact: false })).toBeVisible();
+        await expect(absentToolAssertion.getByText(/^diagnostic: \{"children"/)).toHaveCount(0);
 
         const nestedMismatch = dialog.locator("details").filter({
           hasText: "No private source access · gate failed",

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -305,6 +305,7 @@ memory 的召回全靠这份索引:漏索引的条目等于不存在。维护规
 
 ### 台账
 
+- 已修 [record-only-assertions-labeled-soft](record-only-assertions-labeled-soft.md) — Attempt 展开把未计分 Assertion 标成 `soft`，正常 `notCalledTool` 看不出这是已记录的零命中结果；改为 `recorded passed/failed/unavailable`，并由浏览器 E2E 守住零命中与决定性见证
 - 已修 [commandsucceeded-received-excerpt-not-tail](commandsucceeded-received-excerpt-not-tail.md) — commandSucceeded 失败摘录曾落在输出中段:合并顺序(stdout 前置让 stderr 装包噪声占末尾)+ 摘录窗口宽过终端行预算被从头收口,双因叠加;修为 stderr 在前合并 + 76 字符窗口(src/context/context.ts),合并顺序钉进 display.md;同批裁决 commands.json 落盘不截
 - 已修 [show-locator-scoped-to-current-sample](show-locator-scoped-to-current-sample.md) — `show @<locator>` 曾在 resolveLocator 之后拿 `currentSample().attempts`(现刻水位,同 evalId 只留最新)二次筛,`--history` 印出的历史 attempt 一律报「outside the selected record scope」这第四种失败,违反「作用域是一个记录根」契约;修为删掉二次筛(src/show/index.ts),身份直达不复核范围
 - [show-json-pipe-truncated-at-128k](show-json-pipe-truncated-at-128k.md) — 发现(未修):`show --json` 管进下游只出恰好 128KB,重定向文件完整;疑为 stdout 为 pipe 时异步写未 flush 即 `process.exit`;症状呈现为下游「JSON 语法错误」,极易误怪解析脚本(2026-07-30 MemoryBench 真机)

--- a/memory/record-only-assertions-labeled-soft.md
+++ b/memory/record-only-assertions-labeled-soft.md
@@ -1,0 +1,23 @@
+# Record-only Assertion 被标成 soft
+
+## 现象
+
+Attempt 详情把没有 points、也没有失败 gate 的 Assertion 显示成 `soft passed` 或 `soft failed`。用户展开正常的 `notCalledTool` 时，虽然诊断已经保存 `0 definite matches`，标题仍无法说明这是一条只记录结果、不贡献分数的检查。
+
+## 根因
+
+Report 展示投影只从 gate 是否失败派生 `gate | soft`。它没有读取 sealed score contribution 的 `not-scored` 状态，因此把 record-only 与带 points 的非 gate Assertion 合并成同一个 `soft` 类别。
+
+## 修法
+
+Attempt 展示投影先保留失败 gate，再把 `score.state: "not-scored"` 显示成 `recorded`。带 points 的非 gate Assertion 继续使用 `soft`，已有 contribution 与 `+N` 不变。`notCalledTool` 的展开正文继续来自已封口 diagnostic，并显示零命中或决定性命中位置。
+
+## 回归收据
+
+owner 是 `docs/engineering/testing/e2e/report.md#report-browser-journey`。Report 场景用安装后的候选运行确定性 Experiment，再经 `niceeval view` 和真实 Chromium 打开 Attempt 详情。
+
+- 旧行为 candidate SHA-256 `d478928a7a0f062e385c81c0ce71a4207e5b63475dc940c7c78db3ad8fd18c1f`：浏览器找不到 `Turn completed · recorded passed`，最早在 outcome 检查点变红；artifact `/tmp/niceeval-e2e-artifacts-HPdVOY`。
+- 修复行为 candidate SHA-256 `069d27b886b69b502ef8dbab44dfade591d4c41ff4d5d622bc6f5f229ac530d7`：同一浏览器 owner 通过，artifact `/tmp/niceeval-e2e-artifacts-pCsS9V`。
+- 可靠性接管 candidate SHA-256 `a8407cb45cc00e33f8da05206b08764bfbe2030c296e1ba2ed9c2d71a0e30af5`：三个隔离副本、同一安装副本重复运行、Repo 默认并行入口及目标单测均为 clean pass；矩阵完整，所有运行 `cleanupOk: true`，source snapshot cleanup 成功。summary `/tmp/niceeval-recorded-assertion-takeover.LP2eca/receipts/takeover-summary.json`。
+
+测试不读取 Record 私有文件，也不调用 Report 内部函数；红绿都来自安装后 CLI、HTTP 与浏览器可见结果。

--- a/src/report/components/attempt-detail/compute.ts
+++ b/src/report/components/attempt-detail/compute.ts
@@ -83,8 +83,8 @@ export interface AttemptScoreView {
 export interface AttemptAssertionView {
   readonly entryId: string;
   readonly name: string;
-  /** sealed gate 投影:failed / unavailable 是 gate,其余是 soft。 */
-  readonly severity: "gate" | "soft";
+  /** 展示角色:失败 gate、未计分 recorded、其余带分 soft。 */
+  readonly severity: "gate" | "recorded" | "soft";
   readonly outcome: "passed" | "failed" | "unavailable";
   readonly groupPath: readonly string[];
   /** 展示层预拼好的判定详情(原因 / coverage / limitations / diagnostic)。 */
@@ -500,7 +500,8 @@ function assertionOutcomeOf(entry: SealedAssertionEntryView): AttemptAssertionVi
 }
 
 function assertionSeverityOf(entry: SealedAssertionEntryView): AttemptAssertionView["severity"] {
-  return entry.result.gate === "failed" || entry.result.gate === "unavailable" ? "gate" : "soft";
+  if (entry.result.gate === "failed" || entry.result.gate === "unavailable") return "gate";
+  return entry.result.score.state === "not-scored" ? "recorded" : "soft";
 }
 
 function scoreOf(entry: SealedAssertionEntryView): AttemptScoreView | undefined {

--- a/src/report/components/attempt-detail/validate.tsx
+++ b/src/report/components/attempt-detail/validate.tsx
@@ -32,7 +32,9 @@ function assertionViewProblem(value: unknown, path: string): string | null {
   if (!isObject(value)) return `"${path}" must be an AttemptAssertionView object`;
   if (typeof value.entryId !== "string") return `"${path}.entryId" must be a string`;
   if (typeof value.name !== "string") return `"${path}.name" must be a string`;
-  if (value.severity !== "gate" && value.severity !== "soft") return `"${path}.severity" must be "gate" or "soft"`;
+  if (value.severity !== "gate" && value.severity !== "recorded" && value.severity !== "soft") {
+    return `"${path}.severity" must be "gate" | "recorded" | "soft"`;
+  }
   if (value.outcome !== "passed" && value.outcome !== "failed" && value.outcome !== "unavailable") {
     return `"${path}.outcome" must be "passed" | "failed" | "unavailable"`;
   }


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 9c858a344a4862bafb31391b36c83c0f0b1e9ca5
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: c2fee91465b304e9b02c5145b2143f4791e14a38
-->

## Problem

- User goal: 在经典报告的 Attempt 详情里判断一条 Assertion 是计分检查、失败 gate，还是只记录结果的检查，并看懂 `notCalledTool` 的命中证据。
- Current limitation: 未配置 points 的 Assertion 被统一标为 `soft passed/failed`；正常的 `notCalledTool` 标题因此无法说明它是一个不贡献分数的零命中结果。
- Required capability: Report 必须从 sealed score contribution 区分 `not-scored` 与带分数的非 gate Assertion，同时继续使用已保存 diagnostic 展示匹配数量和决定性见证。
- User outcome: 展开结果时，record-only 检查显示 `recorded`，零命中和异常命中的证据都能直接阅读，无需检查 Record 私有产物。

## Use cases

### Case: 在报告中确认禁止的项目路径没有被工具访问

#### Starting state

```text
一次由 NiceEval 保存且包含 tool calls 的 Eval 运行结果
```

#### Action

```ts
export default defineEval({
  async test(t) {
    const turn = await t.send("produce a deterministic forbidden tool call");
    turn.notCalledTool(
      toolMatch({
        input: referencesAnyPath([
          "package.json",
          "AGENTS.md",
          "CLAUDE.md",
          "INIT.md",
          "node_modules/niceeval",
        ]),
      }),
    ).label("No project guidance access");
  },
});
```

```sh
niceeval view --no-open
```

#### Result

```text
No project guidance access · recorded passed
notCalledTool(toolMatch(input=referencesAnyPath(5 paths))) observed no matching tool
expected: no toolMatch(input=referencesAnyPath(5 paths))
received: 0 definite matches
```

这让报告读者同时确认检查没有参与计分，并确认 Record 中确实没有匹配调用。相同 Journey 也覆盖失败路径：匹配存在时仍显示 `gate failed`、实际命中数、决定结果的 tool occurrence 和输入位置；诊断截断不会抹掉这些决定性事实。

## Observable behavior and data contracts

### Changed

#### Case: record-only Assertion 的 Attempt 标题

##### Before

```ts
turn.succeeded().label("Turn completed");
```

```text
Turn completed · soft passed
```

##### After

```ts
turn.succeeded().label("Turn completed");
```

```text
Turn completed · recorded passed
```

##### User impact

既有 Eval 不需要迁移。没有 points、也没有失败 gate 的 Assertion 会显示 `recorded passed/failed/unavailable`；带 points 的非 gate Assertion 继续显示 `soft` 和实际 contribution，失败 gate 继续显示 `gate failed`。

## Tests

### `e2e/report/evals/deliberate-fail.eval.ts`

- Purpose: feature + bug regression
- Protects: 安装后候选能产生同时包含零命中与决定性命中的公开 Report 输入。
- Runs: 通过 `defineEval()` 和公开 Assertion API 运行确定性 Eval。
- Asserts: 为浏览器 owner 提供 record-only matched、gate mismatched 和普通 mismatch 三类 sealed 结果。

### `e2e/report/evals/deliberate-fail.eval.ts`

- Purpose: `feature + bug regression`
- Protects: 安装后候选能产生同时包含零命中与决定性命中的公开 Report 输入。
- Runs: 通过 defineEval() 和公开 Assertion API 运行确定性 Eval。
- Asserts: 为浏览器 owner 提供 record-only matched、gate mismatched 和普通 mismatch 三类 sealed 结果。

```ts
import { defineEval } from "niceeval";
import { includes, referencesAnyPath, toolMatch } from "niceeval/expect";

// Deterministically failing assertion: the public read face must keep failed distinct
// from errored and JUnit must fold it as <failure>.
export default defineEval({
  description: "deliberate-fail:确定性失败断言",

  async test(t) {
    const turn = await t.send("produce a deterministic forbidden tool call");
    turn.succeeded().label("Turn completed");
    turn.notCalledTool(
      toolMatch({ input: referencesAnyPath(["report-notes.txt", "evals", "agents"]) }),
    ).label("No private source access");
    turn.notCalledTool(
      toolMatch({
        input: referencesAnyPath([
          "package.json",
          "AGENTS.md",
          "CLAUDE.md",
          "INIT.md",
          "node_modules/niceeval",
        ]),
      }),
    ).label("No project guidance access");
    t.check("actual fixture value", includes("expected fixture value"))
      .label("Expected fixture value");
  },
});
```

### `e2e/report/test/report.browser.spec.ts`

- Purpose: feature + bug regression
- Protects: 经典报告不会再把 record-only Assertion 标成 `soft`，也不会丢失 `notCalledTool` 的零命中或决定性见证。
- Runs: 安装候选、运行公开 Experiment、启动 `niceeval view`，并在真实 Chromium 中打开 Attempt 详情。
- Asserts: 标题使用 `recorded passed`；正常检查显示期望零命中和 `0 definite matches`；异常检查显示命中数、tool occurrence 与 `/command`，且不泄露 matcher-tree JSON。

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `feature + bug regression`
- Protects: 经典报告不会再把 record-only Assertion 标成 soft，也不会丢失 notCalledTool 的零命中或决定性见证。
- Runs: 安装候选、运行公开 Experiment、启动 niceeval view，并在真实 Chromium 中打开 Attempt 详情。
- Asserts: 标题使用 recorded passed；正常检查显示期望零命中和 0 definite matches；异常检查显示命中数、tool occurrence 与 /command，且不泄露 matcher-tree JSON。

```ts
// owner: docs/engineering/testing/e2e/report.md#report-browser-journey
// regression: memory/record-only-assertions-labeled-soft.md
// rerun: pnpm e2e --repo report -- --run test/report.browser.spec.ts
//
// The Journey uses only the installed candidate CLI, exported files, real HTTP,
// href navigation, and browser-visible content. It deliberately
// does not inspect renderer classes, layout, paint, CSS selectors, or Record files.

import { pollUntil, waitForOutput } from "@niceeval/testkit";
import { readFile, writeFile } from "node:fs/promises";
import { join } from "node:path";
import { fileURLToPath, pathToFileURL } from "node:url";
import { expect, test } from "@playwright/test";
import { reportCaseArtifacts, reportE2E } from "./support.ts";

type DetailKind = "Source" | "Diff" | "Slot";

test("静态站与 view 对同一用户路由交付相同字节，且离线无 JavaScript 仍可浏览", async ({ browser }) => {
  test.setTimeout(120_000);

  await reportE2E.case(
    "browser-static-site",
    { artifacts: reportCaseArtifacts(["site-export"]) },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      const mainRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(mainRun.expReceipt(), mainRun.diagnostic()).toMatchObject({ completion: "completed" });
      const sourceRun = await niceeval.run(["exp", "source", "--rerun", "all", "--json"]);
      expect(sourceRun.expReceipt(), sourceRun.diagnostic()).toMatchObject({ completion: "completed" });
      const slotCount = mainRun.expEvalEvents().length + sourceRun.expEvalEvents().length;
      expect(slotCount, mainRun.diagnostic()).toBeGreaterThan(0);

      const exported = await niceeval.run([
        "view",
        "--report",
        "./reports/site.tsx",
        "--out",
        "site-export",
        "--no-open",
      ]);
      expect(exported.exitCode, exported.diagnostic()).toBe(0);

      const view = niceeval.start(
        [
          "view",
          "--report",
          "./reports/site.tsx",
          "--host",
          "127.0.0.1",
          "--port",
          "0",
          "--no-open",
        ],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000,
        label: "static-equivalent view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "static-equivalent view readiness");

      const staticRoot = pathToFileURL(join(projectRoot, "site-export", "index.html"));
      await expectSameBody(staticRoot, new URL(origin!));

      const offline = await browser.newContext({ javaScriptEnabled: false });
      try {
        await offline.setOffline(true);
        const page = await offline.newPage();
        await page.goto(staticRoot.href);
        await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
        const staticSiteText = visibleText(page, "Report fixture static site");
        await expect(staticSiteText).toHaveCount(1);
        await expect(staticSiteText).toBeVisible();
        const overviewTabText = visibleText(page, "Fixture overview tab content");
        await expect(overviewTabText).toHaveCount(1);
        await expect(overviewTabText).toBeVisible();
        // Native disclosure: only the first tab is open without JavaScript.
        const fixtureDetailsTab = page.locator("details").filter({
          hasText: "Fixture details tab content",
        }).filter({ visible: true });
        await expect(fixtureDetailsTab).toHaveCount(1);
        await expect(visibleText(page, "Fixture details tab content")).toHaveCount(0);
        await fixtureDetailsTab.locator(":scope > summary").click();
        await expect(fixtureDetailsTab).toHaveAttribute("open", "");
        const expandedDetailsText = visibleText(page, "Fixture details tab content");
        await expect(expandedDetailsText).toHaveCount(1);
        await expect(expandedDetailsText).toBeVisible();

        const detailLinks = await Promise.all(
          (await page.getByRole("link", { name: /^(?:Source|Diff) detail$|^Slot detail / }).all()).map(async (link) => {
            const href = await link.getAttribute("href");
            if (href === null) throw new Error("a visible static detail link has no href");
            return { href, label: await link.innerText() };
          }),
        );
        expect(detailLinks.filter(({ label }) => detailKind(label) === "Slot")).toHaveLength(slotCount);
        expect([...new Set(detailLinks.map(({ label }) => detailKind(label)))].sort()).toEqual(
          ["Diff", "Slot", "Source"],
        );

        for (const detail of detailLinks) {
          const kind = detailKind(detail.label);
          const staticUrl = new URL(detail.href, staticRoot);
          const liveUrl = new URL(detail.href, origin!);
          await expectSameBody(staticUrl, liveUrl);

          // The href is a shareable exported location, not an in-memory router state.
          await page.goto(staticUrl.href);
          const heading = kind === "Slot"
            ? page.getByRole("heading", { name: /^Slot fixture detail slot-/ })
            : page.getByRole("heading", { name: new RegExp(`^${kind} fixture detail$`) });
          await expect(heading).toBeVisible();
          const sharedUrl = page.url();
          await page.reload();
          expect(page.url()).toBe(sharedUrl);
          await expect(heading).toBeVisible();
        }

      } finally {
        await offline.close();
      }

      // A static page must remain complete even if a view-only refresh or host-data
      // probe is unavailable. This context leaves JavaScript enabled and fails every
      // HTTP transport before opening the exported file, without naming a host route.
      const blockedTransport = await browser.newContext();
      try {
        await blockedTransport.route(/^https?:\/\//, (route) => route.abort("failed"));
        const page = await blockedTransport.newPage();
        await page.goto(staticRoot.href);
        await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
      } finally {
        await blockedTransport.close();
      }

      // Open the JavaScript-enhanced live page before changing its watched
      // static import. The user does not reload: a successful new revision must
      // reach the already-open page through the host-owned refresh behavior.
      const liveBrowser = await browser.newContext();
      try {
        const page = await liveBrowser.newPage();
        await page.goto(origin!);
        const slotDetail = page.getByRole("link", { name: /^Slot detail / }).first().filter({ visible: true });
        await expect(slotDetail).toBeVisible();
        await slotDetail.click();
        const dialog = page.getByRole("dialog");
        await expect(dialog).toBeVisible();
        await expect(dialog.getByRole("heading", { name: /^Slot fixture detail slot-/ })).toBeVisible();
        const nestedSource = dialog.getByRole("link", { name: "Source from slot detail" });
        const sourceUrl = new URL("/source/index.html", origin!).href;
        // This is a relative href in the fetched slot document. The dialog
        // must preserve that detail document as the base before insertion.
        await expect(nestedSource).toHaveAttribute("href", sourceUrl);
        await Promise.all([
          page.waitForURL(sourceUrl),
          nestedSource.click(),
        ]);
        await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();

        await page.goto(origin!);
        const initialCopy = visibleText(page, "niceeval report fixture copy text");
        await expect(initialCopy).toHaveCount(1);
        await expect(initialCopy).toBeVisible();
        const overviewTab = page.locator("details").filter({
          hasText: "Fixture overview tab content",
        }).filter({ visible: true });
        const detailsTab = page.locator("details").filter({
          hasText: "Fixture details tab content",
        }).filter({ visible: true });
        await expect(overviewTab).toHaveCount(1);
        await expect(overviewTab).toHaveAttribute("open", "");
        await expect(detailsTab).toHaveCount(1);
        await expect(detailsTab).not.toHaveAttribute("open", "");
        await detailsTab.locator(":scope > summary").click();
        await expect(detailsTab).toHaveAttribute("open", "");
        await expect(overviewTab).not.toHaveAttribute("open", "");
        const selectedDetailsText = visibleText(page, "Fixture details tab content");
        await expect(selectedDetailsText).toHaveCount(1);
        await expect(selectedDetailsText).toBeVisible();
        await expect(visibleText(page, "Fixture overview tab content")).toHaveCount(0);

        const componentPath = join(projectRoot, "reports", "site-copy-block.tsx");
        const component = await readFile(componentPath, "utf8");
        const refreshedMarker = "live view refresh marker 981";
        const refreshedComponent = component.replace("niceeval report fixture copy text", refreshedMarker);
        if (refreshedComponent === component) {
          throw new Error("the watched Report component no longer contains its refresh marker");
        }
        await writeFile(componentPath, refreshedComponent, "utf8");

        const refreshedCopy = visibleText(page, refreshedMarker);
        await expect(refreshedCopy).toHaveCount(1, { timeout: 15_000 });
        await expect(refreshedCopy).toBeVisible();
      } finally {
        await liveBrowser.close();
      }
    },
  );
});

test("零配置 view 使用经典报告完成筛选、原生展开、详情下钻与语言切换", async ({ browser }) => {
  test.setTimeout(180_000);

  await reportE2E.case(
    "browser-default-classic-surface",
    { artifacts: reportCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/memory-b"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const view = niceeval.start(
        [
          "view",
          "--host",
          "127.0.0.1",
          "--port",
          "0",
          "--no-open",
        ],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000,
        label: "classic surface view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "classic surface view readiness");

      const page = await browser.newPage();
      try {
        await page.goto(origin!);
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();

        // A fixed Sample with one named Experiment Group goes straight to its
        // comparison and does not waste Header space on a one-option selector.
        await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);

        const passChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
        await expect(passChart).toHaveCount(1);
        await expect(passChart).toContainText("classic/memory-a");
        await expect(passChart).toContainText("100%");
        await expect(passChart).not.toContainText("ratio");
        const scoreChart = page.locator('svg[aria-label="costUSD × totalScore"]').filter({ visible: true });
        await expect(scoreChart).toHaveCount(0);

        const mixedRun = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
        expect(mixedRun.expReceipt(), mixedRun.diagnostic()).toMatchObject({ completion: "completed" });
        const experimentSelector = page.getByRole("combobox", { name: "Experiments" });
        await expect(experimentSelector).toBeVisible({ timeout: 15_000 });
        await expect(experimentSelector.getByRole("option")).toHaveText(["classic", "main"]);
        await expect(experimentSelector.locator("option:checked")).toHaveText("classic");

        // Opening the site root never exposes an unselected project-wide
        // overview: the first stable Experiment Group is the current value.
        await page.goto(origin!);
        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const classicExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
        await expect(classicExperimentCount.locator(".niceeval-stat-value")).toHaveText("3");

        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "main" });
        await expect(page).toHaveURL(new RegExp("/group/singleton/main/index\\.html$"));
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const mainExperimentCount = page.locator(".niceeval-stat").filter({ hasText: "Experiments", visible: true });
        await expect(mainExperimentCount.locator(".niceeval-stat-value")).toHaveText("1");

        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "classic" });
        await expect(page).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
        const selectedGroupChart = page.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
        await expect(selectedGroupChart).toContainText("classic/memory-a");
        await expect(selectedGroupChart).not.toContainText("main");

        const exported = await niceeval.run(["view", "--out", "group-static", "--no-open"]);
        expect(exported.exitCode, exported.diagnostic()).toBe(0);
        const offline = await browser.newContext({ javaScriptEnabled: false });
        try {
          const staticPage = await offline.newPage();
          await staticPage.goto(pathToFileURL(join(projectRoot, "group-static", "index.html")).href);
          const staticGroups = staticPage.getByRole("navigation", { name: "Experiments" });
          await expect(staticGroups.getByRole("link", { name: "classic" }))
            .toHaveAttribute("href", "group/named/classic/index.html");
          await staticGroups.getByRole("link", { name: "classic" }).click();
          await expect(staticPage).toHaveURL(new RegExp("/group/named/classic/index\\.html$"));
          const staticGroupChart = staticPage.locator('svg[aria-label="costUSD × passRate"]').filter({ visible: true });
          await expect(staticGroupChart).toContainText("classic/memory-a");
          await expect(staticGroupChart).not.toContainText("main");
        } finally {
          await offline.close();
        }
        const filter = page.getByRole("searchbox").filter({ visible: true });
        await expect(filter).toHaveCount(1);
        await expect(filter).toBeVisible();
        const experimentTable = filter.locator("..").getByRole("table");
        await expect(experimentTable).toHaveCount(1);
        await filter.fill("classic/memory-a");
        const memoryA = experimentTable.locator("summary").filter({
          hasText: "classic/memory-a",
        }).filter({ visible: true });
        await expect(memoryA).toHaveCount(1);
        await expect(memoryA).toBeVisible();
        const baseline = experimentTable.locator("summary").filter({
          hasText: "classic/baseline",
        }).filter({ visible: true });
        await expect(baseline).toHaveCount(0);
        await filter.fill("");

        const group = experimentTable.locator("details").filter({
          hasText: "classic/memory-a",
        }).filter({ visible: true });
        await expect(group).toHaveCount(1);
        await expect(group).toBeVisible();
        const groupSummary = group.locator(":scope > summary");
        await groupSummary.focus();
        await groupSummary.press("Space");
        await expect(group).toHaveAttribute("open", "");

        const evalGroupSummary = group.locator("summary").filter({
          hasText: "classic (8 evals)",
        }).filter({ visible: true });
        await expect(evalGroupSummary).toHaveCount(1);
        const evalGroup = evalGroupSummary.locator("..");
        await expect(evalGroup).toHaveCount(1);
        await expect(evalGroup).toBeVisible();
        await evalGroupSummary.focus();
        await evalGroupSummary.press("Space");
        await expect(evalGroup).toHaveAttribute("open", "");

        const evalRowSummary = evalGroup.locator("summary").filter({
          hasText: "recall-constraint",
        }).filter({ visible: true });
        await expect(evalRowSummary).toHaveCount(1);
        const evalRow = evalRowSummary.locator("..");
        await expect(evalRow).toHaveCount(1);
        await evalRowSummary.focus();
        await evalRowSummary.press("Space");
        await expect(evalRow).toHaveAttribute("open", "");

        const attemptLink = evalRow.getByRole("link").filter({
          visible: true,
        });
        await expect(attemptLink).toHaveCount(1);
        await expect(attemptLink).toBeVisible();
        const href = await attemptLink.getAttribute("href");
        if (href === null) throw new Error("an expanded attempt row has no detail href");
        const detail = new URL(href, page.url());
        expect(detail.pathname).toMatch(/^\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}\/index\.html$/);

        // The JavaScript enhancement opens the Host-owned detail dialog around
        // the same href instead of leaving the overview page.
        await attemptLink.click();
        const dialog = page.getByRole("dialog");
        await expect(dialog).toBeVisible();
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await expect(dialog.getByText(/^source · execution · timing(?: · diff)?$/).filter({ visible: true })).toBeVisible();
        await expect(dialog.getByText("Assessment evidence", { exact: true })).toHaveCount(0);
        await expect(dialog.getByText(/^\{\"groupPath\":/)).toHaveCount(0);
        const sendLine = dialog.locator("details.niceeval-source-line--send").filter({ visible: true });
        await expect(sendLine).toHaveCount(1);
        await expect(sendLine).not.toHaveAttribute("open", "");
        await sendLine.locator(":scope > summary").click();
        await expect(sendLine).toHaveAttribute("open", "");
        await expect(sendLine.getByText("Duration", { exact: true })).toBeVisible();
        await expect(sendLine.getByText("Turns", { exact: true })).toBeVisible();
        await expect(sendLine.getByText("Calls", { exact: true })).toBeVisible();
        await expect(sendLine.locator(".niceeval-conversation-turn-head")).toBeVisible();
        const trace = sendLine.locator("[data-niceeval-turn-trace]");
        const traceRows = trace.locator("[data-niceeval-trace-event]");
        const firstTraceRow = traceRows.nth(0);
        const secondTraceRow = traceRows.nth(1);
        const thirdTraceRow = traceRows.nth(2);
        const firstTraceEvidence = firstTraceRow.locator("[data-niceeval-trace-evidence]");
        const secondTraceEvidence = secondTraceRow.locator("[data-niceeval-trace-evidence]");
        const thirdTraceEvidence = thirdTraceRow.locator("[data-niceeval-trace-evidence]");
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await firstTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).toHaveAttribute("open", "");
        await expect(firstTraceRow.locator("[data-niceeval-trace-select]")).toHaveAttribute("aria-expanded", "true");
        await secondTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await expect(secondTraceEvidence).toHaveAttribute("open", "");
        await expect(secondTraceEvidence.locator("[data-tool-evidence-kind='command']")).toBeVisible();
        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").textContent()).toBe(
          "printf 'classic/recall-constraint: recalled=true\\n' > memory-note.txt",
        );
        await thirdTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(secondTraceEvidence).not.toHaveAttribute("open", "");
        await expect(thirdTraceEvidence).toHaveAttribute("open", "");
        await expect(thirdTraceRow.locator(".niceeval-trace-event-summary")).toHaveText("command_execution result");
        await expect(thirdTraceEvidence.locator("[data-tool-evidence-kind='terminal']")).toBeVisible();
        await expect(thirdTraceEvidence.getByText("Exit 0", { exact: true })).toBeVisible();
        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(0).textContent()).toBe(
          "wrote memory-note.txt\nclassic/recall-constraint: recalled=true\n",
        );
        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(1).textContent()).toBe(
          '{\n  "written": true,\n  "recalled": true\n}',
        );
        await thirdTraceEvidence.getByRole("tab", { name: "Raw" }).click();
        await expect(thirdTraceEvidence.getByRole("tab", { name: "Raw" })).toHaveAttribute("aria-selected", "true");
        await expect(thirdTraceEvidence.locator("[data-niceeval-trace-evidence-panel='raw']")).toBeVisible();
        expect(await thirdTraceEvidence.locator(".niceeval-trace-evidence-raw").textContent()).toBe(
          '{"output":"wrote memory-note.txt\\nclassic/recall-constraint: recalled=true\\n","exit_code":0,"written":true,"recalled":true}',
        );
        const deepLink = page.url();
        expect(new URL(deepLink).hash).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);
        await page.keyboard.press("Escape");
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("");

        // The legacy URL contract survives the new closed-site host: opening
        // its hash directly restores the same dialog, and reload keeps it.
        await page.goto(deepLink);
        await expect(dialog).toBeVisible();
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await page.reload();
        expect(page.url()).toBe(deepLink);
        await expect(dialog).toBeVisible();
        await page.goBack();
        await expect(dialog).not.toBeVisible();

        // Assertion source-line details use one display contract across a
        // matched built-in assertions, a nested scoped matcher mismatch, and
        // a direct value mismatch. Record-only checks say `recorded`; scoped
        // matchers expose the decisive count/witness without dumping their
        // matcher tree as user-facing JSON.
        await page.goto(origin!);
        await page.getByRole("combobox", { name: "Experiments" }).selectOption({ label: "main" });
        await expect(page).toHaveURL(new RegExp("/group/singleton/main/index\\.html$"));
        const mainFilter = page.getByRole("searchbox").filter({ visible: true });
        await mainFilter.fill("deliberate-fail");
        const mainTable = mainFilter.locator("..").getByRole("table");
        const mainSummary = mainTable.locator("summary").filter({
          has: page.getByText("main", { exact: true }),
        }).filter({ visible: true });
        await expect(mainSummary).toHaveCount(1);
        await expect(mainSummary).toBeVisible();
        const mainGroup = mainSummary.locator("..");
        await mainSummary.click();
        await expect(mainGroup).toHaveAttribute("open", "");
        const failedEvalSummary = mainGroup.locator("summary").filter({
          has: page.getByText("deliberate-fail", { exact: true }),
        }).filter({ visible: true });
        await expect(failedEvalSummary).toHaveCount(1);
        await expect(failedEvalSummary).toBeVisible();
        const failedEval = failedEvalSummary.locator("..");
        await failedEvalSummary.click();
        await expect(failedEval).toHaveAttribute("open", "");
        await mainFilter.fill("");
        const failedAttemptLink = failedEval.getByRole("link").filter({ visible: true });
        await expect(failedAttemptLink).toHaveCount(1);
        await failedAttemptLink.click();
        await expect(dialog).toBeVisible();

        const matchedAssertion = dialog.locator("details").filter({ hasText: "Turn completed · recorded passed" });
        await expect(matchedAssertion).toHaveCount(1);
        await matchedAssertion.locator(":scope > summary").click();
        await expect(matchedAssertion.getByText("Turn completed · recorded passed", { exact: true })).toBeVisible();

        const absentToolAssertion = dialog.locator("details").filter({
          hasText: "No project guidance access · recorded passed",
        });
        await expect(absentToolAssertion).toHaveCount(1);
        await absentToolAssertion.locator(":scope > summary").click();
        await expect(absentToolAssertion.getByText(
          "notCalledTool(toolMatch(input=referencesAnyPath(5 paths))) observed no matching tool",
          { exact: false },
        )).toBeVisible();
        await expect(absentToolAssertion.getByText(
          "expected: no toolMatch(input=referencesAnyPath(5 paths))",
          { exact: false },
        )).toBeVisible();
        await expect(absentToolAssertion.getByText("received: 0 definite matches", { exact: false })).toBeVisible();
        await expect(absentToolAssertion.getByText(/^diagnostic: \{"children"/)).toHaveCount(0);

        const nestedMismatch = dialog.locator("details").filter({
          hasText: "No private source access · gate failed",
        });
        await expect(nestedMismatch).toHaveCount(1);
        if (await nestedMismatch.getAttribute("open") === null) {
          await nestedMismatch.locator(":scope > summary").click();
        }
        await expect(nestedMismatch.getByText("reason: condition-not-met", { exact: false })).toBeVisible();
        await expect(nestedMismatch.getByText(
          "notCalledTool(toolMatch(input=referencesAnyPath(3 paths))) observed a matching tool",
          { exact: false },
        )).toBeVisible();
        await expect(nestedMismatch.getByText("received: 1 definite match", { exact: false })).toBeVisible();
        await expect(nestedMismatch.getByText("location: tool occurrence", { exact: false })).toBeVisible();
        await expect(nestedMismatch.getByText(/^diagnostic: \{"children"/)).toHaveCount(0);

        const valueMismatch = dialog.locator("details").filter({ hasText: "Expected fixture value · gate failed" });
        await expect(valueMismatch).toHaveCount(1);
        if (await valueMismatch.getAttribute("open") === null) {
          await valueMismatch.locator(":scope > summary").click();
        }
        await expect(valueMismatch.getByText("includes(\"expected fixture value\") did not find the literal text", {
          exact: false,
        })).toBeVisible();
        await expect(valueMismatch.getByText("expected: \"expected fixture value\"", { exact: false })).toBeVisible();
        await expect(valueMismatch.getByText(/^diagnostic: \{/)).toHaveCount(0);
        await page.keyboard.press("Escape");
        await expect(dialog).not.toBeVisible();

        // The href stays a real standalone route: direct navigation reads the
        // same closed detail document.
        await page.goto(detail.href);
        await expect(page.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
        await expect(page.getByText(/^source · execution · timing(?: · diff)?$/).filter({ visible: true })).toBeVisible();

        await page.goto(new URL("group/named/classic/index.html", origin!).href);
        const scatter = page.getByRole("img", { name: "costUSD × passRate" }).filter({ visible: true });
        await expect(scatter).toHaveCount(1);
        await expect(scatter).toContainText("classic/memory-a");
        const pageRouter = page.getByRole("navigation", { name: "Report pages" });
        const pageRouterBox = await pageRouter.boundingBox();
        const viewport = page.viewportSize();
        expect(pageRouterBox, "the whole Page router must have a visible layout box").not.toBeNull();
        expect(viewport, "the browser fixture must expose its viewport").not.toBeNull();
        expect(Math.abs(pageRouterBox!.x + pageRouterBox!.width / 2 - viewport!.width / 2))
          .toBeLessThanOrEqual(1);
        const languageSelector = page.getByRole("combobox", { name: "Language" });
        await expect(languageSelector).toBeVisible();
        await expect(languageSelector.getByRole("option")).toHaveText(["EN", "中文"]);
        await languageSelector.selectOption("zh-CN");
        await expect(page.getByText("总览", { exact: true })).toBeVisible();
        await expect(languageSelector).toHaveValue("zh-CN");
      } finally {
        await page.close();
      }
    },
  );
});

async function expectSameBody(staticUrl: URL, liveUrl: URL): Promise<void> {
  const expected = await readFile(fileURLToPath(staticUrl));
  const response = await fetch(liveUrl);
  expect(response.status, `${liveUrl} should serve the exported body`).toBe(200);
  // Headers and a view-only refresh transport are intentionally outside this
  // oracle; the publicly delivered bytes must still be identical.
  expect(Buffer.from(await response.arrayBuffer()), `${liveUrl} body`).toEqual(expected);
}

function detailKind(label: string): DetailKind {
  const matched = /^(Source|Diff|Slot) detail(?: |$)/.exec(label);
  if (matched === null) throw new Error(`unexpected static detail link label: ${JSON.stringify(label)}`);
  return matched[1] as DetailKind;
}

async function waitForHttp(origin: string, label: string): Promise<void> {
  await pollUntil(
    async () => {
      try {
        return (await fetch(origin)).status === 200 ? true : undefined;
      } catch {
        return undefined;
      }
    },
    { timeoutMs: 15_000, intervalMs: 100, label },
  );
}

function visibleText(page: import("@playwright/test").Page, text: string) {
  return page.getByText(text, { exact: true }).filter({ visible: true });
}
```

### Verification receipt

- Candidate: Git `c2fee91465b304e9b02c5145b2143f4791e14a38`; takeover tarball SHA-256 `a8407cb45cc00e33f8da05206b08764bfbe2030c296e1ba2ed9c2d71a0e30af5`
- Red: old candidate SHA-256 `d478928a7a0f062e385c81c0ce71a4207e5b63475dc940c7c78db3ad8fd18c1f`; `pnpm e2e --repo report -- --run test/report.browser.spec.ts -t "零配置 view 使用经典报告完成筛选、原生展开、详情下钻与语言切换"` 最早在找不到 `Turn completed · recorded passed` 时失败
- Green: 同一公开浏览器 E2E 命令通过，1 passed；`pnpm run build:report`、`pnpm run typecheck` 与 `pnpm lint` 均通过
- Repeatability: takeover 的三个隔离副本、同一安装副本重复运行、Repo 默认并行入口与目标单测全部 clean pass；矩阵完整、每次 cleanup 成功、source snapshot cleanup 成功
- Fixed conditions: checkout `9c858a344a4862bafb31391b36c83c0f0b1e9ca5` 加本 PR diff；锁定 pnpm lockfile；确定性 report fixture；Playwright Chromium；无外部 provider 或随机 seed
- Unit count: not applicable — no Unit changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789821299&installation_model_id=431746&pr_number=80&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F80&signature=30c6d597640fae42df3ee4c41d1593c6e9f8c17867ad80e89d8bb045b4697c9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
