### PR TITLE
fix(report): 集中实验进度并按语义展开 matcher 详情

### DIFF
--- a/docs/feature/assertions/library/display.md
+++ b/docs/feature/assertions/library/display.md
@@ -16,6 +16,8 @@ Pass Eval 的区块顺序是 Execution、Verdict、检查项。Score Eval 的区
 
 `notCalledTool` matched 时，展开区显示期望零命中与 `0 definite matches`。mismatched 时显示实际命中数、决定结果的 tool occurrence，以及命中输入内的位置。诊断采样或截断不能删除 sealed result 与决定性见证。
 
+Web 详情把 matcher 自身作为可展开行：`matched`、`mismatched` 与 `unavailable` 分别使用成功、失败与警告色，并始终同时显示状态文字，颜色不是唯一表达。点击 matcher 后，输入、实际结果、预期结果与诊断在其下方展开；原始 criterion 与 explanation 再收进技术详情。组合 matcher 按原声明层级展开，每个 `and`、`or` 与叶子 matcher 都显示自己的 sealed 状态，因此父组合命中时仍能辨认没有命中的分支。
+
 Assertions display 不携带 source path、origin source snapshot 或跨 family blob ref。需要源码导航时，Analysis 的 source-navigation DomainView 组合 Assertions payload 内的 `sourceSites` 与 origin Sources snapshot。
 没有对应 row 或 Sources 无法形成可用值时，entry 位置显示 `unmapped`，不能猜测当前 worktree。`.orStop()` 已执行的位置可由 role 为 `stop` 的 source site 显示，不能由未保存的控制流推断。
 

--- a/docs/feature/assertions/library/display.md
+++ b/docs/feature/assertions/library/display.md
@@ -16,7 +16,7 @@ Pass Eval 的区块顺序是 Execution、Verdict、检查项。Score Eval 的区
 
 `notCalledTool` matched 时，展开区显示期望零命中与 `0 definite matches`。mismatched 时显示实际命中数、决定结果的 tool occurrence，以及命中输入内的位置。诊断采样或截断不能删除 sealed result 与决定性见证。
 
-Web 详情把 matcher 自身作为可展开行：`matched`、`mismatched` 与 `unavailable` 分别使用成功、失败与警告色，并始终同时显示状态文字，颜色不是唯一表达。点击 matcher 后，输入、实际结果、预期结果与诊断在其下方展开；原始 criterion 与 explanation 再收进技术详情。组合 matcher 按原声明层级展开，每个 `and`、`or` 与叶子 matcher 都显示自己的 sealed 状态，因此父组合命中时仍能辨认没有命中的分支。
+Web 详情把 matcher 自身作为可展开行：`matched`、`mismatched` 与 `unavailable` 分别使用成功、失败与警告色，状态文字进入该行的无障碍名称而不重复占用视觉空间。点击 matcher 后，输入、实际结果与预期结果在其下方展开；source、criterion 与 explanation 的原始字段再收进技术详情。组合 matcher 按原声明层级展开，每个 `and`、`or` 与叶子 matcher 都携带自己的 sealed 状态，因此父组合命中时仍能辨认没有命中的分支。
 
 Assertions display 不携带 source path、origin source snapshot 或跨 family blob ref。需要源码导航时，Analysis 的 source-navigation DomainView 组合 Assertions payload 内的 `sourceSites` 与 origin Sources snapshot。
 没有对应 row 或 Sources 无法形成可用值时，entry 位置显示 `unmapped`，不能猜测当前 worktree。`.orStop()` 已执行的位置可由 role 为 `stop` 的 source site 显示，不能由未保存的控制流推断。

--- a/docs/feature/assertions/library/display.md
+++ b/docs/feature/assertions/library/display.md
@@ -16,7 +16,9 @@ Pass Eval 的区块顺序是 Execution、Verdict、检查项。Score Eval 的区
 
 `notCalledTool` matched 时，展开区显示期望零命中与 `0 definite matches`。mismatched 时显示实际命中数、决定结果的 tool occurrence，以及命中输入内的位置。诊断采样或截断不能删除 sealed result 与决定性见证。
 
-Web 详情把 matcher 自身作为可展开行：`matched`、`mismatched` 与 `unavailable` 分别使用成功、失败与警告色，状态文字进入该行的无障碍名称而不重复占用视觉空间。点击 matcher 后，输入、实际结果与预期结果在其下方展开；source、criterion 与 explanation 的原始字段再收进技术详情。组合 matcher 按原声明层级展开，每个 `and`、`or` 与叶子 matcher 都携带自己的 sealed 状态，因此父组合命中时仍能辨认没有命中的分支。
+Web 详情把 matcher 自身作为可展开行：`matched`、`mismatched` 与 `unavailable` 分别使用成功、失败与警告色，状态文字进入该行的无障碍名称而不重复占用视觉空间。点击 matcher 后按诊断语义展示，而不是固定摊开通用对象：command 显示命令、实际退出码与预期退出码；tool collection 显示计数约束、确定命中数、检查数与候选调用分支；比较与阈值显示有效的实际值和预期值。`kind`、布尔 `outcome` 与 `expected.kind` 等机器路由字段不进入主视图，source、criterion、observed、policy expected 与 explanation 的完整闭合值仍收进技术详情。
+
+组合 matcher 按原声明层级展开，每个 `and`、`or`、`not` 与叶子 matcher 都携带自己的 sealed 状态，因此父组合命中时仍能辨认没有命中的分支。Tool matcher 的候选 occurrence 也使用同一分支树：调用名称、input、output、status 与命令 token 等子 matcher 各自显示状态，并在展开后显示可用的 expected、received、调用 locator 或 unavailable reason。未知或第三方 matcher 使用 generic fallback，不因没有专用展示而丢失输入和闭合诊断。
 
 Assertions display 不携带 source path、origin source snapshot 或跨 family blob ref。需要源码导航时，Analysis 的 source-navigation DomainView 组合 Assertions payload 内的 `sourceSites` 与 origin Sources snapshot。
 没有对应 row 或 Sources 无法形成可用值时，entry 位置显示 `unmapped`，不能猜测当前 worktree。`.orStop()` 已执行的位置可由 role 为 `stop` 的 source site 显示，不能由未保存的控制流推断。

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -401,15 +401,17 @@ ledger 与 reason data types 同样仅以 type-only export 提供。精确调用
 
 `ExperimentTable` 与 `ExperimentScatter` 是具名比较组件。它们只接受 `ExperimentComparisonScope` 或该 scope 产生的同组 branded projection，不接受普通 Sample 或任意 rows。多组输入以 `analysis-comparison-group-mismatch` 失败；同组 member 即使 Eval population 不同也正常渲染，各自指标使用实际运行的 Slot 和自己的分母。没有运行的 Eval 不合成为失败，也不进入共同交集。中立 `Table` 与 `Scatter` 仍可显示任意已闭合值，不承担实验组语义。
 
-`AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。Assertion 展开区对值比较、scope 检查、Sandbox、Judge 与 score 使用同一套中立结构：
+`ExperimentTable` 的每个实验行只在实验名后显示一次 `samples/total`；耗时、Tokens、成本与主结果格不重复同一比值。展开后的 Eval、分组与 Attempt 行仍各自保留自己的读数完整度，因为它们回答的是下钻范围而不是实验行的重复摘要。
 
-- `Source` 显示求值材料、coverage 与 limitations。
+`AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。Assertion 展开区先把 matcher 或检查名、sealed 状态与有界 diagnostic children 投影成可逐层展开的状态树；它按 generic `label / state / diagnostic` 结构工作，不识别 matcher code 或重新执行 matcher。值比较、scope 检查、Sandbox、Judge 与 score 的详情继续使用同一套中立结构：
+
+- `Input` 显示求值材料、coverage 与 limitations。
 - `Check` 显示检查条件。
 - `Observed` 显示实际结果与有界收据。
 - `Expected` 显示预期条件。
 - `Explanation` 只显示 Analysis 已封口的决定性见证与有界代表材料。
 
-Report 不识别 matcher code、不拼 matcher 专属句子，也不把整棵 diagnostic JSON 当作用户文案。某一段在历史 Record 中没有持久化事实时，它以普通的 `not-recorded` 状态显示，不从 diagnostic、得分比例或其它段反推。
+Report 不拼 matcher 专属句子，也不把 diagnostic tree 的结构重新解释成另一套判定；节点状态、标签与字段都原样来自已闭合值。某一段在历史 Record 中没有持久化事实时，它以普通的 `not-recorded` 状态显示，不从 diagnostic、得分比例或其它段反推。
 
 展开 `send` 所在行后，`TurnTrace` 以 `Conversation` 的静态因果事件流为账本，加上 turn 时间概览与可关闭的事件 inspector。
 

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -403,7 +403,9 @@ ledger 与 reason data types 同样仅以 type-only export 提供。精确调用
 
 `ExperimentTable` 的每个实验行只在实验名后显示一次 `samples/total`；耗时、Tokens、成本与主结果格不重复同一比值。展开后的 Eval、分组与 Attempt 行仍各自保留自己的读数完整度，因为它们回答的是下钻范围而不是实验行的重复摘要。
 
