### PR TITLE
feat(report): 为页面和弹窗加入加载骨架

### DIFF
--- a/src/report/assets/styles.css
+++ b/src/report/assets/styles.css
@@ -2644,6 +2644,90 @@ html.niceeval-view-document body {
 
 .niceeval-view-report-slot { margin: 0 auto 36px; }
 
+.niceeval-view-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.niceeval-view-skeleton {
+  --niceeval-skeleton-base: var(--niceeval-color-surface-subtle, #151515);
+  --niceeval-skeleton-shine: var(--niceeval-color-border-strong, #343434);
+  display: grid;
+  gap: 28px;
+  width: 100%;
+  min-height: 440px;
+}
+
+.niceeval-view-skeleton-line,
+.niceeval-view-skeleton-cards > span,
+.niceeval-view-skeleton-chart,
+.niceeval-view-skeleton-table,
+.niceeval-view-skeleton-table > i {
+  display: block;
+  border-radius: var(--niceeval-radius, 0);
+  background: linear-gradient(
+    100deg,
+    var(--niceeval-skeleton-base) 25%,
+    var(--niceeval-skeleton-shine) 44%,
+    var(--niceeval-skeleton-base) 63%
+  );
+  background-size: 300% 100%;
+  animation: niceeval-view-skeleton-shimmer 1.7s ease-in-out infinite;
+}
+
+.niceeval-view-skeleton-heading { display: grid; gap: 12px; }
+.niceeval-view-skeleton-eyebrow { width: 92px; height: 10px; }
+.niceeval-view-skeleton-title { width: min(440px, 68%); height: 32px; }
+.niceeval-view-skeleton-copy { width: min(620px, 86%); height: 14px; }
+
+.niceeval-view-skeleton-cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.niceeval-view-skeleton-cards > span { height: 104px; }
+
+.niceeval-view-skeleton-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(240px, .65fr);
+  gap: 18px;
+}
+
+.niceeval-view-skeleton-chart { min-height: 230px; }
+.niceeval-view-skeleton-table { min-height: 230px; padding: 24px 20px; }
+.niceeval-view-skeleton-table > i { height: 12px; margin-bottom: 24px; }
+.niceeval-view-skeleton-table > i:nth-child(2) { width: 82%; }
+.niceeval-view-skeleton-table > i:nth-child(3) { width: 91%; }
+.niceeval-view-skeleton-table > i:nth-child(4) { width: 68%; }
+
+.niceeval-view-skeleton-overlay {
+  min-height: 360px;
+  padding-top: 12px;
+}
+
+@keyframes niceeval-view-skeleton-shimmer {
+  from { background-position: 100% 0; }
+  to { background-position: 0 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .niceeval-view-skeleton-line,
+  .niceeval-view-skeleton-cards > span,
+  .niceeval-view-skeleton-chart,
+  .niceeval-view-skeleton-table,
+  .niceeval-view-skeleton-table > i {
+    animation: none;
+  }
+}
+
 /* View shell owns only the modal chrome. The report body inside the dialog
    keeps the same closed product markup and the same stylesheet as its direct
    route; the runtime injects no second CSS owner. */
@@ -2758,6 +2842,12 @@ html.niceeval-view-document body {
   .niceeval-view-experiment select { min-width: 108px; }
   .niceeval-view-language select { min-width: 68px; }
   .niceeval-view-main { width: min(calc(100vw - 28px), 1120px); padding-top: 42px; }
+  .niceeval-view-skeleton { min-height: 380px; gap: 20px; }
+  .niceeval-view-skeleton-cards { grid-template-columns: 1fr; }
+  .niceeval-view-skeleton-cards > span:nth-child(n + 2) { display: none; }
+  .niceeval-view-skeleton-content { grid-template-columns: 1fr; }
+  .niceeval-view-skeleton-chart { min-height: 190px; }
+  .niceeval-view-skeleton-table { display: none; }
 }
 
 @media print {

--- a/src/report/client/App.tsx
+++ b/src/report/client/App.tsx
@@ -67,9 +67,35 @@ function FragmentBody({
 }) {
   if (state.status === "loading")
     return (
-      <p role="status" aria-live="polite">
-        {message(locale, overlay ? "loadingDetails" : "loading")}
-      </p>
+      <div
+        className={`niceeval-view-skeleton${overlay ? " niceeval-view-skeleton-overlay" : ""}`}
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+      >
+        <span className="niceeval-view-sr-only">
+          {message(locale, overlay ? "loadingDetails" : "loading")}
+        </span>
+        <div className="niceeval-view-skeleton-heading" aria-hidden="true">
+          <span className="niceeval-view-skeleton-line niceeval-view-skeleton-eyebrow" />
+          <span className="niceeval-view-skeleton-line niceeval-view-skeleton-title" />
+          <span className="niceeval-view-skeleton-line niceeval-view-skeleton-copy" />
+        </div>
+        <div className="niceeval-view-skeleton-cards" aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </div>
+        <div className="niceeval-view-skeleton-content" aria-hidden="true">
+          <span className="niceeval-view-skeleton-chart" />
+          <span className="niceeval-view-skeleton-table">
+            <i />
+            <i />
+            <i />
+            <i />
+          </span>
+        </div>
+      </div>
     );
   if (state.status === "error")
     return (


### PR DESCRIPTION
<!-- niceeval:pr-body
base: eef5801c819a08570f9382cba266ddaa65c50a85
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: f3b9d1166a33fd9e7b5bb981122bd89c706131be
-->

## Problem

- User goal: Report 读者在页面或详情加载期间仍能看懂即将出现的内容结构。
- Current limitation: 普通 Page 与 overlay 只显示一行加载文字；网络稍慢时页面近似空白，modal 也缺少详情内容轮廓。
- Required capability: Report shell 需要为页面和 overlay 共用一套响应式骨架，同时保留现有加载状态的可访问语义。
- User outcome: 页面立即显示标题、摘要、图表和表格占位；打开 Attempt 等 overlay 时，modal 外壳和详情骨架会先出现，再由真实内容原位替换。

## Use cases

### Case: `在 Report 中等待页面或详情加载`

#### Starting state

```text
用户已运行 niceeval view，并打开一个包含普通 Page 与 Attempt overlay 的报告。
```

#### Action

```sh
pnpm exec niceeval view --no-open
```

```text
用户在浏览器打开 view URL，然后点击一个 Attempt 链接。
```

#### Result

```text
普通 Page 加载时显示标题、摘要卡、图表和表格骨架。
Attempt overlay 加载时立即显示 modal 外壳与详情骨架。
加载完成后，骨架由对应 Page 或 Attempt 正文原位替换。
```

这条流程同时覆盖普通 route 与 overlay；加载失败仍进入既有错误提示和 Retry，不改变导航、关闭或重试行为。

## Observable behavior and data contracts

### Changed

#### Case: `Report fragment 加载反馈`

##### Before

```sh
pnpm exec niceeval view --no-open
```

```text
普通 Page：Loading…
Attempt overlay：Loading details…
```

##### After

```sh
pnpm exec niceeval view --no-open
```

```text
页面：标题、摘要卡、图表和表格骨架
Modal：详情内容骨架，保留可关闭的 dialog 外壳
读屏：Loading… / Loading details…，并报告 busy 状态
```

##### User impact

加载过程不再呈现近似空白的页面或只有一行文字的 modal。骨架在窄屏自动简化；系统要求减少动态效果时 shimmer 会停用。Report 作者 API、Record 数据和最终正文均不变化。

## Tests

### Verification receipt

- Candidate: `f3b9d1166a33fd9e7b5bb981122bd89c706131be`; NiceEval tarball SHA-256 `6e1e61bcf5388dc67eababecf5d6a1968e3d032a9bbb49a5e58a5e81f1d7074e`
- Green: `pnpm e2e --repo report -- --run test/report.browser.spec.ts` → Chromium 2 passed；包含拦截详情 fragment、确认 dialog 与 loading status 先出现、释放请求后呈现 Attempt 的公开浏览器流程
- Repeatability: 本次未新增或实质修改自动化 owner，因此不触发 takeover；runner 确认隔离 consumer、进程与 scratch cleanup 均正常结束
- Fixed conditions: 当前 checkout、仓库 lockfile、签入 report fixture、Playwright Chromium 1.61.1；无随机 seed 或外部 provider
- Unit count: `not applicable — no Unit changed`

### Deliberately not automated

- Case: 骨架轮廓、响应式密度与 shimmer 视觉效果
- Public action: 使用候选包运行 `niceeval view --no-open`，在真实 Chromium 中打开普通 Page 与延迟返回的 Attempt overlay
- Observation: 浏览器 owner 已证明 modal 和可访问 loading 状态在详情请求完成前出现；CSS 交付页面与 modal 的结构化骨架、窄屏收敛规则及 reduced-motion 静态状态
- Remaining risk: 自动化不锁私有 CSS class、像素或精确颜色；细微的骨架比例与动画视觉退化仍依赖固定 world 的人工浏览器验收

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789948417&installation_model_id=431746&pr_number=87&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F87&signature=021238f5a15d40b37e03c9662f268766e4c70a6f85e63e945fc21480867781d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
