### PR TITLE
feat(sandbox): 复用并盘点 Docker 任务镜像缓存

### DIFF
--- a/docs-site/zh/reference/cli.mdx
+++ b/docs-site/zh/reference/cli.mdx
@@ -181,6 +181,8 @@ E2B template name 与 Vercel snapshot ID 是 Provider 管理的任意字符串�
 | `--owner-token` | string | `--recover-shared-state` 专用:要恢复的不可变 owner token；错误或过期 token 不会修改 lease。 |
 | `--confirm-owner-terminated` | boolean | `--recover-shared-state` 专用:确认原 owner 已终止。 |
 | `--confirm-remote-quiesced` | boolean | `--recover-shared-state` 专用:确认远端外部状态已静止。 |
+| `--domain` | string | `cache inventory\|gc` 专用：选择一个精确 Materialization Domain。 |
+| `--apply` | string | `cache gc` 专用：执行先前持久化的精确 plan id；省略时只创建预览。 |
 | `--dry` | boolean | 只打印本次会匹配到的 eval × 运行配置,不实际执行(人读文本或 `--json` 单文档,见「机器怎么读:--json」)。 |
 | `--force` | boolean | `sandbox prune` 专用:除 orphan 外也销毁 unverified 实例;`exp` 明确拒绝此 flag,重跑失败项或全部项请用 `--rerun` / `--rerun all`。 |
 | `--rerun` | boolean | `exp` 命令专用:重新运行失败项(裸写/failed)或全部项(all),不改变长期指纹。 |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -97,6 +97,9 @@ Roadmap 提出的候选原语单列在「候选术语」,链接 Roadmap 入口;�
 | 主 Sandbox | —(`workspaceService` 对应实例) | Provider 启动的唯一执行空间;Agent、Eval、文件 API、workdir 与 diff 都锚定它 | [Sandbox 实例与伴随资源](feature/sandbox/case.md#主-sandbox-不变量) |
 | BuildKey | BuildKey | 一次 Provider 构建的输入身份,用于复用 Docker image 或 E2B template 构建结果 | [Sandbox 实例与伴随资源](feature/sandbox/case.md#buildkey-与-casekey两个身份各管一件事) |
 | CaseKey | CaseKey | 完整 attempt 运行条件身份,携带门的判据 | [Sandbox 实例与伴随资源](feature/sandbox/case.md#buildkey-与-casekey两个身份各管一件事) |
+| Provider cache | Provider cache | Provider 为后续 Sandbox 保留的 Agent npm tarball、任务构建结果或原生 build cache；不属于结果携带或留存 Sandbox | [Provider Cache 生命周期](roadmap/sandbox-materialization/cache-lifecycle/README.md) |
+| Materialization Domain | Materialization Domain | 单一 cache backend 的所有权、命中、lease 与回收边界；identity 改变时形成新 Domain | [Provider Cache Architecture](roadmap/sandbox-materialization/cache-lifecycle/architecture.md#materialization-domain) |
+| GC 计划 | GcPlan | 对一个 Materialization Domain 的不可变回收授权预览；apply 只能因事实漂移缩减候选，不能扩大候选 | [Provider Cache CLI](roadmap/sandbox-materialization/cache-lifecycle/cli.md#两阶段回收) |
 | Sandbox 留存能力 | SandboxRetention | Provider 返回的独立能力句柄；主实例与伴随资源同时 suspend，跨进程由 detached provider inspect / wake / destroy | [Sandbox 实例与伴随资源](feature/sandbox/case.md#收尾留存与注册表) |
 
 ### Sandbox stack

--- a/docs/engineering/testing/e2e/cli.md
+++ b/docs/engineering/testing/e2e/cli.md
@@ -47,6 +47,7 @@ When 从安装后的 candidate 运行 `niceeval exp provider-error --rerun all`�
 Then：
 
 - 四条安全封口后的 `error:` 都可见，长文本按显示宽度折行并以 head + tail 收口；不同 message 不因 phase/code 或跨 Run 的局部 `n1` 相同而合并；
+- 两个唯一 BuildKey 各显示一次 cache query 和失败，每行明确只有一条依赖 Attempt，不把共享构建写成 Sandbox 数；
 - Human 不出现 cause secret、`n1`、BuildKey、timing node、failureId、`cause:` 或 `fix:`；
 - 两条 post-Attempt error 各自紧跟 `details: niceeval show @<locator>`；pre-Attempt error 在 receipt 后的 `NEXT`
   按 Experiment 紧跟 `details: niceeval show --run <runId>`；

--- a/docs/engineering/testing/e2e/cli.md
+++ b/docs/engineering/testing/e2e/cli.md
@@ -48,6 +48,14 @@ Then：
 
 - 四条安全封口后的 `error:` 都可见，长文本按显示宽度折行并以 head + tail 收口；不同 message 不因 phase/code 或跨 Run 的局部 `n1` 相同而合并；
 - 两个唯一 BuildKey 各显示一次 cache query 和失败，每行明确只有一条依赖 Attempt，不把共享构建写成 Sandbox 数；
+
+#### cli-cache-inventory
+
+Given Docker 的共享 BuildKit builder 报告总容量和 Provider reclaimable estimate，但没有 NiceEval Domain identity、entry 或 lease。
+
+When 从安装后的 candidate 运行 `niceeval cache inventory --json`。
+
+Then 输出把 BuildKit 放进独立的 `providerObservations`，状态为 `unverified`，不产生 `domainId`、`evictable` 或 GcPlan。
 - Human 不出现 cause secret、`n1`、BuildKey、timing node、failureId、`cause:` 或 `fix:`；
 - 两条 post-Attempt error 各自紧跟 `details: niceeval show @<locator>`；pre-Attempt error 在 receipt 后的 `NEXT`
   按 Experiment 紧跟 `details: niceeval show --run <runId>`；

--- a/docs/engineering/testing/e2e/cli.md
+++ b/docs/engineering/testing/e2e/cli.md
@@ -56,6 +56,15 @@ Given Docker 的共享 BuildKit builder 报告总容量和 Provider reclaimable 
 When 从安装后的 candidate 运行 `niceeval cache inventory --json`。
 
 Then 输出把 BuildKit 放进独立的 `providerObservations`，状态为 `unverified`，不产生 `domainId`、`evictable` 或 GcPlan。
+
+#### cli-docker-task-build-cache
+
+Given 一个 Dockerfile Sandbox 的 BuildKey 未变化，且前一次 Invocation 已把 image 与 manifest 写入受管 registry。
+
+When 从安装后的 candidate 连续两次运行同一 Experiment，并明确要求 rerun Attempt。
+
+Then 第一次只显示一次 `built once`，第二次显示 `build cache hit`，fake Docker 的 build 计数仍为一。
+两次等待 build 与 consumer use lease 都不占 Attempt permit；测试不读取 `.niceeval` 私有结果证明缓存命中。
 - Human 不出现 cause secret、`n1`、BuildKey、timing node、failureId、`cause:` 或 `fix:`；
 - 两条 post-Attempt error 各自紧跟 `details: niceeval show @<locator>`；pre-Attempt error 在 receipt 后的 `NEXT`
   按 Experiment 紧跟 `details: niceeval show --run <runId>`；

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/README.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/README.md
@@ -43,3 +43,6 @@ Sandbox 实例的停驻和销毁归 [Sandbox 默认停驻与回收](../../sandbo
 
 - [CLI](cli.md)定义需求、库存与回收命令。
 - [Architecture](architecture.md)定义 Cache Manifest、Domain、lease 和删除不变量。
+- [并行运行的共享任务镜像](use-case/并行运行的共享任务镜像.md)定义多个 Attempt 怎样等待、命中和复用少量 BuildKey。
+- [回收过期任务镜像](use-case/回收过期任务镜像.md)定义 task-build image 的安全淘汰路径。
+- [盘点共享 BuildKit 缓存](use-case/盘点共享BuildKit缓存.md)定义未验证容量怎样展示，以及用户自行回收的责任边界。

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/architecture.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/architecture.md
@@ -1,5 +1,36 @@
 # Architecture
 
+## Provider 中立边界
+
+缓存不是 `Sandbox` 的通用能力。`SandboxLayer` 仍是纯声明，单个已创建 Sandbox 是由
+`Effect.acquireRelease` 管理的 scoped handle；二者都不携带 Docker image、E2B template、
+Vercel snapshot 或 GC 语义。
+
+Runner 只协调 provider 给出的 `MaterializationScopeId`、`BuildKey` 与 opaque artifact source。
+scope id 是 `{ providerFamily, authorityFingerprint, materializationProtocolVersion }` 的 canonical digest；
+Runner 只比较它，不能解释或把它当成可库存的 Cache Domain。
+
+single-flight identity 固定为 `(MaterializationScopeId, BuildKey)`：Docker 可以把 verified image Domain
+投影进 scope，E2B 可以使用 template authority。Vercel 即使不提供持久 cache，
+也可以在一次 Invocation 内 build once。
+
+Provider lookup 返回 `Hit | Miss | Unsupported`。`Unsupported` 只表示没有持久 lookup，不会关闭 invocation-local
+single-flight。key 级结算只产生 available source；每个 Attempt 在取得执行 permit 前独立 `acquireUse()`，等待
+available 与取得 use handle 都不占 Attempt concurrency。
+
+Effect 边界按生命周期分层：
+
+- 纯函数负责 canonical identity、manifest digest、状态分类、GC policy、plan digest 与 CLI projection；
+- 进程级 Service 只提供无状态 port 或 factory，例如 Clock、Entropy、ProcessIdentity 和 provider client factory；
+- provider Domain scope 持有 verified authority、registry connection、epoch 与 reconciler；
+- operation/consumer scope 持有 reservation、entry lock、lease、scratch 与 use handle；
+- Layer 只在具体 provider 的 composition root 组装 live adapter，不承载策略。
+
+Docker provider 私有组合 Docker Engine port、Docker registry 与 task-build cache。E2B、Vercel 与未来 provider
+无需实现 Docker Domain、SQLite、image lease 或 GC。CLI 也不直接导入 Docker cache：受信任的 provider admin
+adapter 只负责 `listDomains()` 与 `observeProviderCapacity()`；每个受管 Domain 再打开独立的
+`DomainAdministration`。共享 BuildKit observation 没有 Domain controller，类型上不存在 plan/apply。
+
 ## V1 架构裁决
 
 V1 的 Agent 安装正确性路径固定为宿主内容寻址 artifact cache，再由 Sandbox 启动阶段的 Ensure 注入。
@@ -35,11 +66,11 @@ owner state 丢失会产生新 owner；旧 owner 的资源不会被新 owner 自
 | backend | identity |
 |---|---|
 | host CAS | CAS format version、CAS root 内持久随机 UUID、可验证 filesystem 或 volume identity 的摘要 |
-| Docker image store | daemon id、storage driver、NiceEval sentinel volume 内持久随机 UUID 的摘要 |
+| Docker image store | daemon id、storage driver、NiceEval sentinel volume 不可变 label 中持久随机 UUID 的摘要 |
 | BuildKit | 专属 builder 与 node identity、worker identity、受管 storage epoch 的摘要 |
 
 CAS root 初始化时原子写入 UUID 并完成 durable commit。
-Docker sentinel UUID 必须同时通过 daemon inspect 与 volume 内容验证。
+Docker sentinel UUID 必须通过 daemon inspect 与 volume inspect 验证；缺失或非受管 label 会让 Domain 拒绝写入。
 任一组成事实不可验证时，Domain 只读。
 
 identity 变化会创建新 Domain，禁止 rebind 或 adopt。
@@ -104,20 +135,35 @@ interface CacheManifest {
 
 ## Invocation 任务构建协调
 
-一次 Invocation 先按 `(domainId, BuildKey)` 收集并去重冻结选择的任务构建需求。
-BuildKey 相同但 Domain 不同的需求不能共享查询、single-flight、locator 或 lease。
+一次 Invocation 先按 `(MaterializationScopeId, BuildKey)` 收集并去重冻结选择的任务构建需求。
+BuildKey 相同但 provider authority 不同的需求不能共享查询、single-flight、locator 或 use handle。
 
 任务构建协调与 Attempt 调度属于两个独立容量域：
 
 1. BuildKey discovery、cache query、single-flight wait 和实际 build 都不占 Attempt concurrency。
 2. cache query 逻辑并发；Provider 可以配置独立的 query 安全上限，但不能复用 Attempt concurrency。
 3. `buildConcurrency` 只限制实际 miss build，必须大于零；它不限制 query 或同 key waiter。
-4. Attempt 的全部 BuildKey 都 ready，并成功取得所需 read lease 后，才进入 Attempt concurrency 队列。
+4. key 级 `ready` 只表示 artifact available。每个 Attempt 的全部 consumer use handle 都 acquired 后，才进入 Attempt concurrency 队列。
 5. ready key 的 Attempt 立即具备放行资格。较早发现的 miss waiter 不能形成队首阻塞，也不能阻止其它 key 的 hit 放行。
 
 一个 build 失败时，同 key waiter 接收同一个具名 build failure origin。
 取消 waiter 不取消仍被其它 consumer 使用的共享 build；Run 取消则禁止尚未 ready 的 Attempt 继续放行。
 Provider 长操作不持有 registry transaction、Domain 全局锁或 Attempt 调度锁，避免 build lease、entry lock 与执行 permit 形成循环等待。
+
+同一 key 的每个 consumer 都有独立 use handle；一个 Attempt 结束不会释放其它 Attempt 的保护。
+普通 acquire 失败只影响该 consumer；`ArtifactInvalidated` 会撤销 key source，并让尚未 acquired 的 consumer
+共享同一个失效 origin。首次 miss 创建稳定 operation id，reservation、重试、publish 和 reconcile 全程复用；
+coordinator 可以重入同一 operation，但不得因为重试创建新 generation。
+
+Docker 短 lease 到 Sandbox durable root 的交接先写 durable prepared root，再创建 provider reference。
+inspect immutable reference 成功后，registry 通过 CAS 写 active root，最后释放 short lease。
+中途崩溃交给 reconcile，不得直接删除 prepared/active 保护。
+
+## 本轮明确排除
+
+本轮不交付 pressure automatic GC、managed controller、专属 BuildKit Domain 或通用 Sandbox cache service。
+普通本地 Docker max-age GC 只允许显式 preview/apply。共享 BuildKit 仍是 unverified provider observation；
+Sandbox orphan 仍只使用 `niceeval sandbox prune`。
 
 任务构建状态按 key 前进：
 

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/architecture.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/architecture.md
@@ -24,6 +24,9 @@ interface DomainIdentity {
 host CAS、Docker image store 和 BuildKit 是三个 Domain，不能用 Docker daemon id 代替其它 backend identity。
 `cache status` 可以聚合多个 Domain 的需求，库存明细、GcPlan 和 apply 始终只属于一个 Domain。
 
+共享或默认 BuildKit builder 不满足下表的 BuildKit identity，因此不是 Materialization Domain。
+它只能产生 provider-level `unverified` capacity observation，不能取得 domain id、entry、lease 或 GcPlan。
+
 `ownerId` 是当前 OS 用户保存在 `~/.local/state/niceeval/` 的随机 UUID。
 owner state 丢失会产生新 owner；旧 owner 的资源不会被新 owner 自动接管。
 
@@ -98,6 +101,35 @@ interface CacheManifest {
 
 缺少必需兼容轴或遇到未知 schema 时，entry 为 `unverified`。
 `intentProjection` 只解释同一意图的旧配方，不授予命中、迁移或删除资格。
+
+## Invocation 任务构建协调
+
+一次 Invocation 先按 `(domainId, BuildKey)` 收集并去重冻结选择的任务构建需求。
+BuildKey 相同但 Domain 不同的需求不能共享查询、single-flight、locator 或 lease。
+
+任务构建协调与 Attempt 调度属于两个独立容量域：
+
+1. BuildKey discovery、cache query、single-flight wait 和实际 build 都不占 Attempt concurrency。
+2. cache query 逻辑并发；Provider 可以配置独立的 query 安全上限，但不能复用 Attempt concurrency。
+3. `buildConcurrency` 只限制实际 miss build，必须大于零；它不限制 query 或同 key waiter。
+4. Attempt 的全部 BuildKey 都 ready，并成功取得所需 read lease 后，才进入 Attempt concurrency 队列。
+5. ready key 的 Attempt 立即具备放行资格。较早发现的 miss waiter 不能形成队首阻塞，也不能阻止其它 key 的 hit 放行。
+
+一个 build 失败时，同 key waiter 接收同一个具名 build failure origin。
+取消 waiter 不取消仍被其它 consumer 使用的共享 build；Run 取消则禁止尚未 ready 的 Attempt 继续放行。
+Provider 长操作不持有 registry transaction、Domain 全局锁或 Attempt 调度锁，避免 build lease、entry lock 与执行 permit 形成循环等待。
+
+任务构建状态按 key 前进：
+
+```text
+querying → hit → leasing → ready
+        ↘ queued → building → publishing → leasing → ready
+                                              ↘ failed
+```
+
+`hit` 只表示精确索引查询命中，不表示资源已经交付。
+只有 immutable identity 复核、lease 建立和交付入口就绪后才进入 `ready`。
+build 完成但 publish、index、identity 复核或 lease 失败时进入 `failed`，不得计为 hit 或 ready。
 
 ## 两级 fencing
 
@@ -248,6 +280,9 @@ V1 默认值如下：
 `superseded-for-selection` 只用于解释，不能改变优先级或删除资格。
 `legacy`、`foreign` 和 `unverified` 在任何 policy 下都不能成为 `evictable`。
 
+该顺序是安全门之后的稳定淘汰顺序，不是只按最近使用时间排序的 LRU。
+minimum age、`protectedUntil`、policy rule、lease、durable root 和 Provider reference 都先于最后成功使用时间。
+
 `lastSuccessfulUseAt` 只在资源完整交付给 consumer 后更新。
 status、inventory、planning、lease acquire、build 失败和交付失败都不刷新时间。
 新 entry 固定 `protectedUntil = createdAt + minimumAge`；调短 policy 不能缩短已有保护期。
@@ -300,6 +335,31 @@ legacy 资源永不进入 GcPlan、NiceEval apply 或自动迁移。
 
 构建 peak scratch 与稳态 cache 分列。
 缺失需求的增长区间必须展示同 kind、配方和平台的样本数与时间范围；没有实测时显示 unknown。
+
+## Provider-level BuildKit observation
+
+共享或默认 BuildKit builder 只产生只读 observation：
+
+```ts
+interface UnverifiedProviderCapacityObservation {
+  scope: "provider";
+  backendKind: "buildkit";
+  state: "unverified";
+  observedAt: string;
+  totalBytes: number | null;
+  reclaimableEstimateBytes: number | null;
+  reason: "shared-builder-unattributed";
+}
+```
+
+这个 observation 不属于 Domain inventory，不含 `domainId`、entry 或 NiceEval ownership。
+`reclaimableEstimateBytes` 是 Provider 自报估算，不是 NiceEval 的 exact marginal reclaim，也不授权删除。
+
+NiceEval 不为共享 builder 生成 GcPlan、自动 prune 或带 `--force` 的回收路径。
+CLI 可以展示用户自行执行的 Provider 命令，但必须同时说明它可能影响其它项目、builder session 与并行 build。
+
+BuildKit 只有在专属 managed builder 提供稳定 Domain identity、durable registry、lease/root、fencing 和 conditional delete 后，才能进入两阶段 GC。
+repository、image tag、cache record 年龄或 `docker system df` 不能替代这些证明。
 
 ## DestroyOnly 临时资源
 

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/cli.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/cli.md
@@ -7,7 +7,7 @@ niceeval cache status <experiment-prefix> [eval-prefix...] [--json]
 ```
 
 该命令复用 `exp --dry` 的发现、选择、link 和 physical planning，只读取冻结选择的精确需求。
-它可以聚合 host CAS、Docker image store 与 BuildKit Domain，但不会把不同 Domain 的库存或回收权限合并。
+它可以聚合 host CAS、Docker image store、受管 BuildKit Domain 与只读 Provider observation，但不会合并不同范围的库存或回收权限。
 
 人类输出逐类显示 `required-present`、`required-missing`、`superseded-for-selection` 和 `unverified`。
 增长估算必须带样本数、时间范围和 estimate 标记；没有数据时显示 unknown。
@@ -28,11 +28,68 @@ interface CacheStatusDocumentV1 {
     requiredMissing: CacheDemandItem[];
     supersededForSelection: CacheDemandItem[];
   }>;
+  providerObservations: UnverifiedProviderCapacityObservation[];
 }
 ```
 
 status 不会产生删除候选，也不会刷新 last successful use。
 “当前没有选择”与“可以删除”是两个不同事实。
+
+## Invocation 任务构建反馈
+
+真正运行 Experiment 时，`niceeval exp` 在 Attempt 行之外显示一条运行级任务构建摘要。
+它按 `(domainId, BuildKey)` 去重，不把 BuildKey 数写成 Sandbox 数，也不把多个依赖者写成多个 build。
+
+人类反馈使用以下形态：
+
+```text
+8 attempts require 4 BuildKeys · 3 cache hits · 1 built once · 2 attempts waited
+```
+
+逐 key active 行显示有界 label、短 BuildKey、依赖 Attempt 数和状态：`querying`、`hit`、`queued`、`building`、`publishing`、`leasing`、`ready` 或 `failed`。
+共享的是 BuildKey 对应的构建或缓存结果，不是 Attempt；逐 Attempt 的 `creating sandbox` 只在其依赖 key ready 后出现。
+
+JSON progress 与 result 使用独立字段：
+
+```ts
+interface MaterializationCacheSummary {
+  requiredBuildKeys: number;
+  dependentAttempts: number;
+  querying: number;
+  queued: number;
+  building: number;
+  readyFromCache: number;
+  readyFromBuild: number;
+  failed: number;
+  waitingAttempts: number;
+}
+
+interface MaterializationCacheItem {
+  domainId: string;
+  buildKey: string;
+  label: string;
+  dependentAttempts: number;
+  state: "querying" | "hit" | "queued" | "building" | "publishing" | "leasing" | "ready" | "failed";
+  source?: "cache" | "build";
+  operationId?: string;
+  error?: { code: string; message: string };
+}
+
+interface MaterializationCacheEvent extends ExperimentOutputFields {
+  type: "progress" | "result";
+  materializationCache: {
+    summary: MaterializationCacheSummary;
+    items: MaterializationCacheItem[];
+  };
+}
+```
+
+结束摘要从每个 key 的最终状态投影，不累计 progress event。
+重试、状态替换或多个 waiter 不得重复增加 hit、built 或 failed。
+`hit` 尚未建立 lease；只有 `ready` 且 `source: "cache"` 才进入 `readyFromCache`。
+
+`materializationCache` 不进入 `sandboxReuse`、结果携带、Sandbox retention 或 orphan 词表。
+共享 build failure 的 key 只有一个 operation origin；依赖它的 Attempt 继续按既有结果契约投影各自结局。
 
 ## Domain 库存
 
@@ -43,6 +100,10 @@ niceeval cache inventory --domain <domain-id> [--json]
 
 库存命令不加载项目 config、Eval 或 Experiment。
 不指定 Domain 时只列 Domain 摘要；指定后才读取单个 Domain 的 entry、lease、root、policy 和 provider inspect 事实。
+
+共享或默认 BuildKit builder 不是 Domain。
+不指定 Domain 的库存摘要把它放在独立的 `provider observations` 区块，只显示 `unverified` 总量和 reclaimable estimate。
+它不会出现在 `entries`、`evictable` 或 GcPlan 中。
 
 明细按 kind、状态、owner、lease、last successful use 和容量分组。
 逻辑大小、共享大小、estimate 与 exact marginal reclaim 分栏展示，不能相加的数字标为 `not additive`。
@@ -59,6 +120,7 @@ interface CacheInventoryDocumentV1 {
   schemaVersion: 1;
   scope: { kind: "domains" } | { kind: "domain"; domainId: string };
   domains: CacheDomainSummary[];
+  providerObservations: UnverifiedProviderCapacityObservation[];
   entries?: CacheInventoryEntry[];
 }
 ```

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/cli.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/cli.md
@@ -125,6 +125,43 @@ interface CacheInventoryDocumentV1 {
 }
 ```
 
+人类输出示例：
+
+```text
+Docker task builds · verified-managed · domain 8c3d90b7e5b94458
+  4 entries · 1 active-leased · 2 cold-reusable · 1 unverified
+  exact marginal reclaim unknown · shared bytes not additive
+
+BuildKit · unverified shared-builder capacity
+  total 402.6 GB · provider reclaimable estimate 221.6 GB
+  NiceEval ownership unknown · not eligible for NiceEval GC
+```
+
+Domain 明细 JSON 示例：
+
+```json
+{
+  "format": "niceeval.cache-inventory",
+  "schemaVersion": 1,
+  "scope": { "kind": "domain", "domainId": "8c3d90b7e5b94458" },
+  "domains": [{
+    "domainId": "8c3d90b7e5b94458",
+    "providerFamily": "docker",
+    "backendKind": "docker-images",
+    "state": "verified-managed",
+    "entryCount": 4
+  }],
+  "providerObservations": [],
+  "entries": [{
+    "entryId": "task-build:7d38…",
+    "state": "cold-reusable",
+    "immutableResourceIdentity": "sha256:91ac…",
+    "lastSuccessfulUseAt": "2026-08-01T02:10:00.000Z",
+    "exactMarginalReclaimBytes": null
+  }]
+}
+```
+
 ## 两阶段回收
 
 ```sh
@@ -203,6 +240,13 @@ interface CacheGcPlanDocumentV1 {
 每个候选保存 policy version、rule id、observed time、时间与容量 evidence 以及确定 order key。
 人类输出用这些字段解释“为什么该删”，而不是用 repository 名、创建时间或容器引用数单独推断。
 
+```text
+GC preview 3b3e7f0d… · domain 8c3d90b7e5b94458 · expires in 15m
+  2 candidates · rule max-age/task-build
+  exact reclaim unknown
+Apply with: niceeval cache gc --domain 8c3d90b7e5b94458 --apply 3b3e7f0d…
+```
+
 ## Apply JSON
 
 `cache gc --apply <plan-id> --json` 的 stdout 只有一个 JSON 文档：
@@ -247,6 +291,12 @@ interface CacheGcOutcomeDocumentV1 {
 
 重复 apply 读取已有 outcome，并按 architecture 的 deleting 状态机恢复，结果幂等。
 JSON 模式的 stdout 不含日志；诊断写入 stderr。
+
+```text
+GC outcome 3b3e7f0d… · 1 deleted · 1 skipped · 0 failed
+  deleted task-build:7d38… · max-age/task-build
+  skipped task-build:a102… · lease-acquired
+```
 
 ## 退出码
 

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/回收过期任务镜像.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/回收过期任务镜像.md
@@ -1,0 +1,49 @@
+# 回收过期任务镜像
+
+用户发现 Docker image store 中保留了多个历史 canary 的 task-build image，希望回收 NiceEval 自己拥有且不再活跃使用的镜像。
+
+## 先看库存
+
+用户运行：
+
+```sh
+niceeval cache inventory --domain <docker-image-domain>
+```
+
+NiceEval 只把 registry、Cache Manifest 和 Provider immutable identity 双向一致的 indexed image 列为受管 entry。
+共享 base image、layer、repository、tag、legacy image、foreign image 和 unverified image 都不会因此取得删除授权。
+
+库存分开显示逻辑大小、共享且不可相加的大小、estimate 与 exact marginal reclaim。
+Docker 总容量很高但无法取得完整内容图时，exact marginal reclaim 为 unknown；逻辑大小不能相加成可回收空间。
+
+## 生成稳定淘汰计划
+
+用户运行：
+
+```sh
+niceeval cache gc --domain <docker-image-domain>
+```
+
+minimum age、`protectedUntil`、max-age 或 verified pressure rule 先选择安全候选。
+候选再按最后成功使用时间、创建时间和 entry id 稳定排序；这不是绕过安全门并只看最近使用时间的 LRU。
+
+活跃 build/read/handoff lease、Sandbox durable root、container、mount、snapshot parent 或其它 Provider reference 都否决候选。
+一个旧 image 若仍被留存 Sandbox 的 durable root 引用，preview 不把它列入计划。
+
+容量事实不是 exact 时，pressure high-to-low 不产生候选。
+verified entry 仍可按 max-age 进入计划，但回收字节保持 estimate 或 unknown。
+
+## Apply 前出现新使用者
+
+用户使用 preview 返回的 plan id：
+
+```sh
+niceeval cache gc --domain <docker-image-domain> --apply <plan-id>
+```
+
+若某个候选在 preview 后取得新 lease，apply 跳过该 entry，并继续处理其它候选。
+apply 重新检查 manifest、immutable identity、lease、durable root、Provider reference 与 policy；事实漂移只能缩减计划，不能加入新镜像。
+
+删除目标始终是 NiceEval 受管 image root。
+Provider 删除后必须再次 inspect，确认同一 immutable resource 已不存在才写入 tombstone。
+普通本地 Docker 的策略保持 `explicit-only`，容量压力不会触发后台自动删除。

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/并行运行的共享任务镜像.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/并行运行的共享任务镜像.md
@@ -1,0 +1,42 @@
+# 并行运行的共享任务镜像
+
+用户运行一个包含 8 条 Attempt 的 Experiment。两道 Eval 分别使用四个配置，同一配置的两道 Eval 需要同一个 Docker BuildKey，因此冻结选择只有 4 个 `(domainId, BuildKey)` 需求。
+
+## 三个命中，一个缺失
+
+NiceEval 并发查询四个 key。三个 key 已有可验证的 indexed task-build image，一个 key 因 canary 版本变化而缺失。
+
+三个命中分别完成 immutable identity 复核和 read lease 后转为 ready，依赖它们的 6 条 Attempt 立即进入 Attempt 调度队列。
+缺失 key 只构建一次；依赖它的 2 条 Attempt 等待同一个 operation。
+
+BuildKey discovery、query、build 和 waiter 不占 Attempt concurrency。
+等待较早 miss 的 Attempt 不会形成队首阻塞，也不会阻止较晚 ready 的 Attempt 使用全部执行并行度。
+`buildConcurrency` 只限制实际 build，不降低 Attempt concurrency。
+
+live 面板显示：
+
+```text
+8 attempts require 4 BuildKeys · 3 cache hits · 1 building · 2 attempts waiting
+```
+
+缺失 key 发布、index、lease 和交付入口就绪后，摘要变成：
+
+```text
+8 attempts require 4 BuildKeys · 3 cache hits · 1 built once · 2 attempts waited
+```
+
+这两条反馈都只陈述共享任务构建事实。8 条 Attempt 仍各自创建 Sandbox、执行、写入 Attempt 事实并产生 Verdict。
+
+## 共享 build 失败或 Run 取消
+
+build 失败时，该 key 只有一个 build failure origin，两个 waiter 都停止等待。
+失败不能显示成 cache hit、ready 或成功 build；其它三个 key 的 Attempt 不受影响。
+
+Run 取消后，尚未 ready 的 Attempt 不再放行。
+取消一个 waiter 不取消仍有 consumer 的共享 build；取消最后一个 consumer 后，构建操作按 operation identity 由 Provider finalizer 删除 DestroyOnly scratch。
+任何退出路径都不能留下永久 waiter、占用 Attempt permit 或把临时资源登记为留存 Sandbox。
+
+## Orphan 提示
+
+启动前发现的 Sandbox orphan 继续使用独立提示和 `niceeval sandbox prune` 路径。
+任务镜像反馈不自动删除 orphan，也不把 orphan 数量并入 BuildKey hit、build 或 Provider cache GC。

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/并行运行的共享任务镜像.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/并行运行的共享任务镜像.md
@@ -1,12 +1,15 @@
 # 并行运行的共享任务镜像
 
-用户运行一个包含 8 条 Attempt 的 Experiment。两道 Eval 分别使用四个配置，同一配置的两道 Eval 需要同一个 Docker BuildKey，因此冻结选择只有 4 个 `(domainId, BuildKey)` 需求。
+用户运行一个包含 8 条 Attempt 的 Experiment。两道 Eval 分别使用四个配置，同一配置的两道 Eval需要同一个
+Docker BuildKey，因此冻结选择只有 4 个 `(MaterializationScopeId, BuildKey)` 需求。Runner 不知道该 scope
+来自 Docker image Domain。
 
 ## 三个命中，一个缺失
 
 NiceEval 并发查询四个 key。三个 key 已有可验证的 indexed task-build image，一个 key 因 canary 版本变化而缺失。
 
-三个命中分别完成 immutable identity 复核和 read lease 后转为 ready，依赖它们的 6 条 Attempt 立即进入 Attempt 调度队列。
+三个命中分别完成 immutable identity 复核后成为 available。依赖它们的 6 条 Attempt 各自取得 consumer use
+handle 后立即进入 Attempt 调度队列；key 级 ready 不冒充“所有 consumer 都已 leased”。
 缺失 key 只构建一次；依赖它的 2 条 Attempt 等待同一个 operation。
 
 BuildKey discovery、query、build 和 waiter 不占 Attempt concurrency。
@@ -19,13 +22,16 @@ live 面板显示：
 8 attempts require 4 BuildKeys · 3 cache hits · 1 building · 2 attempts waiting
 ```
 
-缺失 key 发布、index、lease 和交付入口就绪后，摘要变成：
+缺失 key 发布、index 并成为 available，两个 consumer 分别 acquired 后，摘要变成：
 
 ```text
 8 attempts require 4 BuildKeys · 3 cache hits · 1 built once · 2 attempts waited
 ```
 
 这两条反馈都只陈述共享任务构建事实。8 条 Attempt 仍各自创建 Sandbox、执行、写入 Attempt 事实并产生 Verdict。
+
+如果同一个 Eval 改用不提供持久 cache 的 Vercel provider，lookup 返回 `Unsupported`，但同一 Invocation 的
+相同 `(MaterializationScopeId, BuildKey)` 仍只构建一次。Vercel 不需要实现 Docker registry、image lease 或 GC。
 
 ## 共享 build 失败或 Run 取消
 

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/盘点共享BuildKit缓存.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/盘点共享BuildKit缓存.md
@@ -1,0 +1,35 @@
+# 盘点共享 BuildKit 缓存
+
+用户看到 Provider 报告 BuildKit cache 占用 402.6GB，其中 221.6GB 标记为 reclaimable，希望知道 NiceEval 能否安全回收。
+
+## 只读容量观察
+
+共享或默认 builder 没有 NiceEval 专属的 builder identity、managed storage epoch、registry、lease 和 root。
+NiceEval 因此只显示 provider-level observation：
+
+```text
+BuildKit · unverified shared-builder capacity
+total 402.6 GB · provider reclaimable estimate 221.6 GB
+NiceEval ownership unknown · not eligible for NiceEval GC
+```
+
+这组数字不进入 Materialization Domain inventory，不取得 domain id，也不出现在 entry、evictable 或 GcPlan 中。
+`reclaimable` 是 Provider 估算，不是 NiceEval 的 exact marginal reclaim。
+
+## 用户自行回收
+
+CLI 可以展示不带 `--force` 的 Provider 命令，但不会执行、持久化或 apply 它。
+反馈必须同时说明 NiceEval 无法把 cache record 归因给自己，命令可能影响其它项目、builder session 和正在进行的 build。
+
+Sandbox orphan、受管 task-build image 和共享 BuildKit cache 分成三个区块：
+
+- Sandbox orphan 继续提示用户运行 `niceeval sandbox prune`；
+- 受管 task-build image 使用 NiceEval 两阶段 GcPlan；
+- 共享 BuildKit cache 只有未验证容量观察和用户自担风险的 Provider 路径。
+
+任何统一的 `Docker cleanup` 汇总都不能暗示一次 NiceEval apply 可以安全回收三类资源。
+
+## 成为受管 Domain 的条件
+
+未来只有专属 managed builder 同时提供稳定 Domain identity、durable registry、lease/root、fencing 和 conditional delete，BuildKit 才能采用 NiceEval 两阶段 GC。
+repository、image tag、record 年龄和 `docker system df` 输出都不能替代这些所有权与活跃引用证明。

--- a/e2e/cli/experiments/cache-hit.ts
+++ b/e2e/cli/experiments/cache-hit.ts
@@ -1,0 +1,15 @@
+import { defineExperiment } from "niceeval";
+import { dockerSandbox } from "niceeval/sandbox";
+import { preContextErrorAgent } from "../agents/deterministic.ts";
+
+export default defineExperiment({
+  description: "同一 Docker task build 在后续 Invocation 从受管 cache 命中",
+  agent: preContextErrorAgent,
+  sandbox: dockerSandbox({
+    source: {
+      type: "dockerfile",
+      context: new URL("../fixtures/cache-hit/", import.meta.url),
+    },
+  }),
+  evals: ["greet/hello"],
+});

--- a/e2e/cli/fixtures/cache-hit/Dockerfile
+++ b/e2e/cli/fixtures/cache-hit/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/e2e/cli/fixtures/cache-hit/bin/docker
+++ b/e2e/cli/fixtures/cache-hit/bin/docker
@@ -1,0 +1,33 @@
+#!/bin/sh
+fixture_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+volume_root="$fixture_root/cache-volume"
+image_state="$fixture_root/image-id"
+case "$*" in
+  "volume inspect --format "*)
+    if [ ! -f "$volume_root/domain-id" ]; then exit 1; fi
+    sed -n '1p' "$volume_root/domain-id"
+    ;;
+  "volume create --label "*)
+    mkdir -p "$volume_root"
+    label=$4
+    printf '%s\n' "${label#*=}" > "$volume_root/domain-id"
+    printf '%s\n' "$5"
+    ;;
+  "info --format {{.ID}}") printf '%s\n' "cache-hit-daemon" ;;
+  "info --format {{.Driver}}") printf '%s\n' "overlay2" ;;
+  "image inspect --format {{.Id}} "*)
+    if [ ! -f "$image_state" ]; then exit 1; fi
+    sed -n '1p' "$image_state"
+    ;;
+  build\ *)
+    printf '%s\n' "sha256:cache-hit-image" > "$image_state"
+    count=0
+    if [ -f "$fixture_root/build-count" ]; then count=$(sed -n '1p' "$fixture_root/build-count"); fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$fixture_root/build-count"
+    ;;
+  *)
+    printf '%s\n' "unexpected docker argv: $*" >&2
+    exit 64
+    ;;
+esac

--- a/e2e/cli/fixtures/cache-hit/bin/docker
+++ b/e2e/cli/fixtures/cache-hit/bin/docker
@@ -1,7 +1,7 @@
 #!/bin/sh
-fixture_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
-volume_root="$fixture_root/cache-volume"
-image_state="$fixture_root/image-id"
+fixture_state="${XDG_STATE_HOME:?}/fake-cache-hit-docker"
+volume_root="$fixture_state/volume"
+image_state="$fixture_state/image-id"
 case "$*" in
   "volume inspect --format "*)
     if [ ! -f "$volume_root/domain-id" ]; then exit 1; fi
@@ -22,9 +22,10 @@ case "$*" in
   build\ *)
     printf '%s\n' "sha256:cache-hit-image" > "$image_state"
     count=0
-    if [ -f "$fixture_root/build-count" ]; then count=$(sed -n '1p' "$fixture_root/build-count"); fi
+    if [ -f "$fixture_state/build-count" ]; then count=$(sed -n '1p' "$fixture_state/build-count"); fi
     count=$((count + 1))
-    printf '%s\n' "$count" > "$fixture_root/build-count"
+    mkdir -p "$fixture_state"
+    printf '%s\n' "$count" > "$fixture_state/build-count"
     ;;
   *)
     printf '%s\n' "unexpected docker argv: $*" >&2