-`AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。Assertion 展开区先把 matcher 或检查名、sealed 状态与有界 diagnostic children 投影成可逐层展开的状态树；它按 generic `label / state / diagnostic` 结构工作，不识别 matcher code 或重新执行 matcher。值比较、scope 检查、Sandbox、Judge 与 score 的详情继续使用同一套中立结构：
+`AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。Assertion 展开区先把 matcher 或检查名、sealed 状态与有界 diagnostic children 投影成可逐层展开的状态树；它不重新执行 matcher。
+
+Report 的内建展示 adapter 可以识别稳定的 built-in criterion ID 与 diagnostic code。command、tool collection、比较／阈值和组合 matcher 使用少量语义读面；未知 code 与第三方 criterion 回落到 generic input／diagnostic 展示。值比较、scope 检查、Sandbox、Judge 与 score 的详情仍来自同一套闭合事实：
 
 - `Input` 显示求值材料、coverage 与 limitations。
 - `Check` 显示检查条件。
@@ -411,7 +413,7 @@ ledger 与 reason data types 同样仅以 type-only export 提供。精确调用
 - `Expected` 显示预期条件。
 - `Explanation` 只显示 Analysis 已封口的决定性见证与有界代表材料。
 
-Report 不拼 matcher 专属句子，也不把 diagnostic tree 的结构重新解释成另一套判定；节点状态、标签与字段都原样来自已闭合值。某一段在历史 Record 中没有持久化事实时，它以普通的 `not-recorded` 状态显示，不从 diagnostic、得分比例或其它段反推。
+Report 只本地化版面标签，不从 matcher name 或 message 文本猜测判定；节点状态、标签、expected、received、locator 与 reason 都来自已闭合值。`kind`、boolean `outcome`、policy 的 boolean `expected` 等路由字段只保留在原始技术详情，不占主要读面。某一段在历史 Record 中没有持久化事实时，它以普通的 `not-recorded` 状态显示，不从得分比例或其它段反推。
 
 展开 `send` 所在行后，`TurnTrace` 以 `Conversation` 的静态因果事件流为账本，加上 turn 时间概览与可关闭的事件 inspector。
 

--- a/e2e/report/evals/classic.eval.ts
+++ b/e2e/report/evals/classic.eval.ts
@@ -1,5 +1,12 @@
 import { defineEval } from "niceeval";
-import { includes } from "niceeval/expect";
+import { and, includes, or } from "niceeval/expect";
+
+function recallMatch() {
+  return and(
+    includes("RECALL_OK"),
+    or(includes("RECALL_OK"), includes("NEVER_PRESENT")),
+  );
+}
 
 function recallEval(topic: string, prompt: string) {
   return defineEval({
@@ -7,7 +14,7 @@ function recallEval(topic: string, prompt: string) {
     async test(t) {
       const turn = await t.send(prompt);
       await turn.succeeded().orStop();
-      t.check(t.reply, includes("RECALL_OK"));
+      t.check(t.reply, recallMatch());
     },
   });
 }
@@ -26,7 +33,7 @@ export default {
       const turn = await t.send("Write a memory note, then recall it.");
       await turn.succeeded().orStop();
       turn.calledTool("write_note", { count: 1 });
-      t.check(t.reply, includes("RECALL_OK"));
+      t.check(t.reply, recallMatch());
     },
   }),
 };

--- a/e2e/report/evals/classic.eval.ts
+++ b/e2e/report/evals/classic.eval.ts
@@ -1,5 +1,5 @@
 import { defineEval } from "niceeval";
-import { and, includes, or } from "niceeval/expect";
+import { and, commandSucceeded, includes, or } from "niceeval/expect";
 
 function recallMatch() {
   return and(
@@ -34,6 +34,12 @@ export default {
       await turn.succeeded().orStop();
       turn.calledTool("write_note", { count: 1 });
       t.check(t.reply, recallMatch());
+      t.check({
+        command: "pnpm test",
+        exitCode: 0,
+        stdout: "",
+        stderr: "PASS src/example.test.ts",
+      }, commandSucceeded());
     },
   }),
 };

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -190,6 +190,39 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
         await page.mouse.click(5, 5);
         await expect(dialog).not.toBeVisible();
         expect(new URL(page.url()).hash).toBe("");
+
+        const baselineSummary = page.locator("summary").filter({ hasText: /^classic\/baseline \(9\/9\)/ }).first();
+        if (await baselineSummary.locator("xpath=..").getAttribute("open") === null) await baselineSummary.click();
+        const classicSummary = page.locator("summary").filter({ hasText: /^classic \(8 evals\)/ }).first();
+        if (await classicSummary.locator("xpath=..").getAttribute("open") === null) await classicSummary.click();
+        const toolEvalSummary = page.locator("summary").filter({ hasText: /^tool-note/ }).first();
+        if (await toolEvalSummary.locator("xpath=..").getAttribute("open") === null) await toolEvalSummary.click();
+        const toolAttemptHref = await toolEvalSummary.locator("xpath=..").locator('a[href^="#/attempt/"]').first().getAttribute("href");
+        expect(toolAttemptHref).toMatch(/^#\/attempt\//);
+        await page.goto(new URL(toolAttemptHref!, origin!).href);
+        await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+        const toolAssertion = dialog.locator("summary").filter({ hasText: 'calledTool("write_note"' }).first();
+        await expect(toolAssertion).toBeVisible({ timeout: 5_000 });
+        if (await toolAssertion.locator("xpath=..").getAttribute("open") === null) await toolAssertion.click();
+        const toolMatcher = dialog.getByLabel(/calledTool.+: mismatched$/).filter({ visible: true }).first();
+        await expect(toolMatcher).toBeVisible({ timeout: 5_000 });
+        await toolMatcher.click();
+        await expect(dialog.getByRole("heading", { name: "Tool calls" })).toBeVisible({ timeout: 5_000 });
+        await expect(dialog.getByText('exactly 1 × toolMatch("write_note")', { exact: true })).toBeVisible();
+        await expect(dialog.getByText("0 definite matches", { exact: true })).toBeVisible();
+
+        const commandAssertion = dialog.locator("summary").filter({ hasText: "t.check({" }).first();
+        await expect(commandAssertion).toBeVisible({ timeout: 5_000 });
+        if (await commandAssertion.locator("xpath=..").getAttribute("open") === null) await commandAssertion.click();
+        const commandMatcher = dialog.getByLabel("commandSucceeded(): matched").filter({ visible: true });
+        await expect(commandMatcher).toBeVisible({ timeout: 5_000 });
+        await commandMatcher.click();
+        await expect(dialog.getByRole("heading", { name: "Command result" })).toBeVisible();
+        await expect(dialog.getByText("pnpm test", { exact: true })).toBeVisible();
+        await expect(dialog.getByText("Exit code 0", { exact: true })).toBeVisible();
+        await expect(dialog.getByText("PASS src/example.test.ts", { exact: true })).not.toBeVisible();
+
       } finally {
         await page.close();
       }

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -151,17 +151,15 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
 
         const assertionLine = dialog.locator("summary").filter({ hasText: "t.check(t.reply" }).first();
         await assertionLine.click();
