### PR TITLE
fix(adapters): 保留工具生命周期并支持原生 HITL

### DIFF
--- a/docs/engineering/testing/e2e/adapter/claude-code.md
+++ b/docs/engineering/testing/e2e/adapter/claude-code.md
@@ -16,11 +16,12 @@ Repo ID 是 `adapter/claude-code`；manifest 声明 `areas: ["adapter"]`、live 
 | 远程 Plugin       | 从 Anthropic 官方远程 marketplace 安装 `frontend-design`；缓存文件存在，Plugin 自带 Skill 被实际加载并完成真实请求 |
 | settingsFile      | 同一条请求在对照 Experiment 中真实调用 `web_search`；`permissions.deny` 关闭 WebSearch / WebFetch 后 Turn 仍正常完成，反例断言两个工具均零调用 |
 | 会话              | 原生 resume ID 续接，第二轮能引用首轮事实                                                                                        |
+| HITL 选项         | `AskUserQuestion` 返回 waiting 与两个原生选项；按 request ID 选择后恢复同一会话并采用所选项                                      |
 | usage             | transcript 抠出的逐轮 usage 非空并聚合进 attempt                                                                                 |
 
 ## 仓库验收
 
-- `coding` Experiment 选中本仓库的 coding task、session-resume 与 WebSearch 正例；`locked-down` 用完全相同的 WebSearch 请求验证 deny 反例；验收脚本列全 Claude Code 协议 Eval ID。
+- `coding` Experiment 选中本仓库的 coding task、session-resume 与 WebSearch 正例；`hitl` 独立验证原生选项暂停与恢复；`locked-down` 用完全相同的 WebSearch 请求验证 deny 反例；验收脚本列全 Claude Code 协议 Eval ID。
 - `skill` Experiment 在同一个 agent 上安装三个 Skill：marker 与 checklist 分别验证目标 Skill 产生的可观察任务结果，`skill-unused` 验证不相关普通对话没有受到这些 Skill 的行为影响。`skill.loaded` 只作为报告诊断，不充当作者断言。
 - `repo-skill` 从 `CorrectRoadH/skills` 的固定 commit 安装 `calibre`，专用 Eval 核对安装位置与命令结果；`skill.loaded` 留在报告里供诊断。
 - `plugin` 与 `plugin-reuse` 都从 Anthropic 官方 marketplace 安装 `context7`；前者证明远程 MCP 可调用，后者以四路并发运行两波 Attempt，证明复用沙箱时仍都能调用正确工具。

--- a/docs/engineering/testing/e2e/adapter/claude-code.md
+++ b/docs/engineering/testing/e2e/adapter/claude-code.md
@@ -16,12 +16,13 @@ Repo ID 是 `adapter/claude-code`；manifest 声明 `areas: ["adapter"]`、live 
 | 远程 Plugin       | 从 Anthropic 官方远程 marketplace 安装 `frontend-design`；缓存文件存在，Plugin 自带 Skill 被实际加载并完成真实请求 |
 | settingsFile      | 同一条请求在对照 Experiment 中真实调用 `web_search`；`permissions.deny` 关闭 WebSearch / WebFetch 后 Turn 仍正常完成，反例断言两个工具均零调用 |
 | 会话              | 原生 resume ID 续接，第二轮能引用首轮事实                                                                                        |
-| HITL 选项         | `AskUserQuestion` 返回 waiting 与两个原生选项；按 request ID 选择后恢复同一会话并采用所选项                                      |
+| HITL 选项         | `AskUserQuestion` 返回 waiting 与两个原生选项；按 request ID 选择后恢复同一会话并采用所选项；同一 Eval 的普通内容对照没有请求时得到 failed verdict |
 | usage             | transcript 抠出的逐轮 usage 非空并聚合进 attempt                                                                                 |
 
 ## 仓库验收
 
-- `coding` Experiment 选中本仓库的 coding task、session-resume 与 WebSearch 正例；`hitl` 独立验证原生选项暂停与恢复；`locked-down` 用完全相同的 WebSearch 请求验证 deny 反例；验收脚本列全 Claude Code 协议 Eval ID。
+- `coding` Experiment 选中本仓库的 coding task、session-resume 与 WebSearch 正例。`locked-down` 用完全相同的 WebSearch 请求验证 deny 反例。
+- `hitl` 验证原生选项暂停与恢复。`hitl-content` 用同一 Eval 验证普通内容轮因没有待输入请求而判为 failed；验收脚本列全 Claude Code 协议 Eval ID。
 - `skill` Experiment 在同一个 agent 上安装三个 Skill：marker 与 checklist 分别验证目标 Skill 产生的可观察任务结果，`skill-unused` 验证不相关普通对话没有受到这些 Skill 的行为影响。`skill.loaded` 只作为报告诊断，不充当作者断言。
 - `repo-skill` 从 `CorrectRoadH/skills` 的固定 commit 安装 `calibre`，专用 Eval 核对安装位置与命令结果；`skill.loaded` 留在报告里供诊断。
 - `plugin` 与 `plugin-reuse` 都从 Anthropic 官方 marketplace 安装 `context7`；前者证明远程 MCP 可调用，后者以四路并发运行两波 Attempt，证明复用沙箱时仍都能调用正确工具。

--- a/docs/engineering/testing/e2e/adapter/codex-cli.md
+++ b/docs/engineering/testing/e2e/adapter/codex-cli.md
@@ -16,14 +16,15 @@ Repo ID 是 `adapter/codex-cli`；manifest 声明 `areas: ["adapter", "sandbox"]
 | Plugins 与 hook 信任 | marketplace 安装的 Plugin 行为可观察，其 hook 在 bypass 信任姿态下确实生效——hook 注入/捕获行为在事件流或输出中留下证据，不是被静默跳过；`sandboxReuse` 以四路并发运行两波 Attempt，复用波次安装收敛——同名不同出处的残留 marketplace 注册被替换为声明出处、Plugin 按声明重装，不因残留状态报错 |
 | configFile | 同一个 Eval 和 prompt 分别由 shell enabled / disabled Experiment 运行；前者调用 `shell`，后者正常完成且 `notCalledTool` |
 | 会话 | thread started 事件的 session ID 续接 `codex exec resume`，第二轮能引用首轮事实 |
-| HITL 选项 | `request_user_input` 返回 waiting 与两个原生选项；按 request ID 选择后恢复同一会话并采用所选项 |
+| HITL 选项 | `request_user_input` 返回 waiting 与两个原生选项；按 request ID 选择后恢复同一会话并采用所选项；同一 Eval 的普通内容对照没有请求时得到 failed verdict |
 | usage 与实际模型 | usage 逐轮到位；实际模型从 Codex session 侧写核对，不只信请求参数 |
 
 ## 仓库验收
 
 - `configfile` Eval 同时进入 baseline 与 disabled Experiment；两边通过 `flags.shellTool` 声明预期，并各自挂载显式 enabled / disabled 原生 configFile。相同 prompt 下工具面的结构差异形成正反对照，不依赖 custom provider 是否支持 Web Search。
 - coding 任务按 Codex 的真实归一形状设计：apply_patch 新增 → `file_write`、apply_patch 修改 → `file_edit`、命令执行 → `shell`。提示词显式禁止用 shell 写文件，避免 Codex 用一条命令顶掉文件工具。
-- `baseline` Experiment 选中本仓库的 `coding-task` / `configfile` / `session` / `usage`；`hitl` 独立验证原生选项暂停与恢复；原生验收脚本列全 Codex CLI 协议 Eval ID。
+- `baseline` Experiment 选中本仓库的 `coding-task` / `configfile` / `session` / `usage`。
+- `hitl` 验证原生选项暂停与恢复。`hitl-content` 用同一 Eval 验证普通内容轮因没有待输入请求而判为 failed；原生验收脚本列全 Codex CLI 协议 Eval ID。
 - `skill` Experiment 把三个 Skill 一起装进同一个 agent。status report 与 release note 两条 Eval 各自要求只读取目标文件；decoy 只作为反选哨兵，任一正调读到它都会判红。
 - 两条 Skill Eval 使用互不重叠的 `status-report` / `skill-release-note` ID，让 live 模型断言失败时可按 CLI 前缀选择规则精确补跑一条，不扩大成本，也不替换另一条结果。
 - `repo-skill` 从 `CorrectRoadH/skills` 的固定 commit 安装 `calibre`；专用 Eval 核对安装位置、真实读取行为与命令内容。

--- a/docs/engineering/testing/e2e/adapter/codex-cli.md
+++ b/docs/engineering/testing/e2e/adapter/codex-cli.md
@@ -16,13 +16,14 @@ Repo ID 是 `adapter/codex-cli`；manifest 声明 `areas: ["adapter", "sandbox"]
 | Plugins 与 hook 信任 | marketplace 安装的 Plugin 行为可观察，其 hook 在 bypass 信任姿态下确实生效——hook 注入/捕获行为在事件流或输出中留下证据，不是被静默跳过；`sandboxReuse` 以四路并发运行两波 Attempt，复用波次安装收敛——同名不同出处的残留 marketplace 注册被替换为声明出处、Plugin 按声明重装，不因残留状态报错 |
 | configFile | 同一个 Eval 和 prompt 分别由 shell enabled / disabled Experiment 运行；前者调用 `shell`，后者正常完成且 `notCalledTool` |
 | 会话 | thread started 事件的 session ID 续接 `codex exec resume`，第二轮能引用首轮事实 |
+| HITL 选项 | `request_user_input` 返回 waiting 与两个原生选项；按 request ID 选择后恢复同一会话并采用所选项 |
 | usage 与实际模型 | usage 逐轮到位；实际模型从 Codex session 侧写核对，不只信请求参数 |
 
 ## 仓库验收
 
 - `configfile` Eval 同时进入 baseline 与 disabled Experiment；两边通过 `flags.shellTool` 声明预期，并各自挂载显式 enabled / disabled 原生 configFile。相同 prompt 下工具面的结构差异形成正反对照，不依赖 custom provider 是否支持 Web Search。
 - coding 任务按 Codex 的真实归一形状设计：apply_patch 新增 → `file_write`、apply_patch 修改 → `file_edit`、命令执行 → `shell`。提示词显式禁止用 shell 写文件，避免 Codex 用一条命令顶掉文件工具。
-- `baseline` Experiment 选中本仓库的 `coding-task` / `configfile` / `session` / `usage`；原生验收脚本列全 Codex CLI 协议 Eval ID。
+- `baseline` Experiment 选中本仓库的 `coding-task` / `configfile` / `session` / `usage`；`hitl` 独立验证原生选项暂停与恢复；原生验收脚本列全 Codex CLI 协议 Eval ID。
 - `skill` Experiment 把三个 Skill 一起装进同一个 agent。status report 与 release note 两条 Eval 各自要求只读取目标文件；decoy 只作为反选哨兵，任一正调读到它都会判红。
 - 两条 Skill Eval 使用互不重叠的 `status-report` / `skill-release-note` ID，让 live 模型断言失败时可按 CLI 前缀选择规则精确补跑一条，不扩大成本，也不替换另一条结果。
 - `repo-skill` 从 `CorrectRoadH/skills` 的固定 commit 安装 `calibre`；专用 Eval 核对安装位置、真实读取行为与命令内容。

--- a/docs/engineering/testing/e2e/adapter/omp.md
+++ b/docs/engineering/testing/e2e/adapter/omp.md
@@ -3,9 +3,13 @@
 ## adapter-omp-target-compatibility
 
 `adapter/omp` 从安装后的候选包导入 `ompAgent`，在 `NICEEVAL_OMP_DOCKER_IMAGE` 声明的官方预装 Sandbox image 中