--- a/e2e/cli/fixtures/cache-inventory/bin/docker
+++ b/e2e/cli/fixtures/cache-inventory/bin/docker
@@ -1,6 +1,24 @@
 #!/bin/sh
-if [ "$*" != "system df --format json" ]; then
-  printf '%s\n' "unexpected docker argv: $*" >&2
-  exit 64
-fi
-printf '%s\n' '{"Active":"0","Reclaimable":"21.5GB","Size":"40.3GB","TotalCount":"17","Type":"Build Cache"}'
+fixture_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+volume_root="$fixture_root/volume"
+case "$*" in
+  "volume inspect --format "*)
+    if [ ! -f "$volume_root/domain-id" ]; then exit 1; fi
+    sed -n '1p' "$volume_root/domain-id"
+    ;;
+  "volume create --label "*)
+    mkdir -p "$volume_root"
+    label=$4
+    printf '%s\n' "${label#*=}" > "$volume_root/domain-id"
+    printf '%s\n' "$5"
+    ;;
+  "info --format {{.ID}}") printf '%s\n' "niceeval-e2e-daemon" ;;
+  "info --format {{.Driver}}") printf '%s\n' "overlay2" ;;
+  "system df --format json")
+    printf '%s\n' '{"Active":"0","Reclaimable":"21.5GB","Size":"40.3GB","TotalCount":"17","Type":"Build Cache"}'
+    ;;
+  *)
+    printf '%s\n' "unexpected docker argv: $*" >&2
+    exit 64
+    ;;
+esac