-        const rootMatch = dialog.locator("summary").filter({ hasText: "and(includes" }).first();
+        const rootMatch = dialog.getByLabel(/^and\(includes.+: matched$/).first();
         await expect(rootMatch).toBeVisible();
-        await expect(rootMatch).toContainText("matched");
         await rootMatch.click();
-        const orMatch = dialog.locator("summary").filter({ hasText: "or(includes" }).first();
-        await expect(orMatch).toContainText("matched");
+        const orMatch = dialog.getByLabel(/^or\(includes.+: matched$/).first();
+        await expect(orMatch).toBeVisible();
         await orMatch.click();
-        const matchedLeaf = dialog.locator("summary").filter({ hasText: 'includes("RECALL_OK")' }).last();
-        const mismatchedLeaf = dialog.locator("summary").filter({ hasText: 'includes("NEVER_PRESENT")' }).last();
-        await expect(matchedLeaf).toContainText("matched");
-        await expect(mismatchedLeaf).toContainText("mismatched");
+        const orNode = orMatch.locator("xpath=..");
+        await expect(orNode.getByLabel('includes("RECALL_OK"): matched')).toBeVisible();
+        await expect(orNode.getByLabel('includes("NEVER_PRESENT"): mismatched')).toBeVisible();
 
         const copiedUrl = page.url();
         await page.getByRole("button", { name: "Close" }).click();

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -109,6 +109,9 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
         const experiment = page.locator('a[href^="#/experiment/"]').filter({
           has: page.locator("title").filter({ hasText: "classic/memory-a" }),
         });
+        const experimentRow = page.locator("summary").filter({ hasText: "classic/memory-a" }).first();
+        await expect(experimentRow).toContainText("classic/memory-a (9/9)");
+        expect((await experimentRow.textContent())?.match(/9\/9/g)).toHaveLength(1);
         await experiment.click();
         await expect(page).toHaveURL(/#\/experiment\//);
 
@@ -145,6 +148,20 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
           await page.unroute(detail.href);
         }
         await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();
+
+        const assertionLine = dialog.locator("summary").filter({ hasText: "t.check(t.reply" }).first();
+        await assertionLine.click();
+        const rootMatch = dialog.locator("summary").filter({ hasText: "and(includes" }).first();
+        await expect(rootMatch).toBeVisible();
+        await expect(rootMatch).toContainText("matched");
+        await rootMatch.click();
+        const orMatch = dialog.locator("summary").filter({ hasText: "or(includes" }).first();
+        await expect(orMatch).toContainText("matched");
+        await orMatch.click();
+        const matchedLeaf = dialog.locator("summary").filter({ hasText: 'includes("RECALL_OK")' }).last();
+        const mismatchedLeaf = dialog.locator("summary").filter({ hasText: 'includes("NEVER_PRESENT")' }).last();
+        await expect(matchedLeaf).toContainText("matched");
+        await expect(mismatchedLeaf).toContainText("mismatched");
 
         const copiedUrl = page.url();
         await page.getByRole("button", { name: "Close" }).click();

--- a/packages/niceeval/src/report/assets/styles.css
+++ b/packages/niceeval/src/report/assets/styles.css
@@ -1648,6 +1648,29 @@ table.niceeval-report,
   display: grid;
   gap: 10px;
 }
+.niceeval-match-facts {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  font: 11px/1.5 var(--font-mono);
+}
+.niceeval-match-facts > div {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, max-content) minmax(0, 1fr);
+  gap: 10px;
+}
+.niceeval-match-facts dt { color: var(--soft); }
+.niceeval-match-facts dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+}
+.niceeval-match-coverage {
+  margin: 0;
+  color: var(--soft);
+  font: 10px/1.5 var(--font-mono);
+}
 .niceeval-match-raw {
   min-width: 0;
   border-top: 1px dashed var(--line);

--- a/packages/niceeval/src/report/assets/styles.css
+++ b/packages/niceeval/src/report/assets/styles.css
@@ -1602,9 +1602,75 @@ table.niceeval-report,
   color: color-mix(in oklch, var(--bad), var(--text) 38%);
 }
 .niceeval-assertion-evidence {
-  display: grid;
   min-width: 0;
+}
+.niceeval-match-node {
+  min-width: 0;
+  border-left: 2px solid var(--line-strong);
+  padding-left: 10px;
+}
+.niceeval-match-node > summary {
+  cursor: pointer;
+  list-style: none;
+}
+.niceeval-match-node > summary::-webkit-details-marker { display: none; }
+.niceeval-match-summary {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 7px;
+  font: 12px/1.5 var(--font-mono);
+  font-weight: 650;
+}
+.niceeval-match-summary code {
+  overflow: hidden;
+  color: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.niceeval-match-summary--matched { color: var(--good); }
+.niceeval-match-summary--mismatched { color: var(--bad); }
+.niceeval-match-summary--unavailable { color: var(--warn); }
+.niceeval-match-detail {
+  display: grid;
+  gap: 10px;
+  padding: 8px 0 4px;
+}
+.niceeval-match-children {
+  display: grid;
+  gap: 7px;
+}
+.niceeval-match-body {
+  display: grid;
+  gap: 10px;
+}
+.niceeval-match-facts,
+.niceeval-match-evidence-grid {
+  display: grid;
+  gap: 10px;
+}
+.niceeval-match-facts { margin: 0; }
+.niceeval-match-facts > div {
+  display: grid;
+  grid-template-columns: minmax(7rem, max-content) minmax(0, 1fr);
+  gap: 10px;
+}
+.niceeval-match-facts dt { color: var(--soft); }
+.niceeval-match-facts dd { min-width: 0; margin: 0; }
+.niceeval-match-raw {
+  min-width: 0;
+  border-top: 1px dashed var(--line);
+  padding-top: 8px;
+}
+.niceeval-match-raw > summary {
+  color: var(--soft);
+  cursor: pointer;
+  font: 11px/1.4 var(--font-mono);
+}
+.niceeval-match-raw > div {
+  display: grid;
   gap: 12px;
+  padding-top: 10px;
 }
 .niceeval-assertion-evidence-section { min-width: 0; }
 .niceeval-assertion-evidence-section > h5 {

--- a/packages/niceeval/src/report/assets/styles.css
+++ b/packages/niceeval/src/report/assets/styles.css
@@ -1644,19 +1644,10 @@ table.niceeval-report,
   display: grid;
   gap: 10px;
 }
-.niceeval-match-facts,
 .niceeval-match-evidence-grid {
   display: grid;
   gap: 10px;
 }
-.niceeval-match-facts { margin: 0; }
-.niceeval-match-facts > div {
-  display: grid;
-  grid-template-columns: minmax(7rem, max-content) minmax(0, 1fr);
-  gap: 10px;
-}
-.niceeval-match-facts dt { color: var(--soft); }
-.niceeval-match-facts dd { min-width: 0; margin: 0; }
 .niceeval-match-raw {
   min-width: 0;
   border-top: 1px dashed var(--line);

--- a/packages/niceeval/src/report/components/attempt-detail/content.tsx
+++ b/packages/niceeval/src/report/components/attempt-detail/content.tsx
@@ -61,7 +61,14 @@ function assertionNodes(assertion: AttemptAssertionView, key: string): ReportNod
       {head}
     </Text>,
   ];
-  nodes.push(<AssertionEvidence key={`${key}:body`} content={assertion.evidence} />);
+  nodes.push(
+    <AssertionEvidence
+      key={`${key}:body`}
+      content={assertion.evidence}
+      label={assertion.name}
+      state={assertion.outcome === "passed" ? "matched" : assertion.outcome === "failed" ? "mismatched" : "unavailable"}
+    />,
+  );
   return nodes;
 }
 

--- a/packages/niceeval/src/report/components/entity-lists/content.ts
+++ b/packages/niceeval/src/report/components/entity-lists/content.ts
@@ -55,14 +55,14 @@ function projectCells(bag: CellBag, columns: readonly ColumnSpec[]): globalThis.
   return cells;
 }
 