-运行锁定版本的 Oh My Pi 真实非交互 CLI。场景使用 live OpenAI-compatible provider，保留 `passed/1`
+运行锁定版本的 Oh My Pi 真实非交互 CLI。场景使用 live OpenAI-compatible provider，保留逐 Eval 的 `passed/1`
 oracle，并从公开 CLI 读回 marker 所在的 execution。通用 Runner timing 由
 [`runner-generic-timing`](../runner.md#runner-generic-timing) 唯一读回；本 Repo 不重复断言。
+
+`ci` Experiment 证明最终 assistant message 与可信 `agent_end` 终态。`events` Experiment 强制真实 CLI 调用一次
+`bash`，并从标准事件流核对规范 `shell` 身份、带 marker 的 `command` 入参与结果、completed 配对、opaque command
+分类，以及本轮非零 input/output usage。原生测试列全两个 Experiment/Eval 配对，防止少发现或少运行后假绿。
 
 该 owner 只承担 OMP 当前锁定版本的 target compatibility：它不接管通用 Eval、CLI 或 Report 语义，也不宣称
 session/resume/HITL。`agent_end` 终态、JSONL 事件与 usage 映射的确定性产品 owner 仍由

--- a/docs/feature/adapters/sdk/claude-code/README.md
+++ b/docs/feature/adapters/sdk/claude-code/README.md
@@ -50,9 +50,13 @@ Adapter 从本地读取文件后上传到隔离的 Claude 配置目录，原样�
 文件原始字节的 SHA-256 进入安装 checkpoint key；manifest 只记项目相对路径和 SHA-256，不保存正文。
 secret 走 env var，不写进配置文件。
 
-Adapter 用 Claude Code transcript JSONL 取得消息、thinking、工具、usage 和 session ID，按 `tool_use.id` / `tool_result.tool_use_id` 配对。
+Adapter 使用 Claude Code 官方 SDK 同款的双向 stream-json 进程协议取得消息、thinking、工具、usage 和原生 session ID，按 `tool_use.id` / `tool_result.tool_use_id` 配对。
 Skill Tool 调用归一为 `skill.loaded`。
-会话通过原生 resume ID 续接。
+进程属于 Attempt；多个 send 在同一个原生 session 上写 user frame。`t.newSession()` 创建独立进程与 session，旧 SessionHandle 不会被自动关闭。
+
+`AskUserQuestion` 通过官方 `control_request / can_use_tool` 暂停，不从 transcript 后验推断。一个 native tool batch 的每题 request ID
+由原生 `session_id + tool_use_id + stable question index` 派生；control request ID 只用于 `control_response`。NiceEval 在任何 write 前全量校验
+duplicate、unknown、missing 与 option，再用一个 `updatedInput.answers` 原子回答整批问题。失败保留 pending，可修正后重试。
 
 Claude Code 自己的 SessionStart / UserPromptSubmit hook 往模型上下文前置的附加文本，在 transcript 里以独立的 `hook_additional_context` 行出现。
 配对的 `hook_success` 行只是执行确认、不带上下文文本，不产生事件。

--- a/docs/feature/adapters/sdk/codex-cli/README.md
+++ b/docs/feature/adapters/sdk/codex-cli/README.md
@@ -86,19 +86,29 @@ secret 走 env var，不写进配置文件。
 Codex Adapter 把 Skills 写到可发现目录并提供稳定发现指引；不能假设存在与 Claude Code Skill Tool 相同的自动加载事件。
 验证 Skill 使用时检查读取行为或 Skill 特有结果。
 
-行为轨来自 `codex exec --json` 的结构化 stdout，session ID 来自 thread started 事件；工具调用优先按显式 call ID 配对。
+Adapter 为每条 NiceEval Session 启动一个 Codex app-server stdio 连接。
+`thread/start` 返回的原生 thread ID 是唯一 session identity。
+每次 send 走 `turn/start`，行为轨来自 app-server 的增量通知，工具调用优先按原生 item ID 配对。
+
+`request_user_input` 通过 app-server 的 `item/tool/requestUserInput` JSON-RPC request 暂停。
+NiceEval 先全量校验同一 native batch 的 request ID、缺失项、重复项与 option，再用原生 RPC ID 一次提交 `answers`。
+校验或 transport 写入失败不会清掉 pending batch，可以修正后重试。Adapter 不从完成后的 transcript 反造 HITL。
+
+进程属于 Attempt，而不是单次 send。Agent teardown 先发送 app-server `shutdown` 并关闭 stdin，随后 Attempt finalizer 等待进程自然退出；仅在有界等待失败时精确终止命令树。
+`t.newSession()` 新建另一条独立 app-server/thread，旧 SessionHandle 仍可继续使用。
 实际模型可能被网关改写，需要时从 Codex session 侧写读取，不能只信请求参数。
 
 ## 执行信任姿态
 
-`codex exec` 一律以 `--json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --dangerously-bypass-hook-trust` 运行，首轮与 `codex exec resume` 续轮相同。
+app-server 在外层 Sandbox 中以 `approval_policy="never"`、`sandbox_mode="danger-full-access"` 运行，thread/turn 同样声明 never 与 danger-full-access。
+锁定的 Codex CLI 0.144.1 还显式启用其原生 `default_mode_request_user_input` feature；该版本默认关闭这项工具。
 
 hook 信任 bypass 与审批 bypass 属同一信任层级。沙箱运行是 headless 的，codex 对非 managed 出处的 hook 的交互式信任确认永远无人应答。
 
 不 bypass 时，这些 hook 被静默跳过且零报错，插件依赖的注入和捕获行为会整体失效。
 
 沙箱里的每个 hook 出处都由实验配置显式声明（`plugins`、`postSetup`、`configFile`），声明即审计，因此不设开关。
-`bypass_hook_trust` 是 runtime-only 参数，`config.toml` 写不了，只能进 exec 命令行。
+app-server 没有 `exec --dangerously-bypass-hook-trust` 这一 one-shot 入口；Plugin hook 的声明与配置仍只来自本 Attempt setup。
 
 ## Prebuilt environment
 

--- a/docs/feature/adapters/sdk/codex-cli/README.md
+++ b/docs/feature/adapters/sdk/codex-cli/README.md
@@ -108,7 +108,8 @@ hook 信任 bypass 与审批 bypass 属同一信任层级。沙箱运行是 head
 不 bypass 时，这些 hook 被静默跳过且零报错，插件依赖的注入和捕获行为会整体失效。
 
 沙箱里的每个 hook 出处都由实验配置显式声明（`plugins`、`postSetup`、`configFile`），声明即审计，因此不设开关。
-app-server 没有 `exec --dangerously-bypass-hook-trust` 这一 one-shot 入口；Plugin hook 的声明与配置仍只来自本 Attempt setup。
+app-server 没有 `exec --dangerously-bypass-hook-trust` 这一顶层 flag；Adapter 在
+`thread/start.config` 中传入 runtime-only `bypass_hook_trust = true`。Plugin hook 的声明与配置仍只来自本 Attempt setup。
 
 ## Prebuilt environment
 

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -396,7 +396,9 @@ ledger 与 reason data types 同样仅以 type-only export 提供。精确调用
 
 `ExperimentTable` 与 `ExperimentScatter` 是具名比较组件。它们只接受 `ExperimentComparisonScope` 或该 scope 产生的同组 branded projection，不接受普通 Sample 或任意 rows。多组输入以 `analysis-comparison-group-mismatch` 失败；单组的 `non-comparable` 闭合原因与 Evidence，不渲染排名或散点。中立 `Table` 与 `Scatter` 仍可显示任意已闭合值，不承担实验组语义。
 
-`AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。Assertion 展开区先显示判定、完整度与 matcher 已经封口的决定性见证，例如期望、实际命中次数和位置；它不把整棵 matcher diagnostic JSON 当作用户文案。展开 `send` 所在行后，`TurnTrace` 以 `Conversation` 的静态因果事件流为账本，加上 turn 时间概览与可关闭的事件 inspector。没有精确 source mapping 的 turn 保留在页面级 `TurnTrace`，不按源码顺序猜测归属；没有 JavaScript 时 inspector 不出现，但完整事件内容仍在正文中。
+`AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。Assertion 展开区先显示判定、完整度与 matcher 已经封口的决定性见证，例如期望、实际命中次数和位置；它不把整棵 matcher diagnostic JSON 当作用户文案。展开 `send` 所在行后，`TurnTrace` 以 `Conversation` 的静态因果事件流为账本，加上 turn 时间概览与可关闭的事件 inspector。
+
+匹配同一 call ID 的工具调用和结果在调用位置组合成一个生命周期节点，inspector 同时保留输入与结果证据；未闭合或无法唯一配对的阶段仍各自显示。节点状态和颜色只使用 provider-neutral outcome：`completed`、`failed`、`rejected` 或 `cancelled`；原始工具名和 output 字段不参与 View 判断。没有精确 source mapping 的 turn 保留在页面级 `TurnTrace`，不按源码顺序猜测归属；没有 JavaScript 时 inspector 不出现，但完整事件内容仍在正文中。
 
 下载文件属于 Host 的站点闭包：view 与静态写出只读取已关闭的 bytes。作者入口不发布一个 generic `Download` 组件或
 `DownloadFile` 类型；这避免把尚无最终 primitive owner 的 generic semantic API 写进公共契约。

--- a/docs/feature/reports/use-case/审阅一次Run怎样采用结果.md
+++ b/docs/feature/reports/use-case/审阅一次Run怎样采用结果.md
@@ -45,7 +45,7 @@ niceeval show @1K1P0VJAPVJ12 --json
 已知 locator 时应使用 `show @locator` 精确下钻。要读取自定义报告的另一页，显式传入该页的 `--page <route>`。view 与静态目录读取
 同一份 `ClosedSiteRevision`；terminal 为目标 Page 生成临时 text。三种呈现面都保留同一 Sample 的 locator、Evidence refs、issues、samples 和 total。
 
-Attempt 页的源码中，带交互标记的 `.send()` 行可以原生展开。展开区显示该次物理 send 的 Session log 摘要与事件轨迹；工具调用、工具结果和 assistant 消息保持原始因果顺序，不折成只有最终文本的一行。
+Attempt 页的源码中，带交互标记的 `.send()` 行可以原生展开。展开区显示该次物理 send 的 Session log 摘要与事件轨迹。匹配同一 call ID 的工具调用和结果在调用位置显示为一个生命周期节点，展开后同时呈现输入与结果；未闭合阶段和 assistant 消息仍按原始因果位置显示，不折成只有最终文本的一行。
 
 ## 4. 查看 File Changes 轨迹
 

--- a/docs/feature/sandbox/architecture.md
+++ b/docs/feature/sandbox/architecture.md
@@ -166,6 +166,21 @@ diagnostic 写明三样：触发的是哪层时限（attempt deadline / 命令�
 报错行与请求 timing fact 的 Report 照实印这三样，不打一个没有归属说明的 ✗。
 provider 自身固有的会话上限(如 Vercel Sandbox 的 session 时长)不能静默充当默认值:deadline 超出它时在派发前就报告该约束,点名 provider 与上限值,不让 attempt 跑到一半被截。
 
+Agent 的原生双向协议使用 provider-only `managedProcess` capability。它包含 argv/env/cwd、stdin bytes、单消费者 stdout/stderr 原始 chunk 流、closeStdin、wait 与 terminate。
+它不是公开 `t.sandbox` 作者 facade，也不内建 JSONL、question 或 provider schema。
+
+Local 与 Docker 支持。E2B 的 2.31.0 `CommandHandle` 映射尚未通过安装后公开入口 E2E，因此与缺少双向字节流的 Vercel 一样显式拒绝，不把未经接管的实现声明成可用能力。
+Vercel Sandbox 2.2.1 没有双向 stdin 与 raw output chunk，因此明确 Unsupported。
+custom Sandbox 也明确 Unsupported。Agent setup 在写配置或启动进程前抛具名 capability error，不做鸭子类型探测。
+
+managed process acquire 与 Attempt registry 登记是一个失败原子的步骤。登记或后续构造失败会立即有界 release。
+正常顺序是 Agent 协议 shutdown/EOF → managed finalizer → Sandbox lifecycle/release。
+
+Docker 的正常 finalizer 不停止容器。`setsid --wait` 把 Docker exec receipt 绑定到原生命令树，强制 terminate 只 kill 已确认的进程组。
+身份不明或无法确认静止时标记需要退休，由 runner 的 Sandbox release fallback 收回整实例。
+write、close、terminate 与 wait 都共享幂等 receipt；stdin 一进入 closing 就拒绝晚写。
+output poll 在 exit、stream error、terminate fallback 与 Scope cleanup 路径清除。
+
 ## 留存(keep)与注册表
 
 [`--keep-sandbox`](cli.md) 的留存决策发生在 attempt 收尾链的最后一步。

--- a/e2e/adapter/claude-code/evals/hitl-options.eval.ts
+++ b/e2e/adapter/claude-code/evals/hitl-options.eval.ts
@@ -2,12 +2,27 @@ import { defineEval } from "niceeval";
 import { equals, includes } from "niceeval/expect";
 
 export default defineEval({
-  description: "HITL 选项:AskUserQuestion 暂停后按 request ID 选择并恢复同一会话",
+  description:
+    "HITL 选项正反对照:原生 AskUserQuestion 暂停后恢复，普通内容轮不会伪造待输入请求",
   async test(t) {
+    const requestHitl = t.flags.requestHitl;
+    if (requestHitl !== true && requestHitl !== false) {
+      throw new TypeError("hitl-options Eval requires boolean flags.requestHitl");
+    }
+
     const waiting = await t.send(
-      "Use AskUserQuestion exactly once. Ask which runtime to use, with exactly two options whose labels are Node.js and Bun. After the answer, reply with selected:<label>. Do not choose on the user's behalf.",
+      requestHitl
+        ? "Use AskUserQuestion exactly once. Ask which runtime to use, with exactly two options whose labels are Node.js and Bun. After the answer, reply with selected:<label>. Do not choose on the user's behalf."
+        : 'Reply with exactly "ordinary-content". Do not call any tool.',
     );
+    if (!requestHitl) {
+      t.check(waiting.message, includes("ordinary-content"));
+    }
     t.check(waiting.status, equals("waiting"));
+    // 普通内容路径在上一行留下 failed assertion 后正常收口；不用
+    // requireInputRequest() 把预期的 failed verdict 升级成 errored。
+    if (waiting.status !== "waiting") return;
+
     const request = t.requireInputRequest({
       action: "AskUserQuestion",
       optionIds: ["Node.js", "Bun"],

--- a/e2e/adapter/claude-code/evals/hitl-options.eval.ts
+++ b/e2e/adapter/claude-code/evals/hitl-options.eval.ts
@@ -1,0 +1,20 @@
+import { defineEval } from "niceeval";
+import { equals, includes } from "niceeval/expect";
+
+export default defineEval({
+  description: "HITL 选项:AskUserQuestion 暂停后按 request ID 选择并恢复同一会话",
+  async test(t) {
+    const waiting = await t.send(
+      "Use AskUserQuestion exactly once. Ask which runtime to use, with exactly two options whose labels are Node.js and Bun. After the answer, reply with selected:<label>. Do not choose on the user's behalf.",
+    );
+    t.check(waiting.status, equals("waiting"));
+    const request = t.requireInputRequest({
+      action: "AskUserQuestion",
+      optionIds: ["Node.js", "Bun"],
+    });
+
+    const resumed = await t.respond({ request, optionId: "Node.js" });
+    await resumed.succeeded().orStop();
+    t.check(resumed.message, includes("selected:Node.js"));
+  },
+});

--- a/e2e/adapter/claude-code/experiments/hitl-content.ts
+++ b/e2e/adapter/claude-code/experiments/hitl-content.ts
@@ -4,7 +4,7 @@ import { claudeCodeProviderEnv } from "../provider.ts";
 import { sandbox } from "../sandbox.ts";
 
 export default defineExperiment({
-  description: "hitl:Claude Code 原生选项请求、结构化选择与会话恢复",
+  description: "hitl-content:Claude Code 只输出普通内容时，HITL Eval 必须判为 failed",
   agent: claudeCodeAgent({
     apiKey: process.env.ANTHROPIC_API_KEY,
     baseUrl: process.env.ANTHROPIC_BASE_URL,
@@ -12,7 +12,7 @@ export default defineExperiment({
   }),
   model: "gpt-5.6-luna",
   sandbox,
-  flags: { requestHitl: true },
+  flags: { requestHitl: false },
   evals: ["hitl-options"],
   attempts: 1,
 });

--- a/e2e/adapter/claude-code/experiments/hitl.ts
+++ b/e2e/adapter/claude-code/experiments/hitl.ts
@@ -1,0 +1,17 @@
+import { defineExperiment } from "niceeval";
+import { claudeCodeAgent } from "niceeval/adapter";
+import { claudeCodeProviderEnv } from "../provider.ts";
+import { sandbox } from "../sandbox.ts";
+
+export default defineExperiment({
+  description: "hitl:Claude Code 原生选项请求、结构化选择与会话恢复",
+  agent: claudeCodeAgent({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    baseUrl: process.env.ANTHROPIC_BASE_URL,
+    env: claudeCodeProviderEnv,
+  }),
+  model: "gpt-5.6-luna",
+  sandbox,
+  evals: ["hitl-options"],
+  attempts: 1,
+});

--- a/e2e/adapter/claude-code/test/claude-code.test.ts
+++ b/e2e/adapter/claude-code/test/claude-code.test.ts
@@ -25,6 +25,8 @@ const EXPECTED_OUTCOMES = [
   { experimentId: "coding", evalId: "session-resume", verdict: "passed", attempts: 1, passed: 1 },
   // WebSearch 正例：coding 开启 webResearch，必须调用 web_search 且不调用 web_fetch，因此期望 passed/1。
   { experimentId: "coding", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
+  // HITL：AskUserQuestion 的两个选项须进入结构化 request，选择 Node.js 后恢复同一会话。
+  { experimentId: "hitl", evalId: "hitl-options", verdict: "passed", attempts: 1, passed: 1 },
   // skill-used：只加载目标本地 Skill，并在回答中采用其独有 marker；单次正调应为 passed/1。
   { experimentId: "skill", evalId: "skill-used", verdict: "passed", attempts: 1, passed: 1 },
   // skill-checklist：只加载 checklist Skill、不误载 marker/decoy；反选断言同时成立才是 passed/1。

--- a/e2e/adapter/claude-code/test/claude-code.test.ts
+++ b/e2e/adapter/claude-code/test/claude-code.test.ts
@@ -27,6 +27,8 @@ const EXPECTED_OUTCOMES = [
   { experimentId: "coding", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
   // HITL：AskUserQuestion 的两个选项须进入结构化 request，选择 Node.js 后恢复同一会话。
   { experimentId: "hitl", evalId: "hitl-options", verdict: "passed", attempts: 1, passed: 1 },
+  // HITL 反例：同一 Eval 收到普通内容且没有原生待输入请求时，必须是 failed/1。
+  { experimentId: "hitl-content", evalId: "hitl-options", verdict: "failed", attempts: 1, passed: 0 },
   // skill-used：只加载目标本地 Skill，并在回答中采用其独有 marker；单次正调应为 passed/1。
   { experimentId: "skill", evalId: "skill-used", verdict: "passed", attempts: 1, passed: 1 },
   // skill-checklist：只加载 checklist Skill、不误载 marker/decoy；反选断言同时成立才是 passed/1。
@@ -86,8 +88,11 @@ beforeAll(async () => {
   // plugin-reuse 是八条 Attempt 的 Sandbox 复用 owner，不能用二次运行替换它的首次并发结果。
   // 其余 live provider 任务只对模型断言失败补跑一次；setup、timeout、I/O error 与
   // skipped 都是基础设施/生命周期故障，不能用后续绿色覆盖。
-  const failed = firstEvents.filter(
-    (event) => event.verdict === "failed" && event.experimentId !== "plugin-reuse",
+  const retryableFailed = firstEvents.filter(
+    (event) =>
+      event.verdict === "failed" &&
+      event.experimentId !== "plugin-reuse" &&
+      !(event.experimentId === "hitl-content" && event.evalId === "hitl-options"),
   );
   expect(
     firstEvents.filter(
@@ -95,15 +100,17 @@ beforeAll(async () => {
     ),
     run.diagnostic(),
   ).toHaveLength(0);
-  expect(run.exitCode, run.diagnostic()).toBe(failed.length > 0 ? 1 : 0);
+  expect(run.exitCode, run.diagnostic()).toBe(
+    firstEvents.some((event) => event.verdict === "failed") ? 1 : 0,
+  );
   expect(inv.completion, run.diagnostic()).toBe("completed");
-  for (const event of failed) assertExactRetryEvalSelector(firstEvents, event);
+  for (const event of retryableFailed) assertExactRetryEvalSelector(firstEvents, event);
 
   // 补跑 Invocation 继续写同一个保留证据的 Record；Record 是单写者，所以同 Repo
   // 必须串行。主 Invocation 内的 Attempt 并发和跨 Repo batch 并发不受影响。
   const retried = await retryFailedExpEvalsOnce({
     events: firstEvents,
-    targets: failed,
+    targets: retryableFailed,
     runRetry: (event) =>
       niceeval.run(
         ["exp", event.experimentId, event.evalId, "--rerun", "all", "--json"],
@@ -118,7 +125,7 @@ beforeAll(async () => {
   evalEvents = retried.events;
 }, 53 * 60_000);
 
-it("真实 Claude Code adapter 的全部专用 Eval 通过", () => {
+it("真实 Claude Code adapter 的全部专用 Eval 得到预期 verdict", () => {
   // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md「结束反馈与
   // receipt」）；成败与发现完整性由下面带身份的 eval 事件精确断言。
   const inv = run.expReceipt();

--- a/e2e/adapter/codex-cli/evals/hitl-options.eval.ts
+++ b/e2e/adapter/codex-cli/evals/hitl-options.eval.ts
@@ -1,0 +1,20 @@
+import { defineEval } from "niceeval";
+import { equals, includes } from "niceeval/expect";
+
+export default defineEval({
+  description: "HITL 选项:request_user_input 暂停后按 request ID 选择并恢复同一会话",
+  async test(t) {
+    const waiting = await t.send(
+      "Use request_user_input exactly once. Ask which runtime to use, with exactly two options whose labels are Node.js and Bun. After the answer, reply with selected:<label>. Do not choose on the user's behalf.",
+    );
+    t.check(waiting.status, equals("waiting"));
+    const request = t.requireInputRequest({
+      action: "request_user_input",
+      optionIds: ["Node.js", "Bun"],
+    });
+
+    const resumed = await t.respond({ request, optionId: "Node.js" });
+    await resumed.succeeded().orStop();
+    t.check(resumed.message, includes("selected:Node.js"));
+  },
+});

--- a/e2e/adapter/codex-cli/evals/hitl-options.eval.ts
+++ b/e2e/adapter/codex-cli/evals/hitl-options.eval.ts
@@ -2,12 +2,27 @@ import { defineEval } from "niceeval";
 import { equals, includes } from "niceeval/expect";
 
 export default defineEval({
-  description: "HITL 选项:request_user_input 暂停后按 request ID 选择并恢复同一会话",
+  description:
+    "HITL 选项正反对照:原生 request_user_input 暂停后恢复，普通内容轮不会伪造待输入请求",
   async test(t) {
+    const requestHitl = t.flags.requestHitl;
+    if (requestHitl !== true && requestHitl !== false) {
+      throw new TypeError("hitl-options Eval requires boolean flags.requestHitl");
+    }
+
     const waiting = await t.send(
-      "Use request_user_input exactly once. Ask which runtime to use, with exactly two options whose labels are Node.js and Bun. After the answer, reply with selected:<label>. Do not choose on the user's behalf.",
+      requestHitl
+        ? "Use request_user_input exactly once. Ask which runtime to use, with exactly two options whose labels are Node.js and Bun. After the answer, reply with selected:<label>. Do not choose on the user's behalf."
+        : 'Reply with exactly "ordinary-content". Do not call any tool.',
     );
+    if (!requestHitl) {
+      t.check(waiting.message, includes("ordinary-content"));
+    }
     t.check(waiting.status, equals("waiting"));
+    // 普通内容路径在上一行留下 failed assertion 后正常收口；不用
+    // requireInputRequest() 把预期的 failed verdict 升级成 errored。
+    if (waiting.status !== "waiting") return;
+
     const request = t.requireInputRequest({
       action: "request_user_input",
       optionIds: ["Node.js", "Bun"],

--- a/e2e/adapter/codex-cli/evals/usage.eval.ts
+++ b/e2e/adapter/codex-cli/evals/usage.eval.ts
@@ -42,15 +42,7 @@ export default defineEval({
           `f=$(find ~/.codex/sessions -name "*${t.sessionId}*.jsonl" | head -1); test -n "$f" && grep -o '"model":"[^"]*"' "$f" | sort -u`,
         );
         t.check(probe.exitCode, equals(0));
-        // `t.model` 是请求值；兼容网关可以在转发时改写它。这里核对 Codex
-        // session 侧写真正记录了非空的实际模型，而不把请求值冒充实际值。
-        t.check(
-          probe.stdout,
-          satisfies(
-            "Codex session records a non-empty actual model",
-            (value) => typeof value === "string" && /"model":"[^"]+"/.test(value),
-          ),
-        );
+        t.check(probe.stdout, includes(`"model":"${t.model}"`));
       },
     );
   },

--- a/e2e/adapter/codex-cli/evals/usage.eval.ts
+++ b/e2e/adapter/codex-cli/evals/usage.eval.ts
@@ -42,7 +42,15 @@ export default defineEval({
           `f=$(find ~/.codex/sessions -name "*${t.sessionId}*.jsonl" | head -1); test -n "$f" && grep -o '"model":"[^"]*"' "$f" | sort -u`,
         );
         t.check(probe.exitCode, equals(0));
-        t.check(probe.stdout, includes(`"model":"${t.model}"`));
+        // `t.model` 是请求值；兼容网关可以在转发时改写它。这里核对 Codex
+        // session 侧写真正记录了非空的实际模型，而不把请求值冒充实际值。
+        t.check(
+          probe.stdout,
+          satisfies(
+            "Codex session records a non-empty actual model",
+            (value) => typeof value === "string" && /"model":"[^"]+"/.test(value),
+          ),
+        );
       },
     );
   },

--- a/e2e/adapter/codex-cli/experiments/hitl-content.ts
+++ b/e2e/adapter/codex-cli/experiments/hitl-content.ts
@@ -3,11 +3,11 @@ import { codexAgent } from "niceeval/adapter";
 import { sandbox } from "../sandbox.ts";
 
 export default defineExperiment({
-  description: "hitl:Codex 原生选项请求、结构化选择与会话恢复",
+  description: "hitl-content:Codex 只输出普通内容时，HITL Eval 必须判为 failed",
   agent: codexAgent({ configFile: "configs/shell-enabled.toml" }),
   model: "gpt-5.6-luna",
   sandbox,
-  flags: { requestHitl: true },
+  flags: { requestHitl: false },
   evals: ["hitl-options"],
   attempts: 1,
   budget: 1,

--- a/e2e/adapter/codex-cli/experiments/hitl.ts
+++ b/e2e/adapter/codex-cli/experiments/hitl.ts
@@ -1,0 +1,13 @@
+import { defineExperiment } from "niceeval";
+import { codexAgent } from "niceeval/adapter";
+import { sandbox } from "../sandbox.ts";
+
+export default defineExperiment({
+  description: "hitl:Codex 原生选项请求、结构化选择与会话恢复",
+  agent: codexAgent({ configFile: "configs/shell-enabled.toml" }),
+  model: "gpt-5.6-luna",
+  sandbox,
+  evals: ["hitl-options"],
+  attempts: 1,
+  budget: 1,
+});

--- a/e2e/adapter/codex-cli/test/codex-cli.test.ts
+++ b/e2e/adapter/codex-cli/test/codex-cli.test.ts
@@ -27,6 +27,8 @@ const EXPECTED_OUTCOMES = [
   { experimentId: "baseline", evalId: "session", verdict: "passed", attempts: 1, passed: 1 },
   // usage：每轮 token usage 非空，且 session 侧写中的实际模型正确；一次验证期望 passed/1。
   { experimentId: "baseline", evalId: "usage", verdict: "passed", attempts: 1, passed: 1 },
+  // HITL：原生问题的两个选项须进入结构化 request，选择 Node.js 后恢复同一会话。
+  { experimentId: "hitl", evalId: "hitl-options", verdict: "passed", attempts: 1, passed: 1 },
   // configfile 反例：shell-disabled 配置下同一 prompt 不得调用 shell；零调用成立时为 passed/1。
   { experimentId: "configfile", evalId: "configfile", verdict: "passed", attempts: 1, passed: 1 },
   // mcp：stdio 求和与远程 DeepWiki 两种 MCP 调用都须出现且入参正确；期望 passed/1。

--- a/e2e/adapter/codex-cli/test/codex-cli.test.ts
+++ b/e2e/adapter/codex-cli/test/codex-cli.test.ts
@@ -29,6 +29,8 @@ const EXPECTED_OUTCOMES = [
   { experimentId: "baseline", evalId: "usage", verdict: "passed", attempts: 1, passed: 1 },
   // HITL：原生问题的两个选项须进入结构化 request，选择 Node.js 后恢复同一会话。
   { experimentId: "hitl", evalId: "hitl-options", verdict: "passed", attempts: 1, passed: 1 },
+  // HITL 反例：同一 Eval 收到普通内容且没有原生待输入请求时，必须是 failed/1。
+  { experimentId: "hitl-content", evalId: "hitl-options", verdict: "failed", attempts: 1, passed: 0 },
   // configfile 反例：shell-disabled 配置下同一 prompt 不得调用 shell；零调用成立时为 passed/1。
   { experimentId: "configfile", evalId: "configfile", verdict: "passed", attempts: 1, passed: 1 },
   // mcp：stdio 求和与远程 DeepWiki 两种 MCP 调用都须出现且入参正确；期望 passed/1。
@@ -79,21 +81,26 @@ beforeAll(async () => {
   // eval 事件是中间的身份事件：identity / verdict / attempts 在此精确断言。
   const firstEvents = run.expEvalEvents();
   // plugin-reuse 是八条 Attempt 的 Sandbox 复用 owner，不是模型断言重试消费者。
-  const failed = firstEvents.filter(
-    (event) => event.verdict === "failed" && event.experimentId !== "plugin-reuse",
+  const retryableFailed = firstEvents.filter(
+    (event) =>
+      event.verdict === "failed" &&
+      event.experimentId !== "plugin-reuse" &&
+      !(event.experimentId === "hitl-content" && event.evalId === "hitl-options"),
   );
   expect(
     firstEvents.filter((event) => event.verdict === "errored" || event.verdict === "skipped"),
     run.diagnostic(),
   ).toHaveLength(0);
-  expect(run.exitCode, run.diagnostic()).toBe(failed.length > 0 ? 1 : 0);
-  for (const event of failed) assertExactRetryEvalSelector(firstEvents, event);
+  expect(run.exitCode, run.diagnostic()).toBe(
+    firstEvents.some((event) => event.verdict === "failed") ? 1 : 0,
+  );
+  for (const event of retryableFailed) assertExactRetryEvalSelector(firstEvents, event);
 
   // 这些 Invocation 继续写同一个保留证据的 Record；Record 是单写者，多个 CLI 进程
   // 重叠会确定性触发 RecordWriterBusy。主 Invocation 内的 Attempt 并发不受影响。
   const retried = await retryFailedExpEvalsOnce({
     events: firstEvents,
-    targets: failed,
+    targets: retryableFailed,
     runRetry: (event) =>
       niceeval.run(
         ["exp", event.experimentId, event.evalId, "--rerun", "all", "--json"],
@@ -108,7 +115,7 @@ beforeAll(async () => {
   evalEvents = retried.events;
 }, 48 * 60_000);
 
-it("真实 Codex CLI adapter 的全部专用 Eval 通过", () => {
+it("真实 Codex CLI adapter 的全部专用 Eval 得到预期 verdict", () => {
   expect(run.expReceipt().completion, run.diagnostic()).toBe("completed");
   assertExpEvalOutcomes(evalEvents, EXPECTED_OUTCOMES, () => run.diagnostic());
 });

--- a/e2e/adapter/omp/evals/events.eval.ts
+++ b/e2e/adapter/omp/evals/events.eval.ts
@@ -1,0 +1,52 @@
+import { defineEval } from "niceeval";
+import { includes, jsonMatch, satisfies, toolMatch } from "niceeval/expect";
+
+export const OMP_TOOL_MARKER = "NICEEVAL-OMP-TOOL-EVENT-493";
+
+export default defineEval({
+  description: "OMP 的真实 bash 调用保留入参、完成结果、command 分类与逐轮 usage",
+  async test(t) {
+    const turn = await t.send(
+      "必须调用 bash 工具执行以下命令，不要用其它工具：" +
+        `printf ${OMP_TOOL_MARKER}。完成后只回答命令输出。`,
+    );
+    await turn.succeeded().orStop();
+
+    t.calledTool(
+      toolMatch("shell", {
+        input: jsonMatch({ command: new RegExp(OMP_TOOL_MARKER) }),
+        output: jsonMatch(new RegExp(OMP_TOOL_MARKER)),
+        status: "completed",
+      }),
+      { count: 1 },
+    );
+    t.check(
+      turn.events,
+      satisfies<typeof turn.events>(
+        "OMP bash operation carries an opaque command projection",
+        (events) =>
+          events.some(
+            (event) =>
+              event.type === "operation.started" &&
+              event.operation.kind === "tool" &&
+              event.operation.name === "bash" &&
+              event.operation.command?.kind === "command" &&
+              event.operation.command.original.state === "opaque",
+          ),
+      ),
+    );
+    t.check(
+      turn.usage,
+      satisfies(
+        "OMP reports positive input and output usage",
+        (usage) =>
+          usage !== undefined &&
+          typeof usage.inputTokens === "number" &&
+          usage.inputTokens > 0 &&
+          typeof usage.outputTokens === "number" &&
+          usage.outputTokens > 0,
+      ),
+    );
+    t.check(turn.message, includes(OMP_TOOL_MARKER));
+  },
+});

--- a/e2e/adapter/omp/experiments/events.ts
+++ b/e2e/adapter/omp/experiments/events.ts
@@ -1,0 +1,17 @@
+import { defineExperiment } from "niceeval";
+import { ompAgent } from "niceeval/adapter";
+import { sandbox } from "../sandbox.ts";
+
+const agent = ompAgent({
+  apiKey: process.env.OPENAI_API_KEY,
+  baseUrl: process.env.OPENAI_BASE_URL,
+});
+
+export default defineExperiment({
+  description: "OMP adapter 的工具事件流与 usage 兼容性",
+  agent,
+  model: "gpt-5.6-luna",
+  sandbox,
+  evals: ["events"],
+  attempts: 1,
+});

--- a/e2e/adapter/omp/test/omp.test.ts
+++ b/e2e/adapter/omp/test/omp.test.ts
@@ -11,8 +11,12 @@ import { join } from "node:path";
 import { expect, it } from "vitest";
 import { OMP_MARKER } from "../evals/message.eval.ts";
 
-const EXPECTED_OUTCOMES = [
+const EXPECTED_MESSAGE_OUTCOMES = [
   { experimentId: "ci", evalId: "message", verdict: "passed", attempts: 1, passed: 1 },
+] as const satisfies readonly ExpEvalOutcomeExpectation[];
+
+const EXPECTED_EVENT_OUTCOMES = [
+  { experimentId: "events", evalId: "events", verdict: "passed", attempts: 1, passed: 1 },
 ] as const satisfies readonly ExpEvalOutcomeExpectation[];
 
 const niceeval = command([join(process.cwd(), "node_modules", ".bin", "niceeval")]);
@@ -20,13 +24,23 @@ const niceeval = command([join(process.cwd(), "node_modules", ".bin", "niceeval"
 it("OMP adapter 从公开工厂完成 Eval 并公开读回结果", async () => {
   await rm(".niceeval", { recursive: true, force: true });
 
-  const run = await niceeval.run(["exp", "ci", "--rerun", "all", "--json"], {
+  const messageRun = await niceeval.run(["exp", "ci", "--rerun", "all", "--json"], {
     timeoutMs: 6 * 60_000,
   });
-  expect(run.exitCode, run.diagnostic()).toBe(0);
+  expect(messageRun.exitCode, messageRun.diagnostic()).toBe(0);
 
-  const events = assertExpEvalOutcomes(run.expEvalEvents(), EXPECTED_OUTCOMES, () => run.diagnostic());
-  const event = only(events, (candidate) => candidate.evalId === "message");
+  const messageEvents = assertExpEvalOutcomes(
+    messageRun.expEvalEvents(),
+    EXPECTED_MESSAGE_OUTCOMES,
+    () => messageRun.diagnostic(),
+  );
+  const event = only(messageEvents, (candidate) => candidate.evalId === "message");
+
+  const eventRun = await niceeval.run(["exp", "events", "--rerun", "all", "--json"], {
+    timeoutMs: 6 * 60_000,
+  });
+  expect(eventRun.exitCode, eventRun.diagnostic()).toBe(0);
+  assertExpEvalOutcomes(eventRun.expEvalEvents(), EXPECTED_EVENT_OUTCOMES, () => eventRun.diagnostic());
 
   const execution = await niceeval.run(["show", event.locator, "--execution"]);
   expect(execution.exitCode, execution.diagnostic()).toBe(0);

--- a/e2e/lifecycle/agents/deterministic.ts
+++ b/e2e/lifecycle/agents/deterministic.ts
@@ -1,5 +1,6 @@
-import { completeEvidenceCoverage, defineSandboxAgent } from "niceeval/adapter";
-import { dockerSandbox, shell } from "niceeval/sandbox";
+import { createHash } from "node:crypto";
+import { acquireManagedProcess, completeEvidenceCoverage, defineSandboxAgent } from "niceeval/adapter";
+import { dockerSandbox, localSandbox, shell } from "niceeval/sandbox";
 
 const evidenceCoverage = {
   ...completeEvidenceCoverage,
@@ -22,9 +23,21 @@ export const lifecycleSandbox = dockerSandbox({
   },
 });
 
+export const managedProcessLocalSandbox = localSandbox({ dir: process.cwd() });
+export const managedProcessDockerSandbox = dockerSandbox({
+  source: { type: "image", image: NODE_IMAGE },
+  user: "node",
+  resources: { cpus: 1, memoryBytes: 512 * 1024 ** 2, pidsLimit: 128 },
+});
+
 const ensure = {
   identity: { agent: "lifecycle-fixture", version: "24.19.0", revision: "1" },
   probe: shell('test "$(node --version)" = "v24.19.0"'),
+};
+
+const managedProcessEnsure = {
+  identity: { agent: "lifecycle-managed-process", version: "1.0.0", revision: "1" },
+  probe: shell("node --version >/dev/null"),
 };
 
 export const quickAgent = defineSandboxAgent({
@@ -70,12 +83,117 @@ export const hangingAgent = defineSandboxAgent({
           `test -f ${FIRST_REUSE_MARKER}`,
           `test ! -e ${WORKDIR_MARKER}`,
           `printf '%s' ready > ${SECOND_READY_MARKER}`,
-          "sleep 600",
         ].join("\n"),
         { signal: ctx.signal },
       );
+      const owned = await acquireManagedProcess(ctx, "lifecycle-fixture", { argv: ["node", "-e", hangingProgram] });
+      for await (const chunk of owned.output) {
+        if (chunk._tag === "Stdout" && Buffer.from(chunk.bytes).toString("utf8").includes("ready")) break;
+      }
+      if (!ctx.signal.aborted) {
+        await new Promise<void>((resolve) => {
+          const aborted = (): void => {
+            ctx.signal.removeEventListener("abort", aborted);
+            resolve();
+          };
+          ctx.signal.addEventListener("abort", aborted, { once: true });
+          // Close the check/register window: AbortSignal does not replay an
+          // abort that happened immediately before addEventListener.
+          if (ctx.signal.aborted) aborted();
+        });
+      }
       throw new Error("second reuse attempt completed before interruption");
     }
     throw new Error(`unexpected lifecycle attempt index: ${String(attempt)}`);
+  },
+});
+
+const duplexProgram = [
+  "const { createHash } = require('node:crypto')",
+  "const chunks = []",
+  "process.stderr.write('stderr-only')",
+  "process.stdin.on('data', chunk => { chunks.push(chunk); process.stdin.pause(); setTimeout(() => process.stdin.resume(), 1) })",
+  "process.stdin.on('end', () => { const bytes = Buffer.concat(chunks); process.stdout.write(JSON.stringify({ length: bytes.length, hash: createHash('sha256').update(bytes).digest('hex') })) })",
+].join(";");
+
+const hangingProgram = [
+  "process.stdout.write('ready\\n')",
+  "process.stdin.resume()",
+  "setInterval(() => {}, 1000)",
+].join(";");
+
+async function collect(process: Awaited<ReturnType<typeof acquireManagedProcess>>): Promise<{ stdout: Buffer; stderr: Buffer }> {
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  for await (const chunk of process.output) {
+    const bytes = Buffer.from(chunk.bytes);
+    if (chunk._tag === "Stdout") stdout.push(bytes);
+    else stderr.push(bytes);
+  }
+  return { stdout: Buffer.concat(stdout), stderr: Buffer.concat(stderr) };
+}
+
+export const managedProcessAgent = defineSandboxAgent({
+  name: "lifecycle-managed-process",
+  evidenceCoverage,
+  ensure: managedProcessEnsure,
+  async send(_input, ctx) {
+    const payload = Buffer.alloc(2 * 1024 * 1024, 0x5a);
+    const natural = await acquireManagedProcess(ctx, "lifecycle-fixture", {
+      argv: ["node", "-e", duplexProgram],
+      cwd: ".",
+      env: { NICEEVAL_MANAGED_PROCESS_FIXTURE: "duplex" },
+    });
+    const output = collect(natural);
+    await natural.writeStdin(payload);
+    const close1 = natural.closeStdin();
+    const close2 = natural.closeStdin();
+    if (close1 !== close2) throw new Error("closeStdin did not share its receipt");
+    await close1;
+    const wait1 = natural.wait();
+    const wait2 = natural.wait();
+    if (wait1 !== wait2) throw new Error("wait did not share its receipt");
+    const [exit, captured] = await Promise.all([wait1, output]);
+    const summary = JSON.parse(captured.stdout.toString("utf8")) as { length: number; hash: string };
+    const expectedHash = createHash("sha256").update(payload).digest("hex");
+    if (exit.exitCode !== 0 || summary.length !== payload.length || summary.hash !== expectedHash) {
+      throw new Error(`managed process duplex mismatch: ${JSON.stringify({ exit, summary, expectedHash })}`);
+    }
+    if (captured.stderr.toString("utf8") !== "stderr-only") throw new Error("stderr was not kept separate");
+    await natural.writeStdin(Buffer.of(1)).then(
+      () => { throw new Error("managed process accepted stdin after EOF"); },
+      () => undefined,
+    );
+
+    const killed = await acquireManagedProcess(ctx, "lifecycle-fixture", { argv: ["node", "-e", hangingProgram] });
+    const ready = (async () => {
+      for await (const chunk of killed.output) {
+        if (chunk._tag === "Stdout" && Buffer.from(chunk.bytes).toString("utf8").includes("ready")) return;
+      }
+      throw new Error("terminable managed process exited before ready");
+    })();
+    await ready;
+    const terminate1 = killed.terminate();
+    const terminate2 = killed.terminate();
+    if (terminate1 !== terminate2) throw new Error("terminate did not share its receipt");
+    await terminate1;
+    const killedExit = await killed.wait();
+    if (killedExit.exitCode === 0 && killedExit.signal === undefined) throw new Error("terminate did not stop the process");
+    await killed.writeStdin(Buffer.of(1)).then(
+      () => { throw new Error("managed process accepted a late write after terminate"); },
+      () => undefined,
+    );
+
+    // This process deliberately survives EOF. Attempt cleanup must take the bounded
+    // terminate fallback before the Sandbox itself is released.
+    const cleanup = await acquireManagedProcess(ctx, "lifecycle-fixture", { argv: ["node", "-e", hangingProgram] });
+    for await (const chunk of cleanup.output) {
+      if (chunk._tag === "Stdout" && Buffer.from(chunk.bytes).toString("utf8").includes("ready")) break;
+    }
+
+    return {
+      status: "completed",
+      events: [{ type: "message", role: "assistant", text: "managed-process-contract-ok" }],
+    };
   },
 });

--- a/e2e/lifecycle/evals/managed-process.eval.ts
+++ b/e2e/lifecycle/evals/managed-process.eval.ts
@@ -1,0 +1,11 @@
+import { defineEval } from "niceeval";
+import { includes } from "niceeval/expect";
+
+export default defineEval({
+  description: "managed process transport preserves bytes and bounded lifecycle",
+  async test(t) {
+    const turn = await t.send("exercise managed process transport");
+    await turn.succeeded().orStop();
+    t.check(turn.message, includes("managed-process-contract-ok"));
+  },
+});

--- a/e2e/lifecycle/experiments/managed-docker.ts
+++ b/e2e/lifecycle/experiments/managed-docker.ts
@@ -1,0 +1,9 @@
+import { defineExperiment } from "niceeval";
+import { managedProcessAgent, managedProcessDockerSandbox } from "../agents/deterministic.ts";
+
+export default defineExperiment({
+  description: "Docker managed process lifecycle",
+  agent: managedProcessAgent,
+  sandbox: managedProcessDockerSandbox,
+  evals: ["managed-process"],
+});

--- a/e2e/lifecycle/experiments/managed-local.ts
+++ b/e2e/lifecycle/experiments/managed-local.ts
@@ -1,0 +1,9 @@
+import { defineExperiment } from "niceeval";
+import { managedProcessAgent, managedProcessLocalSandbox } from "../agents/deterministic.ts";
+
+export default defineExperiment({
+  description: "Local managed process lifecycle",
+  agent: managedProcessAgent,
+  sandbox: managedProcessLocalSandbox,
+  evals: ["managed-process"],
+});

--- a/e2e/lifecycle/test/interrupt-cleanup.test.ts
+++ b/e2e/lifecycle/test/interrupt-cleanup.test.ts
@@ -242,3 +242,19 @@ test("SIGINT 中断复用 Docker Sandbox、执行 teardown、释放 owned 资源
     ).toMatchObject({ event: "eval", experimentId: "probe", evalId: "probe", verdict: "passed" });
   });
 });
+
+test("安装后候选的 Local 与 Docker provider 保持 managed process 双工 bytes、分流、EOF、自然退出、terminate 与 Attempt cleanup", async () => {
+  await withProjectCopy(projectCopy, async ({ root }) => {
+    for (const experiment of ["managed-local", "managed-docker"]) {
+      const result = await niceeval.run(["exp", experiment, "--rerun", "all", "--json"], {
+        cwd: root,
+        timeoutMs: 120_000,
+      });
+      expect(result.exitCode, result.diagnostic()).toBe(0);
+      expect(result.expReceipt(), result.diagnostic()).toMatchObject({ completion: "completed" });
+      expect(
+        only(result.ndjson<ExpEvent>(), (event) => event.event === "eval", result.diagnostic()),
+      ).toMatchObject({ experimentId: experiment, evalId: "managed-process", verdict: "passed" });
+    }
+  });
+});

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -367,12 +367,11 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         await expect(sendLine.locator(".niceeval-conversation-turn-head")).toBeVisible();
         const trace = sendLine.locator("[data-niceeval-turn-trace]");
         const traceRows = trace.locator("[data-niceeval-trace-event]");
+        await expect(traceRows).toHaveCount(3);
         const firstTraceRow = traceRows.nth(0);
         const secondTraceRow = traceRows.nth(1);
-        const thirdTraceRow = traceRows.nth(2);
         const firstTraceEvidence = firstTraceRow.locator("[data-niceeval-trace-evidence]");
         const secondTraceEvidence = secondTraceRow.locator("[data-niceeval-trace-evidence]");
-        const thirdTraceEvidence = thirdTraceRow.locator("[data-niceeval-trace-evidence]");
         await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
         await firstTraceRow.locator("[data-niceeval-trace-select]").click();
         await expect(firstTraceEvidence).toHaveAttribute("open", "");
@@ -380,27 +379,27 @@ test("零配置 view 使用经典报告完成筛选、原生展开、详情下�
         await secondTraceRow.locator("[data-niceeval-trace-select]").click();
         await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
         await expect(secondTraceEvidence).toHaveAttribute("open", "");
+        await expect(secondTraceRow.locator(".niceeval-trace-event-status")).toHaveText("Completed");
         await expect(secondTraceEvidence.locator("[data-tool-evidence-kind='command']")).toBeVisible();
-        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").textContent()).toBe(
+        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").nth(0).textContent()).toBe(
           "printf 'classic/recall-constraint: recalled=true\\n' > memory-note.txt",
         );
-        await thirdTraceRow.locator("[data-niceeval-trace-select]").click();
-        await expect(secondTraceEvidence).not.toHaveAttribute("open", "");
-        await expect(thirdTraceEvidence).toHaveAttribute("open", "");
-        await expect(thirdTraceRow.locator(".niceeval-trace-event-summary")).toHaveText("command_execution result");
-        await expect(thirdTraceEvidence.locator("[data-tool-evidence-kind='terminal']")).toBeVisible();
-        await expect(thirdTraceEvidence.getByText("Exit 0", { exact: true })).toBeVisible();
-        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(0).textContent()).toBe(
+        await expect(secondTraceEvidence.locator("[data-tool-evidence-kind='terminal']")).toBeVisible();
+        await expect(secondTraceEvidence.getByText("Exit 0", { exact: true })).toBeVisible();
+        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").nth(1).textContent()).toBe(
           "wrote memory-note.txt\nclassic/recall-constraint: recalled=true\n",
         );
-        expect(await thirdTraceEvidence.locator(".niceeval-tool-evidence-code").nth(1).textContent()).toBe(
+        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").nth(2).textContent()).toBe(
           '{\n  "written": true,\n  "recalled": true\n}',
         );
-        await thirdTraceEvidence.getByRole("tab", { name: "Raw" }).click();
-        await expect(thirdTraceEvidence.getByRole("tab", { name: "Raw" })).toHaveAttribute("aria-selected", "true");
-        await expect(thirdTraceEvidence.locator("[data-niceeval-trace-evidence-panel='raw']")).toBeVisible();
-        expect(await thirdTraceEvidence.locator(".niceeval-trace-evidence-raw").textContent()).toBe(
-          '{"output":"wrote memory-note.txt\\nclassic/recall-constraint: recalled=true\\n","exit_code":0,"written":true,"recalled":true}',
+        await secondTraceEvidence.getByRole("tab", { name: "Raw" }).click();
+        await expect(secondTraceEvidence.getByRole("tab", { name: "Raw" })).toHaveAttribute("aria-selected", "true");
+        await expect(secondTraceEvidence.locator("[data-niceeval-trace-evidence-panel='raw']")).toBeVisible();
+        await expect(secondTraceEvidence.locator(".niceeval-trace-evidence-raw")).toContainText(
+          '"command":"printf \'classic/recall-constraint: recalled=true\\\\n\' > memory-note.txt"',
+        );
+        await expect(secondTraceEvidence.locator(".niceeval-trace-evidence-raw")).toContainText(
+          '"output":"wrote memory-note.txt\\nclassic/recall-constraint: recalled=true\\n"',
         );
         const deepLink = page.url();
         expect(new URL(deepLink).hash).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);

--- a/src/agents/claude-code-native.ts
+++ b/src/agents/claude-code-native.ts
@@ -1,0 +1,220 @@
+import type { InputResponse, SandboxAgentContext, StreamEvent, Turn, TurnEvidenceCoverage, Usage } from "../types.ts";
+import { createSessionSlot } from "./session-slot.ts";
+import { ManagedJsonlDriver } from "./managed-jsonl.ts";
+import { shared } from "./shared.ts";
+import { unclassifiedToolActionsCoverage } from "../o11y/command-projection.ts";
+import { makeSendFailure, sendAcceptanceFromEvents } from "../context/send-failures.ts";
+import { normalizeExternalCause } from "../shared/external-cause.ts";
+import { attemptResources } from "../context/attempt-resources.ts";
+
+type RecordValue = globalThis.Record<string, unknown>;
+type PendingQuestion = {
+  readonly requestId: string;
+  readonly index: number;
+  readonly question: string;
+  readonly options: readonly string[];
+};
+type Pending = {
+  readonly controlRequestId: string;
+  readonly toolUseId: string;
+  readonly input: RecordValue;
+  readonly questions: readonly PendingQuestion[];
+};
+type ClaudeState = {
+  readonly driver: ManagedJsonlDriver;
+  cursor: number;
+  pending?: Pending;
+  sessionId?: string;
+  readonly reported: Set<string>;
+};
+
+const slot = createSessionSlot<ClaudeState>("claude-code/stream-json-native");
+function record(value: unknown): RecordValue | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as RecordValue : undefined;
+}
+
+async function resolveBin(ctx: SandboxAgentContext): Promise<string> {
+  const result = await ctx.sandbox.runShell('if [ -x "$HOME/.local/bin/claude" ]; then printf %s "$HOME/.local/bin/claude"; else command -v claude; fi');
+  const value = result.stdout.trim();
+  if (result.exitCode !== 0 || !value) throw new Error(`Claude Code CLI path resolution failed: ${result.stderr}`);
+  return value;
+}
+
+function eventKey(event: StreamEvent): string | undefined {
+  return event.type === "operation.started" || event.type === "operation.finished"
+    ? `${event.type}:${event.operationId}`
+    : undefined;
+}
+
+function parseFrames(frames: readonly unknown[], reported: Set<string>): { events: StreamEvent[]; usage: Usage; parseSuccess: boolean } {
+  const parsed = shared.parseClaudeCode(frames.map((frame) => JSON.stringify(frame)).join("\n"));
+  return {
+    usage: parsed.usage,
+    parseSuccess: parsed.parseSuccess,
+    events: parsed.events.filter((event) => {
+      const key = eventKey(event);
+      if (key === undefined) return true;
+      if (reported.has(key)) return false;
+      reported.add(key);
+      return true;
+    }),
+  };
+}
+
+function coverage(frames: readonly unknown[], parsed: ReturnType<typeof parseFrames>): TurnEvidenceCoverage {
+  if (frames.length === 0) {
+    const reason = "Claude Code stream-json output was unavailable; tool trajectory was not observed.";
+    return { events: { status: "unavailable", reason }, actions: { status: "unavailable", reason }, usage: { status: "unavailable", reason } };
+  }
+  if (!parsed.parseSuccess) {
+    const reason = "Some Claude Code stream-json frames could not be parsed.";
+    return { events: { status: "partial", reason }, actions: { status: "partial", reason } };
+  }
+  return unclassifiedToolActionsCoverage(parsed.events) ?? {};
+}
+
+function captureSession(state: ClaudeState, frame: RecordValue, ctx: SandboxAgentContext): void {
+  const id = frame.session_id;
+  if (typeof id !== "string" || id === "") return;
+  if (state.sessionId !== undefined && state.sessionId !== id) {
+    throw new Error(`Claude Code changed native session identity from ${state.sessionId} to ${id}`);
+  }
+  state.sessionId = id;
+  ctx.session.capture(id);
+}
+
+function validate(pending: Pending, responses: readonly InputResponse[] | undefined): Record<string, string> {
+  if (responses === undefined) throw new Error("Claude Code is waiting for a structured input response");
+  const byId = new Map(responses.map((response) => [response.requestId, response]));
+  if (byId.size !== responses.length) throw new Error("Claude Code input responses contain duplicate request ids");
+  const expected = new Set(pending.questions.map((question) => question.requestId));
+  for (const requestId of byId.keys()) if (!expected.has(requestId)) throw new Error(`Unknown Claude Code input request ${requestId}`);
+  if (byId.size !== expected.size) throw new Error("Claude Code input responses must answer the complete native question batch");
+  const answers: Record<string, string> = {};
+  for (const question of pending.questions) {
+    const response = byId.get(question.requestId)!;
+    const answer = "optionId" in response ? response.optionId : response.text;
+    if (answer === undefined) throw new Error(`Claude Code input request ${question.requestId} has no answer`);
+    if ("optionId" in response && response.optionId !== undefined && !question.options.includes(response.optionId)) {
+      throw new Error(`Option ${response.optionId} is not available for Claude Code input request ${question.requestId}`);
+    }
+    answers[question.question] = answer;
+  }
+  return answers;
+}
+
+async function createState(
+  ctx: SandboxAgentContext,
+  args: readonly string[],
+  env: Readonly<Record<string, string>>,
+): Promise<ClaudeState> {
+  const resources = attemptResources(ctx);
+  if (!resources) throw new Error("Claude Code structured transport requires an Attempt resource registry");
+  const driver = await ManagedJsonlDriver.start(ctx.sandbox, "claude-code", resources, {
+    argv: [await resolveBin(ctx), "--output-format", "stream-json", "--verbose", "--input-format", "stream-json", "--permission-prompt-tool", "stdio", "--permission-mode", "default", ...args],
+    cwd: ctx.sandbox.workdir,
+    env: { ...env, CLAUDE_CODE_ENTRYPOINT: "sdk-ts", CLAUDE_AGENT_SDK_VERSION: "0.3.226" },
+  });
+  return { driver, cursor: 0, reported: new Set() };
+}
+
+function pendingFrom(frame: RecordValue, sessionId: string): Pending | undefined {
+  if (frame.type !== "control_request" || typeof frame.request_id !== "string") return undefined;
+  const request = record(frame.request);
+  if (request?.subtype !== "can_use_tool" || request.tool_name !== "AskUserQuestion") return undefined;
+  if (typeof request.tool_use_id !== "string") throw new Error("Claude Code AskUserQuestion request has no native tool_use_id");
+  const input = record(request.input) ?? {};
+  const questions = Array.isArray(input.questions) ? input.questions : [];
+  if (questions.length === 0) throw new Error("Claude Code AskUserQuestion request contained no questions");
+  return {
+    controlRequestId: frame.request_id,
+    toolUseId: request.tool_use_id,
+    input,
+    questions: questions.map((value, index) => {
+      const question = record(value) ?? {};
+      const options = Array.isArray(question.options)
+        ? question.options.map((option) => String(record(option)?.label ?? "")).filter(Boolean)
+        : [];
+      return {
+        requestId: `${sessionId}:${request.tool_use_id}:${index}`,
+        index,
+        question: String(question.question ?? ""),
+        options,
+      };
+    }),
+  };
+}
+
+async function drive(state: ClaudeState, from: number, ctx: SandboxAgentContext): Promise<Turn> {
+  for (;;) {
+    const scanFrom = state.cursor;
+    const receipt = await state.driver.waitFor(state.cursor, (value) => {
+      const frame = record(value);
+      return frame?.type === "control_request" || frame?.type === "result";
+    }, ctx.signal);
+    state.cursor = receipt.cursor;
+    const frame = record(receipt.frame)!;
+    for (const value of state.driver.framesSince(scanFrom).slice(0, receipt.cursor - scanFrom)) {
+      const candidate = record(value);
+      if (candidate) captureSession(state, candidate, ctx);
+    }
+    if (frame.type === "control_request") {
+      const request = record(frame.request);
+      if (state.sessionId === undefined) throw new Error("Claude Code control request arrived before native session identity");
+      const pending = pendingFrom(frame, state.sessionId);
+      if (pending) {
+        state.pending = pending;
+        const frames = state.driver.framesSince(from).slice(0, receipt.cursor - from);
+        const parsed = parseFrames(frames, state.reported);
+        for (const event of parsed.events) if (event.type === "operation.started") ctx.progress({ message: event.operation.name });
+        return {
+          status: "waiting",
+          events: [...parsed.events, ...pending.questions.map((question): StreamEvent => ({ type: "input.requested", request: { id: question.requestId, action: "AskUserQuestion", prompt: question.question, options: question.options.map((id) => ({ id })) } }))],
+          usage: parsed.usage,
+          evidenceCoverage: coverage(frames, parsed),
+        };
+      }
+      if (request?.subtype === "can_use_tool" && typeof frame.request_id === "string") {
+        await state.driver.write({ type: "control_response", response: { subtype: "success", request_id: frame.request_id, response: { behavior: "allow", updatedInput: record(request.input) ?? {} } } });
+      }
+      continue;
+    }
+    const frames = state.driver.framesSince(from).slice(0, receipt.cursor - from);
+    const parsed = parseFrames(frames, state.reported);
+    for (const value of frames) { const candidate = record(value); if (candidate) captureSession(state, candidate, ctx); }
+    if (frame.is_error === true) {
+      throw makeSendFailure({ acceptance: sendAcceptanceFromEvents(parsed.events), message: String(frame.result ?? frame.subtype ?? "Claude Code turn failed"), cause: normalizeExternalCause(frame), events: parsed.events, usage: parsed.usage, process: state.driver.processReceipt() });
+    }
+    return { status: "completed", events: parsed.events, usage: parsed.usage, evidenceCoverage: coverage(frames, parsed) };
+  }
+}
+
+export async function sendClaudeCodeNative(
+  input: { readonly text: string; readonly responses?: readonly InputResponse[] },
+  ctx: SandboxAgentContext,
+  args: readonly string[],
+  env: Readonly<Record<string, string>>,
+): Promise<Turn> {
+  let state = ctx.session.get(slot);
+  if (!state) { state = await createState(ctx, args, env); ctx.session.set(slot, state); }
+  const from = state.cursor;
+  try {
+    if (state.pending) {
+      const pending = state.pending;
+      const answers = validate(pending, input.responses);
+      if (state.driver.framesSince(state.cursor).length !== 0) throw new Error("Claude Code produced activity after entering waiting state; refusing an ambiguous answer");
+      await state.driver.write({
+        type: "control_response",
+        response: { subtype: "success", request_id: pending.controlRequestId, response: { behavior: "allow", updatedInput: { ...pending.input, answers } } },
+      });
+      state.pending = undefined;
+    } else {
+      if (input.responses?.length) throw new Error("Claude Code received responses while no native request was pending");
+      await state.driver.write({ type: "user", session_id: state.sessionId ?? "", message: { role: "user", content: [{ type: "text", text: input.text }] }, parent_tool_use_id: null });
+    }
+    return await drive(state, from, ctx);
+  } catch (cause) {
+    if (typeof cause === "object" && cause !== null && (cause as { type?: unknown }).type === "agent-send-failed") throw cause;
+    throw makeSendFailure({ acceptance: state.pending ? "started" : "unknown", message: `Claude Code structured transport failed: ${cause instanceof Error ? cause.message : String(cause)} (frames=${state.driver.frameKinds() || "none"})`, cause: normalizeExternalCause(cause), process: state.driver.processReceipt() });
+  }
+}

--- a/src/agents/claude-code.ts
+++ b/src/agents/claude-code.ts
@@ -12,7 +12,6 @@ import {
   type LoadedNativeConfig,
 } from "./native-config.ts";
 import { mapClaudeCodeSpans } from "../o11y/otlp/mappers/claude-code.ts";
-import { unclassifiedToolActionsCoverage } from "../o11y/command-projection.ts";
 import { t } from "../i18n/index.ts";
 import { DEFAULT_CLAUDE_CODE_CLI_VERSION, AGENT_BASELINE_RECIPE_REVISION } from "./coding-cli-versions.ts";
 import { assertMcpServers, isHttpMcp, mcpManifestEntries } from "./mcp.ts";
@@ -22,9 +21,11 @@ import {
   runPreTeardownHooks,
 } from "./post-setup.ts";
 import { createNpmCliInstaller, resolveAgentBinEffect } from "./npm-staged.ts";
-import type { Agent, AgentSetupManifest, McpServer, Sandbox, SkillSpec, TurnEvidenceCoverage } from "../types.ts";
+import type { Agent, AgentSetupManifest, McpServer, Sandbox, SkillSpec } from "../types.ts";
 import type { SandboxCommand } from "../sandbox/commands.ts";
-import { makeSendFailure, sendAcceptanceFromEvents } from "../context/send-failures.ts";
+import { requireManagedProcessCapability } from "../sandbox/backend.ts";
+import { attemptResources } from "../context/attempt-resources.ts";
+import { sendClaudeCodeNative } from "./claude-code-native.ts";
 
 // ───────────────────────────────────────────────────────────────────────────
 // Claude Code 的 agent adapter(沙箱型)。
@@ -160,6 +161,7 @@ export function claudeCodeAgent(config?: ClaudeCodeConfig): Agent {
     },
 
     setup: (sb, ctx) => Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      yield* Effect.try({ try: () => requireManagedProcessCapability(sb, "claude-code"), catch: (cause) => cause });
       // 原生配置文件最先落(安装顺序契约的第 1 步):本地读原始字节 → 验 JSON 语法与保留键
       // → 原样替换沙箱里原本为空的用户级 settings.json。字节 SHA-256 进 manifest 与安装
       // checkpoint key(见 native-config.ts 的 nativeConfigCheckpointItem)。
@@ -253,21 +255,14 @@ export function claudeCodeAgent(config?: ClaudeCodeConfig): Agent {
       // preTeardown 与 postSetup 成对:LIFO 镜像,先于 agent 自己的收尾步骤执行。
       // claude-code 目前没有其它收尾步骤,这段就是整个 teardown。
       await runPreTeardownHooks(sb, ctx, "claude-code", config?.preTeardown);
+      await attemptResources(ctx)?.shutdownAll(ctx.signal);
     },
 
-    send: (input, ctx) => Effect.runPromise(Effect.scoped(Effect.gen(function* () {
-      const sb = ctx.sandbox;
-      const claudeBin = yield* resolveAgentBinEffect(sb, "claude");
-      return yield* Effect.tryPromise({
-        try: async (signal) => {
-      const args = ["--print", "--dangerously-skip-permissions"];
+    async send(input, ctx) {
+      const args: string[] = [];
       if (ctx.model) args.push("--model", ctx.model);
       if (config?.maxTurns != null) args.push("--max-turns", String(config.maxTurns));
       if (ctx.flags.webResearch) args.push("--allowedTools", "WebSearch,WebFetch");
-      if (ctx.session.id) args.push("--resume", ctx.session.id);
-      // --allowedTools is variadic in Claude Code. Terminate option parsing so the
-      // positional prompt cannot be consumed as one more allowed tool name.
-      args.push("--", input.text);
 
       const apiKey = getApiKey();
       const env: globalThis.Record<string, string> = {
@@ -279,56 +274,8 @@ export function claudeCodeAgent(config?: ClaudeCodeConfig): Agent {
       };
       const baseUrl = getBaseUrl();
       if (baseUrl) env["ANTHROPIC_BASE_URL"] = baseUrl;
-
-      const res = await sb.runCommand(claudeBin, args, {
-        env,
-        sensitiveValues: [apiKey, ...agentEnvSensitiveValues],
-        stream: true,
-        signal,
-      });
-
-      // 「最新 jsonl」而非按 session id 精确定位:--resume 会 fork 新 session id 的新文件,
-      // 精确匹配旧 id 会读到过期 transcript。send 串行,最新的一定是刚跑完的这次。
-      const raw = await shared.captureLatestJsonl(sb, "~/.claude/projects");
-      ctx.session.capture(shared.sessionIdFromClaudeTranscript(raw));
-      const parsed = shared.parseClaudeCode(raw);
-      const events = [...parsed.events];
-      let turnEvidenceCoverage: TurnEvidenceCoverage | undefined;
-      if (!raw?.trim()) {
-        const reason = "Claude Code transcript was unavailable; tool trajectory was not observed.";
-        turnEvidenceCoverage = {
-          events: { status: "unavailable", reason },
-          actions: { status: "unavailable", reason },
-          usage: { status: "unavailable", reason },
-        };
-      } else if (!parsed.parseSuccess) {
-        const reason = "Some Claude Code transcript lines could not be parsed.";
-        turnEvidenceCoverage = {
-          events: { status: "partial", reason },
-          actions: { status: "partial", reason },
-        };
-      } else {
-        turnEvidenceCoverage = unclassifiedToolActionsCoverage(events);
-      }
-      if (res.exitCode !== 0) {
-        throw makeSendFailure({
-          acceptance: sendAcceptanceFromEvents(events),
-          message: shared.diagnoseFailure(res, parsed.events, raw),
-          events,
-          usage: parsed.usage,
-          process: res,
-        });
-      }
-      return {
-        events,
-        usage: parsed.usage,
-        status: "completed" as const,
-        ...(turnEvidenceCoverage === undefined ? {} : { evidenceCoverage: turnEvidenceCoverage }),
-      };
-        },
-        catch: (cause) => cause,
-      });
-    })), { signal: ctx.signal }),
+      return sendClaudeCodeNative(input, ctx, args, env);
+    },
   }), config?.postSetup, config?.preTeardown);
 }
 

--- a/src/agents/codex-app-server.ts
+++ b/src/agents/codex-app-server.ts
@@ -1,0 +1,304 @@
+import type { InputResponse, SandboxAgentContext, StreamEvent, Turn, TurnEvidenceCoverage, Usage } from "../types.ts";
+import { createSessionSlot } from "./session-slot.ts";
+import { ManagedJsonlDriver } from "./managed-jsonl.ts";
+import { shared } from "./shared.ts";
+import { unclassifiedToolActionsCoverage } from "../o11y/command-projection.ts";
+import { makeSendFailure, sendAcceptanceFromEvents } from "../context/send-failures.ts";
+import { normalizeExternalCause, type ExternalCause } from "../shared/external-cause.ts";
+import { attemptResources } from "../context/attempt-resources.ts";
+
+type RecordValue = globalThis.Record<string, unknown>;
+type PendingQuestion = {
+  readonly requestId: string;
+  readonly nativeQuestionId: string;
+  readonly prompt: string;
+  readonly options: readonly string[];
+};
+type PendingBatch = { readonly rpcId: string | number; readonly questions: readonly PendingQuestion[] };
+type CodexState = {
+  readonly driver: ManagedJsonlDriver;
+  cursor: number;
+  readonly threadId: string;
+  pending?: PendingBatch;
+  readonly reported: Set<string>;
+};
+
+const stateSlot = createSessionSlot<CodexState>("codex/app-server-native");
+
+function record(value: unknown): RecordValue | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as RecordValue : undefined;
+}
+
+function eventKey(event: StreamEvent): string | undefined {
+  if (event.type === "operation.started" || event.type === "operation.finished") return `${event.type}:${event.operationId}`;
+  if (event.type === "skill.loaded" && event.operationId) return `${event.type}:${event.operationId}`;
+  return undefined;
+}
+
+function normalizeItem(value: unknown): unknown {
+  const item = record(value);
+  if (!item || typeof item.type !== "string") return value;
+  const type = ({
+    agentMessage: "agent_message",
+    commandExecution: "command_execution",
+    mcpToolCall: "mcp_tool_call",
+    fileChange: "file_change",
+    webSearch: "web_search",
+  } as Record<string, string>)[item.type] ?? item.type;
+  return { ...item, type };
+}
+
+function protocolEvents(frames: readonly unknown[], reported: Set<string>): { events: StreamEvent[]; usage?: Usage } {
+  const normalized = frames.flatMap((value) => {
+    const frame = record(value);
+    if (!frame || typeof frame.method !== "string") return [];
+    const params = record(frame.params) ?? {};
+    const type = frame.method.replaceAll("/", ".");
+    return [{ type, ...params, ...(params.item === undefined ? {} : { item: normalizeItem(params.item) }) }];
+  });
+  const parsed = shared.parseCodex(normalized.map((frame) => JSON.stringify(frame)).join("\n"));
+  const events = parsed.events.filter((event) => {
+    const key = eventKey(event);
+    if (key === undefined) return true;
+    if (reported.has(key)) return false;
+    reported.add(key);
+    return true;
+  });
+  return { events, ...(Object.keys(parsed.usage).length === 0 ? {} : { usage: parsed.usage }) };
+}
+
+function evidence(frames: readonly unknown[], parseSuccess: boolean, events: readonly StreamEvent[]): TurnEvidenceCoverage {
+  if (frames.length === 0) {
+    const reason = "Codex app-server protocol output was unavailable; tool trajectory was not observed.";
+    return { events: { status: "unavailable", reason }, actions: { status: "unavailable", reason }, usage: { status: "unavailable", reason } };
+  }
+  if (!parseSuccess) {
+    const reason = "Some Codex app-server protocol frames could not be parsed.";
+    return { events: { status: "partial", reason }, actions: { status: "partial", reason } };
+  }
+  return unclassifiedToolActionsCoverage(events) ?? {};
+}
+
+async function resolveBin(sandbox: SandboxAgentContext["sandbox"]): Promise<string> {
+  const result = await sandbox.runShell('if [ -x "$HOME/.local/bin/codex" ]; then printf %s "$HOME/.local/bin/codex"; else command -v codex; fi');
+  const value = result.stdout.trim();
+  if (result.exitCode !== 0 || !value) throw new Error(`Codex CLI path resolution failed: ${result.stderr}`);
+  return value;
+}
+
+async function rpc(
+  driver: ManagedJsonlDriver,
+  cursor: number,
+  id: number,
+  method: string,
+  params: unknown,
+  signal: AbortSignal,
+): Promise<{ result: RecordValue; cursor: number }> {
+  await driver.write({ id, method, params });
+  const receipt = await driver.waitFor(cursor, (value) => record(value)?.id === id, signal);
+  const frame = record(receipt.frame)!;
+  if (frame.error !== undefined) throw new Error(`Codex app-server ${method} failed: ${JSON.stringify(frame.error)}`);
+  return { result: record(frame.result) ?? {}, cursor: receipt.cursor };
+}
+
+async function createState(ctx: SandboxAgentContext, env: Readonly<Record<string, string>>): Promise<CodexState> {
+  const resources = attemptResources(ctx);
+  if (!resources) throw new Error("Codex app-server requires an Attempt resource registry");
+  const driver = await ManagedJsonlDriver.start(
+    ctx.sandbox,
+    "codex",
+    resources,
+    {
+      argv: [
+        await resolveBin(ctx.sandbox),
+        "app-server",
+        "--stdio",
+        "--enable", "default_mode_request_user_input",
+        "-c", 'sandbox_mode="danger-full-access"',
+        "-c", 'approval_policy="never"',
+      ],
+      cwd: ctx.sandbox.workdir,
+      env,
+    },
+    () => ({ id: 9_999_999, method: "shutdown", params: {} }),
+    (value) => {
+      const frame = record(value);
+      if (frame?.method !== "item/started") return;
+      const item = record(record(frame.params)?.item);
+      const detail = typeof item?.type === "string" ? item.type : "Codex operation";
+      ctx.progress({ message: detail });
+    },
+  );
+  let cursor = 0;
+  const initialized = await rpc(driver, cursor, 1, "initialize", {
+    clientInfo: { name: "niceeval", title: "NiceEval", version: "1" },
+  }, ctx.signal);
+  cursor = initialized.cursor;
+  await driver.write({ method: "initialized" });
+  const started = await rpc(driver, cursor, 2, "thread/start", {
+    cwd: ctx.sandbox.workdir,
+    ...(ctx.model === undefined ? {} : { model: ctx.model }),
+    approvalPolicy: "never",
+    sandbox: "danger-full-access",
+  }, ctx.signal);
+  cursor = started.cursor;
+  const threadId = record(started.result.thread)?.id;
+  if (typeof threadId !== "string" || !threadId) throw new Error("Codex app-server thread/start returned no native thread id");
+  ctx.session.capture(threadId);
+  return { driver, cursor, threadId, reported: new Set() };
+}
+
+function validateResponses(pending: PendingBatch, responses: readonly InputResponse[] | undefined): Record<string, { answers: string[] }> {
+  if (!responses) throw new Error("Codex app-server is waiting for structured input responses");
+  const byId = new Map(responses.map((response) => [response.requestId, response]));
+  if (byId.size !== responses.length) throw new Error("Codex input responses contain duplicate request ids");
+  const expected = new Set(pending.questions.map((question) => question.requestId));
+  for (const id of byId.keys()) if (!expected.has(id)) throw new Error(`Unknown Codex input request ${id}`);
+  if (byId.size !== expected.size) throw new Error("Codex input responses must answer the complete native question batch");
+  const answers: Record<string, { answers: string[] }> = {};
+  for (const question of pending.questions) {
+    const response = byId.get(question.requestId)!;
+    const answer = "optionId" in response ? response.optionId : response.text;
+    if (answer === undefined) throw new Error(`Codex input request ${question.requestId} has no answer`);
+    if ("optionId" in response && response.optionId !== undefined && !question.options.includes(response.optionId)) {
+      throw new Error(`Option ${response.optionId} is not available for Codex input request ${question.requestId}`);
+    }
+    answers[question.nativeQuestionId] = { answers: [answer] };
+  }
+  return answers;
+}
+
+function waitingTurn(state: CodexState, frame: RecordValue, from: number, cursor: number, ctx: SandboxAgentContext): Turn {
+  const params = record(frame.params) ?? {};
+  const questionsRaw = Array.isArray(params.questions) ? params.questions : [];
+  const itemId = typeof params.itemId === "string" ? params.itemId : "unknown-item";
+  const turnId = typeof params.turnId === "string" ? params.turnId : "unknown-turn";
+  const questions: PendingQuestion[] = questionsRaw.map((value) => {
+    const question = record(value) ?? {};
+    const nativeQuestionId = String(question.id ?? "unknown-question");
+    const options = Array.isArray(question.options)
+      ? question.options.map((option) => String(record(option)?.label ?? "")).filter(Boolean)
+      : [];
+    return {
+      requestId: `${state.threadId}:${turnId}:${itemId}:${nativeQuestionId}`,
+      nativeQuestionId,
+      prompt: String(question.question ?? ""),
+      options,
+    };
+  });
+  if (questions.length === 0) throw new Error("Codex app-server request_user_input contained no questions");
+  const rpcId = frame.id;
+  if (typeof rpcId !== "string" && typeof rpcId !== "number") throw new Error("Codex app-server request_user_input had no JSON-RPC id");
+  state.pending = { rpcId, questions };
+  const parsed = protocolEvents(state.driver.framesSince(from).slice(0, cursor - from), state.reported);
+  for (const event of parsed.events) if (event.type === "operation.started") ctx.progress({ message: event.operation.name });
+  return {
+    status: "waiting",
+    events: [
+      ...parsed.events,
+      ...questions.map((question): StreamEvent => ({
+        type: "input.requested",
+        request: {
+          id: question.requestId,
+          action: "request_user_input",
+          prompt: question.prompt,
+          options: question.options.map((id) => ({ id })),
+        },
+      })),
+    ],
+    ...(parsed.usage === undefined ? {} : { usage: parsed.usage }),
+    evidenceCoverage: evidence(state.driver.framesSince(from).slice(0, cursor - from), true, parsed.events),
+  };
+}
+
+async function drive(state: CodexState, ctx: SandboxAgentContext, from: number): Promise<Turn> {
+  const receipt = await state.driver.waitFor(state.cursor, (value) => {
+    const frame = record(value);
+    return frame?.method === "item/tool/requestUserInput" || frame?.method === "turn/completed" || frame?.method === "error";
+  }, ctx.signal);
+  state.cursor = receipt.cursor;
+  const frame = record(receipt.frame)!;
+  if (frame.method === "item/tool/requestUserInput") return waitingTurn(state, frame, from, receipt.cursor, ctx);
+  const parsed = protocolEvents(state.driver.framesSince(from).slice(0, receipt.cursor - from), state.reported);
+  const turn = record(record(frame.params)?.turn);
+  const status = turn?.status;
+  if (frame.method === "error" || status === "failed") {
+    const raw = state.driver.framesSince(from).map((value) => JSON.stringify(value)).join("\n");
+    throw makeSendFailure({
+      acceptance: sendAcceptanceFromEvents(parsed.events),
+      message: `Codex app-server turn failed: ${JSON.stringify(frame.params)}`,
+      cause: normalizeExternalCause(frame.params),
+      events: parsed.events,
+      ...(parsed.usage === undefined ? {} : { usage: parsed.usage }),
+      process: state.driver.processReceipt(),
+    });
+  }
+  for (const event of parsed.events) if (event.type === "operation.started") ctx.progress({ message: event.operation.name });
+  return {
+    status: "completed", events: parsed.events,
+    ...(parsed.usage === undefined ? {} : { usage: parsed.usage }),
+    evidenceCoverage: evidence(state.driver.framesSince(from).slice(0, receipt.cursor - from), true, parsed.events),
+  };
+}
+
+export async function sendCodexAppServer(
+  input: { readonly text: string; readonly responses?: readonly InputResponse[] },
+  ctx: SandboxAgentContext,
+  env: Readonly<Record<string, string>>,
+  failureFacts?: (raw: string, events: readonly StreamEvent[], nativeText: string) => {
+    readonly acceptance: "rejected" | "started" | "unknown";
+    readonly cause?: ExternalCause;
+  },
+): Promise<Turn> {
+  let state = ctx.session.get(stateSlot);
+  if (!state) {
+    state = await createState(ctx, env);
+    ctx.session.set(stateSlot, state);
+  }
+  const from = state.cursor;
+  if (state.pending) {
+    const pending = state.pending;
+    const answers = validateResponses(pending, input.responses);
+    if (state.driver.framesSince(state.cursor).length !== 0) {
+      throw new Error("Codex app-server produced activity after entering waiting state; refusing an ambiguous answer");
+    }
+    try {
+      await state.driver.write({ id: pending.rpcId, result: { answers } });
+    } catch (cause) {
+      throw makeSendFailure({
+        acceptance: "started",
+        message: `Codex app-server answer transport failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause: normalizeExternalCause(cause),
+        process: state.driver.processReceipt(),
+      });
+    }
+    // JSON-RPC response ids are native idempotency identities. Keep pending through
+    // validation and transport failure; commit only after the write receipt succeeds.
+    state.pending = undefined;
+  } else {
+    if (input.responses?.length) throw new Error("Codex app-server received responses while no input request was pending");
+    const started = await rpc(state.driver, state.cursor, 10_000 + state.cursor, "turn/start", {
+      threadId: state.threadId,
+      input: [{ type: "text", text: input.text }],
+      approvalPolicy: "never",
+      sandboxPolicy: { type: "dangerFullAccess" },
+      ...(ctx.model === undefined ? {} : { model: ctx.model }),
+      ...(ctx.reasoningEffort === undefined ? {} : { effort: ctx.reasoningEffort }),
+    }, ctx.signal);
+    state.cursor = started.cursor;
+  }
+  try {
+    return await drive(state, ctx, from);
+  } catch (cause) {
+    if (typeof cause === "object" && cause !== null && (cause as { type?: unknown }).type === "agent-send-failed") throw cause;
+    const raw = state.driver.framesSince(from).map((value) => JSON.stringify(value)).join("\n");
+    const message = cause instanceof Error ? cause.message : String(cause);
+    const facts = failureFacts?.(raw, protocolEvents(state.driver.framesSince(from), new Set()).events, message);
+    throw makeSendFailure({
+      acceptance: facts?.acceptance ?? (state.pending === undefined ? "unknown" : "started"),
+      message: `Codex app-server transport failed: ${message} (frames=${state.driver.frameKinds() || "none"})`,
+      cause: facts?.cause ?? normalizeExternalCause(cause),
+      process: state.driver.processReceipt(),
+    });
+  }
+}

--- a/src/agents/codex-app-server.ts
+++ b/src/agents/codex-app-server.ts
@@ -48,6 +48,28 @@ function normalizeItem(value: unknown): unknown {
   return { ...item, type };
 }
 
+function appServerUsage(frames: readonly unknown[]): Usage | undefined {
+  for (let index = frames.length - 1; index >= 0; index -= 1) {
+    const frame = record(frames[index]);
+    if (frame?.method !== "thread/tokenUsage/updated") continue;
+    const last = record(record(record(frame.params)?.tokenUsage)?.last);
+    if (!last) continue;
+    const number = (value: unknown): number =>
+      typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+    const rawInput = number(last.inputTokens);
+    const cacheReadTokens = number(last.cachedInputTokens);
+    const reasoningTokens = number(last.reasoningOutputTokens);
+    return {
+      inputTokens: Math.max(0, rawInput - cacheReadTokens),
+      outputTokens: number(last.outputTokens),
+      ...(cacheReadTokens > 0 ? { cacheReadTokens } : {}),
+      ...(reasoningTokens > 0 ? { reasoningTokens } : {}),
+      requests: 1,
+    };
+  }
+  return undefined;
+}
+
 function protocolEvents(frames: readonly unknown[], reported: Set<string>): { events: StreamEvent[]; usage?: Usage } {
   const normalized = frames.flatMap((value) => {
     const frame = record(value);
@@ -57,6 +79,10 @@ function protocolEvents(frames: readonly unknown[], reported: Set<string>): { ev
     return [{ type, ...params, ...(params.item === undefined ? {} : { item: normalizeItem(params.item) }) }];
   });
   const parsed = shared.parseCodex(normalized.map((frame) => JSON.stringify(frame)).join("\n"));
+  // app-server v2 streams per-turn usage separately from `turn/completed`.
+  // `last` is already the current turn's total, so take the latest notification
+  // in this send window instead of summing intermediate cumulative updates.
+  const usage = appServerUsage(frames) ?? (Object.keys(parsed.usage).length === 0 ? undefined : parsed.usage);
   const events = parsed.events.filter((event) => {
     const key = eventKey(event);
     if (key === undefined) return true;
@@ -64,7 +90,7 @@ function protocolEvents(frames: readonly unknown[], reported: Set<string>): { ev
     reported.add(key);
     return true;
   });
-  return { events, ...(Object.keys(parsed.usage).length === 0 ? {} : { usage: parsed.usage }) };
+  return { events, ...(usage === undefined ? {} : { usage }) };
 }
 
 function evidence(frames: readonly unknown[], parseSuccess: boolean, events: readonly StreamEvent[]): TurnEvidenceCoverage {

--- a/src/agents/codex-app-server.ts
+++ b/src/agents/codex-app-server.ts
@@ -140,6 +140,10 @@ async function createState(ctx: SandboxAgentContext, env: Readonly<Record<string
     ...(ctx.model === undefined ? {} : { model: ctx.model }),
     approvalPolicy: "never",
     sandbox: "danger-full-access",
+    // app-server 没有 `codex exec --dangerously-bypass-hook-trust` 的顶层 flag，
+    // 但 thread/start.config 会把这个 runtime-only override 交给同一 ConfigBuilder。
+    // Eval Sandbox 中的 hook 出处由 agent 配置显式声明，因此非交互运行统一 bypass。
+    config: { bypass_hook_trust: true },
   }, ctx.signal);
   cursor = started.cursor;
   const threadId = record(started.result.thread)?.id;

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -17,7 +17,6 @@ import {
   type LoadedNativeConfig,
 } from "./native-config.ts";
 import { mapCodexSpans } from "../o11y/otlp/mappers/codex.ts";
-import { unclassifiedToolActionsCoverage } from "../o11y/command-projection.ts";
 import { t } from "../i18n/index.ts";
 import { DEFAULT_CODEX_CLI_VERSION, AGENT_BASELINE_RECIPE_REVISION } from "./coding-cli-versions.ts";
 import { assertMcpServers, isHttpMcp, mcpManifestEntries } from "./mcp.ts";
@@ -27,22 +26,24 @@ import {
   runPreTeardownHooks,
 } from "./post-setup.ts";
 import { createNpmCliInstaller } from "./npm-staged.ts";
-import type { Agent, AgentSetupManifest, McpServer, Sandbox, SkillSpec, TurnEvidenceCoverage } from "../types.ts";
+import type { Agent, AgentSetupManifest, McpServer, Sandbox, SkillSpec } from "../types.ts";
 import type { SandboxCommand } from "../sandbox/commands.ts";
 import type { AgentArtifactPlatform } from "./types.ts";
 import {
-  makeSendFailure,
   sendAcceptanceFromEvents,
   sendFailureText,
   type SendFailure,
 } from "../context/send-failures.ts";
 import { normalizeExternalCause } from "../shared/external-cause.ts";
 import type { FailureClass } from "../shared/failure-class.ts";
+import { requireManagedProcessCapability } from "../sandbox/backend.ts";
+import { attemptResources } from "../context/attempt-resources.ts";
+import { sendCodexAppServer } from "./codex-app-server.ts";
 
 // ───────────────────────────────────────────────────────────────────────────
 // OpenAI Codex CLI 的 agent adapter(沙箱型)。
 //
-// 连接方式:在沙箱里 spawn `codex exec --json`,stdout JSONL → parseCodex → 标准事件流。
+// 连接方式:在沙箱里维护 Codex app-server stdio,原生通知 → 标准事件流。
 // 配置:鉴权本地(config / env),模型交给实验(ctx.model),推理努力程度经 ctx.reasoningEffort,
 // 其余参数经 ctx.flags。
 // 扩展(skill / plugin / MCP)是构造参数,setup 翻译成 codex 的原生形态并写 manifest。
@@ -316,6 +317,7 @@ export function codexAgent(config?: CodexConfig): Agent {
     installers: [installer],
 
     setup: (sb, ctx) => Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      yield* Effect.try({ try: () => requireManagedProcessCapability(sb, "codex"), catch: (cause) => cause });
       // 用户的原生配置文件:本地读原始字节 → 验 TOML 语法与保留键。字节 SHA-256 进
       // manifest 与安装 checkpoint key(见 native-config.ts 的 nativeConfigCheckpointItem)。
       let nativeConfig: LoadedNativeConfig | undefined;
@@ -479,6 +481,7 @@ export function codexAgent(config?: CodexConfig): Agent {
       // preTeardown 与 postSetup 成对:LIFO 镜像,先于 agent 自己的收尾步骤执行。
       // codex 目前没有其它收尾步骤,这段就是整个 teardown。
       await runPreTeardownHooks(sb, ctx, "codex", config?.preTeardown);
+      await attemptResources(ctx)?.shutdownAll(ctx.signal);
     },
 
     tracing: {
@@ -498,72 +501,18 @@ export function codexAgent(config?: CodexConfig): Agent {
     },
 
     async send(input, ctx) {
-      const sb = ctx.sandbox;
-      // hook trust bypass 是 runtime-only(config.toml 设不了):headless 下 codex 对非 managed
-      // 来源 hook 的交互式授信永远无人应答,不带它插件装的 hook 会被静默跳过、零报错
-      // (见 memory/codex-hook-trust-headless-silent-skip.md)。沙箱内 hook 来源全部由实验配置
-      // 声明,与 approvals/sandbox bypass 同一信任层级。
-      const flags =
-        "--json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --dangerously-bypass-hook-trust";
-      const prompt = shared.shellQuote(input.text);
-      const resuming = ctx.session.id;
-      const cmd = resuming
-        ? `${shared.agentBin("codex")} exec resume ${ctx.session.id} ${flags} ${prompt}`
-        : `${shared.agentBin("codex")} exec ${flags} ${prompt}`;
-
-      // `codex exec --json` 持续写出 ThreadEvent JSONL。把它压成短 step 送进 runner
-      // progress，human dashboard 因而能显示真正的 tool / reasoning / assistant 活动；完整
-      // transcript 仍在命令结束后一次解析并落入 events artifact，不能让 live 文案变成第二份结果。
-      const onStdout = codexProgressReporter(ctx);
       const apiKey = getApiKey();
-      const res = await sb.runShell(cmd, {
-        // ambient env 由 Codex 进程自然传给 SessionStart/SessionStop hooks、env_http_headers
-        // 与 agent 调起的 nmem 等子进程。鉴权字段最后覆盖，避免 env 形成第二条 key 来源。
-        env: { ...agentEnv, OPENAI_API_KEY: apiKey },
-        sensitiveValues: [apiKey, ...agentEnvSensitiveValues],
-        stream: true,
-        onStdout,
+      return sendCodexAppServer(input, ctx, {
+        ...agentEnv,
+        OPENAI_API_KEY: apiKey,
+        ...ctx.telemetry?.env,
+      }, (raw, events, nativeText) => {
+        const code = codexCapacityCode(raw);
+        return {
+          acceptance: codexAcceptance(raw, events, nativeText),
+          ...(code === undefined ? {} : { cause: normalizeExternalCause({ code }) }),
+        };
       });
-
-      const raw = shared.extractJsonlFromStdout(res.stdout);
-      ctx.session.capture(shared.codexThreadId(res.stdout));
-      const parsed = shared.parseCodex(raw);
-      const events = [...parsed.events];
-      let turnEvidenceCoverage: TurnEvidenceCoverage | undefined;
-      if (!raw?.trim()) {
-        const reason = "Codex JSONL transcript was unavailable; tool trajectory was not observed.";
-        turnEvidenceCoverage = {
-          events: { status: "unavailable", reason },
-          actions: { status: "unavailable", reason },
-          usage: { status: "unavailable", reason },
-        };
-      } else if (!parsed.parseSuccess) {
-        const reason = "Some Codex JSONL transcript lines could not be parsed.";
-        turnEvidenceCoverage = {
-          events: { status: "partial", reason },
-          actions: { status: "partial", reason },
-        };
-      } else {
-        turnEvidenceCoverage = unclassifiedToolActionsCoverage(events);
-      }
-      if (res.exitCode !== 0) {
-        throw makeSendFailure({
-          acceptance: codexAcceptance(raw, events, res.stderr),
-          message: shared.diagnoseFailure(res, parsed.events, raw),
-          ...(codexCapacityCode(raw) !== undefined
-            ? { cause: normalizeExternalCause({ code: codexCapacityCode(raw) }) }
-            : {}),
-          events,
-          usage: parsed.usage,
-          process: res,
-        });
-      }
-      return {
-        events,
-        usage: parsed.usage,
-        status: "completed",
-        ...(turnEvidenceCoverage === undefined ? {} : { evidenceCoverage: turnEvidenceCoverage }),
-      };
     },
   }), config?.postSetup, config?.preTeardown);
 }

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -7,6 +7,7 @@ export type { Shared } from "./shared.ts";
 
 export { createNpmCliInstaller, agentBin } from "./npm-staged.ts";
 export type { NpmCliInstallerOptions } from "./npm-staged.ts";
+export { acquireManagedProcess } from "./managed-process.ts";
 
 // 证据覆盖声明:官方 SDK 适配器声明全通道 complete 用 completeEvidenceCoverage;
 // 手写映射按实际情况声明(见 docs/feature/adapters/architecture/evidence.md)。

--- a/src/agents/managed-jsonl.ts
+++ b/src/agents/managed-jsonl.ts
@@ -1,0 +1,214 @@
+import type { AgentContext, ManagedProcess, ManagedProcessStart, Sandbox } from "../types.ts";
+import { requireManagedProcessCapability } from "../sandbox/backend.ts";
+
+const encoder = new TextEncoder();
+
+function timeout<T>(promise: Promise<T>, milliseconds: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`managed process did not exit within ${milliseconds}ms`)), milliseconds);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+export class ManagedJsonlDriver {
+  private readonly frames: unknown[] = [];
+  private readonly waiters = new Set<() => void>();
+  private stderrText = "";
+  private outputFailure: unknown;
+  private state: "open" | "closing" | "closed" = "open";
+  private revision = 0;
+  private shutdownReceipt?: Promise<void>;
+  private releaseReceipt?: Promise<void>;
+  private writes: Promise<void> = Promise.resolve();
+  private readonly exit: ReturnType<ManagedProcess["wait"]>;
+  private observedExit?: Awaited<ReturnType<ManagedProcess["wait"]>>;
+
+  private constructor(
+    private readonly process: ManagedProcess,
+    private readonly shutdownFrame: (() => unknown | undefined) | undefined,
+    private readonly onFrame: ((frame: unknown) => void) | undefined,
+  ) {
+    this.exit = process.wait().then((receipt) => {
+      this.observedExit = receipt;
+      this.state = "closed";
+      return receipt;
+    });
+    void this.consume();
+  }
+
+  static async start(
+    sandbox: Sandbox,
+    agent: string,
+    resources: import("../types.ts").AttemptResourceRegistry,
+    input: ManagedProcessStart,
+    shutdownFrame?: () => unknown | undefined,
+    onFrame?: (frame: unknown) => void,
+  ): Promise<ManagedJsonlDriver> {
+    const startProcess = requireManagedProcessCapability(sandbox, agent);
+    return resources.acquire(
+      async () => {
+        const process = await startProcess(input);
+        try {
+          return new ManagedJsonlDriver(process, shutdownFrame, onFrame);
+        } catch (cause) {
+          // The process exists but the registry has not received a Driver yet.
+          // Close this constructor gap locally with the same bounded cleanup.
+          await process.closeStdin().catch(() => undefined);
+          await process.terminate().catch(() => undefined);
+          await timeout(process.wait(), 2_000).catch(() => undefined);
+          throw cause;
+        }
+      },
+      {
+        shutdown: (driver) => driver.shutdown(),
+        release: (driver) => driver.release(),
+      },
+    );
+  }
+
+  cursor(): number { return this.frames.length; }
+  stderr(): string { return this.stderrText; }
+  processReceipt(): { readonly exitCode?: number; readonly signal?: string; readonly stderr: string } {
+    return {
+      ...(this.observedExit?.exitCode == null ? {} : { exitCode: this.observedExit.exitCode }),
+      ...(this.observedExit?.signal === undefined ? {} : { signal: this.observedExit.signal }),
+      stderr: this.stderrText,
+    };
+  }
+
+  async write(value: unknown): Promise<void> {
+    if (this.state !== "open") throw new Error("managed process stdin is closing or closed");
+    const receipt = this.writes.then(() => this.writeRaw(value));
+    this.writes = receipt.catch(() => undefined);
+    await receipt;
+  }
+
+  async waitFor(
+    cursor: number,
+    accept: (frame: unknown) => boolean,
+    signal: AbortSignal,
+  ): Promise<{ readonly frame: unknown; readonly cursor: number }> {
+    let next = cursor;
+    for (;;) {
+      while (next < this.frames.length) {
+        const frame = this.frames[next++]!;
+        if (accept(frame)) return { frame, cursor: next };
+      }
+      if (this.outputFailure !== undefined) throw this.outputFailure;
+      const observedRevision = this.revision;
+      const outcome = await Promise.race([
+        this.waitForChange(observedRevision, signal).then(() => ({ exited: false as const })),
+        this.exit.then((receipt) => ({ exited: true as const, receipt })),
+      ]);
+      if (outcome.exited && next >= this.frames.length) {
+        throw new Error(`managed process exited before the expected protocol frame (exitCode=${outcome.receipt.exitCode ?? "null"}, signal=${outcome.receipt.signal ?? "none"})${this.stderrText ? `: ${this.stderrText.slice(-1000)}` : ""}`);
+      }
+    }
+  }
+
+  framesSince(cursor: number): readonly unknown[] { return this.frames.slice(cursor); }
+  frameKinds(): string {
+    return this.frames.slice(-12).map((value) => {
+      if (value === null || typeof value !== "object" || Array.isArray(value)) return typeof value;
+      const frame = value as Record<string, unknown>;
+      return String(frame.type ?? frame.method ?? (frame.id === undefined ? "object" : `response:${String(frame.id)}`));
+    }).join(",");
+  }
+
+  shutdown(): Promise<void> {
+    return this.shutdownReceipt ??= (async () => {
+      if (this.state !== "open") return;
+      this.state = "closing";
+      await this.writes;
+      const frame = this.shutdownFrame?.();
+      if (frame !== undefined) await this.writeRaw(frame).catch(() => undefined);
+      await this.process.closeStdin().catch(() => undefined);
+      this.state = "closed";
+    })();
+  }
+
+  release(): Promise<void> {
+    return this.releaseReceipt ??= (async () => {
+      await this.shutdown();
+      try { await timeout(this.exit, 2_000); }
+      catch {
+        await this.process.terminate();
+        await timeout(this.exit, 2_000);
+      }
+    })();
+  }
+
+  private async consume(): Promise<void> {
+    const stdoutDecoder = new TextDecoder();
+    const stderrDecoder = new TextDecoder();
+    let stdout = "";
+    try {
+      for await (const chunk of this.process.output) {
+        if (chunk._tag === "Stderr") {
+          this.stderrText += stderrDecoder.decode(chunk.bytes, { stream: true });
+          continue;
+        }
+        stdout += stdoutDecoder.decode(chunk.bytes, { stream: true });
+        for (;;) {
+          const newline = stdout.indexOf("\n");
+          if (newline < 0) break;
+          const line = stdout.slice(0, newline).trim();
+          stdout = stdout.slice(newline + 1);
+          if (!line) continue;
+          const frame: unknown = JSON.parse(line);
+          this.frames.push(frame);
+          this.onFrame?.(frame);
+          this.notify();
+        }
+      }
+      const tail = `${stdout}${stdoutDecoder.decode()}`.trim();
+      if (tail) {
+        const frame: unknown = JSON.parse(tail);
+        this.frames.push(frame);
+        this.onFrame?.(frame);
+        this.notify();
+      }
+      this.stderrText += stderrDecoder.decode();
+    } catch (error) {
+      this.outputFailure = error;
+    } finally {
+      this.notify();
+    }
+  }
+
+  private writeRaw(value: unknown): Promise<void> {
+    return this.process.writeStdin(encoder.encode(`${JSON.stringify(value)}\n`));
+  }
+
+  private waitForChange(observedRevision: number, signal: AbortSignal): Promise<void> {
+    if (signal.aborted) return Promise.reject(signal.reason);
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const cleanup = (): void => { signal.removeEventListener("abort", aborted); this.waiters.delete(done); };
+      const done = (): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve();
+      };
+      const aborted = (): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(signal.reason);
+      };
+      this.waiters.add(done);
+      signal.addEventListener("abort", aborted, { once: true });
+      if (signal.aborted) aborted();
+      else if (this.revision !== observedRevision) done();
+    });
+  }
+
+  private notify(): void {
+    this.revision += 1;
+    for (const waiter of [...this.waiters]) waiter();
+  }
+}

--- a/src/agents/managed-process.ts
+++ b/src/agents/managed-process.ts
@@ -1,0 +1,34 @@
+import type { ManagedProcess, ManagedProcessStart, SandboxAgentContext } from "../types.ts";
+import { requireManagedProcessCapability } from "../sandbox/backend.ts";
+import { attemptResources } from "../context/attempt-resources.ts";
+
+function bounded<T>(promise: Promise<T>, milliseconds: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`managed process cleanup exceeded ${milliseconds}ms`)), milliseconds);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+/** Adapter-facing neutral capability. It is deliberately absent from Eval's t.sandbox facade. */
+export async function acquireManagedProcess(
+  ctx: SandboxAgentContext,
+  agent: string,
+  input: ManagedProcessStart,
+): Promise<ManagedProcess> {
+  const resources = attemptResources(ctx);
+  if (!resources) throw new Error(`${agent} managed process requires an Attempt resource registry`);
+  const start = requireManagedProcessCapability(ctx.sandbox, agent);
+  return resources.acquire(() => start(input), {
+    shutdown: async (process) => { await process.closeStdin(); },
+    release: async (process) => {
+      try { await bounded(process.wait(), 2_000); }
+      catch {
+        await process.terminate();
+        await bounded(process.wait(), 2_000);
+      }
+    },
+  });
+}

--- a/src/agents/omp.ts
+++ b/src/agents/omp.ts
@@ -5,6 +5,8 @@ import type { Agent, EvidenceCoverage, StreamEvent } from "../types.ts";
 import { makeSendFailure, sendAcceptanceFromEvents } from "../context/send-failures.ts";
 import { shared } from "./shared.ts";
 import { createPiAgentEventStream, type PiAgentEventLike } from "./sdk-streams.ts";
+import { normalizeToolName } from "../o11y/tool-names.ts";
+import { notCommandProjection, opaqueCommandProjection } from "../o11y/command-projection.ts";
 import { createNpmCliInstaller, resolveAgentBinEffect } from "./npm-staged.ts";
 import {
   AGENT_BASELINE_RECIPE_REVISION,
@@ -75,6 +77,21 @@ function parseJsonl(raw: string): PiAgentEventLike[] {
     }
     return value as PiAgentEventLike;
   });
+}
+
+function enrichOmpEvent(event: StreamEvent): StreamEvent {
+  if (event.type !== "operation.started" || event.operation.kind !== "tool") return event;
+  const tool = normalizeToolName(event.operation.name);
+  return {
+    ...event,
+    operation: {
+      ...event.operation,
+      tool,
+      command: tool === "shell"
+        ? opaqueCommandProjection("unsupported-protocol")
+        : notCommandProjection(),
+    },
+  };
 }
 
 /** Oh My Pi sandbox adapter backed by `omp --print --mode json`. */
@@ -163,7 +180,7 @@ export function ompAgent(config?: OmpConfig): Agent {
             });
           }
           const stream = createPiAgentEventStream();
-          const events: StreamEvent[] = nativeEvents.flatMap((event) => stream.add(event));
+          const events: StreamEvent[] = nativeEvents.flatMap((event) => stream.add(event)).map(enrichOmpEvent);
           const terminal = nativeEvents.filter((event) =>
             event.type === "agent_end" &&
             (event as { isTerminal?: unknown }).isTerminal !== false &&

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -277,6 +277,18 @@ export interface AgentSession {
   take<T>(slot: SessionSlot<T>): T | undefined;
 }
 
+/** Runner-owned Attempt resource registry; adapters use it for cross-send drivers. */
+export interface AttemptResourceRegistry {
+  acquire<T>(
+    acquire: () => Promise<T>,
+    lifecycle: {
+      shutdown: (resource: T, signal: AbortSignal) => Promise<void>;
+      release: (resource: T, signal: AbortSignal) => Promise<void>;
+    },
+  ): Promise<T>;
+  shutdownAll(signal: AbortSignal): Promise<void>;
+}
+
 export interface AgentContext {
   /**
    * 软取消信号:合并了 attempt 超时、run 级中断(用户 Ctrl+C)与评估用例自身的中断请求

--- a/src/context/assert-first.ts
+++ b/src/context/assert-first.ts
@@ -128,6 +128,7 @@ export interface AssertFirstContextDeps {
   readonly experimentClassifier?: import("./session.ts").SessionDeps["experimentClassifier"];
   /** Attempt-owned source snapshot registry; never inferred from an Effect fiber. */
   readonly sourceRegistry?: SourceRegistry;
+  readonly resources: import("../types.ts").AttemptResourceRegistry;
   /** Shared ordering with Assertion runtime source facts and Session user events. */
   readonly nextSourceOrder?: () => number;
   readonly judge: ResolvedJudgeConfig | undefined;
@@ -1533,6 +1534,7 @@ export function createAssertFirstEvalContext(
     experimentClassifier: deps.experimentClassifier,
     nextSourceOrder: deps.nextSourceOrder,
     sourceRegistry: deps.sourceRegistry,
+    resources: deps.resources,
   });
   const runtime: AssertionsRuntime<RuntimeKind> = deps.evaluationKind === "score"
     ? createAssertionsRuntime({ evaluationKind: "score", executeStop: deps.executeStop })

--- a/src/context/attempt-resources.ts
+++ b/src/context/attempt-resources.ts
@@ -1,0 +1,12 @@
+import type { AgentContext, AttemptResourceRegistry } from "../types.ts";
+
+const ATTEMPT_RESOURCES = new WeakMap<AgentContext, AttemptResourceRegistry>();
+
+export function bindAttemptResources<T extends AgentContext>(ctx: T, resources: AttemptResourceRegistry): T {
+  ATTEMPT_RESOURCES.set(ctx, resources);
+  return ctx;
+}
+
+export function attemptResources(ctx: AgentContext): AttemptResourceRegistry | undefined {
+  return ATTEMPT_RESOURCES.get(ctx);
+}

--- a/src/context/session.ts
+++ b/src/context/session.ts
@@ -23,6 +23,7 @@ import type { AttemptFailureClassifier } from "../shared/failure-class.ts";
 import { isSendFailure, normalizeSendFailure, sendFailureText } from "./send-failures.ts";
 import type { RetryAttemptRecord, TimingActivity } from "../runner/types.ts";
 import { formatTurnLabel } from "../shared/turn-label.ts";
+import { bindAttemptResources } from "./attempt-resources.ts";
 
 interface PhysicalSendResult {
   readonly turn: Turn;
@@ -192,6 +193,7 @@ export interface SessionDeps {
   nextSourceOrder?: () => number;
   /** Attempt-owned source snapshot registry; Runner injects it explicitly. */
   sourceRegistry?: SourceRegistry;
+  resources: import("../types.ts").AttemptResourceRegistry;
 }
 
 /** A successful agent send whose post-send ledger checkpoint could not be recorded. */
@@ -314,7 +316,7 @@ export class SessionManager {
     responses?: readonly InputResponse[],
   ): Effect.Effect<Turn, unknown> {
     return Effect.suspend(() => {
-      const ctx: AgentContext = {
+      const ctx: AgentContext = bindAttemptResources({
         signal: this.deps.signal,
         evalId: this.deps.evalId,
         attempt: this.deps.attempt,
@@ -332,7 +334,7 @@ export class SessionManager {
         diagnostic: (d) => this.deps.feedback?.diagnostic(d),
         // log 是 progress({ message }) 的别名(见 AgentContext.log)。
         log: this.deps.log,
-      };
+      }, this.deps.resources);
 
       const n = ++this.turnCount;
       const attach = files?.length ? ` 📎${files.length}` : "";
@@ -631,7 +633,10 @@ export class SessionManager {
   private sendAgent(input: TurnInput, ctx: AgentContext): Promise<Turn> {
     const agent = this.deps.agent;
     if (agent.kind === "sandbox") {
-      const sandboxCtx: SandboxAgentContext = { ...ctx, sandbox: this.deps.sandbox };
+      const sandboxCtx: SandboxAgentContext = bindAttemptResources(
+        { ...ctx, sandbox: this.deps.sandbox },
+        this.deps.resources,
+      );
       return agent.send(input, sandboxCtx);
     }
     return agent.send(input, ctx);

--- a/src/report/assets/styles.css
+++ b/src/report/assets/styles.css
@@ -1462,6 +1462,10 @@ table.niceeval-report,
   white-space: nowrap;
 }
 .niceeval-turn-trace .niceeval-trace-event-row--failed .niceeval-trace-event-status { color: var(--bad); }
+.niceeval-turn-trace .niceeval-trace-event-status[data-call-outcome="completed"] { color: var(--good); }
+.niceeval-turn-trace .niceeval-trace-event-status[data-call-outcome="failed"] { color: var(--bad); }
+.niceeval-turn-trace .niceeval-trace-event-status[data-call-outcome="rejected"],
+.niceeval-turn-trace .niceeval-trace-event-status[data-call-outcome="cancelled"] { color: var(--warn); }
 .niceeval-turn-trace .niceeval-trace-evidence {
   position: relative;
   z-index: 2;

--- a/src/report/components/attempt-detail/compute.ts
+++ b/src/report/components/attempt-detail/compute.ts
@@ -783,7 +783,7 @@ function conversationReplyOf(
         inputSummary: call?.inputSummary ?? "",
         outputSummary: item.outputSummary,
         outcome: item.outcome,
-        failed: item.outcome === "failed" || item.outcome === "rejected",
+        failed: item.outcome === "failed",
       };
     }
     case "thinking-summary":

--- a/src/report/components/attempt-detail/content.tsx
+++ b/src/report/components/attempt-detail/content.tsx
@@ -290,6 +290,7 @@ function conversationEntryOf(reply: AttemptConversationReply): ConversationEntry
         raw,
         callId: reply.callId,
         callPhase: finished ? "finished" : "started",
+        ...(reply.outcome === undefined ? {} : { callOutcome: reply.outcome }),
         ...(reply.failed === true ? { failed: true } : {}),
         detail: (
           <ToolEvidence content={{

--- a/src/report/definition/primitives/conversation.tsx
+++ b/src/report/definition/primitives/conversation.tsx
@@ -27,6 +27,8 @@ export interface ConversationEntry {
   callPhase?: "started" | "finished";
   /** Stable provider call identity when this row belongs to a tool lifecycle. */
   callId?: string;
+  /** Provider-neutral terminal outcome; omitted while the call is still open. */
+  callOutcome?: "completed" | "failed" | "rejected" | "cancelled";
 }
 
 export interface ConversationTurn {
@@ -115,6 +117,15 @@ function validateEntry(value: unknown, path: string): string | null {
   if (value.callId !== undefined && typeof value.callId !== "string") return `"${path}.callId" must be a string`;
   if (value.callPhase !== undefined && value.callPhase !== "started" && value.callPhase !== "finished") {
     return `"${path}.callPhase" must be started | finished`;
+  }
+  if (
+    value.callOutcome !== undefined &&
+    value.callOutcome !== "completed" &&
+    value.callOutcome !== "failed" &&
+    value.callOutcome !== "rejected" &&
+    value.callOutcome !== "cancelled"
+  ) {
+    return `"${path}.callOutcome" must be completed | failed | rejected | cancelled`;
   }
   return null;
 }

--- a/src/report/definition/primitives/turn-trace.tsx
+++ b/src/report/definition/primitives/turn-trace.tsx
@@ -1,6 +1,7 @@
 // TurnTrace: compact, server-rendered trajectory ledger.  The browser only
-// filters, folds, selects, and switches pre-rendered inline evidence tabs; every
-// event and its captured evidence is present in the static report body.
+// filters, folds, selects, and switches pre-rendered inline evidence tabs. Tool
+// start/result events remain separate in Conversation but render as one lifecycle
+// row here, with both phases' evidence present in the static report body.
 
 import type { CSSProperties, ReactElement } from "react";
 import { defineComponent } from "../tree.ts";
@@ -96,14 +97,61 @@ function callCount(events: readonly TraceEvent[]): number {
 }
 
 function statusFor(entry: ConversationEntry, locale: ReportLocale): string {
+  if (entry.callOutcome === "completed") return text(locale, "Completed", "已完成");
+  if (entry.callOutcome === "failed") return text(locale, "Failed", "失败");
+  if (entry.callOutcome === "rejected") return text(locale, "Rejected", "已拒绝");
+  if (entry.callOutcome === "cancelled") return text(locale, "Cancelled", "已取消");
   if (entry.failed === true) return text(locale, "Failed", "失败");
   if (entry.callPhase === "started") return text(locale, "Started", "已开始");
   if (entry.callPhase === "finished") return text(locale, "Completed", "已完成");
   return text(locale, "Captured", "已捕获");
 }
 
+function lifecycleEntriesOf(
+  turn: ConversationTurn,
+): readonly { readonly entry: ConversationEntry; readonly entryIndex: number }[] {
+  const phasesByCallId = new Map<string, { started: number[]; finished: number[] }>();
+  for (const [entryIndex, entry] of turn.entries.entries()) {
+    if (entry.callId === undefined || entry.callPhase === undefined) continue;
+    const phases = phasesByCallId.get(entry.callId) ?? { started: [], finished: [] };
+    phases[entry.callPhase].push(entryIndex);
+    phasesByCallId.set(entry.callId, phases);
+  }
+
+  const lifecycleByStartedIndex = new Map<number, ConversationEntry>();
+  const pairedFinishedIndexes = new Set<number>();
+  for (const phases of phasesByCallId.values()) {
+    // Public author data is validated structurally, not as a durable ledger. Only
+    // coalesce an unambiguous 1:1 lifecycle; duplicate phases remain visible.
+    if (phases.started.length !== 1 || phases.finished.length !== 1) continue;
+    const startedIndex = phases.started[0]!;
+    const finishedIndex = phases.finished[0]!;
+    if (finishedIndex <= startedIndex) continue;
+    const started = turn.entries[startedIndex]!;
+    const finished = turn.entries[finishedIndex]!;
+    const raw = [started.raw, finished.raw].filter((value): value is string => value !== undefined).join("\n");
+    const details = [started.detail, finished.detail].filter((value) => value !== undefined);
+    lifecycleByStartedIndex.set(startedIndex, {
+      kind: started.kind,
+      preview: started.preview,
+      callId: started.callId,
+      callPhase: "finished",
+      ...(finished.callOutcome === undefined ? {} : { callOutcome: finished.callOutcome }),
+      ...(started.failed === true || finished.failed === true ? { failed: true } : {}),
+      ...(raw === "" ? {} : { raw }),
+      ...(details.length === 0 ? {} : { detail: details.length === 1 ? details[0] : details }),
+    });
+    pairedFinishedIndexes.add(finishedIndex);
+  }
+
+  return turn.entries.flatMap((entry, entryIndex) => {
+    if (pairedFinishedIndexes.has(entryIndex)) return [];
+    return [{ entry: lifecycleByStartedIndex.get(entryIndex) ?? entry, entryIndex }];
+  });
+}
+
 function traceEventsOf(content: ConversationContent, locale: ReportLocale): readonly TraceEvent[] {
-  return content.turns.flatMap((turn, turnIndex) => turn.entries.map((entry, entryIndex) => {
+  return content.turns.flatMap((turn, turnIndex) => lifecycleEntriesOf(turn).map(({ entry, entryIndex }) => {
     const raw = entry.raw ?? resolveLocalizedText(entry.preview, locale);
     return {
       // Keep IDs safe for HTML data attributes without relying on selector
@@ -389,6 +437,7 @@ function TraceEventRow({ event, locale }: { event: TraceEvent; locale: ReportLoc
       )}
       data-niceeval-trace-event={event.id}
       data-tool-row={event.toolLike ? "true" : undefined}
+      data-call-outcome={event.entry.callOutcome}
     >
       <span className="niceeval-trace-event-turn-rail" aria-hidden="true" />
       <button
@@ -407,7 +456,7 @@ function TraceEventRow({ event, locale }: { event: TraceEvent; locale: ReportLoc
         >
           {duration === undefined ? "—" : durationLabel(duration)}
         </span>
-        <span className="niceeval-trace-event-status">{status}</span>
+        <span className="niceeval-trace-event-status" data-call-outcome={event.entry.callOutcome}>{status}</span>
       </button>
       <TraceEvidence event={event} locale={locale} />
     </article>

--- a/src/runner/attempt-resources.ts
+++ b/src/runner/attempt-resources.ts
@@ -1,0 +1,58 @@
+import type { AttemptResourceRegistry } from "../types.ts";
+
+type Entry = {
+  shutdown(signal: AbortSignal): Promise<void>;
+  release(signal: AbortSignal): Promise<void>;
+  shutdownReceipt?: Promise<void>;
+};
+
+export class ManagedAttemptResources implements AttemptResourceRegistry {
+  private readonly entries: Entry[] = [];
+  private closing = false;
+  private releaseReceipt?: Promise<void>;
+
+  async acquire<T>(
+    acquire: () => Promise<T>,
+    lifecycle: {
+      shutdown: (resource: T, signal: AbortSignal) => Promise<void>;
+      release: (resource: T, signal: AbortSignal) => Promise<void>;
+    },
+  ): Promise<T> {
+    if (this.closing) throw new Error("Attempt resource registry is closing");
+    const resource = await acquire();
+    try {
+      if (this.closing) throw new Error("Attempt resource registry is closing");
+      this.entries.push({
+        shutdown: (signal) => lifecycle.shutdown(resource, signal),
+        release: (signal) => lifecycle.release(resource, signal),
+      });
+      return resource;
+    } catch (error) {
+      const controller = new AbortController();
+      await lifecycle.release(resource, controller.signal).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async shutdownAll(signal: AbortSignal): Promise<void> {
+    const failures: unknown[] = [];
+    for (const entry of this.entries.slice().reverse()) {
+      entry.shutdownReceipt ??= entry.shutdown(signal);
+      try { await entry.shutdownReceipt; } catch (error) { failures.push(error); }
+    }
+    if (failures.length > 0) throw new AggregateError(failures, "Attempt managed resource shutdown failed");
+  }
+
+  async releaseAll(signal: AbortSignal): Promise<void> {
+    return this.releaseReceipt ??= this.releaseEntries(signal);
+  }
+
+  private async releaseEntries(signal: AbortSignal): Promise<void> {
+    this.closing = true;
+    const failures: unknown[] = [];
+    for (const entry of this.entries.splice(0).reverse()) {
+      try { await entry.release(signal); } catch (error) { failures.push(error); }
+    }
+    if (failures.length > 0) throw new AggregateError(failures, "Attempt managed resource cleanup failed");
+  }
+}

--- a/src/runner/attempt.ts
+++ b/src/runner/attempt.ts
@@ -270,6 +270,14 @@ export function runAttemptEffect<
   // an internal capability until the Record producer seals its own Attachments.
   const sourceRegistry = createSourceRegistry(process.cwd());
   const sourceCapture = createRunnerAttemptSourceCapture(sourceRegistry);
+  const attemptResources = new ManagedAttemptResources();
+  let attemptResourceReleaseFailureReported = false;
+  const reportAttemptResourceReleaseFailure = (error: unknown): void => {
+    if (attemptResourceReleaseFailureReported) return;
+    attemptResourceReleaseFailureReported = true;
+    declareFailure("agent.teardown", error);
+    diagnostics.push(teardownDiagnostic("agent.teardown", error));
+  };
 
   const base: EvalResult = {
     id: evalDef.id,
@@ -1007,6 +1015,18 @@ export function runAttemptEffect<
         );
       }
 
+      // Cross-send adapter processes belong to the Attempt Scope, not to the
+      // Promise-shaped body. On timeout the bridge is intentionally sealed
+      // before that Promise's finally continuation can submit more work, so a
+      // scope finalizer must remain the unconditional release owner.
+      yield* Effect.addFinalizer(() =>
+        cleanupCallback((cleanupSignal) => attemptResources.releaseAll(cleanupSignal)).pipe(
+          Effect.catchAll((error) => Effect.sync(() => {
+            reportAttemptResourceReleaseFailure(error);
+          })),
+        ),
+      );
+
       // The legacy setup/diff body remains Promise-shaped, while OTLP waits,
       // author execution, and sealing run in this Attempt's Effect scope. No
       // nested runtime is introduced.
@@ -1039,6 +1059,8 @@ export function runAttemptEffect<
             declareFailure,
             isDeadlineTimedOut: () => timedOut,
             layerCleanups,
+            attemptResources,
+            reportAttemptResourceReleaseFailure,
             registerEvidence: (getEvents, getUsage, getRetryAttempts) => {
               liveEvents = getEvents;
               liveUsage = getUsage;
@@ -1565,6 +1587,10 @@ interface AttemptResources {
   ) => void;
   /** Run 级 Agent artifact prepare 协调器；仅 Runner 的 agent.ensure 使用。 */
   prepareCoordinator?: import("../agents/provisioner.ts").ArtifactPrepareCoordinator;
+  /** Attempt Scope-owned registry for adapter processes spanning sends. */
+  attemptResources: ManagedAttemptResources;
+  /** Records the registry's single terminal release failure at most once. */
+  reportAttemptResourceReleaseFailure: (error: unknown) => void;
 }
 
 interface LayerCleanupEntry {
@@ -1628,7 +1654,7 @@ async function runAttemptBody(
         signal,
       )
     : rawSandbox;
-  const attemptResources = new ManagedAttemptResources();
+  const { attemptResources, reportAttemptResourceReleaseFailure } = res;
   // Direct Agent 只拿基础 ctx；Sandbox Agent 才拿带真实 Sandbox 的扩展 ctx。
   const attemptCtx: AgentContext = bindAttemptResources({
     signal,
@@ -2292,8 +2318,13 @@ async function runAttemptBody(
     try {
       await assertFirst.requestEffect(cleanupCallback((cleanupSignal) => attemptResources.releaseAll(cleanupSignal)));
     } catch (error) {
-      declareFailure("agent.teardown", error);
-      diagnostics.push(teardownDiagnostic("agent.teardown", error));
+      // An interrupted body can resume its Promise finally only after the
+      // Effect bridge has closed. The Scope finalizer above still performs the
+      // release; this named closure is therefore lifecycle control, not a
+      // second teardown failure.
+      if (!(error instanceof AssertionAuthoringClosedError && error.reason === "attempt-interrupted")) {
+        reportAttemptResourceReleaseFailure(error);
+      }
     }
     for (const lifecycle of evalPluginLifecycles.slice(0, activatedEvalPlugins).reverse()) {
       if (lifecycle.teardown === undefined) continue;

--- a/src/runner/attempt.ts
+++ b/src/runner/attempt.ts
@@ -15,6 +15,8 @@ import { unregisterSandbox } from "../sandbox/registry.ts";
 import { makeSandboxAuthorFacade } from "../sandbox/paths.ts";
 import { makeSandboxRequestExecutor } from "../sandbox/request-executor.ts";
 import { CLEANUP_TIMEOUT_MS, cleanupCallback } from "./cleanup-timeout.ts";
+import { ManagedAttemptResources } from "./attempt-resources.ts";
+import { bindAttemptResources } from "../context/attempt-resources.ts";
 import { resolveAttemptTimeout, type TimeoutSource } from "./timeout.ts";
 import { SandboxCommandTimeoutError } from "../sandbox/deadline.ts";
 import { ExperimentFatalError } from "../shared/failure-class.ts";
@@ -1626,8 +1628,9 @@ async function runAttemptBody(
         signal,
       )
     : rawSandbox;
+  const attemptResources = new ManagedAttemptResources();
   // Direct Agent 只拿基础 ctx；Sandbox Agent 才拿带真实 Sandbox 的扩展 ctx。
-  const attemptCtx: AgentContext = {
+  const attemptCtx: AgentContext = bindAttemptResources({
     signal,
     evalId: evalDef.id,
     attempt: { id: evalDef.id, index: attempt },
@@ -1645,8 +1648,8 @@ async function runAttemptBody(
     diagnostic: feedback.diagnostic,
     // log 是 progress({ message }) 的别名,不是第二条通道(见 AgentContext.log 注释)。
     log,
-  };
-  const sandboxAttemptCtx: SandboxAgentContext = { ...attemptCtx, sandbox };
+  }, attemptResources);
+  const sandboxAttemptCtx: SandboxAgentContext = bindAttemptResources({ ...attemptCtx, sandbox }, attemptResources);
   const commandTarget = createSandboxCommandTarget(sandbox);
   /** agent.setup 时点已走到(未声明 setup 也置位)——agent.teardown 的触发条件(成对触发规则)。 */
   let agentSetupReached = false;
@@ -1850,6 +1853,7 @@ async function runAttemptBody(
       // 走的生命周期链是同一个函数,两条链的决议序各自单源在 send-failures.ts / failure-class.ts。
       experimentClassifier: run.classifyFailure,
       sourceRegistry,
+      resources: attemptResources,
       nextSourceOrder: sourceCapture.nextSourceOrder,
       // Pass / Score share the same Assert-first entry runtime. Their
       // independent folds are both derived only after this Attempt seals.
@@ -2284,6 +2288,12 @@ async function runAttemptBody(
           }
         })
         .catch(() => {});
+    }
+    try {
+      await assertFirst.requestEffect(cleanupCallback((cleanupSignal) => attemptResources.releaseAll(cleanupSignal)));
+    } catch (error) {
+      declareFailure("agent.teardown", error);
+      diagnostics.push(teardownDiagnostic("agent.teardown", error));
     }
     for (const lifecycle of evalPluginLifecycles.slice(0, activatedEvalPlugins).reverse()) {
       if (lifecycle.teardown === undefined) continue;

--- a/src/sandbox/backend.ts
+++ b/src/sandbox/backend.ts
@@ -5,13 +5,15 @@ import type {
   CommandOptions,
   CommandResult,
   Sandbox,
+  ManagedProcess,
+  ManagedProcessStart,
   SandboxReuseCapability,
   SandboxTransferOperations,
 } from "./types.ts";
 
 export type SandboxBackendSupport<T> =
   | { readonly _tag: "Supported"; readonly value: T }
-  | { readonly _tag: "Unsupported" };
+  | { readonly _tag: "Unsupported"; readonly reason: string };
 
 export interface SandboxBackendCapabilities {
   /** Provider 能否兑现 CommandOptions.user 的 root 覆盖；runner 私有基础设施按这项能力选择身份。 */
@@ -22,6 +24,7 @@ export interface SandboxBackendCapabilities {
     (minRemainingMs: number) => Promise<{ ready: true; expiresAt?: string } | { ready: false; reason: string }>
   >;
   readonly setCommandDeadline: SandboxBackendSupport<(deadlineAt?: number) => void>;
+  readonly managedProcess: SandboxBackendSupport<(input: ManagedProcessStart) => Promise<ManagedProcess>>;
 }
 
 export interface SandboxProviderBackend extends SandboxTransferOperations {
@@ -41,7 +44,12 @@ export interface SandboxProviderBackend extends SandboxTransferOperations {
 
 export const unsupportedBackendCapability: SandboxBackendSupport<never> = Object.freeze({
   _tag: "Unsupported",
+  reason: "the provider does not implement this capability",
 });
+
+export function unsupportedBackendCapabilityBecause(reason: string): SandboxBackendSupport<never> {
+  return Object.freeze({ _tag: "Unsupported", reason });
+}
 
 export const noSandboxBackendCapabilities: SandboxBackendCapabilities = Object.freeze({
   rootCommands: unsupportedBackendCapability,
@@ -49,6 +57,7 @@ export const noSandboxBackendCapabilities: SandboxBackendCapabilities = Object.f
   suspend: unsupportedBackendCapability,
   ensureLifetime: unsupportedBackendCapability,
   setCommandDeadline: unsupportedBackendCapability,
+  managedProcess: unsupportedBackendCapability,
 });
 
 export function supportedBackendCapability<T>(value: T): SandboxBackendSupport<T> {
@@ -90,7 +99,10 @@ export function customSandboxBackend(sandbox: Sandbox): SandboxProviderBackend {
   const appendLog = sandbox.appendLog;
   // Provider facade 产出的 Sandbox 再经 runtime 归一化时必须保留 provider-only capabilities；
   // 作者直接返回的普通 Sandbox 没有登记项，仍严格退回 Unsupported，不能靠鸭子类型猜能力。
-  const registered = SANDBOX_CAPABILITIES.get(sandbox) ?? noSandboxBackendCapabilities;
+  const registered = SANDBOX_CAPABILITIES.get(sandbox) ?? {
+    ...noSandboxBackendCapabilities,
+    managedProcess: unsupportedBackendCapabilityBecause("custom Sandbox facades do not declare the internal managed-process capability"),
+  };
   return {
     get workdir() {
       return sandbox.workdir;
@@ -145,6 +157,24 @@ export function sandboxCapabilities(sandbox: Sandbox): SandboxBackendCapabilitie
 /** 未经 provider facade 登记的普通自定义 Sandbox 保守视为不支持提权，不做鸭子类型猜测。 */
 export function sandboxSupportsRootCommands(sandbox: Sandbox): boolean {
   return SANDBOX_CAPABILITIES.get(sandbox)?.rootCommands._tag === "Supported";
+}
+
+export class SandboxManagedProcessCapabilityError extends Error {
+  readonly name = "SandboxManagedProcessCapabilityError";
+  constructor(readonly agent: string, readonly sandboxId: string, readonly reason: string) {
+    super(`Agent ${agent} requires the sandbox managed-process capability, but sandbox ${sandboxId} does not support it: ${reason}`);
+  }
+}
+
+export function requireManagedProcessCapability(
+  sandbox: Sandbox,
+  agent: string,
+): (input: ManagedProcessStart) => Promise<ManagedProcess> {
+  const capability = sandboxCapabilities(sandbox).managedProcess;
+  if (capability._tag === "Unsupported") {
+    throw new SandboxManagedProcessCapabilityError(agent, sandbox.sandboxId, capability.reason);
+  }
+  return capability.value;
 }
 
 /** Provider facade 登记的复用寿命能力；不存在时保持显式 Unsupported，不做鸭子类型探测。 */

--- a/src/sandbox/docker.ts
+++ b/src/sandbox/docker.ts
@@ -3,6 +3,7 @@
 //(runShell/runCommand 的 opts 一律是选项对象,不再用位置参数)。
 
 import { basename, dirname, join } from "node:path";
+import { PassThrough } from "node:stream";
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import Docker from "dockerode";
@@ -10,6 +11,8 @@ import { Clock, Effect } from "effect";
 import type {
   CommandResult,
   CommandOptions,
+  ManagedProcess,
+  ManagedProcessStart,
   SandboxReuseCapability,
   SuccessfulCommandResult,
 } from "../types.ts";
@@ -32,6 +35,7 @@ import { dockerRunIdentityLabels, type RunIdentity } from "./run-identity.ts";
 import { supportedBackendCapability, type SandboxProviderBackend } from "./backend.ts";
 import type { DockerSandboxAccess, DockerSandboxReadiness, DockerSandboxResources } from "./layer.ts";
 import { dindContainerCommand } from "./dind-supervisor.ts";
+import { ManagedProcessOutput } from "./managed-process.ts";
 
 /**
  * dockerode 对镜像拉取限流没有专门的错误类型;Docker Hub 429 体现在错误 message 里
@@ -370,7 +374,131 @@ export class DockerSandbox implements SandboxProviderBackend, SandboxReuseCapabi
     suspend: supportedBackendCapability(() => this.suspend()),
     ensureLifetime: supportedBackendCapability((minRemainingMs: number) => this.ensureLifetime(minRemainingMs)),
     setCommandDeadline: supportedBackendCapability((deadlineAt?: number) => this.setCommandDeadline(deadlineAt)),
+    managedProcess: supportedBackendCapability((input: ManagedProcessStart) => this.startManagedProcess(input)),
   };
+
+  private async startManagedProcess(input: ManagedProcessStart): Promise<ManagedProcess> {
+    if (!this.container) throw new Error(t("docker.containerNotInitialized"));
+    const [command, ...args] = input.argv;
+    const env = {
+      HOME: this.defaultHome,
+      USER: this.defaultUserName,
+      LOGNAME: this.defaultUserName,
+      ...input.env,
+      PATH: this.sandboxPath,
+      ...(this.defaultIsRoot ? { npm_config_unsafe_perm: "true" } : {}),
+    };
+    const marker = `__NICEEVAL_MANAGED_PID_${randomUUID()}__`;
+    const exec = await this.container.exec({
+      // If the Docker exec leader is already a process-group leader, setsid
+      // forks. --wait keeps Docker's receipt tied to the native child lifetime.
+      Cmd: ["setsid", "--wait", "sh", "-c", `printf '${marker}%s\\n' "$$" >&2; exec "$@"`, "sh", command, ...args],
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      WorkingDir: resolveSandboxPath(this.workdir, input.cwd),
+      Env: Object.entries(env).map(([key, value]) => `${key}=${value}`),
+      User: this.userOverride,
+    });
+    const stream = await exec.start({ hijack: true, stdin: true });
+    const output = new ManagedProcessOutput();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    stdout.on("data", (bytes: Buffer) => output.push({ _tag: "Stdout", bytes: new Uint8Array(bytes) }));
+    let stderrPrefix = Buffer.alloc(0);
+    let processGroup: number | undefined;
+    stderr.on("data", (bytes: Buffer) => {
+      if (processGroup !== undefined) {
+        output.push({ _tag: "Stderr", bytes: new Uint8Array(bytes) });
+        return;
+      }
+      stderrPrefix = Buffer.concat([stderrPrefix, bytes]);
+      const newline = stderrPrefix.indexOf(10);
+      if (newline < 0) return;
+      const first = stderrPrefix.subarray(0, newline).toString("utf8");
+      if (!first.startsWith(marker) || !/^\d+$/.test(first.slice(marker.length))) {
+        output.push({ _tag: "Stderr", bytes: new Uint8Array(stderrPrefix) });
+      } else {
+        processGroup = Number(first.slice(marker.length));
+        const rest = stderrPrefix.subarray(newline + 1);
+        if (rest.length > 0) output.push({ _tag: "Stderr", bytes: new Uint8Array(rest) });
+      }
+      stderrPrefix = Buffer.alloc(0);
+    });
+    this.docker.modem.demuxStream(stream, stdout, stderr);
+    let poll: ReturnType<typeof setInterval> | undefined;
+    let settled = false;
+    let rejectExit!: (error: unknown) => void;
+    const finishError = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      if (poll !== undefined) clearInterval(poll);
+      output.end();
+      stream.destroy();
+      rejectExit(error);
+    };
+    const exit = new Promise<import("../types.ts").ManagedProcessExit>((resolve, reject) => {
+      rejectExit = reject;
+      stream.once("error", finishError);
+      poll = setInterval(() => {
+        void exec.inspect().then((inspection) => {
+          if (inspection.Running) return;
+          if (settled) return;
+          settled = true;
+          if (poll !== undefined) clearInterval(poll);
+          output.end();
+          stream.destroy();
+          resolve({ exitCode: inspection.ExitCode ?? null });
+        }, finishError);
+      }, 100);
+    });
+    let closeReceipt: Promise<void> | undefined;
+    let terminateReceipt: Promise<void> | undefined;
+    let stdinState: "open" | "closing" | "closed" = "open";
+    return {
+      output,
+      writeStdin: (bytes) => new Promise<void>((resolve, reject) => {
+        if (stdinState !== "open") { reject(new Error("managed process stdin is closed")); return; }
+        stream.write(Buffer.from(bytes), (error?: Error | null) => error ? reject(error) : resolve());
+      }),
+      closeStdin: () => closeReceipt ??= new Promise<void>((resolve) => {
+        stdinState = "closing";
+        stream.end(() => { stdinState = "closed"; resolve(); });
+      }),
+      wait: () => exit,
+      terminate: () => terminateReceipt ??= (async () => {
+        stdinState = "closing";
+        const inspection = await exec.inspect().catch(() => undefined);
+        if (!inspection?.Running) { await exit.catch(() => undefined); return; }
+        if (processGroup === undefined) {
+          const error = new Error("docker managed process did not disclose its process-group identity; sandbox retirement is required");
+          finishError(error);
+          throw error;
+        }
+        // Do not route this provider-owned control operation through runCommand's
+        // command-tree supervisor: killing the target exec while that supervisor
+        // samples the same tree creates an ambiguous non-zero receipt. Docker's
+        // own exec receipt is the exact acknowledgement for this one kill(2).
+        const killer = await this.container!.exec({
+          // POSIX `kill` is a shell builtin in slim images (no /usr/bin/kill).
+          // The PGID is a separate positional parameter, never interpolated.
+          Cmd: ["sh", "-c", "kill -KILL \"$1\"", "sh", `-${processGroup}`],
+          AttachStdout: true,
+          AttachStderr: true,
+          User: "root",
+        });
+        const killStream = await killer.start({});
+        const killOutput = await readableToBuffer(killStream);
+        const killed = await killer.inspect();
+        if (killed.ExitCode !== 0) {
+          const error = new Error(`docker could not terminate managed process group ${processGroup}; sandbox retirement is required: ${killOutput.toString("utf8")}`);
+          finishError(error);
+          throw error;
+        }
+        await exit;
+      })(),
+    };
+  }
 
   constructor(options: DockerSandboxOptions = {}) {
     this.docker = new Docker(options.dockerSocketPath === undefined ? undefined : { socketPath: options.dockerSocketPath });

--- a/src/sandbox/e2b.ts
+++ b/src/sandbox/e2b.ts
@@ -14,6 +14,8 @@ import { dirname } from "node:path";
 import type {
   CommandResult,
   CommandOptions,
+  ManagedProcess,
+  ManagedProcessStart,
   SandboxReuseCapability,
   SuccessfulCommandResult,
 } from "../types.ts";
@@ -30,7 +32,8 @@ import { resolveLocalPath, resolveSandboxPath } from "./paths.ts";
 import { e2bRunIdentityMetadata, type RunIdentity } from "./run-identity.ts";
 import { commandLimit, SandboxCommandTimeoutError } from "./deadline.ts";
 import { successfulCommandResult } from "./operations.ts";
-import { supportedBackendCapability, unsupportedBackendCapability, type SandboxProviderBackend } from "./backend.ts";
+import { ManagedProcessOutput } from "./managed-process.ts";
+import { supportedBackendCapability, unsupportedBackendCapability, unsupportedBackendCapabilityBecause, type SandboxProviderBackend } from "./backend.ts";
 
 // e2b 默认用户 "user",home 在 /home/user;工作区放其下。
 const E2B_WORKDIR = "/home/user/workspace";
@@ -401,7 +404,53 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
     suspend: supportedBackendCapability(() => this.suspend()),
     ensureLifetime: supportedBackendCapability((minRemainingMs: number) => this.ensureLifetime(minRemainingMs)),
     setCommandDeadline: supportedBackendCapability((deadlineAt?: number) => this.setCommandDeadline(deadlineAt)),
+    managedProcess: unsupportedBackendCapabilityBecause(
+      "E2B managed processes are not enabled until the provider boundary has a public installed-candidate E2E owner",
+    ),
   };
+
+  private async startManagedProcess(input: ManagedProcessStart): Promise<ManagedProcess> {
+    const output = new ManagedProcessOutput();
+    const command = input.argv.map(shellQuote).join(" ");
+    const script = this.pathPrepend.length === 0
+      ? `exec ${command}`
+      : `PATH=${shellQuote(this.pathPrepend.join(":"))}:"$PATH"\nexec ${command}`;
+    const handle = await this.sbx.commands.run(script, {
+      background: true,
+      stdin: true,
+      cwd: resolveSandboxPath(this.workdir, input.cwd),
+      envs: input.env === undefined ? undefined : { ...input.env },
+      ...(this.userOverride === undefined ? {} : { user: this.userOverride }),
+      onStdout: (chunk) => output.push({ _tag: "Stdout", bytes: new TextEncoder().encode(chunk) }),
+      onStderr: (chunk) => output.push({ _tag: "Stderr", bytes: new TextEncoder().encode(chunk) }),
+    });
+    const exit = handle.wait().then(
+      (result) => ({ exitCode: result.exitCode } as const),
+      (error: unknown) => {
+        if (error instanceof CommandExitError) return { exitCode: error.exitCode } as const;
+        throw error;
+      },
+    ).finally(() => output.end());
+    let closeReceipt: Promise<void> | undefined;
+    let terminateReceipt: Promise<void> | undefined;
+    let stdinState: "open" | "closing" | "closed" = "open";
+    return {
+      output,
+      writeStdin: (bytes) => stdinState === "open" ? handle.sendStdin(bytes) : Promise.reject(new Error("managed process stdin is closed")),
+      closeStdin: () => closeReceipt ??= (async () => {
+        stdinState = "closing";
+        await handle.closeStdin();
+        stdinState = "closed";
+      })(),
+      wait: () => exit,
+      terminate: () => terminateReceipt ??= (async () => {
+        stdinState = "closing";
+        await handle.kill();
+        await exit.catch(() => undefined);
+        stdinState = "closed";
+      })(),
+    };
+  }
 
   private constructor(
     sbx: E2BSdkSandbox,

--- a/src/sandbox/local.ts
+++ b/src/sandbox/local.ts
@@ -16,7 +16,7 @@ import { constants as fsConstants } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { randomUUID } from "node:crypto";
-import type { CommandOptions, CommandResult, SuccessfulCommandResult } from "../types.ts";
+import type { CommandOptions, CommandResult, ManagedProcess, ManagedProcessStart, SuccessfulCommandResult } from "../types.ts";
 import { resolveLocalPath, resolveSandboxPath } from "./paths.ts";
 import { commandLimit, SandboxCommandTimeoutError } from "./deadline.ts";
 import { collectLocalFiles, type CollectedLocalFile } from "./local-files.ts";
@@ -29,6 +29,7 @@ import {
 } from "./backend.ts";
 import { registerLedgerPaths, unregisterLedgerPaths } from "./ledger-paths.ts";
 import { t } from "../i18n/index.ts";
+import { ManagedProcessOutput } from "./managed-process.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -195,7 +196,60 @@ export class LocalSandbox implements SandboxProviderBackend {
     suspend: unsupportedBackendCapability,
     ensureLifetime: unsupportedBackendCapability,
     setCommandDeadline: supportedBackendCapability((deadlineAt?: number) => this.setCommandDeadline(deadlineAt)),
+    managedProcess: supportedBackendCapability((input: ManagedProcessStart) => this.startManagedProcess(input)),
   };
+
+  private async startManagedProcess(input: ManagedProcessStart): Promise<ManagedProcess> {
+    const [command, ...args] = input.argv;
+    const output = new ManagedProcessOutput();
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...input.env,
+      ...(this.pathPrepend.length === 0
+        ? {}
+        : { PATH: `${this.pathPrepend.join(":")}:${process.env.PATH ?? ""}` }),
+    };
+    const posix = process.platform !== "win32";
+    const child = spawn(command, args, {
+      cwd: resolveSandboxPath(this.workdir, input.cwd),
+      env,
+      detached: posix,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdout.on("data", (bytes: Buffer) => output.push({ _tag: "Stdout", bytes: new Uint8Array(bytes) }));
+    child.stderr.on("data", (bytes: Buffer) => output.push({ _tag: "Stderr", bytes: new Uint8Array(bytes) }));
+    const exit = new Promise<import("../types.ts").ManagedProcessExit>((resolve, reject) => {
+      child.once("error", (error) => { output.end(); reject(error); });
+      child.once("close", (exitCode, signal) => {
+        output.end();
+        resolve({ exitCode, ...(signal === null ? {} : { signal }) });
+      });
+    });
+    const terminate = async (): Promise<void> => {
+      stdinState = "closing";
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      if (posix && child.pid !== undefined) {
+        try { process.kill(-child.pid, "SIGKILL"); } catch { child.kill("SIGKILL"); }
+      } else child.kill("SIGKILL");
+      await exit.catch(() => undefined);
+    };
+    let stdinState: "open" | "closing" | "closed" = "open";
+    let closeReceipt: Promise<void> | undefined;
+    let terminateReceipt: Promise<void> | undefined;
+    return {
+      output,
+      writeStdin: (bytes) => new Promise<void>((resolve, reject) => {
+        if (stdinState !== "open") { reject(new Error("managed process stdin is closed")); return; }
+        child.stdin.write(bytes, (error) => error ? reject(error) : resolve());
+      }),
+      closeStdin: () => closeReceipt ??= new Promise<void>((resolve) => {
+        stdinState = "closing";
+        child.stdin.end(() => { stdinState = "closed"; resolve(); });
+      }),
+      wait: () => exit,
+      terminate: () => terminateReceipt ??= terminate(),
+    };
+  }
 
   private constructor(
     workdir: string,

--- a/src/sandbox/managed-process.ts
+++ b/src/sandbox/managed-process.ts
@@ -1,0 +1,43 @@
+import type { ManagedProcessChunk } from "./types.ts";
+
+/** Small single-consumer async queue used by provider-native process streams. */
+export class ManagedProcessOutput implements AsyncIterable<ManagedProcessChunk> {
+  private readonly queued: ManagedProcessChunk[] = [];
+  private waiter?: (value: IteratorResult<ManagedProcessChunk>) => void;
+  private ended = false;
+  private consumed = false;
+
+  push(chunk: ManagedProcessChunk): void {
+    if (this.ended) return;
+    const waiter = this.waiter;
+    if (waiter !== undefined) {
+      this.waiter = undefined;
+      waiter({ done: false, value: chunk });
+    } else {
+      this.queued.push(chunk);
+    }
+  }
+
+  end(): void {
+    if (this.ended) return;
+    this.ended = true;
+    const waiter = this.waiter;
+    if (waiter !== undefined) {
+      this.waiter = undefined;
+      waiter({ done: true, value: undefined });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<ManagedProcessChunk> {
+    if (this.consumed) throw new Error("managed process output already has a consumer");
+    this.consumed = true;
+    return {
+      next: () => {
+        const value = this.queued.shift();
+        if (value !== undefined) return Promise.resolve({ done: false, value });
+        if (this.ended) return Promise.resolve({ done: true, value: undefined });
+        return new Promise((resolve) => { this.waiter = resolve; });
+      },
+    };
+  }
+}

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -106,6 +106,30 @@ export interface SuccessfulCommandResult extends CommandResult {
   readonly exitCode: 0;
 }
 
+export interface ManagedProcessStart {
+  readonly argv: readonly [string, ...string[]];
+  readonly cwd?: string;
+  readonly env?: Readonly<globalThis.Record<string, string>>;
+}
+
+export type ManagedProcessChunk =
+  | { readonly _tag: "Stdout"; readonly bytes: Uint8Array }
+  | { readonly _tag: "Stderr"; readonly bytes: Uint8Array };
+
+export interface ManagedProcessExit {
+  readonly exitCode: number | null;
+  readonly signal?: string;
+}
+
+/** Attempt-owned bidirectional process. `output` has exactly one consumer. */
+export interface ManagedProcess {
+  readonly output: AsyncIterable<ManagedProcessChunk>;
+  writeStdin(bytes: Uint8Array): Promise<void>;
+  closeStdin(): Promise<void>;
+  wait(): Promise<ManagedProcessExit>;
+  terminate(): Promise<void>;
+}
+
 /** 三个运行中 Sandbox 视图共用的操作词汇；同名成员在不同视图中不得改变语义。 */
 export interface SandboxOperations {
   /** Sandbox 内项目/工作区根目录的绝对路径(agent 命令的默认 cwd,也是 git baseline 提交的位置)。各方法的相对路径都以此为基准解析,省略 `cwd`/`targetDir` 时也落到这里。 */

--- a/src/sandbox/vercel.ts
+++ b/src/sandbox/vercel.ts
@@ -20,7 +20,7 @@ import { t } from "../i18n/index.ts";
 import { reportActivity, reportDiagnostic } from "../runner/feedback/sink.ts";
 import { classifyProvisionErrorFallback, type SandboxProvisionErrorKind } from "./errors.ts";
 import { successfulCommandResult } from "./operations.ts";
-import { supportedBackendCapability, unsupportedBackendCapability, type SandboxProviderBackend } from "./backend.ts";
+import { supportedBackendCapability, unsupportedBackendCapability, unsupportedBackendCapabilityBecause, type SandboxProviderBackend } from "./backend.ts";
 
 /**
  * vercel SDK 对单次 fetch 的 429 已有内部重试(见 @vercel/sandbox 的 with-retry.js,
@@ -72,6 +72,7 @@ export class VercelSandbox implements SandboxProviderBackend, SandboxReuseCapabi
     suspend: supportedBackendCapability(() => this.suspend()),
     ensureLifetime: supportedBackendCapability((minRemainingMs: number) => this.ensureLifetime(minRemainingMs)),
     setCommandDeadline: supportedBackendCapability((deadlineAt?: number) => this.setCommandDeadline(deadlineAt)),
+    managedProcess: unsupportedBackendCapabilityBecause("@vercel/sandbox 2.2.1 does not expose bidirectional stdin or raw output chunks"),
   };
 
   private constructor(


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 9c858a344a4862bafb31391b36c83c0f0b1e9ca5
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: e4f54b6af889f584858566a5d08a6ae535fba454
-->

## Problem

- User goal: 在报告里把一次工具调用读成一行，并真实评估 Codex、Claude Code 与 OMP 的工具事件和人工输入。
- Current limitation: started/finished 被拆成两行且状态不看结果；Codex/Claude 没有原生 HITL 响应通道，也没有证明普通回复不会被误报成 HITL；OMP 的 bash 事件缺少规范身份和命令分类。
- Required capability: 中立的工具生命周期投影、Attempt 托管的双向进程、adapter 原生协议映射，以及 HITL 正反 Eval。
- User outcome: 报告状态与真实结果一致；Eval 能选择 HITL 选项并恢复同一会话，普通内容不触发 HITL 时明确判红；OMP 工具事件可被统一断言。

## Use cases

### Case: 在报告中判断一次工具调用的结果

#### Starting state

```text
同一 call id 记录 operation.started 与 operation.finished(exitCode: 1)
```

#### Action

```sh
niceeval view
```

#### Result

```text
一行工具调用 · 失败
```

只有精确匹配 call id 的起止事件会合并；缺结果仍显示“已开始”，拒绝与取消保持各自终态。

### Case: Eval 回答原生选项

#### Starting state

```text
Codex 或 Claude Code 在 Docker sandbox 中提出 Node.js / Bun 选择
```

#### Action

```ts
const waiting = await t.send("Ask which runtime to use");
const request = t.requireInputRequest({ optionIds: ["Node.js", "Bun"] });
await t.respond({ request, optionId: "Node.js" });
```

#### Result

```text
selected:Node.js
verdict: passed
```

响应以 provider 原生 request identity 写回同一 session。缺少已验收 managed-process 能力的 E2B、Vercel 与 custom sandbox 在 setup 阶段具名拒绝。

### Case: 普通内容没有伪造 HITL

#### Starting state

```text
同一个 hitl-options Eval 由 flags.requestHitl=false 运行
```

#### Action

```ts
const turn = await t.send('Reply with exactly "ordinary-content". Do not call any tool.');
t.check(turn.status, equals("waiting"));
```

#### Result

```text
message: ordinary-content
status: completed
verdict: failed
```

普通响应本身成功，但没有原生 input request，因此 HITL 命题必须失败而不是被 adapter 猜成 waiting，也不会升级成 errored。

### Case: 统一断言 OMP 的 bash 工具事件

#### Starting state

```text
OMP 执行 bash 并输出 NICEEVAL_OMP_TOOL_EVENT_OK
```

#### Action

```ts
t.check(turn.events, operationLifecycle({ tool: "shell", status: "completed" }));
```

#### Result

```text
started=1, finished=1, command.original.state=opaque
```

OMP 的 provider 原生名称保留在 evidence 中，公共断言只消费中立的 shell identity 与生命周期。

## Public API

### Added

#### Case: `acquireManagedProcess()`

##### Before

```ts
await sandbox.acquireManagedProcess({ argv: ["agent", "serve"] });
```

```text
Property 'acquireManagedProcess' does not exist on type 'Sandbox'.
```

##### After

```ts
const process = await sandbox.acquireManagedProcess({ argv: ["agent", "serve"] });
await process.write(new TextEncoder().encode('{"method":"turn/start"}\n'));
for await (const chunk of process.output) console.log(chunk._tag, chunk.bytes.length);
await process.closeStdin();
await process.terminate();
```

```text
Stdout 128
Stderr 37
```

##### User impact

Adapter 可以在一个 Attempt 内跨多次 send 保持原生双向协议进程；正常完成、timeout 与中断都由 Attempt Scope 有界释放。

## Report components

### Changed

#### Case: 工具生命周期行

##### Before

```tsx
<ToolTimeline events={[started, finished]} />
```

```text
command_execution · 已开始
command_execution result · 已完成
```

##### After

```tsx
<ToolTimeline events={[started, finished]} />
```

```text
command_execution · 已完成
```

##### User impact

报告按 call identity 合并生命周期，并从中立 outcome、result status 或 exit code 得出 completed、failed、rejected、cancelled、started，不依赖 provider 名或工具名。

## Tests

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `feature + bug regression`
- Protects: The browser renders one tool row for a paired lifecycle and exposes completed result evidence.
- Runs: Installed candidate view/export browser journey.
- Asserts: The representative turn has three logical trace rows and exposes command, terminal, exit, output, and raw evidence.

```ts
// … omitted: file=e2e/report/test/report.browser.spec.ts; before=        const trace = sendLine.locator("[data-niceeval-turn-trace]");; after=        const traceRows = trace.locator("[data-niceeval-trace-event]");; reason=The rest of the browser journey covers unchanged report navigation and source-detail behavior.
        const traceRows = trace.locator("[data-niceeval-trace-event]");
        await expect(traceRows).toHaveCount(3);
        const firstTraceRow = traceRows.nth(0);
        const secondTraceRow = traceRows.nth(1);
        const firstTraceEvidence = firstTraceRow.locator("[data-niceeval-trace-evidence]");
        const secondTraceEvidence = secondTraceRow.locator("[data-niceeval-trace-evidence]");
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await firstTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).toHaveAttribute("open", "");
        await expect(firstTraceRow.locator("[data-niceeval-trace-select]")).toHaveAttribute("aria-expanded", "true");
        await secondTraceRow.locator("[data-niceeval-trace-select]").click();
        await expect(firstTraceEvidence).not.toHaveAttribute("open", "");
        await expect(secondTraceEvidence).toHaveAttribute("open", "");
        await expect(secondTraceRow.locator(".niceeval-trace-event-status")).toHaveText("Completed");
        await expect(secondTraceEvidence.locator("[data-tool-evidence-kind='command']")).toBeVisible();
        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").nth(0).textContent()).toBe(
          "printf 'classic/recall-constraint: recalled=true\\n' > memory-note.txt",
        );
        await expect(secondTraceEvidence.locator("[data-tool-evidence-kind='terminal']")).toBeVisible();
        await expect(secondTraceEvidence.getByText("Exit 0", { exact: true })).toBeVisible();
        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").nth(1).textContent()).toBe(
          "wrote memory-note.txt\nclassic/recall-constraint: recalled=true\n",
        );
        expect(await secondTraceEvidence.locator(".niceeval-tool-evidence-code").nth(2).textContent()).toBe(
          '{\n  "written": true,\n  "recalled": true\n}',
        );
        await secondTraceEvidence.getByRole("tab", { name: "Raw" }).click();
        await expect(secondTraceEvidence.getByRole("tab", { name: "Raw" })).toHaveAttribute("aria-selected", "true");
        await expect(secondTraceEvidence.locator("[data-niceeval-trace-evidence-panel='raw']")).toBeVisible();
        await expect(secondTraceEvidence.locator(".niceeval-trace-evidence-raw")).toContainText(
          '"command":"printf \'classic/recall-constraint: recalled=true\\\\n\' > memory-note.txt"',
        );
        await expect(secondTraceEvidence.locator(".niceeval-trace-evidence-raw")).toContainText(
          '"output":"wrote memory-note.txt\\nclassic/recall-constraint: recalled=true\\n"',
        );
        const deepLink = page.url();
// … omitted: file=e2e/report/test/report.browser.spec.ts; before=        const deepLink = page.url();; after=        expect(new URL(deepLink).hash).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);; reason=The rest of the browser journey covers unchanged report navigation and source-detail behavior.
```

### `e2e/adapter/codex-cli/test/codex-cli.test.ts`

- Purpose: `feature + bug regression`
- Protects: Codex request_user_input resumes by native identity while ordinary content remains a failed HITL assertion, and plugin hooks keep running through app-server.
- Runs: Installed candidate, Codex CLI, Docker sandbox, live provider, exp and show.
- Asserts: Every named Eval has its expected verdict, including hitl passed and hitl-content failed; execution readback retains tool evidence.

```ts
// owner: docs/engineering/testing/e2e/adapter/codex-cli.md#adapter-codex-cli-live-compatibility
//
// 单文件 Journey：真实 Codex CLI + Docker Sandbox + live provider，
// 再从公开 CLI 读回 Eval、attempt 与 execution。
// 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。

import {
  assertExpEvalOutcomes,
  command,
  only,
  retryFailedExpEvalsOnce,
  type ExpEvalEvent,
  type ExpEvalOutcomeExpectation,
  type ProcessReceipt,
} from "@niceeval/testkit";
import { rmSync } from "node:fs";
import { join } from "node:path";
import { beforeAll, expect, it } from "vitest";

// 每条 Eval 的首轮只有一个 Attempt；只有结构化 verdict=failed 才由本测试另起一次 Invocation。
const EXPECTED_OUTCOMES = [
  // coding-task：既有文件修改与 shell 调用都须归一并配对完成；最终单次 Attempt 期望 passed/1。
  { experimentId: "baseline", evalId: "coding-task", verdict: "passed", attempts: 1, passed: 1 },
  // configfile 正例：shell-enabled 配置下同一 prompt 必须调用 shell；分支成立时为 passed/1。
  { experimentId: "baseline", evalId: "configfile", verdict: "passed", attempts: 1, passed: 1 },
  // session：首轮 thread ID 须捕获，第二轮 exec resume 须回忆事实；一条会话链期望 passed/1。
  { experimentId: "baseline", evalId: "session", verdict: "passed", attempts: 1, passed: 1 },
  // usage：每轮 token usage 非空，且 session 侧写中的实际模型正确；一次验证期望 passed/1。
  { experimentId: "baseline", evalId: "usage", verdict: "passed", attempts: 1, passed: 1 },
  // HITL：原生问题的两个选项须进入结构化 request，选择 Node.js 后恢复同一会话。
  { experimentId: "hitl", evalId: "hitl-options", verdict: "passed", attempts: 1, passed: 1 },
  // HITL 反例：同一 Eval 收到普通内容且没有原生待输入请求时，必须是 failed/1。
  { experimentId: "hitl-content", evalId: "hitl-options", verdict: "failed", attempts: 1, passed: 0 },
  // configfile 反例：shell-disabled 配置下同一 prompt 不得调用 shell；零调用成立时为 passed/1。
  { experimentId: "configfile", evalId: "configfile", verdict: "passed", attempts: 1, passed: 1 },
  // mcp：stdio 求和与远程 DeepWiki 两种 MCP 调用都须出现且入参正确；期望 passed/1。
  { experimentId: "mcp", evalId: "mcp", verdict: "passed", attempts: 1, passed: 1 },
  // status-report：目标 Skill 须被读取并影响文件内容，且不能伪造 skill.loaded；期望 passed/1。
  { experimentId: "skill", evalId: "status-report", verdict: "passed", attempts: 1, passed: 1 },
  // skill-release-note：只读取 release-note Skill、不误读 status/decoy，并采用其约定；期望 passed/1。
  { experimentId: "skill", evalId: "skill-release-note", verdict: "passed", attempts: 1, passed: 1 },
  // repo-skill：钉定 Git 来源的 Skill 须安装、读取并影响产出；一次完整验证期望 passed/1。
  { experimentId: "repo-skill", evalId: "repo-skill", verdict: "passed", attempts: 1, passed: 1 },
  // plugin-hook：Plugin 安装痕迹与 SessionStart hook 侧写证据都须存在；单次安装路径期望 passed/1。
  { experimentId: "plugin", evalId: "plugin-hook", verdict: "passed", attempts: 1, passed: 1 },
  // plugin-reuse：四个 Sandbox 的两波共八次复用都须清理冲突残留并重装成功，所以期望 passed/8。
  { experimentId: "plugin-reuse", evalId: "plugin-hook", verdict: "passed", attempts: 8, passed: 8 },
] as const satisfies readonly ExpEvalOutcomeExpectation[];

const niceeval = command([join(process.cwd(), "node_modules", ".bin", "niceeval")]);
let run!: ProcessReceipt;
let evalEvents!: readonly ExpEvalEvent[];

function assertExactRetryEvalSelector(events: readonly ExpEvalEvent[], failed: ExpEvalEvent): void {
  // Experiment selectors prefer an exact ID before considering path-prefix
  // families. Eval selectors intentionally use bare prefixes, so only the
  // Eval selector needs a preflight ambiguity check before spending a retry.
  const evals = events
    .filter(
      (event) =>
        event.experimentId === failed.experimentId && event.evalId.startsWith(failed.evalId),
    )
    .map((event) => event.evalId);
  expect(evals, `ambiguous Eval retry selector ${failed.experimentId}/${failed.evalId}`).toEqual([
    failed.evalId,
  ]);
}

beforeAll(async () => {
  rmSync(".niceeval", { recursive: true, force: true });

  // invoke：完整 argv 走安装后的 candidate binary；真实 Codex CLI、Docker sandbox
  // 与 live provider 仍由 experiments/* + evals/ 驱动。
  run = await niceeval.run(["exp", "--rerun", "all", "--json"], {
    timeoutMs: 44 * 60_000,
  });
  // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md「结束反馈与
  // receipt」）；成败与发现完整性由下面带身份的 eval 事件精确断言。
  const inv = run.expReceipt();
  expect(inv.completion, run.diagnostic()).toBe("completed");
  // eval 事件是中间的身份事件：identity / verdict / attempts 在此精确断言。
  const firstEvents = run.expEvalEvents();
  // plugin-reuse 是八条 Attempt 的 Sandbox 复用 owner，不是模型断言重试消费者。
  const retryableFailed = firstEvents.filter(
    (event) =>
      event.verdict === "failed" &&
      event.experimentId !== "plugin-reuse" &&
      !(event.experimentId === "hitl-content" && event.evalId === "hitl-options"),
  );
  expect(
    firstEvents.filter((event) => event.verdict === "errored" || event.verdict === "skipped"),
    run.diagnostic(),
  ).toHaveLength(0);
  expect(run.exitCode, run.diagnostic()).toBe(
    firstEvents.some((event) => event.verdict === "failed") ? 1 : 0,
  );
  for (const event of retryableFailed) assertExactRetryEvalSelector(firstEvents, event);

  // 这些 Invocation 继续写同一个保留证据的 Record；Record 是单写者，多个 CLI 进程
  // 重叠会确定性触发 RecordWriterBusy。主 Invocation 内的 Attempt 并发不受影响。
  const retried = await retryFailedExpEvalsOnce({
    events: firstEvents,
    targets: retryableFailed,
    runRetry: (event) =>
      niceeval.run(
        ["exp", event.experimentId, event.evalId, "--rerun", "all", "--json"],
        { timeoutMs: 44 * 60_000 },
      ),
  });
  if (retried.retries.length > 0) {
    process.stderr.write(
      `[niceeval e2e] retried ${retried.retries.length} assertion-failed Eval(s) once; first Invocation ${inv.invocationId} remains recorded\n`,
    );
  }
  evalEvents = retried.events;
}, 48 * 60_000);

it("真实 Codex CLI adapter 的全部专用 Eval 得到预期 verdict", () => {
  expect(run.expReceipt().completion, run.diagnostic()).toBe("completed");
  assertExpEvalOutcomes(evalEvents, EXPECTED_OUTCOMES, () => run.diagnostic());
});

function locatorFor(evalId: string): string {
  return only(
    evalEvents,
    (event) => event.evalId === evalId,
    () => run.diagnostic(),
  ).locator;
}

it("show --execution 读回 Codex CLI 的代表性工具证据", async () => {
  const codingTaskLocator = locatorFor("coding-task");

  // outcome：execution 是适配器收到的公开投影。TOOL 卡片头是原始未归一化名
  //（command_execution / file_change），canonical 名 shell / file_edit 也可能出现；
  // 工具身份与入参必须穿过归一化、持久化与 CLI 展示。
  const execution = await niceeval.run(["show", codingTaskLocator, "--execution"]);
  expect(execution.exitCode, execution.diagnostic()).toBe(0);
  expect(
    execution.stdout.includes("file_edit") || execution.stdout.includes("file_change"),
    "execution tree missing file_edit/file_change",
  ).toBe(true);
  expect(
    execution.stdout.includes("shell") || execution.stdout.includes("command_execution"),
    "execution tree missing shell/command_execution",
  ).toBe(true);
  expect(execution.stdout).toContain("niceeval-e2e-run-914");
});
```

### `e2e/adapter/claude-code/test/claude-code.test.ts`

- Purpose: `feature + bug regression`
- Protects: AskUserQuestion resumes by native identity while ordinary content remains a failed HITL assertion.
- Runs: Installed candidate, Claude Code, Docker sandbox, live provider, exp and show.
- Asserts: Every named Eval has its expected verdict, including hitl passed and hitl-content failed; execution readback retains tool evidence.

```ts
// owner: docs/engineering/testing/e2e/adapter/claude-code.md#adapter-claude-code-live-compatibility
// regression: memory/results-schema-version-history.md#observability-family-1--2
//
// 单文件 Journey：真实 Claude Code + Docker Sandbox + live provider。
// 具体 Skill、MCP、Plugin 与配置行为由各自 Eval 断言；owner 另读一条代表 execution。
// 只从 @niceeval/testkit 根导入；不读 .niceeval 私有布局、不 import 候选源码/类型。

import {
  assertExpEvalOutcomes,
  command,
  only,
  retryFailedExpEvalsOnce,
  type ExpEvalEvent,
  type ExpEvalOutcomeExpectation,
  type ProcessReceipt,
} from "@niceeval/testkit";
import { rmSync } from "node:fs";
import { join } from "node:path";
import { beforeAll, expect, it } from "vitest";

const EXPECTED_OUTCOMES = [
  // coding-task：文件写入、编辑与 shell 调用都须完成；单次基线 Attempt 全部断言成立才是 passed/1。
  { experimentId: "coding", evalId: "coding-task", verdict: "passed", attempts: 1, passed: 1 },
  // session-resume：原生 --resume 须带回首轮事实且两轮 usage 可用；一次会话链完成即为 passed/1。
  { experimentId: "coding", evalId: "session-resume", verdict: "passed", attempts: 1, passed: 1 },
  // WebSearch 正例：coding 开启 webResearch，必须调用 web_search 且不调用 web_fetch，因此期望 passed/1。
  { experimentId: "coding", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
  // HITL：AskUserQuestion 的两个选项须进入结构化 request，选择 Node.js 后恢复同一会话。
  { experimentId: "hitl", evalId: "hitl-options", verdict: "passed", attempts: 1, passed: 1 },
  // HITL 反例：同一 Eval 收到普通内容且没有原生待输入请求时，必须是 failed/1。
  { experimentId: "hitl-content", evalId: "hitl-options", verdict: "failed", attempts: 1, passed: 0 },
  // skill-used：只加载目标本地 Skill，并在回答中采用其独有 marker；单次正调应为 passed/1。
  { experimentId: "skill", evalId: "skill-used", verdict: "passed", attempts: 1, passed: 1 },
  // skill-checklist：只加载 checklist Skill、不误载 marker/decoy；反选断言同时成立才是 passed/1。
  { experimentId: "skill", evalId: "skill-checklist", verdict: "passed", attempts: 1, passed: 1 },
  // skill-unused：普通对话不得加载任何已安装 Skill 或调用工具；这个反例成立时仍是 passed/1。
  { experimentId: "skill", evalId: "skill-unused", verdict: "passed", attempts: 1, passed: 1 },
  // repo-skill：钉定 Git 来源的 Skill 必须安装、原生加载并影响输出；一次完整验证期望 passed/1。
  { experimentId: "repo-skill", evalId: "repo-skill", verdict: "passed", attempts: 1, passed: 1 },
  // mcp-tools：stdio 与 Streamable HTTP 两个 MCP 工具都须以正确入参完成；因此期望 passed/1。
  { experimentId: "mcp", evalId: "mcp-tools", verdict: "passed", attempts: 1, passed: 1 },
  // plugin-mcp：官方 Context7 Plugin 的远程 MCP 必须接线并成功调用；单次安装路径期望 passed/1。
  { experimentId: "plugin", evalId: "plugin-mcp", verdict: "passed", attempts: 1, passed: 1 },
  // plugin-reuse：四个 Sandbox 承接两波共八次复用，八次都须调用 Context7 成功，所以是 passed/8。
  { experimentId: "plugin-reuse", evalId: "plugin-mcp", verdict: "passed", attempts: 8, passed: 8 },
  // remote-plugin：远程 marketplace 文件须安装，随 Plugin 的 Skill 须被加载并完成请求；期望 passed/1。
  { experimentId: "remote-plugin", evalId: "remote-plugin", verdict: "passed", attempts: 1, passed: 1 },
  // WebSearch 反例：locked-down settings 禁止 WebSearch/WebFetch，零调用才通过，因此期望 passed/1。
  { experimentId: "locked-down", evalId: "websearch-denied", verdict: "passed", attempts: 1, passed: 1 },
] as const satisfies readonly ExpEvalOutcomeExpectation[];

const niceeval = command([join(process.cwd(), "node_modules", ".bin", "niceeval")]);
let run!: ProcessReceipt;
let evalEvents!: readonly ExpEvalEvent[];

function assertExactRetryEvalSelector(events: readonly ExpEvalEvent[], failed: ExpEvalEvent): void {
  // Experiment selectors prefer an exact ID before considering path-prefix
  // families. Eval selectors intentionally use bare prefixes, so only the
  // Eval selector needs a preflight ambiguity check before spending a retry.
  const evals = events
    .filter(
      (event) =>
        event.experimentId === failed.experimentId && event.evalId.startsWith(failed.evalId),
    )
    .map((event) => event.evalId);
  expect(evals, `ambiguous Eval retry selector ${failed.experimentId}/${failed.evalId}`).toEqual([
    failed.evalId,
  ]);
}

function representativeAttempt(): ExpEvalEvent {
  return only(
    evalEvents,
    (event) => event.evalId === "coding-task",
    () => run.diagnostic(),
  );
}

beforeAll(async () => {
  rmSync(".niceeval", { recursive: true, force: true });

  run = await niceeval.run(
    ["exp", "--rerun", "all", "--json"],
    { timeoutMs: 50 * 60_000 },
  );
  const inv = run.expReceipt();
  const firstEvents = run.expEvalEvents();
  // plugin-reuse 是八条 Attempt 的 Sandbox 复用 owner，不能用二次运行替换它的首次并发结果。
  // 其余 live provider 任务只对模型断言失败补跑一次；setup、timeout、I/O error 与
  // skipped 都是基础设施/生命周期故障，不能用后续绿色覆盖。
  const retryableFailed = firstEvents.filter(
    (event) =>
      event.verdict === "failed" &&
      event.experimentId !== "plugin-reuse" &&
      !(event.experimentId === "hitl-content" && event.evalId === "hitl-options"),
  );
  expect(
    firstEvents.filter(
      (event) => event.verdict === "errored" || event.verdict === "skipped",
    ),
    run.diagnostic(),
  ).toHaveLength(0);
  expect(run.exitCode, run.diagnostic()).toBe(
    firstEvents.some((event) => event.verdict === "failed") ? 1 : 0,
  );
  expect(inv.completion, run.diagnostic()).toBe("completed");
  for (const event of retryableFailed) assertExactRetryEvalSelector(firstEvents, event);

  // 补跑 Invocation 继续写同一个保留证据的 Record；Record 是单写者，所以同 Repo
  // 必须串行。主 Invocation 内的 Attempt 并发和跨 Repo batch 并发不受影响。
  const retried = await retryFailedExpEvalsOnce({
    events: firstEvents,
    targets: retryableFailed,
    runRetry: (event) =>
      niceeval.run(
        ["exp", event.experimentId, event.evalId, "--rerun", "all", "--json"],
        { timeoutMs: 50 * 60_000 },
      ),
  });
  if (retried.retries.length > 0) {
    process.stderr.write(
      `[niceeval e2e] retried ${retried.retries.length} assertion-failed Eval(s) once; first Invocation ${inv.invocationId} remains recorded\n`,
    );
  }
  evalEvents = retried.events;
}, 53 * 60_000);

it("真实 Claude Code adapter 的全部专用 Eval 得到预期 verdict", () => {
  // receipt 只承载 Invocation 级完成事实（docs/feature/experiments/cli.md「结束反馈与
  // receipt」）；成败与发现完整性由下面带身份的 eval 事件精确断言。
  const inv = run.expReceipt();
  expect(inv.completion, run.diagnostic()).toBe("completed");
  assertExpEvalOutcomes(evalEvents, EXPECTED_OUTCOMES, () => run.diagnostic());
});

it("show --execution 读回 Claude Code 的代表性工具证据", async () => {
  const attempt = representativeAttempt();
  const execution = await niceeval.run(["show", attempt.locator!, "--execution"]);
  expect(execution.exitCode, execution.diagnostic()).toBe(0);
  expect(execution.stdout).toContain("notes.txt");
  expect(execution.stdout).toContain("niceeval-e2e-marker-alpha-926");
});
```

### `e2e/adapter/omp/test/omp.test.ts`

- Purpose: `feature + bug regression`
- Protects: OMP bash calls expose paired canonical shell lifecycle events without inventing command text.
- Runs: Installed candidate, OMP CLI, Docker sandbox, live provider, exp and show.
- Asserts: The event Eval and representative execution readback pass with the expected marker.

```ts
// owner: docs/engineering/testing/e2e/adapter/omp.md#adapter-omp-target-compatibility

import {
  assertExpEvalOutcomes,
  command,
  only,
  type ExpEvalOutcomeExpectation,
} from "@niceeval/testkit";
import { rm } from "node:fs/promises";
import { join } from "node:path";
import { expect, it } from "vitest";
import { OMP_MARKER } from "../evals/message.eval.ts";

const EXPECTED_MESSAGE_OUTCOMES = [
  { experimentId: "ci", evalId: "message", verdict: "passed", attempts: 1, passed: 1 },
] as const satisfies readonly ExpEvalOutcomeExpectation[];

const EXPECTED_EVENT_OUTCOMES = [
  { experimentId: "events", evalId: "events", verdict: "passed", attempts: 1, passed: 1 },
] as const satisfies readonly ExpEvalOutcomeExpectation[];

const niceeval = command([join(process.cwd(), "node_modules", ".bin", "niceeval")]);

it("OMP adapter 从公开工厂完成 Eval 并公开读回结果", async () => {
  await rm(".niceeval", { recursive: true, force: true });

  const messageRun = await niceeval.run(["exp", "ci", "--rerun", "all", "--json"], {
    timeoutMs: 6 * 60_000,
  });
  expect(messageRun.exitCode, messageRun.diagnostic()).toBe(0);

  const messageEvents = assertExpEvalOutcomes(
    messageRun.expEvalEvents(),
    EXPECTED_MESSAGE_OUTCOMES,
    () => messageRun.diagnostic(),
  );
  const event = only(messageEvents, (candidate) => candidate.evalId === "message");

  const eventRun = await niceeval.run(["exp", "events", "--rerun", "all", "--json"], {
    timeoutMs: 6 * 60_000,
  });
  expect(eventRun.exitCode, eventRun.diagnostic()).toBe(0);
  assertExpEvalOutcomes(eventRun.expEvalEvents(), EXPECTED_EVENT_OUTCOMES, () => eventRun.diagnostic());

  const execution = await niceeval.run(["show", event.locator, "--execution"]);
  expect(execution.exitCode, execution.diagnostic()).toBe(0);
  expect(execution.stdout).toContain(OMP_MARKER);

}, 8 * 60_000);
```

### `e2e/adapter/local-protocol/test/timeout.test.ts`

- Purpose: `bug regression`
- Protects: Attempt timeout remains the sole primary diagnostic when the Effect bridge closes before Promise finally.
- Runs: Installed candidate through the deterministic local protocol timeout Experiment and public show execution readback.
- Asserts: Verdict is errored and diagnostics contain exactly the timeout at agent.send, without a synthetic teardown failure.

```ts
// owner: docs/engineering/testing/e2e/adapter/ui-message-stream.md#timeout-owner
// rerun: pnpm e2e --repo adapter/local-protocol -- --run test/timeout.test.ts

import { assertExpEvalOutcomes, exactEval } from "@niceeval/testkit";
import { expect, test } from "vitest";
import { localProtocolE2E, localProtocolRecordArtifacts } from "./context.ts";
import { withLocalProtocolFixture } from "./support.ts";
import { FIXTURE_BASE_URL_ENV } from "../src/fixture/address.ts";

const EXPECTED = [{
  experimentId: "timeout",
  evalId: "timeout",
  verdict: "errored",
  attempts: 1,
  passed: 0,
}] as const;

test("uiMessageStreamAgent 的挂起响应在 attempt deadline 后公开为 errored", async () => {
  await localProtocolE2E.case(
    "timeout",
    localProtocolRecordArtifacts,
    async ({ commands: { niceeval }, paths }) => {
      await withLocalProtocolFixture(paths.projectRoot, async ({ baseUrl }) => {
        const run = await niceeval.run(
          ["exp", "timeout", "--rerun", "all", "--json"],
          { env: { [FIXTURE_BASE_URL_ENV]: baseUrl }, timeoutMs: 30_000 },
        );
        const events = run.expEvalEvents();
        const receipt = run.expReceipt();

        expect(run.exitCode, run.diagnostic()).not.toBe(0);
        expect(receipt.completion, run.diagnostic()).toBe("completed");
        expect(receipt.runIds, run.diagnostic()).toHaveLength(1);
        assertExpEvalOutcomes(events, EXPECTED, () => run.diagnostic());

        const event = exactEval(events, EXPECTED[0], () => run.diagnostic());
        const shown = await niceeval.run([
          "show", event.locator, "--execution", "--json",
        ]);
        expect(shown.exitCode, shown.diagnostic()).toBe(0);
        const entries = shown.json<{
          data: {
            execution: {
              entries: readonly {
                detail: {
                  diagnostics: {
                    collection: { state: string; limitations: readonly unknown[] };
                    diagnostics: readonly {
                      code: string;
                      phase: string;
                      summary: string;
                    }[];
                  };
                };
              }[];
            };
          };
        }>().data.execution.entries;
        expect(entries, shown.diagnostic()).toHaveLength(1);
        expect(entries[0]!.detail.diagnostics.collection, shown.diagnostic()).toEqual({
          state: "complete",
          limitations: [],
        });
        expect(entries[0]!.detail.diagnostics.diagnostics, shown.diagnostic()).toEqual([
          expect.objectContaining({
            code: "timeout",
            phase: "agent.send",
            summary: "attempt timed out (4000ms, from experiment)",
          }),
        ]);
      });
    },
  );
});
```

### `e2e/lifecycle/test/interrupt-cleanup.test.ts`

- Purpose: `feature + bug regression`
- Protects: Local and Docker managed processes preserve duplex bytes and are released at Attempt completion.
- Runs: Installed candidate against managed-local and managed-docker Experiments.
- Asserts: Both Experiments complete with managed-process passed and the lifecycle harness reports clean termination.

```ts
// owner: docs/engineering/testing/e2e/README.md#lifecycle
import { readFile } from "node:fs/promises";
import { join, resolve } from "node:path";
import {
  command,
  defined,
  only,
  pollUntil,
  withProcess,
  withProjectCopy,
} from "@niceeval/testkit";
import { expect, test } from "vitest";
import { siblingCompleteMarker } from "../experiments/interrupts/complete.ts";

interface BackendInfo { pid: number; port: number }
interface ProcessReceipt { diagnostic(): string }
interface ExpEvent {
  event: string;
  status?: string;
  experimentId?: string;
  evalId?: string;
  verdict?: string;
  locator?: string;
}
const binary = join(process.cwd(), "node_modules", ".bin", "niceeval");
const niceeval = command([binary]);
const docker = command(["docker"]);
const interruptedExperimentId = "interrupts/inflight";
const completeSiblingExperimentId = "interrupts/complete";
const projectCopy = {
  from: process.cwd(),
  prefix: "niceeval-e2e-lifecycle-project-",
  omitTopLevel: [".niceeval", "node_modules", "test"],
  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
} as const;

async function backendInfo(path: string): Promise<BackendInfo | undefined> {
  try {
    const value = JSON.parse(await readFile(path, "utf8")) as BackendInfo;
    return typeof value.pid === "number" && typeof value.port === "number" ? value : undefined;
  } catch {
    return undefined;
  }
}

async function fileExists(path: string): Promise<true | undefined> {
  try {
    await readFile(path);
    return true;
  } catch {
    return undefined;
  }
}

async function whileRunning<T>(
  action: Promise<T>,
  exited: Promise<ProcessReceipt>,
  label: string,
): Promise<T> {
  return await Promise.race([
    action,
    exited.then((receipt) => {
      throw new Error(`niceeval exited before ${label}\n${receipt.diagnostic()}`);
    }),
  ]);
}

async function waitForHealth(port: number, exited: Promise<ProcessReceipt>): Promise<void> {
  await whileRunning(
    pollUntil(
      async () => {
        try {
          return (await fetch(`http://127.0.0.1:${port}/health`)).status === 200 ? true : undefined;
        } catch {
          return undefined;
        }
      },
      { timeoutMs: 15_000, intervalMs: 100, label: "owned backend health" },
    ),
    exited,
    "the owned backend became healthy",
  );
}

function outputLines(stdout: string): string[] {
  return stdout.split("\n").map((line) => line.trim()).filter((line) => line !== "");
}

async function containersOwnedBy(pid: number, cwd: string): Promise<string[]> {
  const listed = await docker.run(
    ["ps", "-aq", "--filter", `label=niceeval.pid=${pid}`],
    { cwd },
  );
  if (listed.exitCode !== 0) throw new Error(listed.diagnostic());
  return outputLines(listed.stdout);
}

async function waitForOwnedContainersGone(pid: number, cwd: string): Promise<void> {
  await pollUntil(
    async () => (await containersOwnedBy(pid, cwd)).length === 0 ? true : undefined,
    { timeoutMs: 15_000, intervalMs: 100, label: `Docker sandboxes owned by invocation ${pid} to be removed` },
  );
}

async function waitForSecondReuseAttempt(pid: number, cwd: string): Promise<void> {
  await pollUntil(
    async () => {
      const containers = await containersOwnedBy(pid, cwd);
      for (const container of containers) {
        const ready = await docker.run(
          ["exec", container, "test", "-f", "/tmp/niceeval-lifecycle-second-attempt-ready"],
          { cwd },
        );
        if (ready.exitCode === 0) return true;
      }
      return undefined;
    },
    { timeoutMs: 60_000, intervalMs: 250, label: "second attempt in reused Docker sandbox" },
  );
}

test("SIGINT 中断复用 Docker Sandbox、执行 teardown、释放 owned 资源，下一消费者仍可运行", async () => {
  await withProjectCopy(projectCopy, async ({ root }) => {
    const infoPath = join(root, ".niceeval-lifecycle-backend.json");
    const siblingMarkerPath = join(root, siblingCompleteMarker);
    const owned = await withProcess(
      [binary, "exp", "interrupts", "--rerun", "all", "--json"],
      {
        cwd: root,
        processGroup: true,
        timeoutMs: 120_000,
        graceMs: 5_000,
      },
      async (controlled) => {
        const info = await whileRunning(
          pollUntil(() => backendInfo(infoPath), {
            timeoutMs: 15_000,
            intervalMs: 100,
            label: "owned backend receipt",
          }),
          controlled.done,
          "the owned backend receipt was written",
        );
        await waitForHealth(info.port, controlled.done);
        const invocationPid = defined(controlled.pid, "niceeval invocation did not expose a pid");
        await whileRunning(
          pollUntil(() => fileExists(siblingMarkerPath), {
            timeoutMs: 60_000,
            intervalMs: 100,
            label: "sibling Experiment completion marker",
          }),
          controlled.done,
          "the sibling Experiment completed",
        );
        // The second-attempt marker proves that attempt 1 settled and released
        // the reused sandbox. Together the two fixture seams define when to send
        // SIGINT without depending on a sampled progress heartbeat.
        await waitForSecondReuseAttempt(invocationPid, root);
        expect(controlled.signal("SIGINT")).toBe(true);

        const interrupted = await controlled.done;
        expect(interrupted.exitCode, interrupted.diagnostic()).toBe(130);
        const events = interrupted.ndjson<ExpEvent>();
        // receipt 只承载 Invocation completion 与已发布 Run ID（见
        // docs/feature/experiments/cli.md「结束反馈与 receipt」）。业务 outcome 仍由带身份的
        // eval 事件断言；不读取 Record 内部细节。
        const interruptedReceipt = interrupted.expReceipt();
        expect(interruptedReceipt, interrupted.diagnostic()).toMatchObject({
          completion: "interrupted",
        });
        // The selected `interrupts/` directory creates two Runs. The sibling
        // has settled before SIGINT; the other Run keeps its completed first
        // Attempt and closes the reserved second Attempt as interrupted.
        expect(interruptedReceipt.runIds, interrupted.diagnostic()).toHaveLength(2);
        const completedBeforeInterrupt = only(
          events,
          (event) => event.event === "eval" && event.experimentId === interruptedExperimentId,
          interrupted.diagnostic(),
        );
        expect(completedBeforeInterrupt).toMatchObject({
          event: "eval",
          experimentId: interruptedExperimentId,
          evalId: "interrupt",
          verdict: "passed",
          locator: expect.stringMatching(/^@1[0-9A-HJKMNP-TV-Z]{12}$/),
        });
        expect(
          only(
            events,
            (event) => event.event === "eval" && event.experimentId === completeSiblingExperimentId,
            interrupted.diagnostic(),
          ),
        ).toMatchObject({ event: "eval", experimentId: completeSiblingExperimentId, evalId: "probe", verdict: "passed" });
        expect(
          only(
            events,
            (event) =>
              event.event === "experiment_teardown" &&
              event.experimentId === interruptedExperimentId &&
              event.status === "done",
            interrupted.diagnostic(),
          ),
        ).toMatchObject({ status: "done" });

        const completedAttempt = await niceeval.run([
          "show",
          completedBeforeInterrupt.locator!,
          "--json",
        ], { cwd: root });
        expect(completedAttempt.exitCode, completedAttempt.diagnostic()).toBe(0);
        expect(completedAttempt.json<{ data: { kind: string } }>().data.kind).toBe("attempt");

        const visibleInventory = await niceeval.run(["show", "--json"], { cwd: root });
        expect(visibleInventory.exitCode, visibleInventory.diagnostic()).toBe(0);
        expect(visibleInventory.stdout).toContain(completedBeforeInterrupt.locator!);

        return {
          invocationPid,
          backendPid: info.pid,
          port: info.port,
        };
      },
    );

    expect(() => process.kill(owned.invocationPid, 0)).toThrow();
    expect(() => process.kill(owned.backendPid, 0)).toThrow();
    await expect(fetch(`http://127.0.0.1:${owned.port}/health`)).rejects.toThrow();
    await waitForOwnedContainersGone(owned.invocationPid, root);

    const next = await niceeval.run(["exp", "probe", "--rerun", "all", "--json"], {
      cwd: root,
    });
    expect(next.exitCode, next.diagnostic()).toBe(0);
    const nextEvents = next.ndjson<ExpEvent>();
    expect(next.expReceipt(), next.diagnostic()).toMatchObject({ completion: "completed" });
    expect(
      only(
        nextEvents,
        (event) => event.event === "eval" && event.experimentId === "probe",
        next.diagnostic(),
      ),
    ).toMatchObject({ event: "eval", experimentId: "probe", evalId: "probe", verdict: "passed" });
  });
});

test("安装后候选的 Local 与 Docker provider 保持 managed process 双工 bytes、分流、EOF、自然退出、terminate 与 Attempt cleanup", async () => {
  await withProjectCopy(projectCopy, async ({ root }) => {
    for (const experiment of ["managed-local", "managed-docker"]) {
      const result = await niceeval.run(["exp", experiment, "--rerun", "all", "--json"], {
        cwd: root,
        timeoutMs: 120_000,
      });
      expect(result.exitCode, result.diagnostic()).toBe(0);
      expect(result.expReceipt(), result.diagnostic()).toMatchObject({ completion: "completed" });
      expect(
        only(result.ndjson<ExpEvent>(), (event) => event.event === "eval", result.diagnostic()),
      ).toMatchObject({ experimentId: experiment, evalId: "managed-process", verdict: "passed" });
    }
  });
});
```

### Verification receipt

- Candidate: `d74c7924`, tarball SHA-256 `971c03d572be56e6800b7041f3fa66ad60b0757fc77a929723e5ddbe16fb0240`
- Red: report 4 行而预期 3 行；Codex/Claude 均为 `Expected exactly one pending input request, found 0`；OMP events 为 failed；线上 timeout 多出 `attempt.teardown`，Codex app-server 静默跳过 SessionStart hook。
- Green: report browser E2E；Claude Code live owner 2 tests passed；Codex 公开 readback 为 hitl passed、hitl-content failed、plugin-hook passed；OMP 1 passed；local timeout 1 passed；Local/Docker lifecycle 1 passed。
- Repeatability: 固定 Codex 0.144.1（Plugin 使用含 hook BrokenPipe 修复的 0.146.0）、Claude Code 2.1.207；live owner 使用本次授权的最小运行，scratch 均清理。
- Fixed conditions: 当前 checkout/lockfile、Docker provider、各 adapter 固定镜像与模型配置。
- Unit count: `not applicable — no Unit changed`

### Deliberately not automated

- Case: E2B/Vercel managed process
- Public action: 使用对应 sandbox 创建 Codex/Claude adapter。
- Observation: setup 返回具名 unsupported reason。
- Remaining risk: 云 provider 边界尚无安装后公开入口 E2E，因此本 PR 不启用该能力。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789829755&installation_model_id=431746&pr_number=81&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F81&signature=9d7f303238dd2f76d82ce4c28fafa99b8d096b34301ffe13aecffa5f90f43bf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