--- a/e2e/cli/fixtures/cache-inventory/bin/docker
+++ b/e2e/cli/fixtures/cache-inventory/bin/docker
@@ -1,6 +1,5 @@
 #!/bin/sh
-fixture_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
-volume_root="$fixture_root/volume"
+volume_root="${XDG_STATE_HOME:?}/fake-cache-inventory-volume"
 case "$*" in
   "volume inspect --format "*)
     if [ ! -f "$volume_root/domain-id" ]; then exit 1; fi

--- a/e2e/cli/fixtures/cache-inventory/bin/docker
+++ b/e2e/cli/fixtures/cache-inventory/bin/docker
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ "$*" != "system df --format json" ]; then
+  printf '%s\n' "unexpected docker argv: $*" >&2
+  exit 64
+fi
+printf '%s\n' '{"Active":"0","Reclaimable":"21.5GB","Size":"40.3GB","TotalCount":"17","Type":"Build Cache"}'

--- a/e2e/cli/fixtures/provider-error-sandbox-secondary/Dockerfile
+++ b/e2e/cli/fixtures/provider-error-sandbox-secondary/Dockerfile
@@ -1,1 +1,2 @@
+# niceeval-e2e-secondary-build
 FROM scratch

--- a/e2e/cli/fixtures/provider-error-sandbox/bin/docker
+++ b/e2e/cli/fixtures/provider-error-sandbox/bin/docker
@@ -1,6 +1,5 @@
 #!/bin/sh
-fixture_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
-volume_root="$fixture_root/cache-volume"
+volume_root="${XDG_STATE_HOME:?}/fake-provider-error-volume"
 case "$*" in
   "volume inspect --format "*)
     if [ ! -f "$volume_root/domain-id" ]; then exit 1; fi

--- a/e2e/cli/fixtures/provider-error-sandbox/bin/docker
+++ b/e2e/cli/fixtures/provider-error-sandbox/bin/docker
@@ -1,9 +1,33 @@
 #!/bin/sh
+fixture_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+volume_root="$fixture_root/cache-volume"
+case "$*" in
+  "volume inspect --format "*)
+    if [ ! -f "$volume_root/domain-id" ]; then exit 1; fi
+    sed -n '1p' "$volume_root/domain-id"
+    exit 0
+    ;;
+  "volume create --label "*)
+    mkdir -p "$volume_root"
+    label=$4
+    printf '%s\n' "${label#*=}" > "$volume_root/domain-id"
+    printf '%s\n' "$5"
+    exit 0
+    ;;
+  "info --format {{.ID}}") printf '%s\n' "provider-error-daemon"; exit 0 ;;
+  "info --format {{.Driver}}") printf '%s\n' "overlay2"; exit 0 ;;
+esac
 if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then
   exit 1
 fi
-case "$*" in
-  *provider-error-sandbox-secondary*)
+secondary=false
+for candidate in "$@"; do
+  if [ -f "$candidate" ] && grep -q 'niceeval-e2e-secondary-build' "$candidate"; then
+    secondary=true
+  fi
+done
+case "$secondary" in
+  true)
     printf '%s\n' '409 Conflict · DOCKER_BUILD_DENIED: the secondary sandbox build was rejected after provider validation; this deliberately long safe explanation repeats context context context context context context context context context context context context context context context context context context context context; request req_docker_secondary_987' >&2
     ;;
   *)

--- a/e2e/cli/test/cache-hit.test.ts
+++ b/e2e/cli/test/cache-hit.test.ts
@@ -1,0 +1,24 @@
+// owner: docs/engineering/testing/e2e/cli.md#cli-docker-task-build-cache
+// rerun: pnpm e2e --repo cli -- --run test/cache-hit.test.ts
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { cliE2E } from "./context.ts";
+
+test("Docker task build 在不同 Invocation 复用受管 image cache", async () => {
+  await cliE2E.case("cache-hit", {}, async ({ commands: { niceeval }, paths }) => {
+    const fakeBin = join(paths.projectRoot, "fixtures/cache-hit/bin");
+    const env = {
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      XDG_STATE_HOME: join(paths.projectRoot, "state"),
+      DOCKER_DEFAULT_PLATFORM: "linux/amd64",
+    };
+    const first = await niceeval.run(["exp", "cache-hit", "--rerun", "all"], { env });
+    expect(first.stdout.replace(/\s+/gu, " "), first.diagnostic()).toContain("built once · docker:dockerfile:cache-hit");
+
+    const second = await niceeval.run(["exp", "cache-hit", "--rerun", "all"], { env });
+    expect(second.stdout.replace(/\s+/gu, " "), second.diagnostic()).toContain("build cache hit · docker:dockerfile:cache-hit");
+    expect(await readFile(join(paths.projectRoot, "fixtures/cache-hit/build-count"), "utf8")).toBe("1\n");
+  });
+});

--- a/e2e/cli/test/cache-hit.test.ts
+++ b/e2e/cli/test/cache-hit.test.ts
@@ -9,16 +9,17 @@ import { cliE2E } from "./context.ts";
 test("Docker task build 在不同 Invocation 复用受管 image cache", async () => {
   await cliE2E.case("cache-hit", {}, async ({ commands: { niceeval }, paths }) => {
     const fakeBin = join(paths.projectRoot, "fixtures/cache-hit/bin");
+    const stateRoot = join(paths.projectRoot, "state");
     const env = {
       PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
-      XDG_STATE_HOME: join(paths.projectRoot, "state"),
+      XDG_STATE_HOME: stateRoot,
       DOCKER_DEFAULT_PLATFORM: "linux/amd64",
     };
     const first = await niceeval.run(["exp", "cache-hit", "--rerun", "all"], { env });
-    expect(first.stdout.replace(/\s+/gu, " "), first.diagnostic()).toContain("built once · docker:dockerfile:cache-hit");
+    expect(first.stdout.replace(/\s+/gu, " "), first.diagnostic()).toContain("built once · docker:dockerfile:greet/hello");
 
     const second = await niceeval.run(["exp", "cache-hit", "--rerun", "all"], { env });
-    expect(second.stdout.replace(/\s+/gu, " "), second.diagnostic()).toContain("build cache hit · docker:dockerfile:cache-hit");
-    expect(await readFile(join(paths.projectRoot, "fixtures/cache-hit/build-count"), "utf8")).toBe("1\n");
+    expect(second.stdout.replace(/\s+/gu, " "), second.diagnostic()).toContain("build cache hit · docker:dockerfile:greet/hello");
+    expect(await readFile(join(stateRoot, "fake-cache-hit-docker/build-count"), "utf8")).toBe("1\n");
   });
 });