-function measureCell(value: MetricValue): Cell {
+function measureCell(value: MetricValue, showCoverage = value.state !== "available"): Cell {
   return {
     kind: "metric",
     metric: value,
     // A complete denominator adds no actionable information to every text
     // cell. Keep partial and exceptional states explicit; the MetricValue
     // itself remains intact for both renderers and machine output.
-    showCoverage: value.state !== "available",
+    showCoverage,
   };
 }
 
@@ -350,17 +350,20 @@ function experimentRow(item: ExperimentListItem, view: HierarchyView): TableCont
   const members: readonly EvalLayoutNode[] = experimentEvalLayout([...new Set([...evalIds, ...item.missingEvalIds])]);
   const attempts = item.evalRows.flatMap((row) => row.attempts);
   const primary = item.evaluationKind === "pass"
-    ? measureCell(item.endToEndPassRate)
+    ? measureCell(item.endToEndPassRate, false)
     : item.totalScore === undefined
     ? { kind: "notApplicable" } as const
     : { kind: "score", earned: item.totalScore } as const;
   const bag: CellBag = {
-    entity: textCell(item.experimentId),
+    entity: identityCell(
+      item.experimentId,
+      `${item.endToEndPassRate.samples}/${item.endToEndPassRate.total}`,
+    ),
     model: item.model === null ? { kind: "notApplicable" } : textCell(item.model),
     agent: item.agent === null ? { kind: "notApplicable" } : textCell(item.agent),
-    durationMs: measureCell(item.durationMs),
-    tokens: measureCell(item.tokens),
-    ...(item.costUSD === undefined ? {} : { costUSD: measureCell(item.costUSD) }),
+    durationMs: measureCell(item.durationMs, false),
+    tokens: measureCell(item.tokens, false),
+    ...(item.costUSD === undefined ? {} : { costUSD: measureCell(item.costUSD, false) }),
     summary: stackCell(primary, verdictCountsCell(attempts)),
   };
   return {

--- a/packages/niceeval/src/report/definition/primitives/assertion-evidence.tsx
+++ b/packages/niceeval/src/report/definition/primitives/assertion-evidence.tsx
@@ -15,6 +15,11 @@ export interface AssertionEvidenceContent {
 type MatchState = "matched" | "mismatched" | "unavailable";
 
 interface MatchDiagnosticView {
+  readonly code?: string;
+  readonly expected?: string;
+  readonly received?: string;
+  readonly reason?: string;
+  readonly locator?: string;
   readonly children: readonly MatchChildView[];
 }
 
@@ -86,8 +91,22 @@ function stringValue(value: ClosedAssertionFactValue | undefined): string | unde
   return value?.kind === "value" && typeof value.value === "string" ? value.value : undefined;
 }
 
+function numberValue(value: ClosedAssertionFactValue | undefined): number | undefined {
+  return value?.kind === "value" && typeof value.value === "number" ? value.value : undefined;
+}
+
 function matcherName(check: ClosedAssertionFactValue): string | undefined {
-  return stringValue(field(field(field(check, "data"), "matcher"), "name"));
+  const data = field(check, "data");
+  const valueMatcher = stringValue(field(field(data, "matcher"), "name"));
+  if (valueMatcher !== undefined) return valueMatcher;
+  if (criterionId(check) !== "occurrence/v1" || stringValue(field(data, "occurrence")) !== "tool") {
+    return undefined;
+  }
+  const toolMatcher = stringValue(field(data, "matcher"));
+  if (toolMatcher === undefined) return undefined;
+  return stringValue(field(data, "assertion")) === "absent"
+    ? `notCalledTool(${toolMatcher})`
+    : `calledTool(${toolMatcher})`;
 }
 
 function matchState(value: ClosedAssertionFactValue | undefined): MatchState | undefined {
@@ -110,8 +129,31 @@ function diagnosticView(value: ClosedAssertionFactValue | undefined): MatchDiagn
       })
     : [];
   return {
+    code: stringValue(field(value, "code")),
+    expected: stringValue(field(value, "expected")),
+    received: stringValue(field(value, "received")),
+    reason: stringValue(field(value, "reason")),
+    locator: stringValue(field(field(value, "locator"), "id")),
     children,
   };
+}
+
+function criterionId(check: ClosedAssertionFactValue): string | undefined {
+  return stringValue(field(check, "id"));
+}
+
+function isToolCriterion(check: ClosedAssertionFactValue): boolean {
+  return criterionId(check) === "occurrence/v1" &&
+    stringValue(field(field(check, "data"), "occurrence")) === "tool";
+}
+
+function semanticExpected(expected: ClosedAssertionFactValue): ClosedAssertionFactValue | undefined {
+  const kind = stringValue(field(expected, "kind"));
+  if (kind === "at-least") {
+    const threshold = numberValue(field(expected, "threshold"));
+    return threshold === undefined ? undefined : { kind: "text", text: `≥ ${threshold}` };
+  }
+  return kind === undefined ? expected : undefined;
 }
 
 function LongString({ value, locale, quoted }: {
@@ -181,6 +223,152 @@ function Section({ heading, value, locale }: {
   );
 }
 
+function SemanticFacts({ rows }: {
+  readonly rows: readonly { readonly label: string; readonly value: string }[];
+}): ReactElement {
+  return (
+    <dl className="niceeval-match-facts">
+      {rows.map((row) => (
+        <div key={row.label}>
+          <dt>{row.label}</dt>
+          <dd>{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function DiagnosticFacts({ diagnostic, locale }: {
+  readonly diagnostic: MatchDiagnosticView;
+  readonly locale: string;
+}): ReactElement | null {
+  const rows = [
+    ...(diagnostic.expected === undefined ? [] : [{
+      label: label(locale, "Expected", "预期"),
+      value: diagnostic.expected,
+    }]),
+    ...(diagnostic.received === undefined ? [] : [{
+      label: label(locale, "Observed", "实际"),
+      value: diagnostic.received,
+    }]),
+    ...(diagnostic.locator === undefined ? [] : [{
+      label: label(locale, "Call", "调用"),
+      value: diagnostic.locator,
+    }]),
+    ...(diagnostic.reason === undefined ? [] : [{
+      label: label(locale, "Reason", "原因"),
+      value: diagnostic.reason,
+    }]),
+  ];
+  return rows.length === 0 ? null : <SemanticFacts rows={rows} />;
+}
+
+function CommandEvidence({ input, diagnostic, locale }: {
+  readonly input: ClosedAssertionFactValue;
+  readonly diagnostic: MatchDiagnosticView | null;
+  readonly locale: string;
+}): ReactElement {
+  const command = stringValue(field(input, "command"));
+  const exitCode = numberValue(field(input, "exitCode"));
+  const rows = [
+    ...(command === undefined ? [] : [{ label: label(locale, "Command", "命令"), value: command }]),
+    ...(exitCode === undefined ? [] : [{
+      label: label(locale, "Result", "结果"),
+      value: label(locale, `Exit code ${exitCode}`, `退出码 ${exitCode}`),
+    }]),
+    ...(diagnostic?.expected === undefined ? [] : [{
+      label: label(locale, "Expected", "预期"),
+      value: diagnostic.expected,
+    }]),
+  ];
+  return (
+    <section className="niceeval-assertion-evidence-section">
+      <h5>{label(locale, "Command result", "命令结果")}</h5>
+      <SemanticFacts rows={rows} />
+    </section>
+  );
+}
+
+function ToolEvidence({ observed, diagnostic, locale }: {
+  readonly observed: ClosedAssertionFactValue;
+  readonly diagnostic: MatchDiagnosticView | null;
+  readonly locale: string;
+}): ReactElement {
+  const receipt = field(observed, "receipt");
+  const examined = numberValue(field(receipt, "examined"));
+  const rows = [
+    ...(diagnostic?.expected === undefined ? [] : [{
+      label: label(locale, "Expected", "预期"),
+      value: diagnostic.expected,
+    }]),
+    ...(diagnostic?.received === undefined ? [] : [{
+      label: label(locale, "Observed", "实际"),
+      value: diagnostic.received,
+    }]),
+    ...(examined === undefined ? [] : [{
+      label: label(locale, "Examined", "已检查"),
+      value: label(locale, `${examined} tool call${examined === 1 ? "" : "s"}`, `${examined} 次工具调用`),
+    }]),
+  ];
+  return (
+    <section className="niceeval-assertion-evidence-section">
+      <h5>{label(locale, "Tool calls", "工具调用")}</h5>
+      <SemanticFacts rows={rows} />
+    </section>
+  );
+}
+
+function GenericEvidence({ content, input, diagnostic, locale }: {
+  readonly content: AssertionEvidenceContent;
+  readonly input: ClosedAssertionFactValue;
+  readonly diagnostic: MatchDiagnosticView | null;
+  readonly locale: string;
+}): ReactElement {
+  const expected = diagnostic?.expected === undefined
+    ? semanticExpected(content.expected)
+    : { kind: "text" as const, text: diagnostic.expected };
+  const received = diagnostic?.received === undefined
+    ? undefined
+    : { kind: "text" as const, text: diagnostic.received };
+  return (
+    <div className="niceeval-match-evidence-grid">
+      <Section heading={label(locale, "Input", "输入")} value={input} locale={locale} />
+      {received === undefined ? null : (
+        <Section heading={label(locale, "Observed", "实际结果")} value={received} locale={locale} />
+      )}
+      {expected === undefined ? null : (
+        <Section heading={label(locale, "Expected", "预期结果")} value={expected} locale={locale} />
+      )}
+    </div>
+  );
+}
+
+function CoverageNotice({ source, locale }: {
+  readonly source: ClosedAssertionFactValue;
+  readonly locale: string;
+}): ReactElement | null {
+  const coverage = field(source, "coverage");
+  const state = stringValue(field(coverage, "state"));
+  if (state === undefined || state === "complete") return null;
+  const reason = stringValue(field(coverage, "reason"));
+  const limitations = field(source, "limitations");
+  const omitted = limitations?.kind === "list"
+    ? limitations.items.map((item) => numberValue(field(item, "omittedBytes"))).find((value) => value !== undefined)
+    : undefined;
+  const detail = [
+    reason,
+    omitted === undefined
+      ? undefined
+      : label(locale, `${omitted} bytes omitted`, `省略 ${omitted} 字节`),
+  ].filter((part): part is string => part !== undefined).join(" · ");
+  return (
+    <p className="niceeval-match-coverage">
+      {label(locale, `Input evidence ${state}`, `输入证据${state === "partial" ? "不完整" : "不可用"}`)}
+      {detail.length === 0 ? "" : ` · ${detail}`}
+    </p>
+  );
+}
+
 function stateLabel(state: MatchState, locale: string): string {
   if (locale === "zh-CN") {
     if (state === "matched") return "命中";
@@ -221,6 +409,7 @@ function MatchNode({ label: nodeLabel, state, diagnostic, locale, root = false, 
               ))}
             </div>
           ) : null}
+          {root || diagnostic === null ? null : <DiagnosticFacts diagnostic={diagnostic} locale={locale} />}
           {children}
         </div>
       )
@@ -243,15 +432,18 @@ function web(
   const diagnostic = diagnosticView(content.explanation);
   const name = matcherName(content.check) ?? labelText ?? label(locale, "Match", "检查");
   const input = field(content.source, "input") ?? content.source;
+  const code = diagnostic?.code;
+  const primary = code === "command-succeeded" || code === "command-failed"
+    ? <CommandEvidence input={input} diagnostic={diagnostic} locale={locale} />
+    : isToolCriterion(content.check)
+      ? <ToolEvidence observed={content.observed} diagnostic={diagnostic} locale={locale} />
+      : <GenericEvidence content={content} input={input} diagnostic={diagnostic} locale={locale} />;
   return (
     <div className="niceeval-assertion-evidence">
       <MatchNode label={name} state={state} diagnostic={diagnostic} locale={locale} root>
         <div className="niceeval-match-body">
-          <div className="niceeval-match-evidence-grid">
-            <Section heading={label(locale, "Input", "输入")} value={input} locale={locale} />
-            <Section heading={label(locale, "Observed", "实际结果")} value={content.observed} locale={locale} />
-            <Section heading={label(locale, "Expected", "预期结果")} value={content.expected} locale={locale} />
-          </div>
+          {primary}
+          <CoverageNotice source={content.source} locale={locale} />
           <details className="niceeval-match-raw">
             <summary>{label(locale, "Raw assertion data", "原始断言数据")}</summary>
             <div>

--- a/packages/niceeval/src/report/definition/primitives/assertion-evidence.tsx
+++ b/packages/niceeval/src/report/definition/primitives/assertion-evidence.tsx
@@ -15,7 +15,6 @@ export interface AssertionEvidenceContent {
 type MatchState = "matched" | "mismatched" | "unavailable";
 
 interface MatchDiagnosticView {
-  readonly fields: readonly { readonly label: string; readonly value: ClosedAssertionFactValue }[];
   readonly children: readonly MatchChildView[];
 }
 
@@ -111,7 +110,6 @@ function diagnosticView(value: ClosedAssertionFactValue | undefined): MatchDiagn
       })
     : [];
   return {
-    fields: value.fields.filter((entry) => entry.label !== "children"),
     children,
   };
 }
@@ -200,10 +198,10 @@ function MatchNode({ label: nodeLabel, state, diagnostic, locale, root = false, 
   readonly root?: boolean;
   readonly children?: ReactElement;
 }): ReactElement {
+  const accessibleLabel = `${nodeLabel}: ${stateLabel(state, locale)}`;
   const summary = (
     <span className={`niceeval-match-summary niceeval-match-summary--${state}`}>
       <code>{nodeLabel}</code>
-      <span>· {stateLabel(state, locale)}</span>
     </span>
   );
   const nested = diagnostic?.children ?? [];
@@ -223,24 +221,14 @@ function MatchNode({ label: nodeLabel, state, diagnostic, locale, root = false, 
               ))}
             </div>
           ) : null}
-          {diagnostic !== null && diagnostic.fields.length > 0 ? (
-            <dl className="niceeval-match-facts">
-              {diagnostic.fields.map((entry, index) => (
-                <div key={`${entry.label}:${index}`}>
-                  <dt>{entry.label}</dt>
-                  <dd><Value value={entry.value} locale={locale} /></dd>
-                </div>
-              ))}
-            </dl>
-          ) : null}
           {children}
         </div>
       )
     : null;
-  if (body === null) return <div className="niceeval-match-node">{summary}</div>;
+  if (body === null) return <div className="niceeval-match-node" aria-label={accessibleLabel}>{summary}</div>;
   return (
     <details className={`niceeval-match-node${root ? " niceeval-match-node--root" : ""}`}>
-      <summary>{summary}</summary>
+      <summary aria-label={accessibleLabel}>{summary}</summary>
       {body}
     </details>
   );
@@ -254,18 +242,20 @@ function web(
 ): ReactElement {
   const diagnostic = diagnosticView(content.explanation);
   const name = matcherName(content.check) ?? labelText ?? label(locale, "Match", "检查");
+  const input = field(content.source, "input") ?? content.source;
   return (
     <div className="niceeval-assertion-evidence">
       <MatchNode label={name} state={state} diagnostic={diagnostic} locale={locale} root>
         <div className="niceeval-match-body">
           <div className="niceeval-match-evidence-grid">
-            <Section heading={label(locale, "Input", "输入")} value={content.source} locale={locale} />
+            <Section heading={label(locale, "Input", "输入")} value={input} locale={locale} />
             <Section heading={label(locale, "Observed", "实际结果")} value={content.observed} locale={locale} />
             <Section heading={label(locale, "Expected", "预期结果")} value={content.expected} locale={locale} />
           </div>
           <details className="niceeval-match-raw">
             <summary>{label(locale, "Raw assertion data", "原始断言数据")}</summary>
             <div>
+              <Section heading={label(locale, "Source", "来源")} value={content.source} locale={locale} />
               <Section heading={label(locale, "Check", "检查条件")} value={content.check} locale={locale} />
               <Section heading={label(locale, "Explanation", "解释")} value={content.explanation} locale={locale} />
             </div>

--- a/packages/niceeval/src/report/definition/primitives/assertion-evidence.tsx
+++ b/packages/niceeval/src/report/definition/primitives/assertion-evidence.tsx
@@ -12,6 +12,19 @@ export interface AssertionEvidenceContent {
   readonly explanation: ClosedAssertionFactValue;
 }
 
+type MatchState = "matched" | "mismatched" | "unavailable";
+
+interface MatchDiagnosticView {
+  readonly fields: readonly { readonly label: string; readonly value: ClosedAssertionFactValue }[];
+  readonly children: readonly MatchChildView[];
+}
+
+interface MatchChildView {
+  readonly label: string;
+  readonly state: MatchState;
+  readonly diagnostic: MatchDiagnosticView | null;
+}
+
 const INLINE_STRING_CHARACTER_LIMIT = 240;
 const STRING_PREVIEW_CHARACTER_LIMIT = 120;
 
@@ -62,6 +75,45 @@ function valueText(value: ClosedAssertionFactValue): string {
     case "list":
       return value.items.map(valueText).join("; ");
   }
+}
+
+function field(value: ClosedAssertionFactValue | undefined, name: string): ClosedAssertionFactValue | undefined {
+  return value?.kind === "fields"
+    ? value.fields.find((entry) => entry.label === name)?.value
+    : undefined;
+}
+
+function stringValue(value: ClosedAssertionFactValue | undefined): string | undefined {
+  return value?.kind === "value" && typeof value.value === "string" ? value.value : undefined;
+}
+
+function matcherName(check: ClosedAssertionFactValue): string | undefined {
+  return stringValue(field(field(field(check, "data"), "matcher"), "name"));
+}
+
+function matchState(value: ClosedAssertionFactValue | undefined): MatchState | undefined {
+  const state = stringValue(value);
+  return state === "matched" || state === "mismatched" || state === "unavailable" ? state : undefined;
+}
+
+function diagnosticView(value: ClosedAssertionFactValue | undefined): MatchDiagnosticView | null {
+  if (value?.kind !== "fields") return null;
+  const childrenValue = field(value, "children");
+  const children = childrenValue?.kind === "list"
+    ? childrenValue.items.flatMap((item, index): MatchChildView[] => {
+        const state = matchState(field(item, "state"));
+        if (state === undefined) return [];
+        return [{
+          label: stringValue(field(item, "label")) ?? `matcher ${index + 1}`,
+          state,
+          diagnostic: diagnosticView(field(item, "diagnostic")),
+        }];
+      })
+    : [];
+  return {
+    fields: value.fields.filter((entry) => entry.label !== "children"),
+    children,
+  };
 }
 
 function LongString({ value, locale, quoted }: {
@@ -131,19 +183,104 @@ function Section({ heading, value, locale }: {
   );
 }
 
-function web(content: AssertionEvidenceContent, locale: string): ReactElement {
+function stateLabel(state: MatchState, locale: string): string {
+  if (locale === "zh-CN") {
+    if (state === "matched") return "命中";
+    if (state === "mismatched") return "未命中";
+    return "无法判断";
+  }
+  return state;
+}
+
+function MatchNode({ label: nodeLabel, state, diagnostic, locale, root = false, children }: {
+  readonly label: string;
+  readonly state: MatchState;
+  readonly diagnostic: MatchDiagnosticView | null;
+  readonly locale: string;
+  readonly root?: boolean;
+  readonly children?: ReactElement;
+}): ReactElement {
+  const summary = (
+    <span className={`niceeval-match-summary niceeval-match-summary--${state}`}>
+      <code>{nodeLabel}</code>
+      <span>· {stateLabel(state, locale)}</span>
+    </span>
+  );
+  const nested = diagnostic?.children ?? [];
+  const body = diagnostic !== null || children !== undefined
+    ? (
+        <div className="niceeval-match-detail">
+          {nested.length > 0 ? (
+            <div className="niceeval-match-children">
+              {nested.map((child, index) => (
+                <MatchNode
+                  key={`${child.label}:${index}`}
+                  label={child.label}
+                  state={child.state}
+                  diagnostic={child.diagnostic}
+                  locale={locale}
+                />
+              ))}
+            </div>
+          ) : null}
+          {diagnostic !== null && diagnostic.fields.length > 0 ? (
+            <dl className="niceeval-match-facts">
+              {diagnostic.fields.map((entry, index) => (
+                <div key={`${entry.label}:${index}`}>
+                  <dt>{entry.label}</dt>
+                  <dd><Value value={entry.value} locale={locale} /></dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+          {children}
+        </div>
+      )
+    : null;
+  if (body === null) return <div className="niceeval-match-node">{summary}</div>;
+  return (
+    <details className={`niceeval-match-node${root ? " niceeval-match-node--root" : ""}`}>
+      <summary>{summary}</summary>
+      {body}
+    </details>
+  );
+}
+
+function web(
+  content: AssertionEvidenceContent,
+  locale: string,
+  labelText: string | undefined,
+  state: MatchState,
+): ReactElement {
+  const diagnostic = diagnosticView(content.explanation);
+  const name = matcherName(content.check) ?? labelText ?? label(locale, "Match", "检查");
   return (
     <div className="niceeval-assertion-evidence">
-      <Section heading={label(locale, "Source", "来源")} value={content.source} locale={locale} />
-      <Section heading={label(locale, "Check", "检查条件")} value={content.check} locale={locale} />
-      <Section heading={label(locale, "Observed", "实际结果")} value={content.observed} locale={locale} />
-      <Section heading={label(locale, "Expected", "预期结果")} value={content.expected} locale={locale} />
-      <Section heading={label(locale, "Explanation", "解释")} value={content.explanation} locale={locale} />
+      <MatchNode label={name} state={state} diagnostic={diagnostic} locale={locale} root>
+        <div className="niceeval-match-body">
+          <div className="niceeval-match-evidence-grid">
+            <Section heading={label(locale, "Input", "输入")} value={content.source} locale={locale} />
+            <Section heading={label(locale, "Observed", "实际结果")} value={content.observed} locale={locale} />
+            <Section heading={label(locale, "Expected", "预期结果")} value={content.expected} locale={locale} />
+          </div>
+          <details className="niceeval-match-raw">
+            <summary>{label(locale, "Raw assertion data", "原始断言数据")}</summary>
+            <div>
+              <Section heading={label(locale, "Check", "检查条件")} value={content.check} locale={locale} />
+              <Section heading={label(locale, "Explanation", "解释")} value={content.explanation} locale={locale} />
+            </div>
+          </details>
+        </div>
+      </MatchNode>
     </div>
   );
 }
 
-export const AssertionEvidence = defineComponent<{ readonly content: AssertionEvidenceContent }>({
+export const AssertionEvidence = defineComponent<{
+  readonly content: AssertionEvidenceContent;
+  readonly label?: string;
+  readonly state?: MatchState;
+}>({
   dimensions: () => ({}),
   text({ content }) {
     return [
@@ -154,8 +291,8 @@ export const AssertionEvidence = defineComponent<{ readonly content: AssertionEv
       `Explanation: ${valueText(content.explanation)}`,
     ].join("\n");
   },
-  web({ content }, ctx) {
-    return web(content, ctx.locale);
+  web({ content, label: labelText, state }, ctx) {
+    return web(content, ctx.locale, labelText, state ?? "unavailable");
   },
 });
 


### PR DESCRIPTION
<!-- niceeval:pr-body
base: d543fed2dc3ec7ee9c0a534db993873023f12877
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: e73ec2a37c34de0e3a9528662aa6114716303feb
-->

## Problem

- User goal: 在实验列表快速看清执行进度，并在 Attempt 详情直接读懂组合、工具和命令 matcher 为什么命中或未命中。
- Current limitation: 同一个 `samples/total` 分散重复在多个指标格；Assertion 展开区把 `kind`、boolean `outcome` 和 policy expected 等机器字段平铺出来，真正的比较结果被淹没。
- Required capability: 实验行需要唯一进度摘要；matcher 详情需要从闭合诊断投影出组合分支、工具调用计数和命令退出码等语义读面。
- User outcome: 列表更紧凑；点击 matcher 后可逐层看各分支状态，并直接看到相关的实际值与预期值，完整原始诊断仍可按需展开。

## Use cases

### Case: 比较实验时只读一次进度

#### Starting state

```text
实验 classic/memory-a 已运行 9/9 个样本，并产生耗时、Tokens、成本和结果读数。
```

#### Action

```sh
pnpm exec niceeval view --no-open
```

#### Result

```text
classic/memory-a (9/9)  gpt-5.6-luna  classic-memory  5ms  156.4 tokens  $0.000071  66.7% · 6 passed · 3 failed
```

进度只跟实验身份出现一次；指标格不再各自重复 `9/9`。

### Case: 检查组合 matcher 的分支结果

#### Starting state

```text
Attempt 已保存 and(includes("RECALL_OK"), or(includes("RECALL_OK"), includes("NEVER_PRESENT"))) 的闭合诊断。
```

#### Action

```sh
pnpm exec niceeval view --no-open
# 打开 Attempt，然后点击源码行和 matcher
```

#### Result

```text
and(includes("RECALL_OK"), or(...))
  includes("RECALL_OK")
  or(includes("RECALL_OK"), includes("NEVER_PRESENT"))
    includes("RECALL_OK")
    includes("NEVER_PRESENT")
```

每个 matcher 自身按状态着色；状态文字进入无障碍名称，不重复占用视觉空间。继续点击节点会在下方展开有效输入与诊断，原始数据收进次级详情。

### Case: 检查工具调用计数与命令退出码

#### Starting state

```text
Attempt 包含 calledTool("write_note", { count: 1 }) 和 commandSucceeded() 两条断言。
```

#### Action

```sh
pnpm exec niceeval view --no-open
# 打开 Attempt，再分别点击两个 matcher
```

#### Result

```text
calledTool(toolMatch("write_note"))
Tool calls
Expected  exactly 1 × toolMatch("write_note")
Observed  0 definite matches
Examined  1 tool call

commandSucceeded()
Command result
Command   pnpm test
Result    Exit code 0
Expected  exit 0
```

工具断言直接说明计数差异，命令断言只显示决定结果的命令与退出码；成功测试日志即使写入 `stderr` 也不会挤进主视图。

## Report components

### Changed

#### Case: `ExperimentTable` 实验行进度

##### Before

```tsx
<ExperimentTable comparison={comparison} />
```

```text
classic/memory-a  5ms 9/9  156.4 tokens 9/9  $0.000071  66.7% 9/9
```

##### After

```tsx
<ExperimentTable comparison={comparison} />
```

```text
classic/memory-a (9/9)  5ms  156.4 tokens  $0.000071  66.7%
```

##### User impact

不改变 `MetricValue`、排序或下钻行的完整度，只把实验级重复比值收敛到身份格。

#### Case: `AttemptDetails` matcher 展开树

##### Before

```tsx
<AttemptDetails locator={locator} />
```

```text
Check: data; matcher; name; state; subject
Observed: kind=boolean; outcome=matched
Expected: true
```

##### After

```tsx
<AttemptDetails locator={locator} />
```

```text
and(...)
  or(...)
    includes("RECALL_OK")
    includes("NEVER_PRESENT")

calledTool(toolMatch("write_note"))
  Expected  exactly 1 × toolMatch("write_note")
  Observed  0 definite matches

commandSucceeded()
  Command   pnpm test
  Result    Exit code 0
```

##### User impact

读者先看到 matcher 自身和逐节点状态。command、tool、比较／阈值与组合 matcher 使用对应的紧凑读面；未知 matcher 回落到通用输入／诊断，完整闭合数据仍在原始详情中，无需迁移既有 Record。

## Tests

### `e2e/report/evals/classic.eval.ts`

- Purpose: `feature + bug regression`
- Protects: 真实 Report fixture 必须产生嵌套 `and` / `or`、tool collection 与 command result 三类闭合诊断。
- Runs: 通过安装后的候选执行 `classic/*` Eval。
- Asserts: fixture 固定组合 matcher 的混合分支、工具调用计数差异，以及 exit code 为零但 `stderr` 非空的成功命令。

### `e2e/report/evals/classic.eval.ts`

- Purpose: `feature + bug regression`
- Protects: Nested, tool collection, and command-result matcher diagnostics remain available to the public report.
- Runs: Installed-candidate classic experiment evals.
- Asserts: The composed matcher has mixed branches, tool count differs, and a zero-exit command carries stderr.

```ts
import { defineEval } from "niceeval";
import { and, commandSucceeded, includes, or } from "niceeval/expect";

function recallMatch() {
  return and(
    includes("RECALL_OK"),
    or(includes("RECALL_OK"), includes("NEVER_PRESENT")),
  );
}

function recallEval(topic: string, prompt: string) {
  return defineEval({
    description: `classic/${topic}: deterministic MemoryBench-like recall`,
    async test(t) {
      const turn = await t.send(prompt);
      await turn.succeeded().orStop();
      t.check(t.reply, recallMatch());
    },
  });
}

export default {
  "recall-name": recallEval("recall-name", "What is the user's name?"),
  "recall-date": recallEval("recall-date", "What date did we last meet?"),
  "recall-fact": recallEval("recall-fact", "What fact should you remember?"),
  "recall-constraint": recallEval("recall-constraint", "What constraint applies?"),
  "recall-procedure": recallEval("recall-procedure", "What procedure should you follow?"),
  "recall-entity": recallEval("recall-entity", "Which entity is in scope?"),
  "recall-multi": recallEval("recall-multi", "Recall the multi-hop chain."),
  "tool-note": defineEval({
    description: "classic/tool-note: deterministic tool evidence plus recall",
    async test(t) {
      const turn = await t.send("Write a memory note, then recall it.");
      await turn.succeeded().orStop();
      turn.calledTool("write_note", { count: 1 });
      t.check(t.reply, recallMatch());
      t.check({
        command: "pnpm test",
        exitCode: 0,
        stdout: "",
        stderr: "PASS src/example.test.ts",
      }, commandSucceeded());
    },
  }),
};
```

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `feature + bug regression`
- Protects: 实验进度不会在指标格重复；组合、工具和命令 matcher 不会退化成最终布尔值或原始对象树。
- Runs: 安装候选后执行三组真实实验，启动 `niceeval view`，经浏览器打开实验与 Attempt overlay，并逐层点击 matcher。
- Asserts: 实验名含唯一 `9/9`；组合分支状态可独立读取；tool 显示期望／实际计数；command 显示退出码且不显示无关 `stderr`；既有 overlay 生命周期继续成立。

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `feature + bug regression`
- Protects: Experiment progress is shown once and nested, tool, and command matcher evidence remains semantic.
- Runs: Installed-candidate exp and view commands plus browser navigation through the Attempt overlay.
- Asserts: One 9/9 label, mixed nested states, tool counts, command exit code, hidden stderr, and overlay lifecycle results.

```ts
// owner: docs/engineering/testing/e2e/report.md#report-browser-journey
// rerun: pnpm e2e --repo report -- --run test/report.browser.spec.ts
//
// This Journey observes only the installed candidate, exported files, HTTP,
// hash navigation, and browser-visible content. It never reads Record files.

import { pollUntil, waitForOutput } from "@niceeval/testkit";
import { createServer, type Server } from "node:http";
import { readFile, readdir, stat } from "node:fs/promises";
import { join, relative, resolve } from "node:path";
import { pathToFileURL } from "node:url";
import { expect, test } from "@playwright/test";
import { reportCaseArtifacts, reportE2E } from "./support.ts";

test("静态站与 view 只交付 SPA shell；普通页面使用 hash 和 fragment，缺少 JavaScript 时明确报错", async ({ browser }) => {
  test.setTimeout(120_000);
  await reportE2E.case(
    "browser-static-spa-site",
    { artifacts: reportCaseArtifacts(["site-export"]) },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      for (const id of ["main", "source"] as const) {
        const run = await niceeval.run(["exp", id, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const exported = await niceeval.run(["view", "--report", "./reports/site.tsx", "--out", "site-export", "--no-open"]);
      expect(exported.exitCode, exported.diagnostic()).toBe(0);

      const exportRoot = join(projectRoot, "site-export");
      await expect(readFile(join(exportRoot, "index.html"), "utf8")).resolves.toContain('src="_niceeval/app.js"');
      expect(await htmlFiles(exportRoot)).toEqual(["index.html"]);

      const live = niceeval.start(
        ["view", "--report", "./reports/site.tsx", "--host", "127.0.0.1", "--port", "0", "--no-open"],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(live, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000, label: "SPA view URL",
      });
      const liveOrigin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(liveOrigin, startup).toBeDefined();
      await waitForHttp(liveOrigin!, "SPA view readiness");
      await expectSameBody(new URL(liveOrigin!), pathToFileURL(join(exportRoot, "index.html")));

      // Exact-file-only HTTP: no /source rewrite exists or is needed for a hash route.
      const staticServer = await serveStaticDirectory(exportRoot);
      try {
        const page = await browser.newPage();
        try {
          await page.goto(new URL("index.html", staticServer.origin).href);
          await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
          const fragment = page.waitForRequest((request) =>
            request.url() === new URL("_niceeval/fragments/source.json", staticServer.origin).href,
          );
          await page.getByRole("link", { name: "Source detail" }).click();
          await expect(page).toHaveURL(/#\/source$/);
          await fragment;
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();

          const copiedUrl = page.url();
          await page.reload();
          expect(page.url()).toBe(copiedUrl);
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();
        } finally {
          await page.close();
        }
        const offline = await browser.newContext({ javaScriptEnabled: false });
        try {
          const page = await offline.newPage();
          await page.goto(new URL("index.html#/source", staticServer.origin).href);
          await expect(page.getByRole("heading", { name: "JavaScript required" })).toBeVisible();
          await expect(page.getByRole("alert")).toContainText("Enable JavaScript to view this NiceEval report.");
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).not.toBeVisible();
        } finally {
          await offline.close();
        }
      } finally {
        await staticServer.close();
      }
    },
  );
});

test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 overlay", async ({ browser }) => {
  test.setTimeout(180_000);
  await reportE2E.case(
    "browser-classic-attempt-overlay",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      for (const id of [
        "classic/baseline",
        "classic/memory-a",
        "classic/incompatible",
      ] as const) {
        const run = await niceeval.run(["exp", id, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const view = niceeval.start(["view", "--host", "127.0.0.1", "--port", "0", "--no-open"], { timeoutMs: 60_000 });
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000, label: "classic SPA view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "classic SPA view readiness");

      const page = await browser.newPage();
      try {
        await page.goto(origin!);
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const experiment = page.locator('a[href^="#/experiment/"]').filter({
          has: page.locator("title").filter({ hasText: "classic/memory-a" }),
        });
        const experimentRow = page.locator("summary").filter({ hasText: "classic/memory-a" }).first();
        await expect(experimentRow).toContainText("classic/memory-a (9/9)");
        expect((await experimentRow.textContent())?.match(/9\/9/g)).toHaveLength(1);
        await experiment.click();
        await expect(page).toHaveURL(/#\/experiment\//);

        const attempt = page.locator('a[href^="#/attempt/"]').filter({ visible: true }).first();
        await expect(attempt).toBeVisible();
        const href = await attempt.getAttribute("href");
        expect(href).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);
        const route = href!.slice(1);
        const detail = new URL(`_niceeval/fragments${route}.json`, origin!);

        let detailRequested!: () => void;
        const requested = new Promise<void>((done) => { detailRequested = done; });
        let releaseDetail!: () => void;
        const released = new Promise<void>((done) => { releaseDetail = done; });
        let detailContinued!: () => void;
        const continued = new Promise<void>((done) => { detailContinued = done; });
        await page.route(detail.href, async (request) => {
          detailRequested();
          await released;
          await request.continue();
          detailContinued();
        });
        const dialog = page.getByRole("dialog");
        try {
          await attempt.click();
          await requested;
          await expect(page).toHaveURL(new RegExp(`#${route}$`));
          await expect(dialog).toBeVisible();
          await expect(dialog.getByRole("status")).toContainText("Loading details…");
          await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        } finally {
          releaseDetail();
          await continued;
          await page.unroute(detail.href);
        }
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();

        const assertionLine = dialog.locator("summary").filter({ hasText: "t.check(t.reply" }).first();
        await assertionLine.click();
        const rootMatch = dialog.getByLabel(/^and\(includes.+: matched$/).first();
        await expect(rootMatch).toBeVisible();
        await rootMatch.click();
        const orMatch = dialog.getByLabel(/^or\(includes.+: matched$/).first();
        await expect(orMatch).toBeVisible();
        await orMatch.click();
        const orNode = orMatch.locator("xpath=..");
        await expect(orNode.getByLabel('includes("RECALL_OK"): matched')).toBeVisible();
        await expect(orNode.getByLabel('includes("NEVER_PRESENT"): mismatched')).toBeVisible();

        const copiedUrl = page.url();
        await page.getByRole("button", { name: "Close" }).click();
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("");

        await page.goForward();
        await expect(dialog).toBeVisible();
        await page.goBack();
        await expect(dialog).not.toBeVisible();
        await page.goForward();
        await expect(dialog).toBeVisible();
        await page.reload();
        expect(page.url()).toBe(copiedUrl);
        await expect(dialog).toBeVisible();

        // Pasting the copied hash restores an overlay over the report, never a
        // separate Attempt document.
        const shared = await browser.newPage();
        try {
          await shared.goto(copiedUrl);
          await expect(shared.getByRole("dialog")).toBeVisible();
          await expect(shared.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        } finally {
          await shared.close();
        }

        await page.mouse.click(5, 5);
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("");

        const baselineSummary = page.locator("summary").filter({ hasText: /^classic\/baseline \(9\/9\)/ }).first();
        if (await baselineSummary.locator("xpath=..").getAttribute("open") === null) await baselineSummary.click();
        const classicSummary = page.locator("summary").filter({ hasText: /^classic \(8 evals\)/ }).first();
        if (await classicSummary.locator("xpath=..").getAttribute("open") === null) await classicSummary.click();
        const toolEvalSummary = page.locator("summary").filter({ hasText: /^tool-note/ }).first();
        if (await toolEvalSummary.locator("xpath=..").getAttribute("open") === null) await toolEvalSummary.click();
        const toolAttemptHref = await toolEvalSummary.locator("xpath=..").locator('a[href^="#/attempt/"]').first().getAttribute("href");
        expect(toolAttemptHref).toMatch(/^#\/attempt\//);
        await page.goto(new URL(toolAttemptHref!, origin!).href);
        await expect(dialog).toBeVisible({ timeout: 10_000 });

        const toolAssertion = dialog.locator("summary").filter({ hasText: 'calledTool("write_note"' }).first();
        await expect(toolAssertion).toBeVisible({ timeout: 5_000 });
        if (await toolAssertion.locator("xpath=..").getAttribute("open") === null) await toolAssertion.click();
        const toolMatcher = dialog.getByLabel(/calledTool.+: mismatched$/).filter({ visible: true }).first();
        await expect(toolMatcher).toBeVisible({ timeout: 5_000 });
        await toolMatcher.click();
        await expect(dialog.getByRole("heading", { name: "Tool calls" })).toBeVisible({ timeout: 5_000 });
        await expect(dialog.getByText('exactly 1 × toolMatch("write_note")', { exact: true })).toBeVisible();
        await expect(dialog.getByText("0 definite matches", { exact: true })).toBeVisible();

        const commandAssertion = dialog.locator("summary").filter({ hasText: "t.check({" }).first();
        await expect(commandAssertion).toBeVisible({ timeout: 5_000 });
        if (await commandAssertion.locator("xpath=..").getAttribute("open") === null) await commandAssertion.click();
        const commandMatcher = dialog.getByLabel("commandSucceeded(): matched").filter({ visible: true });
        await expect(commandMatcher).toBeVisible({ timeout: 5_000 });
        await commandMatcher.click();
        await expect(dialog.getByRole("heading", { name: "Command result" })).toBeVisible();
        await expect(dialog.getByText("pnpm test", { exact: true })).toBeVisible();
        await expect(dialog.getByText("Exit code 0", { exact: true })).toBeVisible();
        await expect(dialog.getByText("PASS src/example.test.ts", { exact: true })).not.toBeVisible();

      } finally {
        await page.close();
      }
    },
  );
});

async function expectSameBody(liveUrl: URL, staticUrl: URL): Promise<void> {
  const expected = await readFile(staticUrl);
  const response = await fetch(liveUrl);
  expect(response.status, `${liveUrl} should serve the exported shell`).toBe(200);
  expect(Buffer.from(await response.arrayBuffer()), `${liveUrl} body`).toEqual(expected);
}

async function htmlFiles(root: string): Promise<readonly string[]> {
  const paths: string[] = [];
  async function visit(directory: string): Promise<void> {
    for (const entry of await readdir(directory, { withFileTypes: true })) {
      const file = join(directory, entry.name);
      if (entry.isDirectory()) await visit(file);
      else if (entry.isFile() && entry.name.endsWith(".html")) paths.push(relative(root, file));
    }
  }
  await visit(root);
  return paths.sort();
}

async function waitForHttp(origin: string, label: string): Promise<void> {
  await pollUntil(async () => {
    try {
      return (await fetch(origin)).status === 200 ? true : undefined;
    } catch {
      return undefined;
    }
  }, { timeoutMs: 15_000, intervalMs: 100, label });
}

async function serveStaticDirectory(root: string): Promise<{ readonly origin: string; readonly close: () => Promise<void> }> {
  const absoluteRoot = resolve(root);
  const server = createServer(async (request, response) => {
    const pathname = decodeURIComponent(new URL(request.url ?? "/", "http://static.invalid").pathname);
    const file = resolve(absoluteRoot, `.${pathname === "/" ? "/index.html" : pathname}`);
    if (file !== absoluteRoot && !file.startsWith(`${absoluteRoot}/`)) return void response.writeHead(403).end();
    try {
      if (!(await stat(file)).isFile()) throw new Error("not a file");
      const mediaType = file.endsWith(".html") ? "text/html; charset=utf-8"
        : file.endsWith(".js") ? "text/javascript; charset=utf-8"
        : file.endsWith(".css") ? "text/css; charset=utf-8"
        : file.endsWith(".json") ? "application/json; charset=utf-8"
        : "application/octet-stream";
      response.writeHead(200, { "content-type": mediaType }).end(await readFile(file));
    } catch {
      response.writeHead(404).end();
    }
  });
  await new Promise<void>((done, reject) => {
    server.once("error", reject);
    server.listen(0, "127.0.0.1", done);
  });
  const address = server.address();
  if (address === null || typeof address === "string") throw new Error("static server did not expose a TCP address");
  return { origin: `http://127.0.0.1:${address.port}/`, close: () => closeServer(server) };
}

async function closeServer(server: Server): Promise<void> {
  await new Promise<void>((done, reject) => server.close((error) => error === undefined ? done() : reject(error)));
}
```

### Verification receipt

- Candidate: `e73ec2a3`; NiceEval tarball SHA-256 `81abc905d4b00558b52450e1dae49b01776b70a7997c7c45ffe1b4cd718acf38`。
- Red: 旧候选 SHA-256 `3695ee61c2a58a09019514aa2a4162334347a6f738ca099c49c41033773a8770` 在安装后浏览器中找不到具名且带 sealed mismatch 状态的 `calledTool(...)` matcher 节点；原有实验进度与组合树红灯收据继续保留。
- Green: 定向 browser Journey 1 项通过；可靠性接管的 3 个隔离副本、同一副本连续 2 次、默认并行全 Report suite（6 个 Vitest 文件 13 项、2 项 Playwright）和最终单项复跑全部通过。
- Repeatability: 修改既有 `report-browser-journey` owner；`pnpm e2e takeover` 的全部矩阵使用同一候选与固定 fixture，并成功 cleanup。
- Fixed conditions: checkout `e73ec2a3`、签入 lockfile、确定性 classic agent、Playwright Chromium 1.61.1；无付费 Provider、随机 seed 或外部网络依赖。
- Unit count: `not applicable — no Unit changed`；`pnpm run typecheck`、`pnpm run build:report` 与 `pnpm lint` 均通过。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789966471&installation_model_id=431746&pr_number=94&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F94&signature=8b80cb620de9b2a4259d4720fa7caf9a43b7b32292b0223521f3003819a8a5a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