--- a/e2e/cli/test/cache-inventory.test.ts
+++ b/e2e/cli/test/cache-inventory.test.ts
@@ -8,8 +8,9 @@ import { cliE2E } from "./context.ts";
 test("共享 BuildKit 容量只作为未验证 Provider observation 展示", async () => {
   await cliE2E.case("cache-inventory", {}, async ({ commands: { niceeval }, paths }) => {
     const fakeBin = join(paths.projectRoot, "fixtures/cache-inventory/bin");
+    const stateRoot = join(paths.projectRoot, "state");
     const result = await niceeval.run(["cache", "inventory", "--json"], {
-      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
     });
 
     expect(result.exitCode, result.diagnostic()).toBe(0);
@@ -20,9 +21,15 @@ test("共享 BuildKit 容量只作为未验证 Provider observation 展示", asy
       providerObservations: Array<Record<string, unknown>>;
     };
     expect(document.format).toBe("niceeval.cache-inventory");
-    expect(document.domains).toEqual([]);
+    expect(document.domains).toEqual([{
+      domainId: expect.any(String),
+      backendKind: "docker-images",
+      state: "verified-managed",
+      entryCount: 0,
+    }]);
     expect(document.providerObservations).toEqual([{
       scope: "provider",
+      providerFamily: "docker",
       backendKind: "buildkit",
       state: "unverified",
       observedAt: expect.any(String),
@@ -30,8 +37,22 @@ test("共享 BuildKit 容量只作为未验证 Provider observation 展示", asy
       reclaimableEstimateBytes: 21_500_000_000,
       reason: "shared-builder-unattributed",
     }]);
-    expect(result.stdout).not.toContain("domainId");
     expect(result.stdout).not.toContain("evictable");
     expect(result.stdout).not.toContain("planId");
+
+    const domainId = (document.domains[0] as { domainId: string }).domainId;
+    const preview = await niceeval.run(["cache", "gc", "--domain", domainId, "--json"], {
+      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
+    });
+    expect(preview.exitCode, preview.diagnostic()).toBe(0);
+    const previewDocument = JSON.parse(preview.stdout) as { format: string; plan: { planId: string; candidates: unknown[] } };
+    expect(previewDocument.format).toBe("niceeval.cache-gc-plan");
+    expect(previewDocument.plan.candidates).toEqual([]);
+
+    const apply = await niceeval.run(["cache", "gc", "--domain", domainId, "--apply", previewDocument.plan.planId, "--json"], {
+      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
+    });
+    expect(apply.exitCode, apply.diagnostic()).toBe(0);
+    expect(JSON.parse(apply.stdout)).toMatchObject({ format: "niceeval.cache-gc-outcome", outcomes: [] });
   });
 });

--- a/e2e/cli/test/cache-inventory.test.ts
+++ b/e2e/cli/test/cache-inventory.test.ts
@@ -1,0 +1,37 @@
+// owner: docs/engineering/testing/e2e/cli.md#cli-cache-inventory
+// rerun: pnpm e2e --repo cli -- --run test/cache-inventory.test.ts
+
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { cliE2E } from "./context.ts";
+
+test("共享 BuildKit 容量只作为未验证 Provider observation 展示", async () => {
+  await cliE2E.case("cache-inventory", {}, async ({ commands: { niceeval }, paths }) => {
+    const fakeBin = join(paths.projectRoot, "fixtures/cache-inventory/bin");
+    const result = await niceeval.run(["cache", "inventory", "--json"], {
+      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(result.exitCode, result.diagnostic()).toBe(0);
+    expect(result.stderr).toBe("");
+    const document = JSON.parse(result.stdout) as {
+      format: string;
+      domains: unknown[];
+      providerObservations: Array<Record<string, unknown>>;
+    };
+    expect(document.format).toBe("niceeval.cache-inventory");
+    expect(document.domains).toEqual([]);
+    expect(document.providerObservations).toEqual([{
+      scope: "provider",
+      backendKind: "buildkit",
+      state: "unverified",
+      observedAt: expect.any(String),
+      totalBytes: 40_300_000_000,
+      reclaimableEstimateBytes: 21_500_000_000,
+      reason: "shared-builder-unattributed",
+    }]);
+    expect(result.stdout).not.toContain("domainId");
+    expect(result.stdout).not.toContain("evictable");
+    expect(result.stdout).not.toContain("planId");
+  });
+});

--- a/e2e/cli/test/cache-inventory.test.ts
+++ b/e2e/cli/test/cache-inventory.test.ts
@@ -23,6 +23,7 @@ test("共享 BuildKit 容量只作为未验证 Provider observation 展示", asy
     expect(document.format).toBe("niceeval.cache-inventory");
     expect(document.domains).toEqual([{
       domainId: expect.any(String),
+      providerFamily: "docker",
       backendKind: "docker-images",
       state: "verified-managed",
       entryCount: 0,
@@ -41,6 +42,16 @@ test("共享 BuildKit 容量只作为未验证 Provider observation 展示", asy
     expect(result.stdout).not.toContain("planId");
 
     const domainId = (document.domains[0] as { domainId: string }).domainId;
+    const detail = await niceeval.run(["cache", "inventory", "--domain", domainId, "--json"], {
+      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
+    });
+    expect(detail.exitCode, detail.diagnostic()).toBe(0);
+    expect(JSON.parse(detail.stdout)).toMatchObject({
+      scope: { kind: "domain", domainId },
+      entries: [],
+      providerObservations: [],
+    });
+
     const preview = await niceeval.run(["cache", "gc", "--domain", domainId, "--json"], {
       env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
     });

--- a/e2e/cli/test/provider-error-feedback.test.ts
+++ b/e2e/cli/test/provider-error-feedback.test.ts
@@ -26,6 +26,7 @@ test("provider 与 sandbox 错误只展示真实问题并给出所属 details", 
           env: {
             PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
             DOCKER_DEFAULT_PLATFORM: "linux/amd64",
+            XDG_STATE_HOME: join(paths.projectRoot, "state"),
           },
         },
       );

--- a/e2e/cli/test/provider-error-feedback.test.ts
+++ b/e2e/cli/test/provider-error-feedback.test.ts
@@ -46,6 +46,9 @@ test("provider 与 sandbox 错误只展示真实问题并给出所属 details", 
       expect(compact).toContain(PRIMARY_ERROR_TAIL);
       expect(compact).toContain(SECONDARY_ERROR_HEAD);
       expect(compact).toContain(SECONDARY_ERROR_TAIL);
+      expect(compact, result.diagnostic()).toContain("checking build cache");
+      expect(compact.match(/checking build cache · docker:dockerfile:greet\/hello · 1 attempt/gu) ?? []).toHaveLength(2);
+      expect(compact.match(/build failed · docker:dockerfile:greet\/hello · 1 attempt/gu) ?? []).toHaveLength(2);
       expect(compact).toContain("2 attempts not started");
       expect(result.stdout).not.toContain("e2b-cause-secret-must-not-reach-human");
       expect(result.stdout).not.toContain("vercel-cause-secret-must-not-reach-human");

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -434,7 +434,7 @@ function numberFlag(name: string, raw: string | undefined): number | undefined {
   return n;
 }
 
-const CLI_COMMANDS = ["check", "exp", "debug", "accept", "show", "list", "view", "clean", "migrate", "init", "run", "sandbox", "session", "docker"] as const;
+const CLI_COMMANDS = ["check", "exp", "debug", "accept", "show", "list", "view", "clean", "migrate", "init", "run", "sandbox", "session", "docker", "cache"] as const;
 type CliCommand = (typeof CLI_COMMANDS)[number];
 
 interface ParsedCliArgs {
@@ -1373,6 +1373,27 @@ function runDockerCommand(
     return yield* cliPromise(
       "run Docker profile command",
       () => runDockerProfileCommand(positionals, { json: flags.json, smoke: flags.smoke }),
+    );
+  });
+}
+
+function runCacheCliCommand(
+  positionals: readonly string[],
+  flags: Flags,
+): Effect.Effect<number, CliFailure> {
+  return Effect.gen(function* () {
+    const { runCacheCommand } = (yield* cliPromise(
+      "load Provider cache command",
+      () => import("../sandbox/cache-cli.ts"),
+    )) as {
+      runCacheCommand(
+        positionals: readonly string[],
+        options: { readonly json: boolean },
+      ): Promise<number>;
+    };
+    return yield* cliPromise(
+      "run Provider cache command",
+      () => runCacheCommand(positionals, { json: flags.json }),
     );
   });
 }
@@ -3408,6 +3429,7 @@ export const cliProgram = (interruption?: CliInterruptionOwnership) => Effect.ge
   }
 
   if (command === "docker") return yield* runDockerCommand(positionals, flags);
+  if (command === "cache") return yield* runCacheCliCommand(positionals, flags);
 
   if (command === "accept") {
     const locators = yield* Effect.try({

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -313,6 +313,10 @@ export interface Flags {
   confirmOwnerTerminated: boolean;
   /** 明确确认远端外部状态已静止；没有它恢复拒绝执行。 */
   confirmRemoteQuiesced: boolean;
+  /** `cache inventory|gc` 专用：选择一个精确 Materialization Domain。 */
+  domain?: string;
+  /** `cache gc` 专用：执行先前持久化的精确 plan id。 */
+  apply?: string;
 }
 
 // 表驱动的 flag 定义(node:util parseArgs)。--no-x 显式声明，不依赖 Node 20.14+
@@ -404,6 +408,10 @@ export const FLAG_OPTIONS = {
   "confirm-owner-terminated": { type: "boolean" },
   /** `--recover-shared-state` 专用:确认远端外部状态已静止。 */
   "confirm-remote-quiesced": { type: "boolean" },
+  /** `cache inventory|gc` 专用：选择一个精确 Materialization Domain。 */
+  domain: { type: "string" },
+  /** `cache gc` 专用：执行先前持久化的精确 plan id；省略时只创建预览。 */
+  apply: { type: "string" },
   /** 只打印本次会匹配到的 eval × 运行配置,不实际执行(人读文本或 `--json` 单文档,见「机器怎么读:--json」)。 */
   dry: { type: "boolean" },
   /** `sandbox prune` 专用:除 orphan 外也销毁 unverified 实例;`exp` 明确拒绝此 flag,重跑失败项或全部项请用 `--rerun` / `--rerun all`。 */
@@ -618,6 +626,8 @@ function parseArgs(
     ownerToken: values["owner-token"] as string | undefined,
     confirmOwnerTerminated: values["confirm-owner-terminated"] === true,
     confirmRemoteQuiesced: values["confirm-remote-quiesced"] === true,
+    domain: values.domain as string | undefined,
+    apply: values.apply as string | undefined,
   };
   return { command, positionals, flags, providedOptions };
 }
@@ -1388,12 +1398,12 @@ function runCacheCliCommand(
     )) as {
       runCacheCommand(
         positionals: readonly string[],
-        options: { readonly json: boolean },
+        options: { readonly json: boolean; readonly domain?: string; readonly apply?: string },
       ): Promise<number>;
     };
     return yield* cliPromise(
       "run Provider cache command",
-      () => runCacheCommand(positionals, { json: flags.json }),
+      () => runCacheCommand(positionals, { json: flags.json, domain: flags.domain, apply: flags.apply }),
     );
   });
 }

--- a/src/runner/build-preparation.ts
+++ b/src/runner/build-preparation.ts
@@ -2,7 +2,7 @@
 // 本模块只去重 BuildKey、路由 provider，并跳过已经完整携带的 pair。
 
 import { Effect, Option } from "effect";
-import type { SandboxBuildProvider, SandboxBuildWork } from "../sandbox/build-coordinator.ts";
+import type { SandboxBuildProvider, SandboxBuildRef, SandboxBuildWork } from "../sandbox/build-coordinator.ts";
 import { routeBuildProviders } from "../sandbox/dockerfile-build.ts";
 import type { BuildKey } from "../sandbox/identity.ts";
 import {
@@ -14,7 +14,7 @@ import type { RunOptions } from "./types.ts";
 
 export interface CollectedBuildPreparation {
   readonly works: readonly SandboxBuildWork[];
-  readonly pairBuildKeys: Readonly<globalThis.Record<string, readonly BuildKey[]>>;
+  readonly pairBuildKeys: Readonly<globalThis.Record<string, readonly SandboxBuildRef[]>>;
   readonly provider: SandboxBuildProvider;
 }
 
@@ -32,9 +32,9 @@ export function collectBuildPreparation(opts: {
   SandboxRuntimeMaterializationError
 > {
   return Effect.gen(function* () {
-    const worksByKey = new Map<BuildKey, SandboxBuildWork>();
-    const providerByKey = new Map<BuildKey, SandboxBuildProvider>();
-    const pairBuildKeys = new Map<string, BuildKey[]>();
+    const worksByKey = new Map<SandboxBuildRef, SandboxBuildWork>();
+    const providerByKey = new Map<SandboxBuildRef, SandboxBuildProvider>();
+    const pairBuildKeys = new Map<string, SandboxBuildRef[]>();
 
     for (const pair of opts.preparedPairs) {
       const carried = opts.carriedAttemptsByKey.get(pair.key);
@@ -72,11 +72,11 @@ export function collectBuildPreparation(opts: {
           cause: new Error("build key mismatch"),
         });
       }
-      const keys: BuildKey[] = [];
+      const keys: SandboxBuildRef[] = [];
       for (const work of collected.works) {
-        if (!worksByKey.has(work.buildKey)) worksByKey.set(work.buildKey, work);
-        providerByKey.set(work.buildKey, opts.provider ?? collected.provider);
-        if (!keys.includes(work.buildKey)) keys.push(work.buildKey);
+        if (!worksByKey.has(work.ref)) worksByKey.set(work.ref, work);
+        providerByKey.set(work.ref, opts.provider ?? collected.provider);
+        if (!keys.includes(work.ref)) keys.push(work.ref);
       }
       if (keys.length > 0) pairBuildKeys.set(pair.key, keys);
     }

--- a/src/runner/run.ts
+++ b/src/runner/run.ts
@@ -622,6 +622,13 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
     ? Option.flatMap(collected, toBuildPreparation)
     : Option.some(opts.buildPreparation);
   const buildPrep = Option.getOrUndefined(buildPreparation);
+  const buildDependents = new Map<BuildKey, number>();
+  if (buildPrep !== undefined) {
+    for (const attempt of attempts) {
+      const keys = buildPrep.pairBuildKeys[cacheKey(attempt.run, attempt.evalDef.id)] ?? [];
+      for (const key of keys) buildDependents.set(key, (buildDependents.get(key) ?? 0) + 1);
+    }
+  }
   // 共享构建**不阻塞派发**:整批 key 同时开工,每条 attempt 只等自己引用的那几个 key
   // (case.md「Run 级构建协调」第 4 条的逐 key 放行)。全局 barrier 会让 10 个已就绪的镜像
   // 陪着最慢的那个构建干等(台账见 memory/shared-build-single-barrier-not-per-buildkey.md)。
@@ -636,10 +643,21 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
           signal: opts.signal,
           // 最小反馈钩子:共享构建投影为运行级 active 行 / 非 TTY 起止事件,不占 attempt 位。
           onActivity: (event) => {
+            const dependents = buildDependents.get(event.buildKey) ?? 0;
+            const shared = `${dependents} attempt${dependents === 1 ? "" : "s"}`;
+            const action = event.status === "started"
+              ? "checking build cache"
+              : event.outcome === "hit"
+              ? "build cache hit"
+              : event.outcome === "built"
+              ? "built once"
+              : event.outcome === "cancelled"
+              ? "build cancelled"
+              : "build failed";
             reportRunActivity({
               id: event.id,
               key: event.key,
-              label: event.label,
+              label: `${action} · ${event.label} · ${shared}`,
               status: event.status,
               ...("durationMs" in event ? { durationMs: event.durationMs } : {}),
             });

--- a/src/runner/run.ts
+++ b/src/runner/run.ts
@@ -609,7 +609,6 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
   const runTiming = createRunTimingRecorder();
   let sandboxBuildRecords: SandboxBuildRecord[] = [];
   const buildFailureByPair = new Map<string, AttemptError>();
-  const buildLocatorsByPair = new Map<string, Map<BuildKey, JsonValue>>();
 
   const collected =
     opts.buildPreparation === undefined
@@ -622,7 +621,7 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
     ? Option.flatMap(collected, toBuildPreparation)
     : Option.some(opts.buildPreparation);
   const buildPrep = Option.getOrUndefined(buildPreparation);
-  const buildDependents = new Map<BuildKey, number>();
+  const buildDependents = new Map<import("../sandbox/build-coordinator.ts").SandboxBuildRef, number>();
   if (buildPrep !== undefined) {
     for (const attempt of attempts) {
       const keys = buildPrep.pairBuildKeys[cacheKey(attempt.run, attempt.evalDef.id)] ?? [];
@@ -643,7 +642,7 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
           signal: opts.signal,
           // 最小反馈钩子:共享构建投影为运行级 active 行 / 非 TTY 起止事件,不占 attempt 位。
           onActivity: (event) => {
-            const dependents = buildDependents.get(event.buildKey) ?? 0;
+            const dependents = buildDependents.get(event.ref) ?? 0;
             const shared = `${dependents} attempt${dependents === 1 ? "" : "s"}`;
             const action = event.status === "started"
               ? "checking build cache"
@@ -666,15 +665,23 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
       : undefined;
 
   // 逐 pair 的放行闸:第一次问到就记下等待,之后同 pair 的其它 attempt 复用同一条。
+  const buildUseKey = (a: Attempt): string => `${cacheKey(a.run, a.evalDef.id)}|${a.attempt}`;
   const buildWaits = new Map<string, Promise<void>>();
-  const awaitBuildsFor = (pairKey: string): Promise<void> => {
+  const buildUseHandles = new Map<string, Array<{ release(): Promise<void> | void }>>();
+  const buildLocatorsByAttempt = new Map<string, Map<BuildKey, JsonValue>>();
+  const buildWorkByRef = new Map(buildPrep?.works.map((work) => [work.ref, work]) ?? []);
+  const awaitBuildsFor = (a: Attempt): Promise<void> => {
+    const pairKey = cacheKey(a.run, a.evalDef.id);
     const keys = buildPrep?.pairBuildKeys[pairKey];
     if (runningBuilds === undefined || keys === undefined || keys.length === 0) return Promise.resolve();
-    let pending = buildWaits.get(pairKey);
+    const useKey = buildUseKey(a);
+    let pending = buildWaits.get(useKey);
     if (pending !== undefined) return pending;
     pending = (async () => {
       for (const key of keys) await runningBuilds.settled(key);
       const locators = new Map<BuildKey, JsonValue>();
+      const handles: Array<{ release(): Promise<void> | void }> = [];
+      buildUseHandles.set(useKey, handles);
       for (const key of keys) {
         const failure = runningBuilds.failures.get(key);
         if (failure !== undefined) {
@@ -687,14 +694,27 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
           });
           return;
         }
-        const locator = runningBuilds.locators.get(key);
-        if (locator !== undefined) locators.set(key, locator);
+        const source = runningBuilds.sources.get(key);
+        const work = buildWorkByRef.get(key);
+        if (source !== undefined && work !== undefined) {
+          const handle = await source.acquireUse(opts.signal ?? new AbortController().signal);
+          handles.push(handle);
+          locators.set(work.buildKey, handle.locator);
+        }
       }
-      if (locators.size > 0) buildLocatorsByPair.set(pairKey, locators);
+      if (locators.size > 0) buildLocatorsByAttempt.set(useKey, locators);
     })();
-    buildWaits.set(pairKey, pending);
+    buildWaits.set(useKey, pending);
     return pending;
   };
+  const releaseBuildUsesFor = (a: Attempt): Effect.Effect<void> => Effect.tryPromise({
+    try: async () => {
+      const handles = buildUseHandles.get(buildUseKey(a)) ?? [];
+      buildUseHandles.delete(buildUseKey(a));
+      await Promise.all(handles.map((handle) => handle.release()));
+    },
+    catch: () => undefined,
+  }).pipe(Effect.ignore);
 
   // Run 级 Agent artifact prepare:由 attempt 内探测到目标 Sandbox 平台后触发 single-flight。
   // 绝不能在这里按宿主平台 eager prepare：macOS 宿主跑 Linux Sandbox 会拿到错误制品。
@@ -2528,7 +2548,7 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
             ]);
             // BuildKey / CaseKey 已在 Attempt.plan 的 physical completion state 中确定；
             // 这里只把协调器执行结果作为必填运行输入传给 materializer，不回写 Attempt。
-            const buildLocators = buildLocatorsByPair.get(cacheKey(a.run, a.evalDef.id)) ?? new Map<BuildKey, JsonValue>();
+            const buildLocators = buildLocatorsByAttempt.get(buildUseKey(a)) ?? new Map<BuildKey, JsonValue>();
 
             // 派发前的确定性失败(实验级 setup 失败 / 判分预检失败):不派发 agent、不建沙箱。
             // 这类 Slot 没有 origin Attempt，因而会使 V1 draft 保持 incomplete；不能为它
@@ -2936,9 +2956,8 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
           }
           // ⓪ 逐 BuildKey 放行:只等本 eval 引用的那几个 key,不引用任何 key 的 attempt
           // 立刻进入许可链。等在这里不占全局并发位,慢构建因此不挡住同批别的 eval。
-          const pairKey = cacheKey(a.run, a.evalDef.id);
           yield* Effect.tryPromise({
-            try: () => awaitBuildsFor(pairKey),
+            try: () => awaitBuildsFor(a),
             catch: (error) => error,
           });
           for (;;) {
@@ -2985,6 +3004,7 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
               Effect.ensuring(releaseCaseLockIfDone(caseState, a.attempt)),
             );
         const withWaveLifecycle = withCaseLifecycle.pipe(
+          Effect.ensuring(releaseBuildUsesFor(a)),
           Effect.ensuring(arriveAtDispatchWave),
         );
         if (predecessor === undefined) return withWaveLifecycle;
@@ -3007,10 +3027,18 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
         return Effect.failCause(cause); // 非中断的意外缺陷:照常抛出
       }),
     );
+  const releaseBuildSources = Effect.tryPromise({
+    try: async () => {
+      const sources = new Set(runningBuilds?.sources.values() ?? []);
+      await Promise.all([...sources].map((source) => source.release()));
+    },
+    catch: () => undefined,
+  }).pipe(Effect.ignore);
   const exit = yield* Effect.exit(
-    opts.signal === undefined
+    (opts.signal === undefined
       ? dispatchEffect
-      : Effect.raceFirst(dispatchEffect, interruptOnAbort(opts.signal)),
+      : Effect.raceFirst(dispatchEffect, interruptOnAbort(opts.signal)))
+      .pipe(Effect.ensuring(releaseBuildSources)),
   );
   // A full-carry / zero-Attempt invocation has no dispatch fiber that could
   // await startup recovery. Seal its selected-Experiment obligation here; for

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -1290,7 +1290,7 @@ export interface RunOptions<RecordError = never, RecordRequirements = never> {
     readonly works: readonly import("../sandbox/build-coordinator.ts").SandboxBuildWork[];
     readonly provider: import("../sandbox/build-coordinator.ts").SandboxBuildProvider;
     /** `${experimentId}|${evalId}` → 该 pair 的 fresh attempt 依赖的 BuildKey。 */
-    readonly pairBuildKeys: Readonly<globalThis.Record<string, readonly BuildKey[]>>;
+    readonly pairBuildKeys: Readonly<globalThis.Record<string, readonly import("../sandbox/build-coordinator.ts").SandboxBuildRef[]>>;
     readonly maxConcurrency?: number;
     readonly buildTimeoutMs?: number;
     readonly prepareBudgetMs?: number;

--- a/src/sandbox/build-coordinator.ts
+++ b/src/sandbox/build-coordinator.ts
@@ -76,6 +76,7 @@ export type SandboxBuildActivityEvent =
     }
   | {
       status: "done" | "failed";
+      outcome: SandboxBuildRecord["status"];
       buildKey: BuildKey;
       id: string;
       key: typeof SANDBOX_BUILD_ACTIVITY;
@@ -292,6 +293,7 @@ function prepareOne(
       }
       ctx.onActivity?.({
         status: status === "failed" || status === "cancelled" ? "failed" : "done",
+        outcome: status,
         buildKey: work.buildKey,
         id: parent.id,
         key: SANDBOX_BUILD_ACTIVITY,

--- a/src/sandbox/build-coordinator.ts
+++ b/src/sandbox/build-coordinator.ts
@@ -6,6 +6,7 @@
 // 内部是 Effect 协调:逐 key 结算用 Deferred、整批收工用 Fiber 观察、退避用 Clock.sleep、
 // 并发闸用 Semaphore;公开 RunningSandboxBuilds 保持 Promise ABI,只在方法边界 runPromise。
 
+import { createHash, randomUUID } from "node:crypto";
 import { Deferred, Duration, Effect, Exit, Fiber, FiberId, Random } from "effect";
 import type { JsonValue } from "../shared/types.ts";
 import type { RunTimingRecorder } from "../runner/timing.ts";
@@ -16,8 +17,31 @@ import type { BuildKey } from "./identity.ts";
 /** Run 级开放 activity key;与 Record 契约同名。 */
 export const SANDBOX_BUILD_ACTIVITY = "sandbox.build" as const;
 
+declare const MaterializationScopeIdBrand: unique symbol;
+export type MaterializationScopeId = string & { readonly [MaterializationScopeIdBrand]: true };
+declare const SandboxBuildRefBrand: unique symbol;
+export type SandboxBuildRef = string & { readonly [SandboxBuildRefBrand]: true };
+
+export function materializationScopeId(input: {
+  readonly providerFamily: string;
+  readonly authorityFingerprint: string;
+  readonly materializationProtocolVersion: number;
+}): MaterializationScopeId {
+  return createHash("sha256").update(JSON.stringify([
+    input.providerFamily,
+    input.authorityFingerprint,
+    input.materializationProtocolVersion,
+  ])).digest("hex") as MaterializationScopeId;
+}
+
+export function sandboxBuildRef(scopeId: MaterializationScopeId, buildKey: BuildKey): SandboxBuildRef {
+  return createHash("sha256").update(`${scopeId}\0${buildKey}`).digest("hex") as SandboxBuildRef;
+}
+
 /** 一条待协调的构建工作(同 BuildKey 只保留第一次出现的 inputs / provider)。 */
 export interface SandboxBuildWork {
+  readonly ref: SandboxBuildRef;
+  readonly scopeId: MaterializationScopeId;
   readonly buildKey: BuildKey;
   readonly provider: string;
   /** 解析后的构建输入投影;不含凭据值。 */
@@ -26,18 +50,36 @@ export interface SandboxBuildWork {
   readonly label?: string;
 }
 
+export interface SandboxBuildUseHandle {
+  readonly locator: JsonValue;
+  release(): Promise<void> | void;
+}
+
+export interface SandboxBuildArtifactSource {
+  readonly locator: JsonValue;
+  readonly source: "cache" | "build";
+  acquireUse(signal: AbortSignal): Promise<SandboxBuildUseHandle>;
+  release(): Promise<void> | void;
+}
+
+export type SandboxBuildLookup =
+  | { readonly _tag: "Hit"; readonly source: SandboxBuildArtifactSource }
+  | { readonly _tag: "Miss" }
+  | { readonly _tag: "Unsupported" };
+
 /** provider 侧 cache 查询与真实构建。 */
 export interface SandboxBuildProvider {
   /** 查 provider 原生 cache / 本地 build registry;命中返回 locator。 */
-  lookup(work: SandboxBuildWork, signal: AbortSignal): Promise<JsonValue | undefined>;
+  lookup(work: SandboxBuildWork, signal: AbortSignal): Promise<SandboxBuildLookup>;
   /** cache miss 时调用原生构建 API。 */
-  build(work: SandboxBuildWork, ctx: SandboxBuildExecutionContext): Promise<JsonValue>;
+  build(work: SandboxBuildWork, ctx: SandboxBuildExecutionContext): Promise<SandboxBuildArtifactSource>;
   /** 可选:Invocation abort / timeout 时取消远端 build。 */
   cancel?(work: SandboxBuildWork): Promise<void>;
 }
 
 /** 构建执行上下文:子 activity 挂在当前 sandbox.build 节点下。 */
 export interface SandboxBuildExecutionContext {
+  readonly operationId: string;
   readonly signal: AbortSignal;
   readonly timing: RunTimingRecorder;
   readonly parent: TimingActivity;
@@ -69,6 +111,7 @@ export interface PrepareSandboxBuildsOptions {
 export type SandboxBuildActivityEvent =
   | {
       status: "started";
+      ref: SandboxBuildRef;
       buildKey: BuildKey;
       id: string;
       key: typeof SANDBOX_BUILD_ACTIVITY;
@@ -77,6 +120,7 @@ export type SandboxBuildActivityEvent =
   | {
       status: "done" | "failed";
       outcome: SandboxBuildRecord["status"];
+      ref: SandboxBuildRef;
       buildKey: BuildKey;
       id: string;
       key: typeof SANDBOX_BUILD_ACTIVITY;
@@ -85,6 +129,7 @@ export type SandboxBuildActivityEvent =
     };
 
 export interface SandboxBuildFailure {
+  readonly ref: SandboxBuildRef;
   readonly buildKey: BuildKey;
   readonly timingNodeId: string;
   readonly status: "failed" | "cancelled";
@@ -93,21 +138,21 @@ export interface SandboxBuildFailure {
 
 export interface SandboxBuildPreparation {
   /** 成功(hit / built)的 BuildKey → locator。 */
-  readonly locators: ReadonlyMap<BuildKey, JsonValue>;
+  readonly sources: ReadonlyMap<SandboxBuildRef, SandboxBuildArtifactSource>;
   /** 实际查询或构建过的每条 provenance(不含完全携带、从未过问的 key)。 */
   readonly records: readonly SandboxBuildRecord[];
   /** 失败或取消的 BuildKey → 共用同一 Run timing origin 的错误。 */
-  readonly failures: ReadonlyMap<BuildKey, SandboxBuildFailure>;
+  readonly failures: ReadonlyMap<SandboxBuildRef, SandboxBuildFailure>;
 }
 
 /** 进行中的 Run 级共享准备:逐 BuildKey 放行,依赖者只等自己引用的那几个 key。 */
 export interface RunningSandboxBuilds {
   /** 已结算 key 的实时视图(随构建推进增补,不等整批收工)。 */
-  readonly locators: ReadonlyMap<BuildKey, JsonValue>;
+  readonly sources: ReadonlyMap<SandboxBuildRef, SandboxBuildArtifactSource>;
   /** 已失败 / 已取消 key 的实时视图。 */
-  readonly failures: ReadonlyMap<BuildKey, SandboxBuildFailure>;
+  readonly failures: ReadonlyMap<SandboxBuildRef, SandboxBuildFailure>;
   /** 等某个 BuildKey 结算;不在本次协调范围内的 key 立即返回。 */
-  settled(buildKey: BuildKey): Promise<void>;
+  settled(ref: SandboxBuildRef): Promise<void>;
   /** 全部 key 结算后的汇总(provenance 在这里齐全)。 */
   readonly done: Promise<SandboxBuildPreparation>;
 }
@@ -133,9 +178,9 @@ export function startSandboxBuilds(
 ): RunningSandboxBuilds {
   const unique = dedupeWorks(works);
   if (unique.length === 0) {
-    const empty: SandboxBuildPreparation = { locators: new Map(), records: [], failures: new Map() };
+    const empty: SandboxBuildPreparation = { sources: new Map(), records: [], failures: new Map() };
     return {
-      locators: empty.locators,
+      sources: empty.sources,
       failures: empty.failures,
       async settled() {},
       done: Promise.resolve(empty),
@@ -143,9 +188,9 @@ export function startSandboxBuilds(
   }
 
   const maxConcurrency = Math.max(1, opts.maxConcurrency ?? 2);
-  const locators = new Map<BuildKey, JsonValue>();
+  const sources = new Map<SandboxBuildRef, SandboxBuildArtifactSource>();
   const records: SandboxBuildRecord[] = [];
-  const failures = new Map<BuildKey, SandboxBuildFailure>();
+  const failures = new Map<SandboxBuildRef, SandboxBuildFailure>();
 
   const prepareSignal = combineSignals([
     opts.signal,
@@ -156,9 +201,9 @@ export function startSandboxBuilds(
   // 不等同批其它 key(single-flight 仍靠这张表,同 key 的第二个 work 复用同一条)。
   // 在方法边界同步创建,settled() 在任意时刻调用都拿到同一结果;
   // Deferred 结算后状态保持,迟到等待方同样立即放行。
-  const perKey = new Map<BuildKey, Deferred.Deferred<void, never>>();
+  const perKey = new Map<SandboxBuildRef, Deferred.Deferred<void, never>>();
   for (const work of unique) {
-    perKey.set(work.buildKey, Deferred.unsafeMake(FiberId.unsafeMake()));
+    perKey.set(work.ref, Deferred.unsafeMake(FiberId.unsafeMake()));
   }
 
   const ctx = {
@@ -166,7 +211,7 @@ export function startSandboxBuilds(
     provider: opts.provider,
     buildTimeoutMs: opts.buildTimeoutMs,
     signal: prepareSignal,
-    locators,
+    sources,
     records,
     failures,
     onActivity: opts.onActivity,
@@ -182,22 +227,22 @@ export function startSandboxBuilds(
     const fibers = yield* Effect.forEach(unique, (work) =>
       Effect.fork(
         gate.withPermits(1)(prepareOne(work, ctx)).pipe(
-          Effect.ensuring(Effect.asVoid(Deferred.succeed(perKey.get(work.buildKey)!, undefined))),
+          Effect.ensuring(Effect.asVoid(Deferred.succeed(perKey.get(work.ref)!, undefined))),
         ),
       ));
     const exits = yield* Effect.forEach(fibers, Fiber.await, { concurrency: "unbounded" });
     const failed = exits.find(Exit.isFailure);
     if (failed !== undefined && Exit.isFailure(failed)) return yield* Effect.failCause(failed.cause);
-    return { locators, records, failures } satisfies SandboxBuildPreparation;
+    return { sources, records, failures } satisfies SandboxBuildPreparation;
   });
   // 边界:唯一一次把 Effect 驱动进公开 Promise ABI。
   const done = Effect.runPromise(coordination);
 
   return {
-    locators,
+    sources,
     failures,
-    async settled(buildKey) {
-      const deferred = perKey.get(buildKey);
+    async settled(ref) {
+      const deferred = perKey.get(ref);
       if (deferred === undefined) return;
       await Effect.runPromise(Deferred.await(deferred));
     },
@@ -221,9 +266,9 @@ export function buildFailureOrigin(
 }
 
 function dedupeWorks(works: readonly SandboxBuildWork[]): SandboxBuildWork[] {
-  const seen = new Map<BuildKey, SandboxBuildWork>();
+  const seen = new Map<SandboxBuildRef, SandboxBuildWork>();
   for (const work of works) {
-    if (!seen.has(work.buildKey)) seen.set(work.buildKey, work);
+    if (!seen.has(work.ref)) seen.set(work.ref, work);
   }
   return [...seen.values()];
 }
@@ -235,9 +280,9 @@ function prepareOne(
     provider: SandboxBuildProvider;
     buildTimeoutMs: number | undefined;
     signal: AbortSignal;
-    locators: Map<BuildKey, JsonValue>;
+    sources: Map<SandboxBuildRef, SandboxBuildArtifactSource>;
     records: SandboxBuildRecord[];
-    failures: Map<BuildKey, SandboxBuildFailure>;
+    failures: Map<SandboxBuildRef, SandboxBuildFailure>;
     onActivity?: (event: SandboxBuildActivityEvent) => void;
     buildAttempts: number;
     buildRetryBaseMs: number;
@@ -256,6 +301,7 @@ function prepareOne(
     });
     ctx.onActivity?.({
       status: "started",
+      ref: work.ref,
       buildKey: work.buildKey,
       id: parent.id,
       key: SANDBOX_BUILD_ACTIVITY,
@@ -267,7 +313,7 @@ function prepareOne(
       ctx.buildTimeoutMs !== undefined ? AbortSignal.timeout(ctx.buildTimeoutMs) : undefined,
     ]);
 
-    const finish = (status: SandboxBuildRecord["status"], locator?: JsonValue, error?: SandboxBuildRecord["error"]) => {
+    const finish = (status: SandboxBuildRecord["status"], source?: SandboxBuildArtifactSource, error?: SandboxBuildRecord["error"]) => {
       parent.durationMs = Math.max(0, ctx.timing.offsetNow() - startOffsetMs);
       if (status === "failed" || status === "cancelled") parent.failed = true;
       const record: SandboxBuildRecord = {
@@ -276,15 +322,16 @@ function prepareOne(
         status,
         timingNodeId: parent.id,
         inputs: work.inputs,
-        ...(locator !== undefined ? { locator } : {}),
+        ...(source !== undefined ? { locator: source.locator } : {}),
         ...(error !== undefined ? { error } : {}),
       };
       ctx.records.push(record);
-      if (locator !== undefined && (status === "hit" || status === "built")) {
-        ctx.locators.set(work.buildKey, locator);
+      if (source !== undefined && (status === "hit" || status === "built")) {
+        ctx.sources.set(work.ref, source);
       }
       if (error !== undefined && (status === "failed" || status === "cancelled")) {
-        ctx.failures.set(work.buildKey, {
+        ctx.failures.set(work.ref, {
+          ref: work.ref,
           buildKey: work.buildKey,
           timingNodeId: parent.id,
           status,
@@ -293,6 +340,7 @@ function prepareOne(
       }
       ctx.onActivity?.({
         status: status === "failed" || status === "cancelled" ? "failed" : "done",
+        ref: work.ref,
         outcome: status,
         buildKey: work.buildKey,
         id: parent.id,
@@ -327,16 +375,18 @@ function prepareOne(
       catch: (error) => error,
     }));
     if (lookup._tag === "Left") return yield* finishFailure(lookup.left);
-    if (lookup.right !== undefined) {
-      finish("hit", lookup.right);
+    if (lookup.right._tag === "Hit") {
+      finish("hit", lookup.right.source);
       return;
     }
 
     // 瞬时构建失败(基线镜像拉取限流、传输层中断)退避重试:构建产物是镜像与 template,
     // 没有计费实例的泄漏面,歧义类同样可重试(case.md「Run 级构建协调」第 5 条)。
-    const build = (attempt: number): Effect.Effect<JsonValue, unknown> =>
+    const operationId = randomUUID();
+    const build = (attempt: number): Effect.Effect<SandboxBuildArtifactSource, unknown> =>
       Effect.tryPromise({
         try: () => ctx.provider.build(work, {
+          operationId,
           signal: keySignal,
           timing: ctx.timing,
           parent,

--- a/src/sandbox/cache-administration-live.ts
+++ b/src/sandbox/cache-administration-live.ts
@@ -1,0 +1,42 @@
+import { Effect, Layer } from "effect";
+import {
+  CacheAdministrationRegistry,
+  type CacheAdministrationAdapter,
+  type CacheDomainDescriptor,
+} from "./cache-administration.ts";
+import {
+  liveTaskBuildCacheAdminService,
+  listDockerCacheDomains,
+  observeDockerBuildKitCapacity,
+} from "./docker-task-build-cache.ts";
+
+const dockerAdapter: CacheAdministrationAdapter = Object.freeze({
+  providerFamily: "docker",
+  listDomains: () => Effect.tryPromise({
+    try: () => listDockerCacheDomains(),
+    catch: (cause) => new Error(cause instanceof Error ? cause.message : String(cause)),
+  }),
+  observeProviderCapacity: () => Effect.tryPromise({
+    try: async () => [await observeDockerBuildKitCapacity()],
+    catch: (cause) => new Error(cause instanceof Error ? cause.message : String(cause)),
+  }),
+  openDomain: (descriptor: CacheDomainDescriptor) => Effect.succeed({
+    descriptor,
+    inventory: () => Effect.tryPromise({
+      try: () => liveTaskBuildCacheAdminService.inventory(),
+      catch: (cause) => new Error(cause instanceof Error ? cause.message : String(cause)),
+    }),
+    planGc: () => Effect.tryPromise({
+      try: () => liveTaskBuildCacheAdminService.planGc(descriptor.domainId),
+      catch: (cause) => new Error(cause instanceof Error ? cause.message : String(cause)),
+    }),
+    applyGc: (planId: string) => Effect.tryPromise({
+      try: () => liveTaskBuildCacheAdminService.applyGc(descriptor.domainId, planId),
+      catch: (cause) => new Error(cause instanceof Error ? cause.message : String(cause)),
+    }),
+  }),
+});
+
+export const CacheAdministrationLive = Layer.succeed(CacheAdministrationRegistry, {
+  adapters: [dockerAdapter],
+});

--- a/src/sandbox/cache-administration.ts
+++ b/src/sandbox/cache-administration.ts
@@ -1,0 +1,45 @@
+import { Context, Effect } from "effect";
+
+/** Provider-neutral descriptor. Its locator is opaque and never grants ownership. */
+export interface CacheDomainDescriptor {
+  readonly providerFamily: string;
+  readonly adminProtocolVersion: number;
+  readonly domainId: string;
+  readonly backendKind: string;
+  readonly state: "verified-managed" | "verified-read-only" | "unverified" | "unavailable";
+}
+
+export interface ProviderCapacityObservation {
+  readonly scope: "provider";
+  readonly providerFamily: string;
+  readonly backendKind: string;
+  readonly state: "unverified";
+  readonly observedAt: string;
+  readonly totalBytes: number | null;
+  readonly reclaimableEstimateBytes: number | null;
+  readonly reason: string;
+}
+
+export interface CacheDomainAdministration {
+  readonly descriptor: CacheDomainDescriptor;
+  inventory(): Effect.Effect<unknown, Error>;
+  planGc(): Effect.Effect<unknown, Error>;
+  applyGc(planId: string): Effect.Effect<unknown, Error>;
+}
+
+/** Optional provider capability. Providers without managed cache simply do not register one. */
+export interface CacheAdministrationAdapter {
+  readonly providerFamily: string;
+  listDomains(): Effect.Effect<readonly CacheDomainDescriptor[], Error>;
+  observeProviderCapacity(): Effect.Effect<readonly ProviderCapacityObservation[], Error>;
+  openDomain(descriptor: CacheDomainDescriptor): Effect.Effect<CacheDomainAdministration, Error>;
+}
+
+export interface CacheAdministrationRegistryService {
+  readonly adapters: readonly CacheAdministrationAdapter[];
+}
+
+export class CacheAdministrationRegistry extends Context.Tag("niceeval/sandbox/CacheAdministrationRegistry")<
+  CacheAdministrationRegistry,
+  CacheAdministrationRegistryService
+>() {}

--- a/src/sandbox/cache-cli.ts
+++ b/src/sandbox/cache-cli.ts
@@ -1,0 +1,98 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+interface DockerDfRow {
+  readonly Type?: unknown;
+  readonly Size?: unknown;
+  readonly Reclaimable?: unknown;
+}
+
+interface BuildKitObservation {
+  readonly scope: "provider";
+  readonly backendKind: "buildkit";
+  readonly state: "unverified";
+  readonly observedAt: string;
+  readonly totalBytes: number | null;
+  readonly reclaimableEstimateBytes: number | null;
+  readonly reason: "shared-builder-unattributed";
+}
+
+function bytes(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const match = /^([0-9]+(?:\.[0-9]+)?)\s*([kmgtp]?b)$/iu.exec(value.trim());
+  if (match === null) return null;
+  const unit = match[2]!.toLowerCase();
+  const power = ["b", "kb", "mb", "gb", "tb", "pb"].indexOf(unit);
+  if (power < 0) return null;
+  return Math.round(Number(match[1]) * 1000 ** power);
+}
+
+function sizeHead(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return value.trim().split(/\s+/u)[0] ?? null;
+}
+
+async function observeSharedBuildKit(): Promise<BuildKitObservation> {
+  const { stdout } = await execFileAsync("docker", ["system", "df", "--format", "json"], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  const rows = stdout.split(/\r?\n/u).filter(Boolean).map((line): DockerDfRow => JSON.parse(line));
+  const build = rows.find((row) => row.Type === "Build Cache");
+  return Object.freeze({
+    scope: "provider",
+    backendKind: "buildkit",
+    state: "unverified",
+    observedAt: new Date().toISOString(),
+    totalBytes: bytes(build?.Size),
+    reclaimableEstimateBytes: bytes(sizeHead(build?.Reclaimable)),
+    reason: "shared-builder-unattributed",
+  });
+}
+
+function humanSize(value: number | null): string {
+  if (value === null) return "unknown";
+  const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+  let amount = value;
+  let unit = 0;
+  while (amount >= 1000 && unit < units.length - 1) {
+    amount /= 1000;
+    unit += 1;
+  }
+  return `${amount.toFixed(amount >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+export async function runCacheCommand(
+  positionals: readonly string[],
+  options: { readonly json: boolean },
+): Promise<number> {
+  if (positionals.length !== 1 || positionals[0] !== "inventory") {
+    process.stderr.write("Usage: niceeval cache inventory [--json]\n");
+    return 2;
+  }
+  try {
+    const observation = await observeSharedBuildKit();
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({
+        format: "niceeval.cache-inventory",
+        schemaVersion: 1,
+        scope: { kind: "domains" },
+        domains: [],
+        providerObservations: [observation],
+      }, null, 2)}\n`);
+      return 0;
+    }
+    process.stdout.write(
+      `BuildKit · unverified shared-builder capacity\n` +
+      `  total ${humanSize(observation.totalBytes)} · provider reclaimable estimate ${humanSize(observation.reclaimableEstimateBytes)}\n` +
+      `  NiceEval ownership unknown · not eligible for NiceEval GC\n` +
+      `  Provider prune may affect other projects, builder sessions, and builds currently in progress.\n`,
+    );
+    return 0;
+  } catch (cause) {
+    process.stderr.write(`cache inventory failed: ${cause instanceof Error ? cause.message : String(cause)}\n`);
+    return 4;
+  }
+}

--- a/src/sandbox/cache-cli.ts
+++ b/src/sandbox/cache-cli.ts
@@ -1,56 +1,6 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-
-interface DockerDfRow {
-  readonly Type?: unknown;
-  readonly Size?: unknown;
-  readonly Reclaimable?: unknown;
-}
-
-interface BuildKitObservation {
-  readonly scope: "provider";
-  readonly backendKind: "buildkit";
-  readonly state: "unverified";
-  readonly observedAt: string;
-  readonly totalBytes: number | null;
-  readonly reclaimableEstimateBytes: number | null;
-  readonly reason: "shared-builder-unattributed";
-}
-
-function bytes(value: unknown): number | null {
-  if (typeof value !== "string") return null;
-  const match = /^([0-9]+(?:\.[0-9]+)?)\s*([kmgtp]?b)$/iu.exec(value.trim());
-  if (match === null) return null;
-  const unit = match[2]!.toLowerCase();
-  const power = ["b", "kb", "mb", "gb", "tb", "pb"].indexOf(unit);
-  if (power < 0) return null;
-  return Math.round(Number(match[1]) * 1000 ** power);
-}
-
-function sizeHead(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  return value.trim().split(/\s+/u)[0] ?? null;
-}
-
-async function observeSharedBuildKit(): Promise<BuildKitObservation> {
-  const { stdout } = await execFileAsync("docker", ["system", "df", "--format", "json"], {
-    encoding: "utf8",
-    maxBuffer: 1024 * 1024,
-  });
-  const rows = stdout.split(/\r?\n/u).filter(Boolean).map((line): DockerDfRow => JSON.parse(line));
-  const build = rows.find((row) => row.Type === "Build Cache");
-  return Object.freeze({
-    scope: "provider",
-    backendKind: "buildkit",
-    state: "unverified",
-    observedAt: new Date().toISOString(),
-    totalBytes: bytes(build?.Size),
-    reclaimableEstimateBytes: bytes(sizeHead(build?.Reclaimable)),
-    reason: "shared-builder-unattributed",
-  });
-}
+import { Effect } from "effect";
+import { CacheAdministrationRegistry } from "./cache-administration.ts";
+import { CacheAdministrationLive } from "./cache-administration-live.ts";
 
 function humanSize(value: number | null): string {
   if (value === null) return "unknown";
@@ -66,33 +16,102 @@ function humanSize(value: number | null): string {
 
 export async function runCacheCommand(
   positionals: readonly string[],
-  options: { readonly json: boolean },
+  options: { readonly json: boolean; readonly domain?: string; readonly apply?: string },
 ): Promise<number> {
-  if (positionals.length !== 1 || positionals[0] !== "inventory") {
-    process.stderr.write("Usage: niceeval cache inventory [--json]\n");
+  const command = positionals.length === 1 ? positionals[0] : undefined;
+  if (command !== "inventory" && command !== "gc") {
+    process.stderr.write("Usage: niceeval cache inventory [--domain <domain-id>] [--json]\n       niceeval cache gc --domain <domain-id> [--apply <plan-id>] [--json]\n");
+    return 2;
+  }
+  if (command === "gc" && options.domain === undefined) {
+    process.stderr.write("cache gc requires --domain <domain-id>\n");
     return 2;
   }
   try {
-    const observation = await observeSharedBuildKit();
+    return await Effect.runPromise(Effect.gen(function* () {
+      const registry = yield* CacheAdministrationRegistry;
+      const descriptors = yield* Effect.forEach(registry.adapters, (adapter) => adapter.listDomains(), { concurrency: "unbounded" })
+        .pipe(Effect.map((groups) => groups.flat()));
+      const selected = options.domain === undefined ? undefined : descriptors.find((item) => item.domainId === options.domain);
+      if (options.domain !== undefined && selected === undefined) {
+        process.stderr.write(`unknown cache domain ${options.domain}\n`);
+        return 2;
+      }
+      if (selected?.state === "unavailable" || selected?.state === "unverified") {
+        process.stderr.write(`cache domain ${selected.domainId} is ${selected.state}; ownership is not available\n`);
+        return 4;
+      }
+
+      if (command === "gc") {
+        const adapter = registry.adapters.find((item) => item.providerFamily === selected!.providerFamily)!;
+        const domain = yield* adapter.openDomain(selected!);
+      if (options.apply !== undefined) {
+        const startedAt = new Date().toISOString();
+        const result = yield* domain.applyGc(options.apply) as Effect.Effect<{ planId: string; domainId: string; outcomes: Array<{ buildKey: string; status: string; reason: string }> }, Error>;
+        const document = {
+          format: "niceeval.cache-gc-outcome",
+          schemaVersion: 1,
+          ...result,
+          startedAt,
+          finishedAt: new Date().toISOString(),
+        };
+        if (options.json) process.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
+        else {
+          process.stdout.write(`GC plan ${result.planId}\n`);
+          for (const outcome of result.outcomes) process.stdout.write(`  ${outcome.status} ${outcome.buildKey} · ${outcome.reason}\n`);
+        }
+          return result.outcomes.some((item) => item.status !== "deleted" && item.status !== "already-absent") ? 1 : 0;
+      }
+        const plan = yield* domain.planGc() as Effect.Effect<{ planId: string; expiresAt: string; candidates: readonly unknown[] }, Error>;
+      const document = {
+        format: "niceeval.cache-gc-plan",
+        schemaVersion: 1,
+        plan,
+        summary: { candidateCount: plan.candidates.length, exactReclaimBytes: null },
+      };
+      if (options.json) process.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
+      else process.stdout.write(`GC preview ${plan.planId} · ${plan.candidates.length} candidates · expires ${plan.expiresAt}\n`);
+        return 0;
+      }
+
+      const availableDescriptors = descriptors.filter((descriptor) => descriptor.state === "verified-managed" || descriptor.state === "verified-read-only");
+      const inventories = yield* Effect.forEach(availableDescriptors, (descriptor) => {
+        const adapter = registry.adapters.find((item) => item.providerFamily === descriptor.providerFamily)!;
+        return adapter.openDomain(descriptor).pipe(Effect.flatMap((domain) => domain.inventory()));
+      }, { concurrency: "unbounded" }) as Effect.Effect<Array<{ domainId: string; backendKind: string; state: string; entries: readonly unknown[] }>, Error>;
+      const detailed = selected === undefined ? undefined : inventories.find((item) => item.domainId === selected.domainId)?.entries;
+      const observations = options.domain === undefined
+        ? yield* Effect.forEach(registry.adapters, (adapter) => adapter.observeProviderCapacity(), { concurrency: "unbounded" }).pipe(Effect.map((groups) => groups.flat()))
+        : [];
     if (options.json) {
       process.stdout.write(`${JSON.stringify({
         format: "niceeval.cache-inventory",
         schemaVersion: 1,
-        scope: { kind: "domains" },
-        domains: [],
-        providerObservations: [observation],
+        scope: options.domain === undefined ? { kind: "domains" } : { kind: "domain", domainId: selected!.domainId },
+        domains: [
+          ...inventories.map(({ entries, ...domain }) => ({ ...domain, entryCount: entries.length })),
+          ...descriptors.filter((descriptor) => descriptor.state === "unavailable" || descriptor.state === "unverified")
+            .map((descriptor) => ({ ...descriptor, entryCount: null })),
+        ],
+        providerObservations: observations,
+        ...(detailed === undefined ? {} : { entries: detailed }),
       }, null, 2)}\n`);
       return 0;
     }
+      const taskDomain = inventories[0]!;
+      const observation = observations[0]!;
     process.stdout.write(
+      `Docker images · managed · ${taskDomain.domainId} · ${taskDomain.entries.length} entries\n` +
       `BuildKit · unverified shared-builder capacity\n` +
       `  total ${humanSize(observation.totalBytes)} · provider reclaimable estimate ${humanSize(observation.reclaimableEstimateBytes)}\n` +
       `  NiceEval ownership unknown · not eligible for NiceEval GC\n` +
       `  Provider prune may affect other projects, builder sessions, and builds currently in progress.\n`,
     );
-    return 0;
+      return 0;
+    }).pipe(Effect.provide(CacheAdministrationLive)));
   } catch (cause) {
-    process.stderr.write(`cache inventory failed: ${cause instanceof Error ? cause.message : String(cause)}\n`);
-    return 4;
+    const message = cause instanceof Error ? cause.message : String(cause);
+    process.stderr.write(`cache command failed: ${message}\n`);
+    return /expired|corrupt|authority changed/iu.test(message) ? 3 : 4;
   }
 }

--- a/src/sandbox/compose.ts
+++ b/src/sandbox/compose.ts
@@ -20,7 +20,13 @@ import {
   type BuildContextSpec,
   type LeakGateHints,
 } from "../runner/leak-gate.ts";
-import type { SandboxBuildExecutionContext, SandboxBuildProvider, SandboxBuildWork } from "./build-coordinator.ts";
+import {
+  materializationScopeId,
+  sandboxBuildRef,
+  type SandboxBuildExecutionContext,
+  type SandboxBuildProvider,
+  type SandboxBuildWork,
+} from "./build-coordinator.ts";
 import type {
   MaterializedSandboxCase,
   SandboxMaterializeContext,
@@ -923,7 +929,14 @@ function collectComposeBuildsInternal(
             );
           }
           buildKeys.push(collected.buildKey);
+          const scopeId = materializationScopeId({
+            providerFamily: "docker",
+            authorityFingerprint: JSON.stringify(providerIdentityMarker ?? ["docker", "default"]),
+            materializationProtocolVersion: 1,
+          });
           works.push({
+            ref: sandboxBuildRef(scopeId, collected.buildKey),
+            scopeId,
             buildKey: collected.buildKey,
             provider: "docker",
             label: `compose:${service.name}`,
@@ -984,7 +997,14 @@ export function dockerComposeBuildProvider(opts?: {
     async lookup(work) {
       const tag = composeBuildTag(work.buildKey);
       const hit = await dockerImageExists(tag);
-      return hit ? tag : undefined;
+      return hit
+        ? { _tag: "Hit", source: {
+            locator: tag,
+            source: "cache",
+            acquireUse: async () => ({ locator: tag, release() {} }),
+            release() {},
+          } }
+        : { _tag: "Miss" };
     },
     async build(work, ctx) {
       const inputs = work.inputs as globalThis.Record<string, unknown>;
@@ -1019,7 +1039,12 @@ export function dockerComposeBuildProvider(opts?: {
       // 构建产物以 service 镜像为准;再打 BuildKey tag 便于 lookup。
       const imageId = await composeServiceImageId(composeFile, service, cwd, composeEnv, runCompose);
       if (imageId) await dockerTag(imageId, tag);
-      return tag;
+      return {
+        locator: tag,
+        source: "build",
+        acquireUse: async () => ({ locator: tag, release() {} }),
+        release() {},
+      };
     },
   };
 }

--- a/src/sandbox/docker-task-build-cache.ts
+++ b/src/sandbox/docker-task-build-cache.ts
@@ -1,0 +1,604 @@
+import { createHash, randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { DatabaseSync } from "node:sqlite";
+import type { ProviderCapacityObservation } from "./cache-administration.ts";
+import type { CacheDomainDescriptor } from "./cache-administration.ts";
+
+const execFileAsync = promisify(execFile);
+const MINIMUM_AGE_MS = 24 * 60 * 60 * 1000;
+const MAX_TASK_BUILD_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const PLAN_TTL_MS = 15 * 60 * 1000;
+
+interface EntryRow {
+  readonly build_key: string;
+  readonly tag: string;
+  readonly image_id: string;
+  readonly created_at: string;
+  readonly last_successful_use_at: string | null;
+  readonly protected_until: string;
+  readonly manifest_digest: string;
+  readonly generation: number;
+  readonly operation_id: string;
+  readonly state: "indexed" | "deleting" | "tombstoned" | "unverified";
+}
+
+export interface TaskBuildInventoryEntry {
+  readonly buildKey: string;
+  readonly tag: string;
+  readonly imageId: string;
+  readonly createdAt: string;
+  readonly lastSuccessfulUseAt: string | null;
+  readonly protectedUntil: string;
+  readonly state: "active-leased" | "cold-reusable" | "unverified";
+}
+
+export interface TaskBuildDomainInventory {
+  readonly domainId: string;
+  readonly backendKind: "docker-images";
+  readonly state: "verified-managed";
+  readonly entries: readonly TaskBuildInventoryEntry[];
+}
+
+export interface TaskBuildCacheService {
+  lookup(buildKey: string, tag: string, manifestDigest: string, dockerSocketPath?: string): Promise<boolean>;
+  publish(buildKey: string, tag: string, manifestDigest: string, operationId: string, dockerSocketPath?: string): Promise<void>;
+  acquireUse(buildKey: string, tag: string, manifestDigest: string, dockerSocketPath?: string): Promise<{ release(): void }>;
+}
+
+export interface TaskBuildCacheAdminService {
+  inventory(): Promise<TaskBuildDomainInventory>;
+  planGc(domainId: string): Promise<TaskBuildGcPlan>;
+  applyGc(domainId: string, planId: string): Promise<TaskBuildGcOutcome>;
+}
+
+export interface TaskBuildGcPlan {
+  readonly schemaVersion: 1;
+  readonly planId: string;
+  readonly domainId: string;
+  readonly ownerId: string;
+  readonly backendIdentity: string;
+  readonly authorityEpoch: string;
+  readonly policyVersion: 1;
+  readonly registrySafetyRevision: number;
+  readonly observedAt: string;
+  readonly expiresAt: string;
+  readonly planDigest: string;
+  readonly candidates: ReadonlyArray<{
+    readonly buildKey: string;
+    readonly tag: string;
+    readonly imageId: string;
+    readonly manifestDigest: string;
+    readonly generation: number;
+    readonly evidenceDigest: string;
+    readonly ruleId: "max-age/task-build";
+  }>;
+}
+
+interface DomainHandle {
+  readonly domainId: string;
+  readonly ownerId: string;
+  readonly authorityEpoch: string;
+  readonly backendIdentity: string;
+  readonly db: DatabaseSync;
+}
+
+function domainIdFor(ownerId: string, daemonId: string, storageDriver: string, sentinelId: string): string {
+  return createHash("sha256")
+    .update(`docker-images\0${ownerId}\0${daemonId}\0${storageDriver}\0${sentinelId}`)
+    .digest("hex").slice(0, 24);
+}
+
+function inventoryState(actual: string | undefined, expected: string, leases: number): TaskBuildInventoryEntry["state"] {
+  return actual !== expected ? "unverified" : leases > 0 ? "active-leased" : "cold-reusable";
+}
+
+function passesGcAgePolicy(row: EntryRow, now: number): boolean {
+  const lastUse = Date.parse(row.last_successful_use_at ?? row.created_at);
+  return Date.parse(row.protected_until) <= now && now - lastUse >= MAX_TASK_BUILD_AGE_MS;
+}
+
+function canonicalDigest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function digestPlan(plan: Omit<TaskBuildGcPlan, "planDigest">): string {
+  return canonicalDigest(plan);
+}
+
+function entryEvidence(row: EntryRow): Record<string, unknown> {
+  return {
+    buildKey: row.build_key,
+    imageId: row.image_id,
+    manifestDigest: row.manifest_digest,
+    generation: row.generation,
+    createdAt: row.created_at,
+    lastSuccessfulUseAt: row.last_successful_use_at,
+    protectedUntil: row.protected_until,
+  };
+}
+
+function stateRoot(): string {
+  const base = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
+  return join(base, "niceeval", "cache", "v2", "domains");
+}
+
+async function docker(args: readonly string[], dockerSocketPath?: string): Promise<string> {
+  const connection = dockerSocketPath === undefined ? [] : ["--host", `unix://${dockerSocketPath}`];
+  const result = await execFileAsync("docker", [...connection, ...args], { encoding: "utf8", maxBuffer: 4 * 1024 * 1024 });
+  return result.stdout.trim();
+}
+
+function decimalBytes(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const match = /^([0-9]+(?:\.[0-9]+)?)\s*([kmgtp]?b)$/iu.exec(value.trim());
+  if (match === null) return null;
+  const power = ["b", "kb", "mb", "gb", "tb", "pb"].indexOf(match[2]!.toLowerCase());
+  return power < 0 ? null : Math.round(Number(match[1]) * 1000 ** power);
+}
+
+export async function observeDockerBuildKitCapacity(): Promise<ProviderCapacityObservation> {
+  const output = await docker(["system", "df", "--format", "json"]);
+  const rows = output.split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>);
+  const build = rows.find((row) => row.Type === "Build Cache");
+  const reclaimable = typeof build?.Reclaimable === "string" ? build.Reclaimable.trim().split(/\s+/u)[0] : undefined;
+  return Object.freeze({
+    scope: "provider",
+    providerFamily: "docker",
+    backendKind: "buildkit",
+    state: "unverified",
+    observedAt: new Date().toISOString(),
+    totalBytes: decimalBytes(build?.Size),
+    reclaimableEstimateBytes: decimalBytes(reclaimable),
+    reason: "shared-builder-unattributed",
+  });
+}
+
+async function openDomain(dockerSocketPath?: string): Promise<DomainHandle> {
+  if (dockerSocketPath !== undefined) throw new Error("managed Docker cache requires the default local Unix socket");
+  const root = stateRoot();
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  const ownerPath = join(root, "owner-id");
+  let ownerId: string;
+  try {
+    ownerId = readFileSync(ownerPath, "utf8").trim();
+  } catch {
+    ownerId = randomUUID();
+    const temporary = `${ownerPath}.${process.pid}.${randomUUID()}.tmp`;
+    writeFileSync(temporary, `${ownerId}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    try {
+      renameSync(temporary, ownerPath);
+    } catch {
+      ownerId = readFileSync(ownerPath, "utf8").trim();
+    }
+  }
+  const sentinelName = `niceeval-cache-${createHash("sha256").update(ownerId).digest("hex").slice(0, 16)}`;
+  const sentinelLabel = "io.niceeval.cache-domain";
+  let sentinelId: string | undefined;
+  try {
+    sentinelId = await docker(["volume", "inspect", "--format", `{{index .Labels \"${sentinelLabel}\"}}`, sentinelName]);
+  } catch {
+    sentinelId = randomUUID();
+    await docker(["volume", "create", "--label", `${sentinelLabel}=${sentinelId}`, sentinelName]);
+    sentinelId = await docker(["volume", "inspect", "--format", `{{index .Labels \"${sentinelLabel}\"}}`, sentinelName]);
+  }
+  if (sentinelId.length === 0 || sentinelId === "<no value>") throw new Error(`Docker cache sentinel ${sentinelName} has no managed identity`);
+  const daemonId = await docker(["info", "--format", "{{.ID}}"], dockerSocketPath);
+  const storageDriver = await docker(["info", "--format", "{{.Driver}}"], dockerSocketPath);
+  const domainId = domainIdFor(ownerId, daemonId, storageDriver, sentinelId);
+  const backendIdentity = createHash("sha256").update(`${daemonId}\0${storageDriver}\0${sentinelId}`).digest("hex");
+  const directory = join(stateRoot(), domainId);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const db = new DatabaseSync(join(directory, "registry.sqlite"));
+  db.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA foreign_keys=ON;");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS entries (
+      build_key TEXT PRIMARY KEY,
+      tag TEXT NOT NULL,
+      image_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      last_successful_use_at TEXT,
+      protected_until TEXT NOT NULL,
+      manifest_digest TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      operation_id TEXT NOT NULL,
+      state TEXT NOT NULL CHECK(state IN ('indexed','deleting','tombstoned','unverified'))
+    );
+    CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE IF NOT EXISTS leases (
+      lease_id TEXT PRIMARY KEY,
+      build_key TEXT NOT NULL REFERENCES entries(build_key),
+      holder_pid INTEGER NOT NULL,
+      holder_boot_id TEXT NOT NULL,
+      holder_process_start TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      created_at TEXT NOT NULL,
+      heartbeat_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS roots (
+      root_id TEXT PRIMARY KEY,
+      build_key TEXT NOT NULL REFERENCES entries(build_key),
+      generation INTEGER NOT NULL,
+      holder_boot_id TEXT NOT NULL,
+      holder_pid INTEGER NOT NULL,
+      holder_process_start TEXT NOT NULL,
+      state TEXT NOT NULL CHECK(state IN ('prepared','active')),
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS gc_plans (
+      plan_id TEXT PRIMARY KEY,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      digest TEXT NOT NULL,
+      outcome TEXT
+    );
+  `);
+  const epochRow = db.prepare("SELECT value FROM metadata WHERE key = 'authorityEpoch'").get() as { value: string } | undefined;
+  const authorityEpoch = epochRow?.value ?? randomUUID();
+  db.prepare("INSERT OR IGNORE INTO metadata(key, value) VALUES ('authorityEpoch', ?)").run(authorityEpoch);
+  db.prepare("INSERT OR IGNORE INTO metadata(key, value) VALUES ('safetyRevision', '1')").run();
+  const catalog = new DatabaseSync(join(root, "catalog.sqlite"));
+  catalog.exec(`
+    PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;
+    CREATE TABLE IF NOT EXISTS domains (
+      domain_id TEXT PRIMARY KEY,
+      provider_family TEXT NOT NULL,
+      admin_protocol_version INTEGER NOT NULL,
+      backend_kind TEXT NOT NULL,
+      first_verified_at TEXT NOT NULL,
+      last_verified_at TEXT NOT NULL,
+      last_state TEXT NOT NULL
+    );
+  `);
+  const verifiedAt = new Date().toISOString();
+  catalog.prepare(`
+    INSERT INTO domains(domain_id, provider_family, admin_protocol_version, backend_kind, first_verified_at, last_verified_at, last_state)
+    VALUES (?, 'docker', 1, 'docker-images', ?, ?, 'verified-managed')
+    ON CONFLICT(domain_id) DO UPDATE SET last_verified_at=excluded.last_verified_at, last_state='verified-managed'
+  `).run(domainId, verifiedAt, verifiedAt);
+  catalog.close();
+  return { domainId, ownerId, authorityEpoch, backendIdentity, db };
+}
+
+export async function listDockerCacheDomains(): Promise<readonly CacheDomainDescriptor[]> {
+  const current = await openDomain();
+  current.db.close();
+  const catalog = new DatabaseSync(join(stateRoot(), "catalog.sqlite"), { readOnly: true });
+  const rows = catalog.prepare("SELECT domain_id, provider_family, admin_protocol_version, backend_kind FROM domains ORDER BY first_verified_at, domain_id").all() as Array<{
+    domain_id: string; provider_family: string; admin_protocol_version: number; backend_kind: string;
+  }>;
+  catalog.close();
+  return rows.map((row) => ({
+    providerFamily: row.provider_family,
+    adminProtocolVersion: row.admin_protocol_version,
+    domainId: row.domain_id,
+    backendKind: row.backend_kind,
+    state: row.domain_id === current.domainId ? "verified-managed" : "unavailable",
+  }));
+}
+
+export async function dockerTaskBuildAuthorityFingerprint(): Promise<string> {
+  const domain = await openDomain();
+  domain.db.close();
+  return domain.domainId;
+}
+
+async function imageId(tag: string, dockerSocketPath?: string): Promise<string | undefined> {
+  try {
+    return await docker(["image", "inspect", "--format", "{{.Id}}", tag], dockerSocketPath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function hasContainerReference(image: string, dockerSocketPath?: string): Promise<boolean> {
+  return (await docker(["ps", "-a", "--filter", `ancestor=${image}`, "--quiet"], dockerSocketPath)).length > 0;
+}
+
+function holderIdentity(pid = process.pid): { bootId: string; processStart: string } {
+  const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+  const stat = readFileSync(`/proc/${pid}/stat`, "utf8").trim();
+  const processStart = stat.slice(stat.lastIndexOf(")") + 2).split(/\s+/u)[19];
+  if (bootId.length === 0 || processStart === undefined) throw new Error("cannot verify local process identity");
+  return { bootId, processStart };
+}
+
+function processIdentityIsLive(pid: number, bootId: string, processStart: string): boolean {
+  try {
+    const actual = holderIdentity(pid);
+    return actual.bootId === bootId && actual.processStart === processStart;
+  } catch {
+    return false;
+  }
+}
+
+class LiveTaskBuildCacheSession implements TaskBuildCacheService {
+  async lookup(buildKey: string, tag: string, manifestDigest: string, dockerSocketPath?: string): Promise<boolean> {
+    const domain = await openDomain(dockerSocketPath);
+    const row = domain.db.prepare("SELECT * FROM entries WHERE build_key = ? AND state = 'indexed'").get(buildKey) as EntryRow | undefined;
+    if (row === undefined || row.tag !== tag || row.manifest_digest !== manifestDigest) {
+      domain.db.close();
+      return false;
+    }
+    const actual = await imageId(tag, dockerSocketPath);
+    if (actual === undefined || actual !== row.image_id) {
+      domain.db.prepare("UPDATE entries SET state = 'unverified' WHERE build_key = ?").run(buildKey);
+      domain.db.close();
+      return false;
+    }
+    domain.db.close();
+    return true;
+  }
+
+  async publish(buildKey: string, tag: string, manifestDigest: string, operationId: string, dockerSocketPath?: string): Promise<void> {
+    const actual = await imageId(tag, dockerSocketPath);
+    if (actual === undefined) throw new Error(`built image ${tag} is absent after build`);
+    const domain = await openDomain(dockerSocketPath);
+    const now = new Date();
+    domain.db.prepare(`
+      INSERT INTO entries(build_key, tag, image_id, created_at, last_successful_use_at, protected_until, manifest_digest, generation, operation_id, state)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, 'indexed')
+      ON CONFLICT(build_key) DO UPDATE SET
+        tag=excluded.tag, image_id=excluded.image_id, created_at=excluded.created_at,
+        last_successful_use_at=excluded.last_successful_use_at,
+        protected_until=excluded.protected_until, manifest_digest=excluded.manifest_digest,
+        generation=CASE WHEN entries.operation_id = excluded.operation_id THEN entries.generation ELSE entries.generation + 1 END,
+        operation_id=excluded.operation_id, state='indexed'
+    `).run(buildKey, tag, actual, now.toISOString(), now.toISOString(), new Date(now.getTime() + MINIMUM_AGE_MS).toISOString(), manifestDigest, operationId);
+    domain.db.prepare("UPDATE metadata SET value = CAST(value AS INTEGER) + 1 WHERE key = 'safetyRevision'").run();
+    domain.db.close();
+  }
+
+  async acquireUse(buildKey: string, tag: string, manifestDigest: string, dockerSocketPath?: string): Promise<{ release(): void }> {
+    const domain = await openDomain(dockerSocketPath);
+    const row = domain.db.prepare("SELECT * FROM entries WHERE build_key = ? AND state = 'indexed'").get(buildKey) as EntryRow | undefined;
+    if (row === undefined || row.tag !== tag || row.manifest_digest !== manifestDigest || await imageId(tag, dockerSocketPath) !== row.image_id) {
+      domain.db.close();
+      throw new Error(`Docker task-build artifact ${buildKey.slice(0, 12)} is no longer available`);
+    }
+    const leaseId = randomUUID();
+    const rootId = randomUUID();
+    const now = new Date().toISOString();
+    const holder = holderIdentity();
+    domain.db.exec("BEGIN IMMEDIATE");
+    try {
+      domain.db.prepare("INSERT INTO leases(lease_id, build_key, holder_pid, holder_boot_id, holder_process_start, generation, created_at, heartbeat_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)")
+        .run(leaseId, buildKey, process.pid, holder.bootId, holder.processStart, row.generation, now, now);
+      domain.db.prepare("INSERT INTO roots(root_id, build_key, generation, holder_boot_id, holder_pid, holder_process_start, state, created_at) VALUES (?, ?, ?, ?, ?, ?, 'prepared', ?)")
+        .run(rootId, buildKey, row.generation, holder.bootId, process.pid, holder.processStart, now);
+      domain.db.prepare("UPDATE roots SET state = 'active' WHERE root_id = ? AND state = 'prepared'").run(rootId);
+      domain.db.prepare("UPDATE entries SET last_successful_use_at = ? WHERE build_key = ?").run(now, buildKey);
+      domain.db.exec("COMMIT");
+    } catch (cause) {
+      domain.db.exec("ROLLBACK");
+      domain.db.close();
+      throw cause;
+    }
+    let released = false;
+    return { release() {
+      if (released) return;
+      released = true;
+      domain.db.exec("BEGIN IMMEDIATE");
+      try {
+        domain.db.prepare("DELETE FROM roots WHERE root_id = ?").run(rootId);
+        domain.db.prepare("DELETE FROM leases WHERE lease_id = ?").run(leaseId);
+        domain.db.exec("COMMIT");
+      } catch (cause) {
+        domain.db.exec("ROLLBACK");
+        throw cause;
+      }
+      domain.db.close();
+    } };
+  }
+}
+
+export function makeTaskBuildCacheService(): TaskBuildCacheService {
+  return new LiveTaskBuildCacheSession();
+}
+
+function liveLeaseCount(db: DatabaseSync, buildKey: string): number {
+  const rows = db.prepare("SELECT lease_id, holder_pid, holder_boot_id, holder_process_start FROM leases WHERE build_key = ?").all(buildKey) as Array<{
+    lease_id: string; holder_pid: number; holder_boot_id: string; holder_process_start: string;
+  }>;
+  let live = 0;
+  for (const row of rows) {
+    if (processIdentityIsLive(row.holder_pid, row.holder_boot_id, row.holder_process_start)) {
+      live += 1;
+    } else {
+      db.prepare("DELETE FROM leases WHERE lease_id = ?").run(row.lease_id);
+    }
+  }
+  return live;
+}
+
+function liveRootCount(db: DatabaseSync, buildKey: string): number {
+  const rows = db.prepare("SELECT root_id, holder_pid, holder_boot_id, holder_process_start FROM roots WHERE build_key = ?").all(buildKey) as Array<{
+    root_id: string; holder_pid: number; holder_boot_id: string; holder_process_start: string;
+  }>;
+  let live = 0;
+  for (const row of rows) {
+    if (processIdentityIsLive(row.holder_pid, row.holder_boot_id, row.holder_process_start)) live += 1;
+    else db.prepare("DELETE FROM roots WHERE root_id = ?").run(row.root_id);
+  }
+  return live;
+}
+
+export async function inventoryTaskBuildDomain(dockerSocketPath?: string): Promise<TaskBuildDomainInventory> {
+  const domain = await openDomain(dockerSocketPath);
+  const rows = domain.db.prepare("SELECT * FROM entries ORDER BY COALESCE(last_successful_use_at, created_at), created_at, build_key").all() as unknown as EntryRow[];
+  const entries: TaskBuildInventoryEntry[] = [];
+  for (const row of rows) {
+    const actual = await imageId(row.tag, dockerSocketPath);
+    const leases = liveLeaseCount(domain.db, row.build_key) + liveRootCount(domain.db, row.build_key);
+    entries.push({
+      buildKey: row.build_key,
+      tag: row.tag,
+      imageId: row.image_id,
+      createdAt: row.created_at,
+      lastSuccessfulUseAt: row.last_successful_use_at,
+      protectedUntil: row.protected_until,
+      state: inventoryState(actual, row.image_id, leases),
+    });
+  }
+  domain.db.close();
+  return { domainId: domain.domainId, backendKind: "docker-images", state: "verified-managed", entries };
+}
+
+export async function planTaskBuildGc(domainId: string): Promise<TaskBuildGcPlan> {
+  const domain = await openDomain();
+  if (domain.domainId !== domainId) {
+    domain.db.close();
+    throw new Error(`unknown Docker image cache domain ${domainId}`);
+  }
+  const now = new Date();
+  const candidates: TaskBuildGcPlan["candidates"][number][] = [];
+  const rows = domain.db.prepare("SELECT * FROM entries WHERE state = 'indexed' ORDER BY COALESCE(last_successful_use_at, created_at), created_at, build_key").all() as unknown as EntryRow[];
+  for (const row of rows) {
+    if (!passesGcAgePolicy(row, now.getTime())) continue;
+    if (liveLeaseCount(domain.db, row.build_key) > 0) continue;
+    if (liveRootCount(domain.db, row.build_key) > 0) continue;
+    if (await imageId(row.tag) !== row.image_id) continue;
+    if (await hasContainerReference(row.image_id)) continue;
+    const evidence = entryEvidence(row);
+    candidates.push({
+      buildKey: row.build_key,
+      tag: row.tag,
+      imageId: row.image_id,
+      manifestDigest: row.manifest_digest,
+      generation: row.generation,
+      evidenceDigest: canonicalDigest(evidence),
+      ruleId: "max-age/task-build",
+    });
+  }
+  const revision = Number((domain.db.prepare("SELECT value FROM metadata WHERE key = 'safetyRevision'").get() as { value: string }).value);
+  const unsigned: Omit<TaskBuildGcPlan, "planDigest"> = {
+    schemaVersion: 1,
+    planId: randomUUID(),
+    domainId,
+    ownerId: domain.ownerId,
+    backendIdentity: domain.backendIdentity,
+    authorityEpoch: domain.authorityEpoch,
+    policyVersion: 1,
+    registrySafetyRevision: revision,
+    observedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + PLAN_TTL_MS).toISOString(),
+    candidates,
+  };
+  const plan: TaskBuildGcPlan = { ...unsigned, planDigest: digestPlan(unsigned) };
+  domain.db.prepare("INSERT INTO gc_plans(plan_id, created_at, expires_at, payload, digest) VALUES (?, ?, ?, ?, ?)")
+    .run(plan.planId, plan.observedAt, plan.expiresAt, JSON.stringify(plan), plan.planDigest);
+  domain.db.close();
+  return plan;
+}
+
+export interface TaskBuildGcOutcome {
+  readonly planId: string;
+  readonly domainId: string;
+  readonly outcomes: ReadonlyArray<{ readonly buildKey: string; readonly status: "deleted" | "already-absent" | "skipped" | "failed"; readonly reason: string }>;
+}
+
+export async function applyTaskBuildGc(domainId: string, planId: string): Promise<TaskBuildGcOutcome> {
+  const domain = await openDomain();
+  if (domain.domainId !== domainId) {
+    domain.db.close();
+    throw new Error(`unknown Docker image cache domain ${domainId}`);
+  }
+  const saved = domain.db.prepare("SELECT expires_at, payload, digest, outcome FROM gc_plans WHERE plan_id = ?").get(planId) as
+    | { expires_at: string; payload: string; digest: string; outcome: string | null }
+    | undefined;
+  if (saved === undefined) {
+    domain.db.close();
+    throw new Error(`unknown GC plan ${planId}`);
+  }
+  if (saved.outcome !== null) {
+    const outcome = JSON.parse(saved.outcome);
+    domain.db.close();
+    return outcome;
+  }
+  if (Date.parse(saved.expires_at) < Date.now()) {
+    domain.db.close();
+    throw new Error(`GC plan ${planId} expired`);
+  }
+  const plan = JSON.parse(saved.payload) as TaskBuildGcPlan;
+  const { planDigest: persistedPlanDigest, ...unsigned } = plan;
+  if (saved.digest !== persistedPlanDigest || digestPlan(unsigned) !== persistedPlanDigest) {
+    domain.db.close();
+    throw new Error(`GC plan ${planId} is corrupt`);
+  }
+  if (
+    plan.domainId !== domain.domainId ||
+    plan.ownerId !== domain.ownerId ||
+    plan.backendIdentity !== domain.backendIdentity ||
+    plan.authorityEpoch !== domain.authorityEpoch ||
+    plan.policyVersion !== 1
+  ) {
+    domain.db.close();
+    throw new Error(`GC plan ${planId} authority changed`);
+  }
+  const outcomes: Array<{ buildKey: string; status: "deleted" | "already-absent" | "skipped" | "failed"; reason: string }> = [];
+  for (const candidate of plan.candidates) {
+    domain.db.exec("BEGIN IMMEDIATE");
+    let row: EntryRow | undefined;
+    try {
+      row = domain.db.prepare("SELECT * FROM entries WHERE build_key = ?").get(candidate.buildKey) as EntryRow | undefined;
+      if (row === undefined || (row.state !== "indexed" && row.state !== "deleting") || row.image_id !== candidate.imageId ||
+        row.manifest_digest !== candidate.manifestDigest || row.generation !== candidate.generation ||
+        canonicalDigest(entryEvidence(row)) !== candidate.evidenceDigest ||
+        liveLeaseCount(domain.db, candidate.buildKey) > 0 || liveRootCount(domain.db, candidate.buildKey) > 0) {
+        domain.db.exec("ROLLBACK");
+        outcomes.push({ buildKey: candidate.buildKey, status: "skipped", reason: "entry-lease-root-or-generation-changed" });
+        continue;
+      }
+      domain.db.prepare("UPDATE entries SET state = 'deleting' WHERE build_key = ? AND generation = ? AND state IN ('indexed','deleting')")
+        .run(candidate.buildKey, candidate.generation);
+      domain.db.exec("COMMIT");
+    } catch (cause) {
+      domain.db.exec("ROLLBACK");
+      outcomes.push({ buildKey: candidate.buildKey, status: "failed", reason: cause instanceof Error ? cause.message : String(cause) });
+      continue;
+    }
+    const actual = await imageId(row.tag);
+    if (actual === undefined) {
+      domain.db.prepare("UPDATE entries SET state = 'tombstoned' WHERE build_key = ? AND generation = ? AND state = 'deleting'")
+        .run(candidate.buildKey, candidate.generation);
+      outcomes.push({ buildKey: candidate.buildKey, status: "already-absent", reason: "provider-confirmed-absent" });
+      continue;
+    }
+    if (actual !== candidate.imageId || await hasContainerReference(candidate.imageId)) {
+      domain.db.prepare("UPDATE entries SET state = 'indexed' WHERE build_key = ? AND generation = ? AND state = 'deleting'")
+        .run(candidate.buildKey, candidate.generation);
+      outcomes.push({ buildKey: candidate.buildKey, status: "skipped", reason: "resource-or-reference-changed" });
+      continue;
+    }
+    try {
+      await docker(["image", "rm", candidate.imageId]);
+      if (await imageId(row.tag) !== undefined || await hasContainerReference(candidate.imageId)) {
+        domain.db.prepare("UPDATE entries SET state = 'unverified' WHERE build_key = ? AND generation = ? AND state = 'deleting'")
+          .run(candidate.buildKey, candidate.generation);
+        outcomes.push({ buildKey: candidate.buildKey, status: "failed", reason: "image-still-present" });
+        continue;
+      }
+      domain.db.prepare("UPDATE entries SET state = 'tombstoned' WHERE build_key = ? AND generation = ? AND state = 'deleting'")
+        .run(candidate.buildKey, candidate.generation);
+      outcomes.push({ buildKey: candidate.buildKey, status: "deleted", reason: "max-age/task-build" });
+    } catch (cause) {
+      domain.db.prepare("UPDATE entries SET state = 'unverified' WHERE build_key = ? AND generation = ? AND state = 'deleting'")
+        .run(candidate.buildKey, candidate.generation);
+      outcomes.push({ buildKey: candidate.buildKey, status: "failed", reason: cause instanceof Error ? cause.message : String(cause) });
+    }
+  }
+  const result = { planId, domainId, outcomes } as const;
+  domain.db.prepare("UPDATE gc_plans SET outcome = ? WHERE plan_id = ?").run(JSON.stringify(result), planId);
+  domain.db.close();
+  return result;
+}
+
+export const liveTaskBuildCacheAdminService: TaskBuildCacheAdminService = Object.freeze({
+  inventory: inventoryTaskBuildDomain,
+  planGc: planTaskBuildGc,
+  applyGc: applyTaskBuildGc,
+});

--- a/src/sandbox/docker-task-build-cache.ts
+++ b/src/sandbox/docker-task-build-cache.ts
@@ -38,6 +38,7 @@ export interface TaskBuildInventoryEntry {
 
 export interface TaskBuildDomainInventory {
   readonly domainId: string;
+  readonly providerFamily: "docker";
   readonly backendKind: "docker-images";
   readonly state: "verified-managed";
   readonly entries: readonly TaskBuildInventoryEntry[];
@@ -445,7 +446,7 @@ export async function inventoryTaskBuildDomain(dockerSocketPath?: string): Promi
     });
   }
   domain.db.close();
-  return { domainId: domain.domainId, backendKind: "docker-images", state: "verified-managed", entries };
+  return { domainId: domain.domainId, providerFamily: "docker", backendKind: "docker-images", state: "verified-managed", entries };
 }
 
 export async function planTaskBuildGc(domainId: string): Promise<TaskBuildGcPlan> {

--- a/src/sandbox/docker-task-build-cache.ts
+++ b/src/sandbox/docker-task-build-cache.ts
@@ -380,9 +380,19 @@ class LiveTaskBuildCacheSession implements TaskBuildCacheService {
       throw cause;
     }
     let released = false;
+    const heartbeat = setInterval(() => {
+      if (released) return;
+      try {
+        domain.db.prepare("UPDATE leases SET heartbeat_at = ? WHERE lease_id = ?").run(new Date().toISOString(), leaseId);
+      } catch {
+        // The holder identity and durable root remain authoritative; reconciliation will classify an unreadable registry as unverified.
+      }
+    }, 30_000);
+    heartbeat.unref();
     return { release() {
       if (released) return;
       released = true;
+      clearInterval(heartbeat);
       domain.db.exec("BEGIN IMMEDIATE");
       try {
         domain.db.prepare("DELETE FROM roots WHERE root_id = ?").run(rootId);

--- a/src/sandbox/dockerfile-build.ts
+++ b/src/sandbox/dockerfile-build.ts
@@ -3,12 +3,21 @@
 // 契约单源：docs/feature/sandbox/case.md「按需构建单 Sandbox」「Run 级构建协调」。
 
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { isAbsolute, resolve as resolvePath } from "node:path";
 import { Data, Effect } from "effect";
-import type { SandboxBuildExecutionContext, SandboxBuildProvider, SandboxBuildWork } from "./build-coordinator.ts";
+import {
+  materializationScopeId,
+  sandboxBuildRef,
+  type SandboxBuildArtifactSource,
+  type SandboxBuildExecutionContext,
+  type SandboxBuildProvider,
+  type SandboxBuildWork,
+} from "./build-coordinator.ts";
 import { detectDockerBuildPlatform, normalizeBuildPlatform } from "./compose.ts";
 import { computeCaseKey, type BuildKey, type CaseKey } from "./identity.ts";
+import { dockerTaskBuildAuthorityFingerprint, makeTaskBuildCacheService } from "./docker-task-build-cache.ts";
 import {
   DOCKERFILE_MATERIALIZER_REVISION,
   resolveDockerfileBuildIdentity,
@@ -71,6 +80,12 @@ export function collectDockerfileBuildFromIdentity(input: {
         message: "Dockerfile build inputs changed after physical planning. Restart the Run to plan the new inputs.",
       }));
     }
+    const authorityFingerprint = input.provider === "docker" && input.dockerSocketPath === undefined
+      ? yield* Effect.tryPromise({
+          try: () => dockerTaskBuildAuthorityFingerprint(),
+          catch: (cause) => new DockerfileBuildCollectionError({ message: cause instanceof Error ? cause.message : String(cause) }),
+        })
+      : JSON.stringify(identity.providerIdentityMarker ?? [input.provider, input.dockerSocketPath ?? "default"]);
     return yield* Effect.try({
       try: () => {
         const caseKey = computeCaseKey({
@@ -89,12 +104,19 @@ export function collectDockerfileBuildFromIdentity(input: {
           platform: input.platform,
           ...(input.dockerSocketPath === undefined ? {} : { dockerSocketPath: input.dockerSocketPath }),
         };
+        const scopeId = materializationScopeId({
+          providerFamily: input.provider,
+          authorityFingerprint,
+          materializationProtocolVersion: 1,
+        });
         return Object.freeze({
           buildKey: identity.buildKey,
           caseKey,
           details,
           ...(identity.providerIdentityMarker === undefined ? {} : { providerIdentityMarker: identity.providerIdentityMarker }),
           work: Object.freeze({
+            ref: sandboxBuildRef(scopeId, identity.buildKey),
+            scopeId,
             buildKey: identity.buildKey,
             provider: input.provider,
             label: `${input.provider}:dockerfile:${input.profile}`,
@@ -142,6 +164,27 @@ export function dockerfileBuildProvider(
   const runDockerBuild = hooks.runDockerBuild ?? defaultRunDockerBuild;
   const templateExists = hooks.e2bTemplateExists ?? defaultE2BTemplateExists;
   const buildE2BTemplate = hooks.buildE2BTemplate ?? defaultBuildE2BTemplate;
+  const managedDockerCache = hooks.dockerImageExists === undefined && hooks.runDockerBuild === undefined &&
+    collections.every((collection) => collection.details.dockerSocketPath === undefined)
+    ? makeTaskBuildCacheService()
+    : undefined;
+
+  const source = (
+    work: SandboxBuildWork,
+    locator: string,
+    origin: "cache" | "build",
+    detail: DockerfileBuildDetails,
+  ): SandboxBuildArtifactSource => ({
+    locator,
+    source: origin,
+    acquireUse: async () => {
+      const lease = detail.provider === "docker" && managedDockerCache !== undefined
+        ? await managedDockerCache.acquireUse(work.buildKey, locator, buildManifestDigest(work), detail.dockerSocketPath)
+        : { release() {} };
+      return { locator, release: () => lease.release() };
+    },
+    release() {},
+  });
 
   const detailFor = (work: SandboxBuildWork): DockerfileBuildDetails => {
     const detail = details.get(work.buildKey);
@@ -156,30 +199,50 @@ export function dockerfileBuildProvider(
       const detail = detailFor(work);
       if (detail.provider === "docker") {
         const tag = dockerBuildTag(work.buildKey);
-        return (await imageExists(tag, detail.dockerSocketPath)) ? tag : undefined;
+        if (managedDockerCache !== undefined) {
+          return await managedDockerCache.lookup(work.buildKey, tag, buildManifestDigest(work), detail.dockerSocketPath)
+            ? { _tag: "Hit", source: source(work, tag, "cache", detail) }
+            : { _tag: "Miss" };
+        }
+        return (await imageExists(tag, detail.dockerSocketPath))
+          ? { _tag: "Hit", source: source(work, tag, "cache", detail) }
+          : { _tag: "Miss" };
       }
       const name = e2bBuildName(work.buildKey);
-      return (await templateExists(name, signal)) ? name : undefined;
+      return (await templateExists(name, signal))
+        ? { _tag: "Hit", source: source(work, name, "cache", detail) }
+        : { _tag: "Miss" };
     },
     async build(work, ctx) {
       const detail = detailFor(work);
       if (detail.provider === "docker") {
         const tag = dockerBuildTag(work.buildKey);
         await runDockerBuild(detail, tag, ctx);
-        return tag;
+        await managedDockerCache?.publish(work.buildKey, tag, buildManifestDigest(work), ctx.operationId, detail.dockerSocketPath);
+        return source(work, tag, "build", detail);
       }
       const name = e2bBuildName(work.buildKey);
       await buildE2BTemplate(detail, name, ctx);
-      return name;
+      return source(work, name, "build", detail);
     },
   };
 }
 
+function buildManifestDigest(work: SandboxBuildWork): string {
+  return createHash("sha256").update(JSON.stringify({
+    schemaVersion: 1,
+    scopeId: work.scopeId,
+    buildKey: work.buildKey,
+    provider: work.provider,
+    inputs: work.inputs,
+  })).digest("hex");
+}
+
 export function routeBuildProviders(
-  routes: ReadonlyMap<BuildKey, SandboxBuildProvider>,
+  routes: ReadonlyMap<import("./build-coordinator.ts").SandboxBuildRef, SandboxBuildProvider>,
 ): SandboxBuildProvider {
   const providerFor = (work: SandboxBuildWork): SandboxBuildProvider => {
-    const provider = routes.get(work.buildKey);
+    const provider = routes.get(work.ref);
     if (provider === undefined) throw new Error(`no sandbox build provider for BuildKey ${work.buildKey.slice(0, 12)}…`);
     return provider;
   };

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -147,11 +147,18 @@ export type {
 export type {
   SandboxBuildWork,
   SandboxBuildProvider,
+  SandboxBuildRef,
+  MaterializationScopeId,
+  SandboxBuildLookup,
+  SandboxBuildArtifactSource,
+  SandboxBuildUseHandle,
   SandboxBuildExecutionContext,
   SandboxBuildPreparation,
   SandboxBuildFailure,
   PrepareSandboxBuildsOptions,
 } from "./build-coordinator.ts";
+
+export { materializationScopeId, sandboxBuildRef } from "./build-coordinator.ts";
 
 export {
   DockerProfileError,


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 1cb8dfbef1b1e3263f174b8c59c74cd6eb2be6dc
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: 8c2820e10116ecae225a881c668be68518e8cc29
-->

## Problem

- User goal: 并行运行多个 Eval/config 时，相同任务镜像只构建一次，并在后续 Invocation 继续复用。
- Current limitation: Docker image 虽然仍在本机，但 NiceEval 没有持久所有权索引、consumer lease 或可解释的缓存反馈；共享 BuildKit 容量也容易被误认为可安全清理。
- Required capability: provider-owned 的 Docker task-build cache、provider 中立的构建协调、受管 Domain inventory，以及带事实复核的两阶段 GC。
- User outcome: 不降低 Attempt 并行度即可复用相同 BuildKey；中断后已发布的 image 仍可命中；用户能区分受管 image、共享 BuildKit 和 Sandbox orphan。

## Use cases

### Case: 并行 Attempt 共享任务镜像

#### Starting state

```text
8 attempts · 2 evals × 4 configs · concurrency 10
两道 Eval 对每个 config 使用相同 Dockerfile BuildKey
```

#### Action

```sh
niceeval exp harness
```

#### Result

```text
8 attempts require 4 BuildKeys · 3 cache hits · 1 built once · 2 attempts waited
```

Runner 按 `(MaterializationScopeId, BuildKey)` single-flight。等待 build 和每个 consumer 的 use lease 都发生在 Attempt permit 之前，因此不会降低执行并行度。完整流程见 [并行运行的共享任务镜像](docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/并行运行的共享任务镜像.md)。

### Case: 后续 Invocation 命中已发布 image

#### Starting state

```text
前一次 Invocation 已完成 Docker build 和 registry publish；Attempt 后续失败或进程随后中断
```

#### Action

```sh
niceeval exp cache-hit --rerun all
niceeval exp cache-hit --rerun all
```

#### Result

```text
# first invocation
built once · docker:dockerfile:greet/hello · 1 attempt

# second invocation
build cache hit · docker:dockerfile:greet/hello · 1 attempt
```

发布发生在 image build 后、Sandbox Attempt 前；registry 和 immutable image identity 一致时，进程重启不需要重新构建。没有新 registry/manifest 证明的旧 image 只作为 legacy/unverified，不会被自动接管或删除。

### Case: 显式回收过期受管 image

#### Starting state

```text
Docker Domain 中存在超过 max-age、没有 live lease/root/container reference 的 indexed task-build entry
```

#### Action

```sh
niceeval cache gc --domain 82d042f7c79a4aedd51294fb --json
niceeval cache gc --domain 82d042f7c79a4aedd51294fb --apply <plan-id> --json
```

#### Result

```json
{
  "format": "niceeval.cache-gc-outcome",
  "schemaVersion": 1,
  "outcomes": [
    { "status": "deleted", "reason": "max-age/task-build" }
  ]
}
```

Preview 持久化 immutable plan 与 digest；apply 复核 owner/backend/epoch/policy、manifest、generation、lease/root、immutable image 和 container reference。事实漂移只会缩减计划。完整流程见 [回收过期任务镜像](docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/回收过期任务镜像.md)。

### Case: 共享 BuildKit 只做容量观察

#### Starting state

```text
Docker 默认 builder 报告 402.6 GB Build Cache，其中 221.6 GB reclaimable
```

#### Action

```sh
niceeval cache inventory
```

#### Result

```text
BuildKit · unverified shared-builder capacity
  total 402.6 GB · provider reclaimable estimate 221.6 GB
  NiceEval ownership unknown · not eligible for NiceEval GC
```

共享 builder 没有 Domain controller，类型上不能 plan/apply。Sandbox orphan 仍只提示 `niceeval sandbox prune`。完整边界见 [盘点共享 BuildKit 缓存](docs/roadmap/sandbox-materialization/cache-lifecycle/use-case/盘点共享BuildKit缓存.md)。

## Public API

### Changed

#### Case: 自定义 `SandboxBuildProvider` 返回 scoped artifact source

##### Before

```ts
const provider: SandboxBuildProvider = {
  async lookup() { return "image:tag" },
  async build() { return "image:tag" },
}
```

```text
一个裸 locator 被所有 Attempt 共享，无法表达 provider authority 或独立 use 生命周期
```

##### After

```ts
const scopeId = materializationScopeId({
  providerFamily: "example",
  authorityFingerprint: "account/project",
  materializationProtocolVersion: 1,
})

const provider: SandboxBuildProvider = {
  async lookup() { return { _tag: "Miss" } },
  async build() {
    return {
      locator: "image:tag",
      source: "build",
      async acquireUse() { return { locator: "image:tag", release() {} } },
      release() {},
    }
  },
}
```

```text
single-flight 按 provider authority 隔离，每个 Attempt 独立 acquire/release use handle
```

##### User impact

直接注入内部构建 provider 的调用方需要返回 `Hit | Miss | Unsupported` 和 scoped artifact source。普通 `dockerSandbox`、`e2bSandbox`、`vercelSandbox` 作者 API 不变；provider 没有持久 cache 时返回 `Unsupported` 即可。

## CLI

### Added

#### Case: 查看 Cache Domain 与共享 Provider 容量

##### Before

```sh
niceeval cache inventory --json
```

```text
error: unknown command "cache"
```

##### After

```sh
niceeval cache inventory --json
```

```json
{
  "format": "niceeval.cache-inventory",
  "schemaVersion": 1,
  "domains": [{
    "providerFamily": "docker",
    "backendKind": "docker-images",
    "state": "verified-managed",
    "entryCount": 0
  }],
  "providerObservations": [{
    "providerFamily": "docker",
    "backendKind": "buildkit",
    "state": "unverified",
    "reason": "shared-builder-unattributed"
  }]
}
```

##### User impact

用户可以从公开 CLI 区分 NiceEval 有权管理的 Docker task-build Domain 与只读的共享 BuildKit capacity；`--domain` 才展开 entry 明细。

#### Case: Preview 后按 plan id 回收

##### Before

```sh
niceeval cache gc --domain <domain-id>
```

```text
error: unknown command "cache"
```

##### After

```sh
niceeval cache gc --domain <domain-id>
niceeval cache gc --domain <domain-id> --apply <plan-id>
```

```text
GC preview <plan-id> · 2 candidates · expires <time>
GC plan <plan-id>
  deleted <build-key> · max-age/task-build
```

##### User impact

GC 不提供 force 或隐式重新规划。apply 只能删除 preview 已授权且复核仍安全的 entry；新 lease、root 或 provider reference 会让对应候选跳过。

## Tests

### `e2e/cli/test/cache-hit.test.ts`

- Purpose: `feature + bug regression`
- Protects: A published image is built once and reused by a later Invocation without consuming another build.
- Runs: Two installed-candidate niceeval exp invocations with --rerun all.
- Asserts: First output says built once, second says cache hit, and provider build count remains one.

```ts
// owner: docs/engineering/testing/e2e/cli.md#cli-docker-task-build-cache
// rerun: pnpm e2e --repo cli -- --run test/cache-hit.test.ts

import { readFile } from "node:fs/promises";
import { join } from "node:path";
import { expect, test } from "vitest";
import { cliE2E } from "./context.ts";

test("Docker task build 在不同 Invocation 复用受管 image cache", async () => {
  await cliE2E.case("cache-hit", {}, async ({ commands: { niceeval }, paths }) => {
    const fakeBin = join(paths.projectRoot, "fixtures/cache-hit/bin");
    const stateRoot = join(paths.projectRoot, "state");
    const env = {
      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
      XDG_STATE_HOME: stateRoot,
      DOCKER_DEFAULT_PLATFORM: "linux/amd64",
    };
    const first = await niceeval.run(["exp", "cache-hit", "--rerun", "all"], { env });
    expect(first.stdout.replace(/\s+/gu, " "), first.diagnostic()).toContain("built once · docker:dockerfile:greet/hello");

    const second = await niceeval.run(["exp", "cache-hit", "--rerun", "all"], { env });
    expect(second.stdout.replace(/\s+/gu, " "), second.diagnostic()).toContain("build cache hit · docker:dockerfile:greet/hello");
    expect(await readFile(join(stateRoot, "fake-cache-hit-docker/build-count"), "utf8")).toBe("1\n");
  });
});
```

### `e2e/cli/test/cache-inventory.test.ts`

- Purpose: `feature + bug regression`
- Protects: Managed Docker domains stay separate from shared BuildKit observations and GC requires a persisted plan id.
- Runs: Installed-candidate cache inventory summary/detail, gc preview, and gc apply commands.
- Asserts: Stable JSON formats, domain ownership, unverified BuildKit capacity, empty safe plan, and idempotent apply output.

```ts
// owner: docs/engineering/testing/e2e/cli.md#cli-cache-inventory
// rerun: pnpm e2e --repo cli -- --run test/cache-inventory.test.ts

import { join } from "node:path";
import { expect, test } from "vitest";
import { cliE2E } from "./context.ts";

test("共享 BuildKit 容量只作为未验证 Provider observation 展示", async () => {
  await cliE2E.case("cache-inventory", {}, async ({ commands: { niceeval }, paths }) => {
    const fakeBin = join(paths.projectRoot, "fixtures/cache-inventory/bin");
    const stateRoot = join(paths.projectRoot, "state");
    const result = await niceeval.run(["cache", "inventory", "--json"], {
      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
    });

    expect(result.exitCode, result.diagnostic()).toBe(0);
    expect(result.stderr).toBe("");
    const document = JSON.parse(result.stdout) as {
      format: string;
      domains: unknown[];
      providerObservations: Array<Record<string, unknown>>;
    };
    expect(document.format).toBe("niceeval.cache-inventory");
    expect(document.domains).toEqual([{
      domainId: expect.any(String),
      providerFamily: "docker",
      backendKind: "docker-images",
      state: "verified-managed",
      entryCount: 0,
    }]);
    expect(document.providerObservations).toEqual([{
      scope: "provider",
      providerFamily: "docker",
      backendKind: "buildkit",
      state: "unverified",
      observedAt: expect.any(String),
      totalBytes: 40_300_000_000,
      reclaimableEstimateBytes: 21_500_000_000,
      reason: "shared-builder-unattributed",
    }]);
    expect(result.stdout).not.toContain("evictable");
    expect(result.stdout).not.toContain("planId");

    const domainId = (document.domains[0] as { domainId: string }).domainId;
    const detail = await niceeval.run(["cache", "inventory", "--domain", domainId, "--json"], {
      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
    });
    expect(detail.exitCode, detail.diagnostic()).toBe(0);
    expect(JSON.parse(detail.stdout)).toMatchObject({
      scope: { kind: "domain", domainId },
      entries: [],
      providerObservations: [],
    });

    const preview = await niceeval.run(["cache", "gc", "--domain", domainId, "--json"], {
      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
    });
    expect(preview.exitCode, preview.diagnostic()).toBe(0);
    const previewDocument = JSON.parse(preview.stdout) as { format: string; plan: { planId: string; candidates: unknown[] } };
    expect(previewDocument.format).toBe("niceeval.cache-gc-plan");
    expect(previewDocument.plan.candidates).toEqual([]);

    const apply = await niceeval.run(["cache", "gc", "--domain", domainId, "--apply", previewDocument.plan.planId, "--json"], {
      env: { PATH: `${fakeBin}:${process.env.PATH ?? ""}`, XDG_STATE_HOME: stateRoot },
    });
    expect(apply.exitCode, apply.diagnostic()).toBe(0);
    expect(JSON.parse(apply.stdout)).toMatchObject({ format: "niceeval.cache-gc-outcome", outcomes: [] });
  });
});
```

### `e2e/cli/test/provider-error-feedback.test.ts`

- Purpose: `feature + bug regression`
- Protects: Build cache activity remains visible without hiding provider errors or exposing internal coordination fields.
- Runs: Installed-candidate experiment with Docker, E2B, and Vercel provider failures.
- Asserts: Per-key checking/failure feedback, provider diagnostics, attempt/run details commands, and secret redaction.

```ts
// owner: docs/engineering/testing/e2e/cli.md#cli-provider-error-feedback
// regression: memory/human-error-feedback-folds-provider-messages.md
// rerun: pnpm e2e --repo cli -- --run test/provider-error-feedback.test.ts

import { join } from "node:path";
import { expect, test } from "vitest";
import { cliE2E } from "./context.ts";

const E2B_ERROR_HEAD = "401 Unauthorized — E2B";
const E2B_ERROR_TAIL = "request req_e2b_feedback_123";
const VERCEL_ERROR = "403 Forbidden — Vercel rejected the sandbox request because team access is required for request iad1::feedback-456";
const PRIMARY_ERROR_HEAD = "502 Bad Gateway · DOCKER_PROVIDER_TIMEOUT";
const PRIMARY_ERROR_TAIL = "request req_docker_primary_789";
const SECONDARY_ERROR_HEAD = "409 Conflict · DOCKER_BUILD_DENIED";
const SECONDARY_ERROR_TAIL = "request req_docker_secondary_987";

test("provider 与 sandbox 错误只展示真实问题并给出所属 details", async () => {
  await cliE2E.case(
    "provider-error-feedback",
    { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
    async ({ commands: { niceeval }, paths }) => {
      const fakeBin = join(paths.projectRoot, "fixtures/provider-error-sandbox/bin");
      const result = await niceeval.run(
        ["exp", "provider-error", "--rerun", "all"],
        {
          env: {
            PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
            DOCKER_DEFAULT_PLATFORM: "linux/amd64",
            XDG_STATE_HOME: join(paths.projectRoot, "state"),
          },
        },
      );

      expect(result.exitCode, result.diagnostic()).toBe(1);
      expect(result.stderr).toBe("");
      const compact = result.stdout.replace(/\s+/gu, " ");
      expect(compact).toContain(`error: ${E2B_ERROR_HEAD}`);
      expect(compact).toContain(E2B_ERROR_TAIL);
      const failurePanel = compact.slice(compact.indexOf("FAILURES"));
      const e2bHumanError = /error: (401 Unauthorized .*?request req_e2b_feedback_123) details:/u.exec(failurePanel)?.[1];
      expect(e2bHumanError, result.diagnostic()).toBeTruthy();
      // regression: Human 限额按 UTF-8 bytes 计算，且不在 emoji surrogate pair 中间截断。
      expect(new TextEncoder().encode(e2bHumanError!).byteLength).toBeLessThanOrEqual(240);
      expect(e2bHumanError).not.toContain("�");
      expect(compact).toContain(`error: ${VERCEL_ERROR}`);
      expect(compact).toContain(PRIMARY_ERROR_HEAD);
      expect(compact).toContain(PRIMARY_ERROR_TAIL);
      expect(compact).toContain(SECONDARY_ERROR_HEAD);
      expect(compact).toContain(SECONDARY_ERROR_TAIL);
      expect(compact, result.diagnostic()).toContain("checking build cache");
      expect(compact.match(/checking build cache · docker:dockerfile:greet\/hello · 1 attempt/gu) ?? []).toHaveLength(2);
      expect(compact.match(/build failed · docker:dockerfile:greet\/hello · 1 attempt/gu) ?? []).toHaveLength(2);
      expect(compact).toContain("2 attempts not started");
      expect(result.stdout).not.toContain("e2b-cause-secret-must-not-reach-human");
      expect(result.stdout).not.toContain("vercel-cause-secret-must-not-reach-human");
      expect(result.stdout).not.toMatch(/shared failure:|\bBuildKey\b|\btiming node\b|\bfailureId\b|\bcause:|\bfix:/u);

      const attemptDetails = [...result.stdout.matchAll(/details: niceeval show (@[A-Z0-9]+)/gu)];
      expect(attemptDetails).toHaveLength(2);
      for (const match of attemptDetails) {
        const shown = await niceeval.run(["show", match[1]!, "--record", ".niceeval/record"]);
        expect(shown.exitCode, shown.diagnostic()).toBe(0);
        expect(shown.stdout).toContain("Attempt overview");
        expect(shown.stdout).toMatch(/401 Unauthorized|403 Forbidden/u);
      }

      const runDetails = [...compact.matchAll(
        /(provider-error\/sandbox(?:-secondary)?)\s+details: niceeval show --run\s+([0-9a-f-]{36})/gu,
      )];
      expect(runDetails, result.diagnostic()).toHaveLength(2);
      for (const match of runDetails) {
        const shownRun = await niceeval.run(["show", "--run", match[2]!, "--record", ".niceeval/record"]);
        expect(shownRun.exitCode, shownRun.diagnostic()).toBe(0);
        const shown = shownRun.stdout.replace(/\s+/gu, " ");
        expect(shown).toContain("Run results");
        expect(shown).toContain("Run errors");
        expect(shown).toContain("1 attempt not started");
        if (match[1] === "provider-error/sandbox") {
          expect(shown).toContain(PRIMARY_ERROR_HEAD);
          expect(shown).toContain(PRIMARY_ERROR_TAIL);
        } else {
          expect(shown).toContain(SECONDARY_ERROR_HEAD);
          expect(shown).toContain(SECONDARY_ERROR_TAIL);
        }
        expect(shown).not.toMatch(
          /Pass rate|Included attempts|Assessment evidence|Analysis notes|Membership|Shared failure|Selected run|\bSlot\b|\bRelation\b|\bfix:/u,
        );
      }

      const judge = await niceeval.run(
        ["exp", "judge-precheck-error", "--rerun", "all", "--json"],
        { env: { CLI_JUDGE_TEST_KEY: "fixture-key" } },
      );
      expect(judge.exitCode, judge.diagnostic()).toBe(1);
      const judgeRunId = judge.expReceipt().runIds[0]!;
      const sandboxRunId = runDetails.find((match) => match[1] === "provider-error/sandbox")?.[2];
      expect(sandboxRunId).toBeTruthy();
      const combined = await niceeval.run([
        "show",
        "--run",
        sandboxRunId!,
        "--run",
        judgeRunId,
        "--record",
        ".niceeval/record",
      ]);
      expect(combined.exitCode, combined.diagnostic()).toBe(0);
      const combinedText = combined.stdout.replace(/\s+/gu, " ");
      // regression: Run errors 只统计它展示的 Sandbox build 影响，不吸收另一 Run 的 Judge 未启动项。
      expect(combinedText).toContain("Run errors 1 attempt not started");
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789956355&installation_model_id=431746&pr_number=88&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F88&signature=c913717193bc5055b6472f772e2c8aed48ce474a9788d98d457af25acb8d5a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
