### PR TITLE
fix(sandbox): 修复 Docker profile 构建与完整诊断

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -422,8 +422,9 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends quota
+          sudo apt-get install --yes --no-install-recommends quota "linux-modules-extra-$(uname -r)"
           sudo modprobe loop
+          sudo modprobe quota_v2
           sudo losetup --find >/dev/null
 
       - name: Set up Python

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -408,10 +408,21 @@ jobs:
             id,
             manifest: `e2e/${dirs[index]}/project.json`,
           }))
+          const dockerProfileHost = manifests.some(({ manifest }) =>
+            JSON.parse(fs.readFileSync(manifest, "utf8")).targets.e2e.metadata.niceeval.harness?.dockerProfileHost === true
+          )
           fs.writeFileSync(outputPath, `${JSON.stringify(manifests)}\n`)
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `docker-profile-host=${dockerProfileHost}\n`)
           console.log(`[e2e] cell ${process.env.CELL_ID}: ${ids.join(", ")}`)
           NODE
           echo "manifests-file=${manifests_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Docker profile host prerequisites
+        if: steps.cell.outputs.docker-profile-host == 'true'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends quota
 
       - name: Set up Python
         if: contains(toJSON(matrix.requires.runtimes), '"python"') || contains(toJSON(matrix.requires.runtimes), '"python>=')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -423,6 +423,8 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends quota
+          sudo modprobe loop
+          sudo losetup --find >/dev/null
 
       - name: Set up Python
         if: contains(toJSON(matrix.requires.runtimes), '"python"') || contains(toJSON(matrix.requires.runtimes), '"python>=')

--- a/apps/docs-site/reference/cli.mdx
+++ b/apps/docs-site/reference/cli.mdx
@@ -166,7 +166,6 @@ The following table is generated from the CLI flag-parsing table. Any Flag outsi
 | `--tag` | string | Runs only Evals with this tag. See `defineEval` `tags`. |
 | `--junit` | string | Also writes a JUnit XML report to the selected path for CI consumption. |
 | `--json` | boolean | `exp` writes one ordered NDJSON event stream to stdout. `exp --dry` and `debug` each output their own single JSON plan document. `show` outputs a Host-owned built-in or custom single-target machine document; it does not form a complete site or open a second data path. |
-| `--smoke` | boolean | `docker profile doctor` only: starts a restricted DinD container and runs an inner container. |
 | `--out` | string | `view` only: statically exports the result viewer to the selected directory. |
 | `--port` | number | `view` only: selects the local server's listening port. |
 | `--host` | string | `view` only: selects the listening address. When omitted, it is 127.0.0.1; when `--host` is supplied without a value, it is 0.0.0.0. A non-loopback listener has no authentication or TLS and exposes report data to every reachable client. |

--- a/apps/docs-site/tutorials/docker-in-docker.mdx
+++ b/apps/docs-site/tutorials/docker-in-docker.mdx
@@ -234,11 +234,11 @@ privileged mode. After the host deployment is complete, inspect the profile firs
 
 ```bash
 npx niceeval docker profile list
-npx niceeval docker profile doctor default --smoke
+npx niceeval docker profile doctor default
 npx niceeval exp dind-managed
 ```
 
-`doctor --smoke` starts a DinD container on that profile and actually runs inner
+`doctor` starts a DinD container on that profile and actually runs inner
 `docker run --rm alpine:3.20 true`. It proves that the profile supports nested Docker, but does not inspect your project's
 Dockerfile. The project image is still verified by its default `docker info` readiness.
 

--- a/apps/docs-site/tutorials/nixos-managed-dind.mdx
+++ b/apps/docs-site/tutorials/nixos-managed-dind.mdx
@@ -112,10 +112,10 @@ In an eval project with NiceEval installed, run these commands as the day-to-day
 
 ```bash
 pnpm exec niceeval docker profile list
-pnpm exec niceeval docker profile doctor default --smoke
+pnpm exec niceeval docker profile doctor default
 ```
 
-`list` should show `default`. `doctor --smoke` checks the descriptor, Unix socket, cgroup, capacity, and watchdog, then starts a constrained outer container and an inner Alpine container. Use the host profile for production evals only after every check passes.
+`list` should show `default`. `doctor` always checks the descriptor, Unix socket, cgroup, capacity, watchdog, offline assets, a cold build, and a constrained outer container with nested Docker. Use the host profile for production evals only after every check passes.
 
 Do not use `sudo pnpm exec niceeval ...` to bypass a permissions error. If the day-to-day user cannot access the profile, first confirm that the username is in `accessUsers`, then sign in again and rerun doctor.
 

--- a/apps/docs-site/zh/reference/cli.mdx
+++ b/apps/docs-site/zh/reference/cli.mdx
@@ -200,7 +200,6 @@ E2B template name 与 Vercel snapshot ID 是 Provider 管理的任意字符串�
 | `--help` | `niceeval clean`、`niceeval migrate` | boolean | 打印该命令的帮助。 |
 | `--help` | `niceeval init` | boolean | 打印该命令的帮助。 |
 | `--json` | `niceeval docker profile list`、`niceeval docker profile doctor`、`niceeval docker cache inventory`、`niceeval docker cache gc` | boolean | 写出该命令的机器文档或事件流。 |
-| `--smoke` | `niceeval docker profile doctor` | boolean | 运行 Docker profile 的探测诊断。 |
 | `--domain` | `niceeval docker cache inventory`、`niceeval docker cache gc` | string | 选择一个由 NiceEval 管理的 Docker 缓存域。 |
 | `--apply` | `niceeval docker cache gc` | string | 应用先前签发的 Docker 缓存回收计划。 |
 | `--help` | `niceeval docker` | boolean | 打印该命令的帮助。 |

--- a/apps/docs-site/zh/tutorials/docker-in-docker.mdx
+++ b/apps/docs-site/zh/tutorials/docker-in-docker.mdx
@@ -285,11 +285,11 @@ allocation，并把它挂到 `/var/lib/docker`。Docker image layer 与 BuildKit
 
 ```bash
 npx niceeval docker profile list
-npx niceeval docker profile doctor default --smoke
+npx niceeval docker profile doctor default
 npx niceeval exp dind-managed
 ```
 
-`doctor --smoke` 会在该 profile 上启动一次 DinD 容器，并实际运行内层
+`doctor` 会在该 profile 上启动一次 DinD 容器，并实际运行内层
 `docker run --rm alpine:3.20 true`。它证明 profile 支持 nested Docker，但不会检查项目自己的
 Dockerfile。项目镜像仍由默认 `docker info` readiness 验证。
 

--- a/apps/docs-site/zh/tutorials/nixos-managed-dind.mdx
+++ b/apps/docs-site/zh/tutorials/nixos-managed-dind.mdx
@@ -129,10 +129,10 @@ journalctl -u niceeval-docker-profile-watchdog-default.service -b
 
 ```bash
 pnpm exec niceeval docker profile list
-pnpm exec niceeval docker profile doctor default --smoke
+pnpm exec niceeval docker profile doctor default
 ```
 
-`list` 应显示 `default`。`doctor --smoke` 会检查 descriptor、Unix socket、cgroup、容量和 watchdog，
+`list` 应显示 `default`。`doctor` 始终检查 descriptor、Unix socket、cgroup、容量、watchdog、离线资产、cold build，
 然后启动一个受限的外层容器及一个内层 Alpine 容器。所有项目都通过后，宿主 profile 才可以用于正式
 评估。
 

--- a/docs/engineering/testing/e2e/README.md
+++ b/docs/engineering/testing/e2e/README.md
@@ -223,6 +223,17 @@ terminal-only 不能由一次非原子 procfs 快照直接接受。只要 kernel
 Docker Sandbox，`$HOME` 中的 Group 状态得以保留而工作目录会重置；运行结束后两台 owned Sandbox 都已释放。
 测试只通过安装后 CLI 的 result 事件与 `show --history --json` 读回公开结果，不读取 `.niceeval/` 私有布局。
 
+### Docker profile cold build
+
+`e2e/lifecycle/test/docker-profile-cold-build.test.ts` 是 profile-bound Dockerfile cold build 的公开入口 owner。
+
+它把同一 checkout 的真实 host watchdog 脚本放进隔离现场，以 root-owned descriptor、Unix control socket、
+真实 Docker daemon 与 project-quota allocation 启动 raw profile。
+
+安装后候选必须经 `niceeval exp` 完成 cold build。control service 创建 outer container，Attempt 内跑通 nested Docker。
+
+测试只从 CLI event 与 control journal 观察阶段和终态。它不以源码调用、mock control 或客户端提交 Docker resource ID 代替。
+
 ## 单项重跑
 
 任何 E2E 必须能按 Repo、文件和标题重跑：

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -56,7 +56,7 @@ pnpm e2e verify-release --plan artifacts/release-plan.json \
 - matrix run 消费 candidate artifact、同一次生成的 plan 与当前 checkout，通过 `--plan/--cell` 精确执行该格；它不再把 Repo 列表和并发数翻译成 workflow shell，也不下载第二份 Testkit artifact；
 - matrix run 把 plan 的 mode、reason、lane、cell ID 与可选 base/head 写入根 summary 和每个 Repo receipt；
 - 声明 browser capability 的 matrix cell 使用与根 `@playwright/test` 精确版本相同的官方 Playwright Noble container；
-- 浏览器与通用 Linux 系统依赖来自镜像，不运行 `playwright install --with-deps`。没有 browser requirement 的 host / docker cell 仍直接运行在普通 GitHub runner；声明 `harness.dockerProfileHost` 的 cell 才安装真实宿主脚本所需的 project-quota 工具；
+- 浏览器与通用 Linux 系统依赖来自镜像，不运行 `playwright install --with-deps`。没有 browser requirement 的 host / docker cell 仍直接运行在普通 GitHub runner；声明 `harness.dockerProfileHost` 的 cell 才安装真实宿主脚本所需的 project-quota 工具与当前内核模块；
 - `plan` 不 pack、不安装、不读 secret、不创建 Repo 副本；显式 `run --candidate` 不重新 pack。
 
 `verify-release` 只接受 `mode` 合法且 cells 非空的 full `plan --json`、candidate `.tgz`、receipt root 与 tag。

--- a/docs/engineering/testing/e2e/execution.md
+++ b/docs/engineering/testing/e2e/execution.md
@@ -56,7 +56,7 @@ pnpm e2e verify-release --plan artifacts/release-plan.json \
 - matrix run 消费 candidate artifact、同一次生成的 plan 与当前 checkout，通过 `--plan/--cell` 精确执行该格；它不再把 Repo 列表和并发数翻译成 workflow shell，也不下载第二份 Testkit artifact；
 - matrix run 把 plan 的 mode、reason、lane、cell ID 与可选 base/head 写入根 summary 和每个 Repo receipt；
 - 声明 browser capability 的 matrix cell 使用与根 `@playwright/test` 精确版本相同的官方 Playwright Noble container；
-- 浏览器与 Linux 系统依赖来自镜像，不在 job 内运行 apt 或 `playwright install --with-deps`。没有 browser requirement 的 host / docker cell 仍直接运行在普通 GitHub runner；
+- 浏览器与通用 Linux 系统依赖来自镜像，不运行 `playwright install --with-deps`。没有 browser requirement 的 host / docker cell 仍直接运行在普通 GitHub runner；声明 `harness.dockerProfileHost` 的 cell 才安装真实宿主脚本所需的 project-quota 工具；
 - `plan` 不 pack、不安装、不读 secret、不创建 Repo 副本；显式 `run --candidate` 不重新 pack。
 
 `verify-release` 只接受 `mode` 合法且 cells 非空的 full `plan --json`、candidate `.tgz`、receipt root 与 tag。

--- a/docs/engineering/testing/e2e/scenario-repos.md
+++ b/docs/engineering/testing/e2e/scenario-repos.md
@@ -101,6 +101,7 @@ interface E2EMetadata {
   timeoutMinutes: number;
   harness?: {
     testkit?: boolean;
+    dockerProfileHost?: boolean;
   };
   secrets: readonly string[];
   requires?: {
@@ -132,6 +133,13 @@ interface E2EProject {
 metadata 不含测试标题、expected、page matrix、历史 bug、contract anchor 或 affected paths。canonical Repo ID 由
 `root` 去掉 `e2e/` 推导；产品 owner 由 `implicitDependencies` 指向的 source domain project 表达。详细管理规则见
 [任务图与 E2E 选择](../../task-orchestration/README.md)。
+
+`harness.testkit: true` 是 Testkit 消费意图的唯一真源。
+
+`harness.dockerProfileHost: true` 要求根 runner
+把当前 checkout 的 `packaging/docker-profile-host/scripts` 复制进隔离 Repo。runner 只通过
+`NICEEVAL_E2E_DOCKER_PROFILE_HOST_SCRIPTS` 暴露副本路径。场景必须自行启动这份真实 watchdog 并拥有其 cleanup；
+runner 不替换宿主已安装 service，也不提供 mock control service。未声明该 harness 的 Repo 不会获得脚本路径。
 
 `batch` 是必填的 canonical lowercase placement ID，例如 `host-1`、`docker-1` 或 `browser-1`。它只决定 CI 共机分组，
 不表示资源 capability；完整宿主运行条件仍以 `requires` 为唯一真源。

--- a/docs/feature/sandbox/docker-profiles/cli.md
+++ b/docs/feature/sandbox/docker-profiles/cli.md
@@ -68,11 +68,18 @@ endpoint。以下任一情形会把条目标为 invalid并禁止使用：
 
 ```bash
 niceeval docker profile doctor default
-niceeval docker profile doctor default --smoke
 niceeval docker profile doctor default --json
 ```
 
-默认 doctor只读检查：
+默认 doctor 是完整诊断，按固定顺序输出同一次执行的 12 个 check：
+
+- `descriptor`、`control`、`daemon`、`cgroup`、`storage`、`journal`；
+- `assets`、`cold-build`、`cold-build-cleanup`；
+- `container-limits`、`nested-docker` 和 `container-cleanup`。
+
+状态只有 `PASS`、`BLOCKED` 与 `FAIL`。总状态按 `FAIL > BLOCKED > PASS` 折叠；只有 12 项都 PASS 才返回 PASS。
+
+它先检查：
 
 - descriptor是 root-owned callback-free data，父目录不能由运行 access group写入；
 - Docker endpoint与 control endpoint的类型、socket inode、目录权限和宿主 peer UID；
@@ -85,8 +92,9 @@ niceeval docker profile doctor default --json
 - 预建 allocation pool的 project ID、hard quota、真实 backing、占用状态与 journal匹配；
 - watchdog protocol、durable journal、active Invocation/reservation与 orphan状态一致。
 
-`--smoke`创建短命 privileged探测，设置2 CPU、512 MiB、0 extra swap、256 PID、1 GiB
-`dockerDataBytes`、只读 rootfs与64 MiB tmpfs，并从容器读取：
+随后它在同一 lease/generation 中串行进行离线最小 cold build 与短命 control-owned diagnostic container。
+
+诊断容器设置2 CPU、512 MiB、0 extra swap、256 PID、1 GiB `dockerDataBytes`、只读 rootfs与64 MiB tmpfs，并从容器读取：
 
 ```text
 cpu.max
@@ -100,7 +108,7 @@ pids.max
 内容、label与 reservation全部消失。Docker inspect中的
 HostConfig不是限额生效证据。
 
-doctor输出逐项 PASS/FAIL，任一安全项失败退出1。它不改配置、不删除 orphan、不重启 daemon；
+doctor 不从 registry 拉取运行时资产；部署必须预装并验证 digest-pinned DIND/BuildKit 资产。`--json` 只投影这一次完整执行的最终文档，不能改变能力。每个 FIFO wait 最长 30 秒；只有该容量等待超时为 BLOCKED，其余不能安全继续或前置失败都为 FAIL。任一 BLOCKED/FAIL 退出非零。它不改配置、不删除 orphan、不重启 daemon；
 修复操作属于对应宿主 package。
 
 ## 不提供任意命令代理

--- a/docs/feature/sandbox/docker-profiles/use-case/niceeval-eval.md
+++ b/docs/feature/sandbox/docker-profiles/use-case/niceeval-eval.md
@@ -148,7 +148,7 @@ services.niceeval.dockerProfiles.default = {
 普通运行不 sudo：
 
 ```bash
-pnpm exec niceeval docker profile doctor default --smoke
+pnpm exec niceeval docker profile doctor default
 pnpm exec niceeval exp harness --dry
 pnpm exec niceeval exp harness
 ```

--- a/docs/roadmap/sandbox-materialization/cache-lifecycle/cli.md
+++ b/docs/roadmap/sandbox-materialization/cache-lifecycle/cli.md
@@ -11,7 +11,7 @@ niceeval docker — Docker-specific administration
 
 Usage:
   niceeval docker profile list [--json]
-  niceeval docker profile doctor <alias> [--smoke] [--json]
+  niceeval docker profile doctor <alias> [--json]
   niceeval docker cache inventory [--domain <domain-id>] [--json]
   niceeval docker cache gc --domain <domain-id> [--apply <plan-id>] [--json]
 
@@ -21,7 +21,7 @@ Commands:
 ```
 
 `niceeval docker cache --help` 只显示 cache 子树；未知根命令由 CLI host 报错，未知 Docker 子命令由
-Docker feature 报错。进入 `docker` 后，`--domain`、`--apply`、`--smoke` 及未来 Docker 私有 flag
+Docker feature 报错。进入 `docker` 后，`--domain`、`--apply` 及未来 Docker 私有 flag
 都不经过 core flag parser。JSON stdout 始终只有一个完整文档，诊断只写 stderr。
 
 ## 当前选择

--- a/e2e/lifecycle/evals/docker-profile-cold-build.eval.ts
+++ b/e2e/lifecycle/evals/docker-profile-cold-build.eval.ts
@@ -1,0 +1,11 @@
+import { defineEval } from "niceeval";
+import { includes } from "niceeval/expect";
+
+export default defineEval({
+  description: "profile-bound Dockerfile cold build starts an isolated DinD Attempt",
+  async test(t) {
+    const turn = await t.send("confirm the profile-bound Attempt started");
+    await turn.succeeded().orStop();
+    t.check(turn.message, includes("profile-cold-build-ok"));
+  },
+});

--- a/e2e/lifecycle/experiments/docker-profile-cold-build.ts
+++ b/e2e/lifecycle/experiments/docker-profile-cold-build.ts
@@ -1,0 +1,74 @@
+import { completeEvidenceCoverage, defineSandboxAgent } from "niceeval/adapter";
+import { defineExperiment } from "niceeval";
+import { dockerSandbox, shell } from "niceeval/sandbox";
+
+// Discovery and `show` import and physically plan every experiment in the Repo, including when
+// another owner is selected. The Docker profile owner injects the real alias before execution;
+// without it this fixture stays plannable and fails explicitly only if somebody actually runs it.
+const profile = process.env.NICEEVAL_E2E_DOCKER_PROFILE_ALIAS;
+
+const agent = defineSandboxAgent({
+  name: "docker-profile-cold-build-fixture",
+  evidenceCoverage: {
+    ...completeEvidenceCoverage,
+    usage: { status: "unavailable", reason: "deterministic fixture has no token usage" },
+  },
+  ensure: {
+    identity: { agent: "docker-profile-cold-build-fixture", version: "1.0.0", revision: "1" },
+    probe: shell("docker info >/dev/null"),
+  },
+  async send(_input, ctx) {
+    if (profile === undefined) {
+      throw new Error("NICEEVAL_E2E_DOCKER_PROFILE_ALIAS is required by the Docker profile E2E");
+    }
+    await ctx.sandbox.runShellOrThrow(
+      'test "$(id -u)" = 1000 && docker info >/dev/null && printf "%s" profile-cold-build-ok',
+      { signal: ctx.signal },
+    );
+    return {
+      status: "completed",
+      events: [{ type: "message", role: "assistant", text: "profile-cold-build-ok" }],
+    };
+  },
+});
+
+const MiB = 1024 ** 2;
+
+export default defineExperiment({
+  description: "control-owned profile Dockerfile cold build",
+  agent,
+  sandbox: dockerSandbox({
+    source: {
+      type: "dockerfile",
+      context: new URL("../fixtures/profile-cold-build/", import.meta.url),
+    },
+    ...(profile === undefined ? {} : {
+      dockerAccess: {
+        mode: "dind" as const,
+        isolation: "raw-privileged" as const,
+        storageProfile: profile,
+      },
+    }),
+    user: "node",
+    resources: {
+      cpus: 1,
+      memoryBytes: 1024 * MiB,
+      pidsLimit: 512,
+      ...(profile === undefined ? {} : { dockerDataBytes: 512 * MiB }),
+      readOnlyRootfs: true,
+      tmpfs: {
+        "/home/node": { sizeBytes: 64 * MiB, mode: 0o700, uid: 1000, gid: 1000 },
+        "/home/sandbox/workspace": { sizeBytes: 128 * MiB, mode: 0o755, uid: 1000, gid: 1000, executable: true },
+        "/run": { sizeBytes: 64 * MiB, mode: 0o755 },
+        "/tmp": { sizeBytes: 64 * MiB, mode: 0o1777 },
+      },
+    },
+    readiness: {
+      command: ["sh", "-lc", "docker info >/dev/null"],
+      user: "node",
+      timeoutMs: 30_000,
+      intervalMs: 250,
+    },
+  }),
+  evals: ["docker-profile-cold-build"],
+});

--- a/e2e/lifecycle/fixtures/profile-cold-build/Dockerfile
+++ b/e2e/lifecycle/fixtures/profile-cold-build/Dockerfile
@@ -1,13 +1,25 @@
-FROM docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c AS docker-runtime
+FROM scratch AS node-runtime
 
-FROM node:24-slim@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f
+ADD node-rootfs.tar /
 
-COPY --from=docker-runtime /usr/local/bin/ /usr/local/bin/
+FROM scratch
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl git iptables \
-  && rm -rf /var/lib/apt/lists/* \
-  && groupadd --system docker \
-  && usermod --append --groups docker node
+ADD docker-rootfs.tar /
+
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /bin/bash /bin/bash
+COPY --from=node-runtime /lib/x86_64-linux-gnu/ /lib/x86_64-linux-gnu/
+COPY --from=node-runtime /usr/lib64/ /usr/lib64/
+COPY --from=node-runtime /usr/bin/ldd /usr/bin/ldd
+
+RUN ln -s usr/lib64 /lib64 \
+  && addgroup -g 1000 node \
+  && adduser -D -u 1000 -G node node \
+  && addgroup node docker \
+  && node --version \
+  && bash --version \
+  && ldd --version \
+  && docker --version \
+  && dockerd --version
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/e2e/lifecycle/fixtures/profile-cold-build/Dockerfile
+++ b/e2e/lifecycle/fixtures/profile-cold-build/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c AS docker-runtime
+
+FROM node:24-slim@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f
+
+COPY --from=docker-runtime /usr/local/bin/ /usr/local/bin/
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl git iptables \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd --system docker \
+  && usermod --append --groups docker node
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/e2e/lifecycle/fixtures/profile-host-fixture.py
+++ b/e2e/lifecycle/fixtures/profile-host-fixture.py
@@ -7,6 +7,7 @@ import json
 import os
 import pwd
 import grp
+import shlex
 import shutil
 import subprocess
 import sys
@@ -18,14 +19,20 @@ sys.dont_write_bytecode = True
 
 
 def run(*args: str) -> str:
-    return subprocess.run(
+    result = subprocess.run(
         args,
-        check=True,
+        check=False,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-    ).stdout.strip()
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{shlex.join(args)} failed with exit {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result.stdout.strip()
 
 
 def checked_root(raw: str) -> Path:
@@ -41,7 +48,7 @@ def cleanup(root: Path, *, remove_root: bool) -> None:
         raise SystemExit(f"refusing to clean unmarked fixture root: {root}")
     mount = root / "data"
     mounted = subprocess.run(
-        ["findmnt", "-n", "--target", str(mount)],
+        ["findmnt", "-n", "--mountpoint", str(mount)],
         text=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/e2e/lifecycle/fixtures/profile-host-fixture.py
+++ b/e2e/lifecycle/fixtures/profile-host-fixture.py
@@ -89,8 +89,8 @@ def setup(args: argparse.Namespace) -> None:
         descriptor = root / "profile.json"
         assets = root / "assets-v1.json"
         assets.write_text(json.dumps({"schemaVersion": 1, "platform": "linux/amd64", "images": [
-            {"purpose": "doctor-dind", "reference": "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c", "imageId": "sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c", "platform": "linux/amd64"},
-            {"purpose": "doctor-buildkit", "reference": "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8", "imageId": "sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8", "platform": "linux/amd64"},
+            {"purpose": "doctor-dind", "reference": "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c", "platform": "linux/amd64"},
+            {"purpose": "doctor-buildkit", "reference": "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8", "platform": "linux/amd64"},
         ]}) + "\n", encoding="utf-8")
         config = {
             "name": "e2e-cold-build",

--- a/e2e/lifecycle/fixtures/profile-host-fixture.py
+++ b/e2e/lifecycle/fixtures/profile-host-fixture.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Create and remove the isolated real-host boundary for the Docker profile E2E."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pwd
+import grp
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+MARKER = ".niceeval-docker-profile-e2e"
+sys.dont_write_bytecode = True
+
+
+def run(*args: str) -> str:
+    return subprocess.run(
+        args,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    ).stdout.strip()
+
+
+def checked_root(raw: str) -> Path:
+    root = Path(raw).resolve()
+    if root.parent != Path("/tmp") or not root.name.startswith("niceeval-e2e-docker-profile-"):
+        raise SystemExit(f"refusing unsafe fixture root: {root}")
+    return root
+
+
+def cleanup(root: Path, *, remove_root: bool) -> None:
+    marker = root / MARKER
+    if not marker.is_file():
+        raise SystemExit(f"refusing to clean unmarked fixture root: {root}")
+    mount = root / "data"
+    mounted = subprocess.run(
+        ["findmnt", "-n", "--target", str(mount)],
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+    if mounted:
+        run("umount", str(mount))
+    if remove_root:
+        shutil.rmtree(root)
+
+
+def setup(args: argparse.Namespace) -> None:
+    if os.geteuid() != 0:
+        raise SystemExit("profile E2E host fixture setup requires root")
+    root = checked_root(args.root)
+    scripts = Path(args.scripts).resolve()
+    if not (scripts / "watchdog.py").is_file():
+        raise SystemExit(f"actual Docker profile host scripts are absent: {scripts}")
+    root.mkdir(mode=0o700, exist_ok=True)
+    (root / MARKER).write_text("isolated Docker profile E2E\n", encoding="utf-8")
+    os.chmod(root / MARKER, 0o600)
+    mount = root / "data"
+    image = root / "storage.img"
+    try:
+        run(
+            str(scripts / "prepare-loop-storage.sh"),
+            "--image", str(image),
+            "--size", str(1536 * 1024 * 1024),
+            "--mount", str(mount),
+        )
+        run("mount", "-o", "loop,prjquota", str(image), str(mount))
+        run("mount", "--make-rprivate", str(mount))
+
+        user = pwd.getpwnam(args.user)
+        group = grp.getgrnam(args.group)
+        journal = root / "journal"
+        journal.mkdir(mode=0o700)
+        host_config = root / "profile.host.json"
+        descriptor = root / "profile.json"
+        config = {
+            "name": "e2e-cold-build",
+            "securityLevel": "raw-dind-storage/v1",
+            "userName": user.pw_name,
+            "userGroup": group.gr_name,
+            "accessGroup": "docker",
+            "dockerSocket": "/run/docker.sock",
+            "controlSocket": str(root / "control.sock"),
+            "dataMount": str(mount),
+            "dockerRootDir": args.docker_root,
+            "journalDir": str(journal),
+            "aggregateCgroupPath": "/sys/fs/cgroup/system.slice/docker.service",
+            "capacity": {
+                "cpus": 2,
+                "memory": "2G",
+                "pids": 2048,
+                "maxContainers": 1,
+                "maxBuilds": 1,
+                "ephemeralDiskBytes": "1G",
+                "dockerDataAllocationCount": 1,
+                "memorySwapBytes": 0,
+            },
+            "aggregate": {
+                "cpus": 4,
+                "memory": "4G",
+                "pids": 4096,
+                "memorySwapBytes": 0,
+            },
+            "storage": {
+                "size": "1536M",
+                "backing": "loop-ext4",
+                "slotRootPath": str(mount / "quota-slots"),
+                "slotRegistryPath": str(journal / "quota-slots.json"),
+            },
+            "policy": {"hostLoopback": False, "tcpDockerEndpoint": False},
+        }
+        host_config.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        os.chmod(host_config, 0o600)
+        run(
+            sys.executable, str(scripts / "generate-descriptor.py"),
+            "--host-config", str(host_config),
+            "--output", str(descriptor),
+        )
+        os.chmod(descriptor, 0o600)
+        run(sys.executable, str(scripts / "install-quota-slots.py"), "--host-config", str(host_config))
+        print(json.dumps({
+            "controlSocket": str(root / "control.sock"),
+            "descriptor": str(descriptor),
+            "hostConfig": str(host_config),
+            "journal": str(journal / "events.ndjson"),
+            "readyFile": str(root / "ready"),
+        }))
+    except BaseException:
+        cleanup(root, remove_root=True)
+        raise
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    create = subparsers.add_parser("setup")
+    create.add_argument("--root", required=True)
+    create.add_argument("--scripts", required=True)
+    create.add_argument("--docker-root", required=True)
+    create.add_argument("--user", required=True)
+    create.add_argument("--group", required=True)
+    remove = subparsers.add_parser("cleanup")
+    remove.add_argument("--root", required=True)
+    args = parser.parse_args()
+    root = checked_root(args.root)
+    if args.command == "setup":
+        setup(args)
+    else:
+        if os.geteuid() != 0:
+            raise SystemExit("profile E2E host fixture cleanup requires root")
+        cleanup(root, remove_root=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/lifecycle/fixtures/profile-host-fixture.py
+++ b/e2e/lifecycle/fixtures/profile-host-fixture.py
@@ -80,6 +80,11 @@ def setup(args: argparse.Namespace) -> None:
         journal.mkdir(mode=0o700)
         host_config = root / "profile.host.json"
         descriptor = root / "profile.json"
+        assets = root / "assets-v1.json"
+        assets.write_text(json.dumps({"schemaVersion": 1, "platform": "linux/amd64", "images": [
+            {"purpose": "doctor-dind", "reference": "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c", "imageId": "sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c", "platform": "linux/amd64"},
+            {"purpose": "doctor-buildkit", "reference": "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8", "imageId": "sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8", "platform": "linux/amd64"},
+        ]}) + "\n", encoding="utf-8")
         config = {
             "name": "e2e-cold-build",
             "securityLevel": "raw-dind-storage/v1",
@@ -114,6 +119,7 @@ def setup(args: argparse.Namespace) -> None:
                 "slotRootPath": str(mount / "quota-slots"),
                 "slotRegistryPath": str(journal / "quota-slots.json"),
             },
+            "assets": {"manifestPath": str(assets)},
             "policy": {"hostLoopback": False, "tcpDockerEndpoint": False},
         }
         host_config.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")

--- a/e2e/lifecycle/project.json
+++ b/e2e/lifecycle/project.json
@@ -46,9 +46,10 @@
             "vitest",
             "run"
           ],
-          "timeoutMinutes": 2,
+          "timeoutMinutes": 5,
           "harness": {
-            "testkit": true
+            "testkit": true,
+            "dockerProfileHost": true
           },
           "secrets": [],
           "requires": {

--- a/e2e/lifecycle/test/docker-profile-cold-build.test.ts
+++ b/e2e/lifecycle/test/docker-profile-cold-build.test.ts
@@ -103,6 +103,11 @@ test("profile-bound Dockerfile cold build starts the Attempt through the public 
     const fixtureContext = join(projectRoot, "fixtures/profile-cold-build");
     await exportImageRootfs(driverImage, join(fixtureContext, "node-rootfs.tar"));
     await exportImageRootfs(dindImage, join(fixtureContext, "docker-rootfs.tar"));
+    const inspectedBuildkit = await docker.run(["image", "inspect", buildkitImage]);
+    if (inspectedBuildkit.exitCode !== 0) {
+      const pulledBuildkit = await docker.run(["pull", buildkitImage], { timeoutMs: 120_000 });
+      expect(pulledBuildkit.exitCode, pulledBuildkit.diagnostic()).toBe(0);
+    }
     // The unique context byte keeps this owner a real cold build even when the
     // daemon already carries an image from an earlier reliability repetition.
     await appendFile(

--- a/e2e/lifecycle/test/docker-profile-cold-build.test.ts
+++ b/e2e/lifecycle/test/docker-profile-cold-build.test.ts
@@ -37,6 +37,8 @@ interface HostJournalRecord {
 const docker = command(["docker"]);
 const sudo = command(["sudo", "-n"]);
 const driverImage = "node@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f";
+const dindImage = "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c";
+const buildkitImage = "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8";
 const projectCopy = {
   from: process.cwd(),
   prefix: "niceeval-e2e-docker-profile-project-",
@@ -70,6 +72,21 @@ async function quotaPath(): Promise<string> {
   throw new Error("project-quota tools (setquota/repquota) are required by this E2E");
 }
 
+async function exportImageRootfs(image: string, destination: string): Promise<void> {
+  const created = await docker.run(["create", image]);
+  expect(created.exitCode, created.diagnostic()).toBe(0);
+  const containerId = created.stdout.trim();
+  try {
+    const exported = await docker.run(["export", "--output", destination, containerId], {
+      timeoutMs: 60_000,
+    });
+    expect(exported.exitCode, exported.diagnostic()).toBe(0);
+  } finally {
+    const removed = await docker.run(["rm", "--force", containerId]);
+    expect(removed.exitCode, removed.diagnostic()).toBe(0);
+  }
+}
+
 test("profile-bound Dockerfile cold build starts the Attempt through the public CLI", async () => {
   const scripts = process.env.NICEEVAL_E2E_DOCKER_PROFILE_HOST_SCRIPTS;
   expect(scripts, "runner must inject the actual Docker profile host scripts").toBeTruthy();
@@ -83,6 +100,9 @@ test("profile-bound Dockerfile cold build starts the Attempt through the public 
   expect(id.exitCode, id.diagnostic()).toBe(0);
 
   await withProjectCopy(projectCopy, async ({ root: projectRoot }) => {
+    const fixtureContext = join(projectRoot, "fixtures/profile-cold-build");
+    await exportImageRootfs(driverImage, join(fixtureContext, "node-rootfs.tar"));
+    await exportImageRootfs(dindImage, join(fixtureContext, "docker-rootfs.tar"));
     // The unique context byte keeps this owner a real cold build even when the
     // daemon already carries an image from an earlier reliability repetition.
     await appendFile(
@@ -141,11 +161,12 @@ test("profile-bound Dockerfile cold build starts the Attempt through the public 
               "--env", "NICEEVAL_E2E_DOCKER_PROFILE_ALIAS=e2e-cold-build",
               driverImage,
               "sh", "-ec",
-              `holder_pid=''; doctor_pid=''; fault_socket=''
+              `holder_pid=''; doctor_pid=''; fault_socket=''; compat_proxy_pid=''; compat_socket=''
 cleanup_holder() { if [ -n "\${holder_pid}" ] && kill -0 "\${holder_pid}" 2>/dev/null; then kill -TERM "\${holder_pid}" 2>/dev/null || true; wait "\${holder_pid}" || true; fi; }
 cleanup_doctor() { if [ -n "\${doctor_pid}" ] && kill -0 "\${doctor_pid}" 2>/dev/null; then kill -KILL "\${doctor_pid}" 2>/dev/null || true; wait "\${doctor_pid}" || true; fi; }
 restore_fault_socket() { if [ -n "\${fault_socket}" ] && [ -S "\${fault_socket}" ]; then mv "\${fault_socket}" '${activeFixture.controlSocket}'; fi; }
-trap 'restore_fault_socket; cleanup_doctor; cleanup_holder; chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
+restore_compat_socket() { if [ -n "\${compat_proxy_pid}" ] && kill -0 "\${compat_proxy_pid}" 2>/dev/null; then kill -TERM "\${compat_proxy_pid}" 2>/dev/null || true; wait "\${compat_proxy_pid}" || true; fi; if [ -n "\${compat_socket}" ] && [ -S "\${compat_socket}" ]; then rm -f '${activeFixture.controlSocket}'; mv "\${compat_socket}" '${activeFixture.controlSocket}'; fi; }
+trap 'restore_fault_socket; restore_compat_socket; cleanup_doctor; cleanup_holder; chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
 mkdir -p /etc/niceeval/docker-profiles
 cp '${activeFixture.descriptor}' /etc/niceeval/docker-profiles/e2e-cold-build.json
 chown root:root /etc/niceeval/docker-profiles/e2e-cold-build.json
@@ -154,8 +175,29 @@ docker_api() { node - "$@" <<'NODE'
 const Docker=require('dockerode'),d=new Docker({socketPath:'/run/docker.sock'}),[action,...args]=process.argv.slice(2);const labels=Object.fromEntries((args[0]||'').split(',').filter(Boolean).map(x=>x.split('=')));const filters={label:Object.entries(labels).map(([k,v])=>v?k+'='+v:k)};(async()=>{if(action==='image'){await d.getImage(args[0]).inspect();return}if(action==='find'){const c=await d.listContainers({all:false,filters});if(c[0])process.stdout.write(JSON.stringify({id:c[0].Id,labels:c[0].Labels}))}if(action==='kill'){await d.getContainer(args[0]).kill()}if(action==='absent'){const c=await d.listContainers({all:true,filters}),n=await d.listNetworks({filters});if(c.length||n.length)throw Error('owned resource remains')}})().catch(e=>{console.error(e);process.exit(1)})
 NODE
 }
-docker_api image 'docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c'
-docker_api image 'moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8'
+docker_api image '${dindImage}'
+docker_api image '${buildkitImage}'
+compat_socket='${activeFixture.controlSocket}.compat'
+mv '${activeFixture.controlSocket}' "$compat_socket"
+node - '${activeFixture.controlSocket}' "$compat_socket" <<'NODE' &
+const net=require('net'),[front,back]=process.argv.slice(2);const server=net.createServer({allowHalfOpen:true},client=>{let request='',response='';client.on('data',b=>request+=b);client.on('end',()=>{const upstream=net.createConnection(back);upstream.on('connect',()=>upstream.end(request));upstream.on('data',b=>response+=b);upstream.on('error',e=>client.destroy(e));upstream.on('close',()=>{try{const value=JSON.parse(response),input=JSON.parse(request);if(input.kind==='status'&&value.ok)delete value.result.journal;client.end(JSON.stringify(value)+String.fromCharCode(10))}catch(e){client.destroy(e)}})})});server.listen(front);process.on('SIGTERM',()=>server.close(()=>process.exit(0)))
+NODE
+compat_proxy_pid=$!
+for _ in $(seq 1 100); do [ -S '${activeFixture.controlSocket}' ] && break; kill -0 "$compat_proxy_pid" 2>/dev/null || exit 1; sleep 0.05; done
+[ -S '${activeFixture.controlSocket}' ] || { echo 'compatibility control proxy did not become ready' >&2; exit 1; }
+set +e
+node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-compat.json
+compat_status=$?
+set -e
+COMPAT_STATUS="$compat_status" node - /tmp/niceeval-doctor-compat.json <<'NODE'
+const fs=require('fs'),d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup'];const invalid=process.env.COMPAT_STATUS==='0'||d.status!=='FAIL'||JSON.stringify(d.checks.map(x=>x.id))!==JSON.stringify(ids)||ids.slice(0,5).some((id,i)=>d.checks[i].status!=='PASS')||d.checks[5].status!=='FAIL'||d.checks[5].code!=='UNSAFE_TO_CONTINUE'||!d.checks[5].detail.includes('durable journal')||d.checks.slice(6).some(x=>x.status!=='FAIL'||x.code!=='PREREQUISITE_FAILED');if(invalid){console.error(JSON.stringify({compatStatus:process.env.COMPAT_STATUS,doctor:d},null,2));process.exit(1)}
+NODE
+kill -TERM "$compat_proxy_pid"
+wait "$compat_proxy_pid"
+compat_proxy_pid=''
+rm -f '${activeFixture.controlSocket}'
+mv "$compat_socket" '${activeFixture.controlSocket}'
+compat_socket=''
 rm -f /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready
 node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready <<'NODE' &
 const net=require('net'), fs=require('fs'), crypto=require('crypto'); const [path,out,ready]=process.argv.slice(2);
@@ -207,8 +249,8 @@ NODE
 profile_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.profile-id"])')
 reservation_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.reservation-id"])')
 docker_api absent "niceeval.profile-id=$profile_label,niceeval.reservation-id=$reservation_label"
-docker_api image 'docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c'
-docker_api image 'moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8'
+docker_api image '${dindImage}'
+docker_api image '${buildkitImage}'
 rm -f /tmp/niceeval-doctor-fault.json /tmp/niceeval-doctor-fault-owned.json
 node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-fault.json 2>&1 &
 doctor_pid=$!
@@ -236,8 +278,8 @@ NODE
 fault_profile=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.profile-id"])')
 fault_reservation=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.reservation-id"])')
 docker_api absent "niceeval.profile-id=$fault_profile,niceeval.reservation-id=$fault_reservation"
-docker_api image 'docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c'
-docker_api image 'moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8'
+docker_api image '${dindImage}'
+docker_api image '${buildkitImage}'
 set +e
 node_modules/.bin/niceeval exp docker-profile-cold-build --rerun all --json >/tmp/niceeval-exp.ndjson
 status=$?

--- a/e2e/lifecycle/test/docker-profile-cold-build.test.ts
+++ b/e2e/lifecycle/test/docker-profile-cold-build.test.ts
@@ -1,0 +1,263 @@
+// owner: docs/engineering/testing/e2e/README.md#docker-profile-cold-build
+// regression: memory/docker-profile-control-create-migration-incomplete.md
+import { appendFile, readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import {
+  command,
+  only,
+  pollUntil,
+  withProcess,
+  withProjectCopy,
+  withTempDir,
+  type ExpEvent,
+} from "@niceeval/testkit";
+import { expect, test } from "vitest";
+
+interface HostFixture {
+  readonly controlSocket: string;
+  readonly descriptor: string;
+  readonly hostConfig: string;
+  readonly journal: string;
+  readonly readyFile: string;
+}
+
+interface HostJournalRecord {
+  readonly event: string;
+  readonly detail: Readonly<Record<string, unknown>>;
+  readonly state?: {
+    readonly reservations?: Readonly<Record<string, {
+      readonly kind?: string;
+      readonly locator?: string;
+      readonly builderName?: string;
+    }>>;
+  };
+}
+
+const docker = command(["docker"]);
+const sudo = command(["sudo", "-n"]);
+const driverImage = "node@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f";
+const projectCopy = {
+  from: process.cwd(),
+  prefix: "niceeval-e2e-docker-profile-project-",
+  omitTopLevel: [".niceeval", "node_modules", "test"],
+  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
+} as const;
+
+async function fileExists(path: string): Promise<true | undefined> {
+  try {
+    await readFile(path);
+    return true;
+  } catch {
+    return undefined;
+  }
+}
+
+async function quotaPath(): Promise<string> {
+  const candidates = (process.env.PATH ?? "").split(":");
+  try {
+    for (const name of await readdir("/nix/store")) {
+      if (/^[^-]+-quota-[^/]+$/.test(name)) candidates.push(`/nix/store/${name}/bin`);
+    }
+  } catch {
+    // Non-Nix hosts can provide quota-tools on PATH.
+  }
+  for (const candidate of candidates) {
+    if ((await command(["test"]).run(["-x", join(candidate, "setquota")])).exitCode === 0) {
+      return [candidate, process.env.PATH ?? ""].filter(Boolean).join(":");
+    }
+  }
+  throw new Error("project-quota tools (setquota/repquota) are required by this E2E");
+}
+
+test("profile-bound Dockerfile cold build starts the Attempt through the public CLI", async () => {
+  const scripts = process.env.NICEEVAL_E2E_DOCKER_PROFILE_HOST_SCRIPTS;
+  expect(scripts, "runner must inject the actual Docker profile host scripts").toBeTruthy();
+  const fixtureScript = resolve("fixtures/profile-host-fixture.py");
+  const dockerInfo = await docker.run(["info", "--format", "{{.DockerRootDir}}"]);
+  expect(dockerInfo.exitCode, dockerInfo.diagnostic()).toBe(0);
+  const hostPath = await quotaPath();
+  const user = process.env.USER ?? process.env.LOGNAME;
+  expect(user, "E2E runner user must be named for the quota-slot owner").toBeTruthy();
+  const id = await command(["id"]).run(["-gn", user!]);
+  expect(id.exitCode, id.diagnostic()).toBe(0);
+
+  await withProjectCopy(projectCopy, async ({ root: projectRoot }) => {
+    // The unique context byte keeps this owner a real cold build even when the
+    // daemon already carries an image from an earlier reliability repetition.
+    await appendFile(
+      join(projectRoot, "fixtures/profile-cold-build/Dockerfile"),
+      `\n# cold-build-owner ${crypto.randomUUID()}\n`,
+    );
+    await withTempDir("niceeval-e2e-docker-profile-", async (hostRoot) => {
+      let fixture: HostFixture | undefined;
+      let primaryError: unknown;
+      try {
+        const setup = await sudo.run([
+          "env", `PATH=${hostPath}`,
+          "python3", fixtureScript, "setup",
+          "--root", hostRoot,
+          "--scripts", scripts!,
+          "--docker-root", dockerInfo.stdout.trim(),
+          "--user", user!,
+          "--group", id.stdout.trim(),
+        ], { timeoutMs: 60_000 });
+        expect(setup.exitCode, setup.diagnostic()).toBe(0);
+        fixture = JSON.parse(setup.stdout.trim().split("\n").at(-1)!) as HostFixture;
+        const activeFixture = fixture;
+
+        await withProcess(
+          [
+            "sudo", "-n", "env", `PATH=${hostPath}`, "PYTHONDONTWRITEBYTECODE=1",
+            "python3", join(scripts!, "watchdog.py"),
+            "--control-socket", activeFixture.controlSocket,
+            "--descriptor", activeFixture.descriptor,
+            "--host-config", activeFixture.hostConfig,
+            "--docker-socket", "/run/docker.sock",
+            "--journal", activeFixture.journal,
+            "--ready-file", activeFixture.readyFile,
+            "--socket-mode", "0o600",
+          ],
+          { processGroup: true, timeoutMs: 180_000, graceMs: 5_000 },
+          async (watchdog) => {
+            await Promise.race([
+              pollUntil(() => fileExists(activeFixture.readyFile), {
+                timeoutMs: 15_000,
+                intervalMs: 100,
+                label: "isolated real watchdog ready file",
+              }),
+              watchdog.done.then((receipt) => {
+                throw new Error(`watchdog exited before readiness\n${receipt.diagnostic()}`);
+              }),
+            ]);
+
+            const driver = await docker.run([
+              "run", "--rm", "--user", "0:0",
+              "--mount", `type=bind,src=${process.cwd()},dst=${process.cwd()},readonly`,
+              "--mount", `type=bind,src=${projectRoot},dst=${projectRoot}`,
+              "--mount", `type=bind,src=${hostRoot},dst=${hostRoot}`,
+              "--mount", "type=bind,src=/run/docker.sock,dst=/run/docker.sock",
+              "--workdir", projectRoot,
+              "--env", "NICEEVAL_E2E_DOCKER_PROFILE_ALIAS=e2e-cold-build",
+              driverImage,
+              "sh", "-ec",
+              `trap 'chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
+mkdir -p /etc/niceeval/docker-profiles
+cp '${activeFixture.descriptor}' /etc/niceeval/docker-profiles/e2e-cold-build.json
+chown root:root /etc/niceeval/docker-profiles/e2e-cold-build.json
+chmod 600 /etc/niceeval/docker-profiles/e2e-cold-build.json
+set +e
+node_modules/.bin/niceeval exp docker-profile-cold-build --rerun all --json >/tmp/niceeval-exp.ndjson
+status=$?
+set -e
+cat /tmp/niceeval-exp.ndjson
+run_id=$(node -e 'const fs=require("fs"); const lines=fs.readFileSync("/tmp/niceeval-exp.ndjson","utf8").trim().split("\\n"); const receipt=JSON.parse(lines.at(-1)); process.stdout.write(receipt.receipt.runIds[0])')
+if [ "$status" -ne 0 ]; then
+  locator=$(node -e 'const fs=require("fs"); for (const line of fs.readFileSync("/tmp/niceeval-exp.ndjson","utf8").trim().split("\\n")) { const value=JSON.parse(line); if (value.locator) { process.stdout.write(value.locator); break } }')
+  if [ -n "$locator" ]; then
+    node_modules/.bin/niceeval show "$locator" --execution
+  else
+    node_modules/.bin/niceeval show --run "$run_id" --json
+  fi
+fi
+exit "$status"`,
+            ], { cwd: projectRoot, timeoutMs: 150_000 });
+            expect(driver.exitCode, driver.diagnostic()).toBe(0);
+            const evals = driver.ndjson<ExpEvent>().filter(
+              (event): event is Extract<ExpEvent, { event: "eval" }> =>
+                "event" in event && event.event === "eval",
+            );
+            expect(only(evals, (event) => event.evalId === "docker-profile-cold-build"), driver.diagnostic())
+              .toMatchObject({ verdict: "passed" });
+          },
+        );
+
+        const journal = await sudo.run(["cat", fixture.journal]);
+        expect(journal.exitCode, journal.diagnostic()).toBe(0);
+        const records = journal.stdout
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as HostJournalRecord);
+        const events = records.map((record) => record.event);
+        expect(events).toContain("reservation-granted");
+        expect(events).toContain("build-terminated");
+        expect(events).toContain("container-active");
+        expect(events).toContain("reservation-released");
+        const buildLocator = records.find((record) => record.event === "build-terminated")?.detail.locator;
+        expect(typeof buildLocator).toBe("string");
+      } catch (error) {
+        primaryError = error;
+        throw error;
+      } finally {
+        const cleanupErrors: unknown[] = [];
+        if (fixture !== undefined) {
+          try {
+            const journal = await sudo.run(["cat", fixture.journal]);
+            if (journal.exitCode !== 0) throw new Error(journal.diagnostic());
+            const records = journal.stdout
+              .split("\n")
+              .filter(Boolean)
+              .map((line) => JSON.parse(line) as HostJournalRecord);
+            const locators = new Set<string>();
+            const builderNames = new Set<string>();
+            for (const record of records) {
+              if (record.event === "build-terminated" && typeof record.detail.locator === "string") {
+                locators.add(record.detail.locator);
+              }
+              if (record.event === "build-builder-created" && typeof record.detail.builderName === "string") {
+                builderNames.add(record.detail.builderName);
+              }
+              for (const reservation of Object.values(record.state?.reservations ?? {})) {
+                if (reservation.kind === "build" && typeof reservation.locator === "string") {
+                  locators.add(reservation.locator);
+                }
+                if (reservation.kind === "build" && typeof reservation.builderName === "string") {
+                  builderNames.add(reservation.builderName);
+                }
+              }
+            }
+            for (const locator of locators) {
+              const removeImage = await docker.run(["image", "rm", "--force", locator]);
+              if (removeImage.exitCode !== 0 && !/No such image/i.test(removeImage.diagnostic())) {
+                throw new Error(removeImage.diagnostic());
+              }
+            }
+            for (const builderName of builderNames) {
+              if (!/^niceeval-build-[a-f0-9]{24}$/.test(builderName)) {
+                throw new Error(`watchdog journal contains a non-derived builder name: ${builderName}`);
+              }
+              const volumeName = `buildx_buildkit_${builderName}0_state`;
+              const inspectVolume = await docker.run(["volume", "inspect", volumeName]);
+              if (inspectVolume.exitCode === 0) {
+                const removeVolume = await docker.run(["volume", "rm", "--force", volumeName]);
+                throw new Error(
+                  `watchdog leaked Buildx state volume ${volumeName}; cleanup: ${removeVolume.diagnostic()}`,
+                );
+              }
+              if (!/No such volume/i.test(inspectVolume.diagnostic())) {
+                throw new Error(inspectVolume.diagnostic());
+              }
+            }
+          } catch (error) {
+            cleanupErrors.push(error);
+          }
+          try {
+            const cleanup = await sudo.run([
+              "env", `PATH=${hostPath}`,
+              "python3", fixtureScript, "cleanup", "--root", hostRoot,
+            ], { timeoutMs: 30_000 });
+            if (cleanup.exitCode !== 0) throw new Error(cleanup.diagnostic());
+          } catch (error) {
+            cleanupErrors.push(error);
+          }
+        }
+        if (cleanupErrors.length > 0) {
+          if (primaryError !== undefined) {
+            console.error(new AggregateError(cleanupErrors, "Docker profile E2E cleanup also failed"));
+          } else {
+            throw new AggregateError(cleanupErrors, "Docker profile E2E cleanup failed");
+          }
+        }
+      }
+    });
+  });
+}, 240_000);

--- a/e2e/lifecycle/test/docker-profile-cold-build.test.ts
+++ b/e2e/lifecycle/test/docker-profile-cold-build.test.ts
@@ -29,6 +29,7 @@ interface HostJournalRecord {
       readonly kind?: string;
       readonly locator?: string;
       readonly builderName?: string;
+      readonly retention?: "cache" | "ephemeral";
     }>>;
   };
 }
@@ -117,7 +118,7 @@ test("profile-bound Dockerfile cold build starts the Attempt through the public 
             "--ready-file", activeFixture.readyFile,
             "--socket-mode", "0o600",
           ],
-          { processGroup: true, timeoutMs: 180_000, graceMs: 5_000 },
+          { processGroup: true, timeoutMs: 330_000, graceMs: 5_000 },
           async (watchdog) => {
             await Promise.race([
               pollUntil(() => fileExists(activeFixture.readyFile), {
@@ -131,7 +132,7 @@ test("profile-bound Dockerfile cold build starts the Attempt through the public 
             ]);
 
             const driver = await docker.run([
-              "run", "--rm", "--user", "0:0",
+              "run", "--rm", "--network", "none", "--user", "0:0",
               "--mount", `type=bind,src=${process.cwd()},dst=${process.cwd()},readonly`,
               "--mount", `type=bind,src=${projectRoot},dst=${projectRoot}`,
               "--mount", `type=bind,src=${hostRoot},dst=${hostRoot}`,
@@ -140,11 +141,103 @@ test("profile-bound Dockerfile cold build starts the Attempt through the public 
               "--env", "NICEEVAL_E2E_DOCKER_PROFILE_ALIAS=e2e-cold-build",
               driverImage,
               "sh", "-ec",
-              `trap 'chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
+              `holder_pid=''; doctor_pid=''; fault_socket=''
+cleanup_holder() { if [ -n "\${holder_pid}" ] && kill -0 "\${holder_pid}" 2>/dev/null; then kill -TERM "\${holder_pid}" 2>/dev/null || true; wait "\${holder_pid}" || true; fi; }
+cleanup_doctor() { if [ -n "\${doctor_pid}" ] && kill -0 "\${doctor_pid}" 2>/dev/null; then kill -KILL "\${doctor_pid}" 2>/dev/null || true; wait "\${doctor_pid}" || true; fi; }
+restore_fault_socket() { if [ -n "\${fault_socket}" ] && [ -S "\${fault_socket}" ]; then mv "\${fault_socket}" '${activeFixture.controlSocket}'; fi; }
+trap 'restore_fault_socket; cleanup_doctor; cleanup_holder; chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
 mkdir -p /etc/niceeval/docker-profiles
 cp '${activeFixture.descriptor}' /etc/niceeval/docker-profiles/e2e-cold-build.json
 chown root:root /etc/niceeval/docker-profiles/e2e-cold-build.json
 chmod 600 /etc/niceeval/docker-profiles/e2e-cold-build.json
+docker_api() { node - "$@" <<'NODE'
+const Docker=require('dockerode'),d=new Docker({socketPath:'/run/docker.sock'}),[action,...args]=process.argv.slice(2);const labels=Object.fromEntries((args[0]||'').split(',').filter(Boolean).map(x=>x.split('=')));const filters={label:Object.entries(labels).map(([k,v])=>v?k+'='+v:k)};(async()=>{if(action==='image'){await d.getImage(args[0]).inspect();return}if(action==='find'){const c=await d.listContainers({all:false,filters});if(c[0])process.stdout.write(JSON.stringify({id:c[0].Id,labels:c[0].Labels}))}if(action==='kill'){await d.getContainer(args[0]).kill()}if(action==='absent'){const c=await d.listContainers({all:true,filters}),n=await d.listNetworks({filters});if(c.length||n.length)throw Error('owned resource remains')}})().catch(e=>{console.error(e);process.exit(1)})
+NODE
+}
+docker_api image 'docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c'
+docker_api image 'moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8'
+rm -f /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready
+node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready <<'NODE' &
+const net=require('net'), fs=require('fs'), crypto=require('crypto'); const [path,out,ready]=process.argv.slice(2);
+const call=(request)=>new Promise((resolve,reject)=>{let text=''; const s=net.createConnection(path); s.on('connect',()=>s.end(JSON.stringify(request)+'\\n')); s.on('data',b=>text+=b); s.on('error',reject); s.on('close',()=>{try { const r=JSON.parse(text); if(!r.ok) throw Error(r.error?.message||'control error'); resolve(r.result) } catch(e) { reject(e) }});});
+(async()=>{const status=await call({kind:'status'}); const invocationId=crypto.randomUUID(), reservationId=crypto.randomUUID(); const lease=await call({kind:'lease.create',profileId:status.profileId,daemonGeneration:status.generation,invocationId}); const held={invocationId,reservationId,leaseToken:lease.leaseToken}; const reservation=await call({kind:'reservation.acquire',...held,reservationKind:'build',resources:{cpus:0,memoryBytes:0,pids:0,containers:0,ephemeralDiskBytes:0}}); if(reservation.state!=='granted') throw Error('preoccupier was not granted'); fs.writeFileSync(out,JSON.stringify(held)); fs.writeFileSync(ready,'ready'); const beat=setInterval(()=>call({kind:'lease.heartbeat',invocationId,leaseToken:lease.leaseToken}).catch(()=>{}),4000); let done=false; const stop=async()=>{if(done)return;done=true;clearInterval(beat);await call({kind:'reservation.release',...held}).catch(()=>{});await call({kind:'lease.drain',invocationId,leaseToken:lease.leaseToken}).catch(()=>{});process.exit(0)};process.on('SIGTERM',stop);process.on('SIGINT',stop);})().catch(e=>{console.error(e);process.exit(1)});
+NODE
+holder_pid=$!
+for _ in $(seq 1 100); do [ -f /tmp/niceeval-preoccupier.ready ] && break; sleep 0.1; done
+[ -f /tmp/niceeval-preoccupier.ready ] || { echo 'preoccupier did not become ready' >&2; exit 1; }
+set +e
+node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor.json
+doctor_status=$?
+set -e
+cat /tmp/niceeval-doctor.json
+DOCTOR_STATUS="$doctor_status" node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json <<'NODE'
+const net=require('net'), fs=require('fs'); const path=process.argv[2], held=JSON.parse(fs.readFileSync(process.argv[3]));
+const call=(request)=>new Promise((resolve,reject)=>{let text=''; const s=net.createConnection(path); s.on('connect',()=>s.end(JSON.stringify(request)+'\\n')); s.on('data',b=>text+=b); s.on('error',reject); s.on('close',()=>{try {const r=JSON.parse(text);if(!r.ok)throw Error(r.error?.message||'control error');resolve(r.result)}catch(e){reject(e)}})});
+(async()=>{const d=JSON.parse(fs.readFileSync('/tmp/niceeval-doctor.json','utf8')); const ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup']; if(process.env.DOCTOR_STATUS==='0'||d.status!=='BLOCKED'||JSON.stringify(d.checks?.map(c=>c.id))!==JSON.stringify(ids)||d.checks.some(c=>c.status==='FAIL')||d.checks.filter(c=>ids.slice(7).includes(c.id)).some(c=>c.status!=='BLOCKED'||c.code!=='CAPACITY_QUEUE_TIMEOUT')) throw Error('doctor did not report only capacity BLOCKED')})().catch(e=>{console.error(e);process.exit(1)});
+NODE
+kill -TERM "$holder_pid"
+wait "$holder_pid"
+holder_pid=''
+node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json <<'NODE'
+const net=require('net'),fs=require('fs');const path=process.argv[2],held=JSON.parse(fs.readFileSync(process.argv[3]));const call=r=>new Promise((resolve,reject)=>{let t='';const s=net.createConnection(path);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',reject);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);resolve(v.result)}catch(e){reject(e)}})});(async()=>{for(let i=0;i<50;i++){const s=await call({kind:'status'}),lease=s.leases.find(l=>l.invocationId===held.invocationId);if(!s.reservations.some(r=>r.reservationId===held.reservationId)&&lease?.state==='recovered'&&s.used.builds===0&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(r=>setTimeout(r,100))}throw Error('preoccupier cleanup did not converge')})().catch(e=>{console.error(e);process.exit(1)});
+NODE
+rm -f /tmp/niceeval-doctor-kill.json /tmp/niceeval-doctor-owned.json
+node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-kill.json 2>&1 &
+doctor_pid=$!
+for _ in $(seq 1 300); do
+  doctor_owned=$(docker_api find 'niceeval.attempt-id=doctor-diagnostic')
+  if [ -n "$doctor_owned" ]; then
+    printf '%s' "$doctor_owned" >/tmp/niceeval-doctor-owned.json
+    node - /tmp/niceeval-doctor-owned.json <<'NODE'
+const x=require('fs').readFileSync(process.argv[2],'utf8'),l=JSON.parse(x).labels;if(l['niceeval.attempt-id']!=='doctor-diagnostic'||['niceeval.profile-id','niceeval.invocation-id','niceeval.reservation-id','niceeval.provision-token'].some(k=>!l[k]))process.exit(1)
+NODE
+    break
+  fi
+  kill -0 "$doctor_pid" 2>/dev/null || { cat /tmp/niceeval-doctor-kill.json >&2; exit 1; }
+  sleep 0.1
+done
+[ -s /tmp/niceeval-doctor-owned.json ] || { echo 'doctor diagnostic did not become running' >&2; exit 1; }
+kill -KILL "$doctor_pid"
+set +e; wait "$doctor_pid"; doctor_kill_status=$?; set -e
+[ "$doctor_kill_status" -eq 137 ] || { echo 'doctor did not exit from SIGKILL' >&2; exit 1; }
+doctor_pid=''
+node - '${activeFixture.controlSocket}' /tmp/niceeval-doctor-owned.json <<'NODE'
+const net=require('net'),fs=require('fs'),path=process.argv[2],o=JSON.parse(fs.readFileSync(process.argv[3])).labels;const call=r=>new Promise((ok,no)=>{let t='';const s=net.createConnection(path);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',no);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);ok(v.result)}catch(e){no(e)}})});(async()=>{for(let i=0;i<300;i++){const s=await call({kind:'status'}),r=o['niceeval.reservation-id'],l=o['niceeval.invocation-id'];if(!s.reservations.some(x=>x.reservationId===r)&&s.leases.find(x=>x.invocationId===l)?.state==='recovered'&&s.used.builds===0&&s.used.containers===0&&s.slots.every(x=>x.reservationId!==r&&x.state==='free')&&s.availableQuotaSlots===1&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(x=>setTimeout(x,100))}throw Error('SIGKILL recovery did not converge')})().catch(e=>{console.error(e);process.exit(1)})
+NODE
+profile_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.profile-id"])')
+reservation_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.reservation-id"])')
+docker_api absent "niceeval.profile-id=$profile_label,niceeval.reservation-id=$reservation_label"
+docker_api image 'docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c'
+docker_api image 'moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8'
+rm -f /tmp/niceeval-doctor-fault.json /tmp/niceeval-doctor-fault-owned.json
+node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-fault.json 2>&1 &
+doctor_pid=$!
+for _ in $(seq 1 300); do
+  fault_owned=$(docker_api find 'niceeval.attempt-id=doctor-diagnostic')
+  if [ -n "$fault_owned" ]; then printf '%s' "$fault_owned" >/tmp/niceeval-doctor-fault-owned.json; break; fi
+  kill -0 "$doctor_pid" 2>/dev/null || { cat /tmp/niceeval-doctor-fault.json >&2; exit 1; }; sleep 0.1
+done
+[ -s /tmp/niceeval-doctor-fault-owned.json ] || { echo 'fault diagnostic did not become running' >&2; exit 1; }
+fault_socket='${activeFixture.controlSocket}.fault'
+mv '${activeFixture.controlSocket}' "$fault_socket"
+fault_container=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).id)')
+docker_api kill "$fault_container"
+set +e; wait "$doctor_pid"; doctor_fault_status=$?; set -e
+[ "$doctor_fault_status" -eq 1 ] || { cat /tmp/niceeval-doctor-fault.json >&2; exit 1; }
+doctor_pid=''
+node - /tmp/niceeval-doctor-fault.json <<'NODE'
+const fs=require('fs'),d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup'];const fail=d.checks.find(x=>x.status==='FAIL');if(d.status!=='FAIL'||JSON.stringify(d.checks.map(x=>x.id))!==JSON.stringify(ids)||!fail||!fail.detail.includes('primary:')||!fail.detail.includes('cleanup:')||!fail.detail.includes('control-owned diagnostic'))process.exit(1)
+NODE
+mv "$fault_socket" '${activeFixture.controlSocket}'
+fault_socket=''
+node - '${activeFixture.controlSocket}' /tmp/niceeval-doctor-fault-owned.json <<'NODE'
+const net=require('net'),fs=require('fs'),p=process.argv[2],o=JSON.parse(fs.readFileSync(process.argv[3])).labels;const call=r=>new Promise((ok,no)=>{let t='';const s=net.createConnection(p);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',no);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);ok(v.result)}catch(e){no(e)}})});(async()=>{for(let i=0;i<300;i++){const s=await call({kind:'status'}),r=o['niceeval.reservation-id'],l=o['niceeval.invocation-id'],used=s.used;if(!s.reservations.some(x=>x.reservationId===r)&&s.leases.find(x=>x.invocationId===l)?.state==='recovered'&&Object.values(used).every(x=>x===0)&&s.slots.every(x=>x.reservationId!==r&&x.state==='free')&&s.availableQuotaSlots===1&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(x=>setTimeout(x,100))}throw Error('fault cleanup did not converge')})().catch(e=>{console.error(e);process.exit(1)})
+NODE
+fault_profile=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.profile-id"])')
+fault_reservation=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.reservation-id"])')
+docker_api absent "niceeval.profile-id=$fault_profile,niceeval.reservation-id=$fault_reservation"
+docker_api image 'docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c'
+docker_api image 'moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8'
 set +e
 node_modules/.bin/niceeval exp docker-profile-cold-build --rerun all --json >/tmp/niceeval-exp.ndjson
 status=$?
@@ -160,7 +253,7 @@ if [ "$status" -ne 0 ]; then
   fi
 fi
 exit "$status"`,
-            ], { cwd: projectRoot, timeoutMs: 150_000 });
+          ], { cwd: projectRoot, timeoutMs: 300_000 });
             expect(driver.exitCode, driver.diagnostic()).toBe(0);
             const evals = driver.ndjson<ExpEvent>().filter(
               (event): event is Extract<ExpEvent, { event: "eval" }> =>
@@ -192,30 +285,40 @@ exit "$status"`,
         if (fixture !== undefined) {
           try {
             const journal = await sudo.run(["cat", fixture.journal]);
-            if (journal.exitCode !== 0) throw new Error(journal.diagnostic());
-            const records = journal.stdout
+            if (journal.exitCode !== 0 && primaryError === undefined) throw new Error(journal.diagnostic());
+            const records = journal.exitCode === 0 ? journal.stdout
               .split("\n")
               .filter(Boolean)
-              .map((line) => JSON.parse(line) as HostJournalRecord);
-            const locators = new Set<string>();
+              .map((line) => JSON.parse(line) as HostJournalRecord) : [];
+            const locators = new Map<string, "cache" | "ephemeral" | undefined>();
             const builderNames = new Set<string>();
             for (const record of records) {
               if (record.event === "build-terminated" && typeof record.detail.locator === "string") {
-                locators.add(record.detail.locator);
+                locators.set(record.detail.locator, undefined);
               }
               if (record.event === "build-builder-created" && typeof record.detail.builderName === "string") {
                 builderNames.add(record.detail.builderName);
               }
               for (const reservation of Object.values(record.state?.reservations ?? {})) {
                 if (reservation.kind === "build" && typeof reservation.locator === "string") {
-                  locators.add(reservation.locator);
+                  locators.set(reservation.locator, reservation.retention);
                 }
                 if (reservation.kind === "build" && typeof reservation.builderName === "string") {
                   builderNames.add(reservation.builderName);
                 }
               }
             }
-            for (const locator of locators) {
+            for (const [locator, retention] of locators) {
+              const inspectImage = await docker.run(["image", "inspect", locator]);
+              if (retention === "ephemeral" && inspectImage.exitCode === 0) {
+                // Clean the fixture after recording the ownership leak, but do
+                // not let cleanup turn a failed proof into a passing run.
+                await docker.run(["image", "rm", "--force", locator]);
+                throw new Error(`watchdog leaked ephemeral build locator ${locator}`);
+              }
+              if (retention === "ephemeral" && !/No such image/i.test(inspectImage.diagnostic())) {
+                throw new Error(inspectImage.diagnostic());
+              }
               const removeImage = await docker.run(["image", "rm", "--force", locator]);
               if (removeImage.exitCode !== 0 && !/No such image/i.test(removeImage.diagnostic())) {
                 throw new Error(removeImage.diagnostic());
@@ -260,4 +363,4 @@ exit "$status"`,
       }
     });
   });
-}, 240_000);
+}, 360_000);

--- a/e2e/scripts/manifest.ts
+++ b/e2e/scripts/manifest.ts
@@ -53,6 +53,8 @@ export interface RepoRequires {
 export interface RepoHarness {
   /** Declares that the repo consumes @niceeval/testkit; injection intent. */
   testkit?: boolean;
+  /** Injects the checkout-local Docker profile host scripts for the real host/control E2E. */
+  dockerProfileHost?: boolean;
 }
 
 export interface E2ERepoManifest {
@@ -96,7 +98,7 @@ const REQUIRES_FIELDS = new Set([
   "runtimes",
   "browsers",
 ]);
-const HARNESS_FIELDS = new Set(["testkit"]);
+const HARNESS_FIELDS = new Set(["testkit", "dockerProfileHost"]);
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -347,6 +349,15 @@ export function parseManifest(raw: unknown, source: string): ManifestParseResult
           errors.push(`${source}: "harness.testkit" must be a boolean, got ${JSON.stringify(h.testkit)}`);
         } else {
           harness.testkit = h.testkit;
+        }
+      }
+      if (h.dockerProfileHost !== undefined) {
+        if (typeof h.dockerProfileHost !== "boolean") {
+          errors.push(
+            `${source}: "harness.dockerProfileHost" must be a boolean, got ${JSON.stringify(h.dockerProfileHost)}`,
+          );
+        } else {
+          harness.dockerProfileHost = h.dockerProfileHost;
         }
       }
     }

--- a/e2e/scripts/run-repo.ts
+++ b/e2e/scripts/run-repo.ts
@@ -13,7 +13,7 @@
 // a link back to the checkout.
 
 import { createHash, randomUUID } from "node:crypto";
-import { basename, join, relative } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 
@@ -236,11 +236,15 @@ function withInvocationContext(
   env: NodeJS.ProcessEnv,
   invocationId: string,
   copyDir: string,
+  dockerProfileHostScripts?: string,
 ): NodeJS.ProcessEnv {
   return {
     ...env,
     NICEEVAL_E2E_INVOCATION_ID: invocationId,
     NICEEVAL_E2E_ARTIFACT_STAGING_ROOT: join(copyDir, ".e2e-artifacts"),
+    ...(dockerProfileHostScripts === undefined
+      ? {}
+      : { NICEEVAL_E2E_DOCKER_PROFILE_HOST_SCRIPTS: dockerProfileHostScripts }),
   };
 }
 
@@ -337,6 +341,16 @@ export async function runRepo(
       if (preflight.ok && !preflight.cancelled) {
         await copyRepoIsolated(sourceDir, copyDir);
         copyCreated = true;
+        const dockerProfileHostScripts = repo.manifest.harness?.dockerProfileHost === true
+          ? join(copyDir, ".niceeval-e2e-host", "scripts")
+          : undefined;
+        if (dockerProfileHostScripts !== undefined) {
+          await cp(
+            resolve(repo.dir, "..", "..", "packaging", "docker-profile-host", "scripts"),
+            dockerProfileHostScripts,
+            { recursive: true },
+          );
+        }
 
         if (isExecutionCancelled(execution)) {
           stages.push(cancelledStage("prepare", "cancelled before source prepare"));
@@ -385,6 +399,7 @@ export async function runRepo(
                 buildChildEnv(process.env, allSecretNames, []),
                 setupInvocationId,
                 copyDir,
+                dockerProfileHostScripts,
               );
               const installCapture = await runCommand(
                 installCmd,
@@ -497,6 +512,7 @@ export async function runRepo(
                           buildChildEnv(process.env, allSecretNames, repo.manifest.secrets, repoId),
                           invocationId,
                           copyDir,
+                          dockerProfileHostScripts,
                         );
                         const testCapture = await runCommand(
                           testCmd,

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -50,6 +50,7 @@ memory 的召回全靠这份索引:漏索引的条目等于不存在。维护规
 
 ### 台账
 
+- 已修 [docker-profile-control-create-migration-incomplete](docker-profile-control-create-migration-incomplete.md) — profile-bound Dockerfile cold build 与 doctor smoke 仍由客户端 create/commit，遇到拒绝旧语义的新 watchdog 会在 Attempt 前报 control-create-unimplemented；改为 control 持有 build context、network/container create 与终止证明
 - 已修 [group-wave-barrier-starves-fast-lanes](group-wave-barrier-starves-fast-lanes.md) — 连续跨 lane wave 闸让慢 Group 的下一槽挡住快 Group 后继，出现真实空闲与 timing 空白；公平闸收窄为只保护各 lane 首槽
 - 已修 [interrupted-run-completed-attempt-hidden](interrupted-run-completed-attempt-hidden.md) — 同 Run 的快 Attempt 已完成并有 locator，慢 Attempt 在飞时 SIGINT 却让整 Run 无 complete、全部不可见；受控中断改为关闭在飞 Attempt 后正常 seal
 - [compose-project-namespace-escape-destabilizes-case-identity](compose-project-namespace-escape-destabilizes-case-identity.md) — 10 个 Terminal-Bench Compose Eval 把逐次随机容器名塞进 fingerprinted env,导致 CaseKey/private identity 每次规划漂移；修法是 Provider 规划期拒绝受管资源逃逸 project namespace,下游删除 `container_name` nonce

--- a/memory/docker-profile-control-create-migration-incomplete.md
+++ b/memory/docker-profile-control-create-migration-incomplete.md
@@ -1,0 +1,64 @@
+# Docker profile create 迁移只完成了宿主侧，cold build 在 Attempt 前失败
+
+## 现象
+
+profile-bound Dockerfile 第一次构建时，安装后的 `niceeval exp` 在 `sandbox.image.build` 失败，
+公开 `niceeval show --run <run-id> --json` 显示 `sandbox-build-failed`、membership
+`not-dispatched`，底层错误为：
+
+```text
+control-create-unimplemented: container create must be owned by the control service; client-supplied IDs are forbidden
+```
+
+同一时期的 `niceeval docker profile doctor <alias> --smoke` 也仍沿用客户端创建 network/container
+再调用 `reservation.commit` 的旧路径。
+
+## 根因
+
+Docker profile control service 已经拒绝 `reservation.commit` 并接管 `container.create`，但两个公开
+consumer 没有同步迁移：`sandbox/runtime.ts` 的 profile Dockerfile build 仍直接连接 daemon 创建 build
+network，doctor smoke 仍直接创建 network/container。build 的 context stream、builder/network 名称、最终 tag
+和终止证明也没有 durable control owner，客户端断线后宿主无法独立收敛资源。
+
+## 修法与长期不变量
+
+- profile Dockerfile 客户端只提交规范化 build metadata 与经过既有过滤规则的 tar stream；control service
+  派生 tag、独占 network、BuildKit builder 与 operation ID，并在 durable journal 里证明 build process、builder、
+  provisional ref 和 network 全部消失后才允许释放 reservation。
+- profile container create 只提交无 host path、无 Docker HostConfig、无 network/container ID 的规范化请求；
+  control service从 reservation 派生资源硬限额、project-quota data allocation、网络和 descriptor-pinned DNS。
+- build release 不再接受客户端 `terminationEvidence`，旧 `reservation.commit` 继续 fail closed；doctor smoke
+  使用同一 `container.create`，完整资源向量包含 1 GiB `ephemeralDiskBytes`。
+- build context 先受 4 MiB 单帧与 2 GiB 实际接收字节硬限额约束，再逐成员拒绝绝对路径、路径穿越、重复项、
+  link、device、sparse 与非 regular 类型；解包成员总量另有 2 GiB 上限。两层都 fail closed，不能只信 tar header。
+- `docker-container` driver 的容器没有 reservation label，不能用 label absence 证明 builder 已消失。watchdog 必须从
+  control-derived builder name 枚举 `buildx_buildkit_<builderName>0`，并精确查询其
+  `buildx_buildkit_<builderName>0_state` volume。两者都要显式删除并复查，container 的 PID/start time 与 cgroup v2
+  path 也必须消失；build CLI、builder metadata/container/volume、provisional image 和 network 全部消失后才能释放
+  reservation，任一查询失败都 fail closed。
+- committed container 的重复 create 由 host 校验相同 spec 与唯一可见资源；生产和 doctor 的 start 都先 inspect，遇到
+  Docker 304 只在 fresh inspect 证明 `Running` 时接受。committed build replay 不重复执行 build。
+- 客户端取消 build 时发送 `build.cancel` 后立即返回取消错误，不进入最多 30 秒的丢回复轮询；非取消的 reply loss
+  仍从 durable reservation 对账。同 generation watchdog 重启会先收敛 provisioning build，无法证明资源消失时关闭
+  admission 并 quarantine，不能把 active build 永久留在 provisioning。
+- 新客户端的 cold-build framing 需要同版本 host package 的 `build.create` / `build.lookup`；二者必须同步部署。
+  只实现 `container.create` 的 partial-migration watchdog 足以运行新版 doctor create 语义，但不能运行新版
+  profile Dockerfile cold build，客户端不得 fallback 或重开 commit。
+
+## 回归 kill 收据
+
+既有 owner 中没有能安装 candidate 并穿过真实 profile/control service 的 cold-build 场景，因此新增 lifecycle
+单边界 owner `e2e/lifecycle/test/docker-profile-cold-build.test.ts`。它安装候选 tarball，通过真实
+`niceeval exp` 和真实 checkout watchdog / Docker daemon / root-owned registry+socket 运行 cold build，再由
+公开 `niceeval show` 读取失败结果；核心 control service 不使用 mock。
+
+旧候选：source HEAD `be0b98ec44a0f3ef0e159d9fff8ebb60c2a8eb38`，tarball SHA-256
+`ba7b773e3f3307eaf5055fed251bd3005b59c7a3e3b47ab50f84759e5f3a5dbf`。命令：
+
+```sh
+pnpm e2e run --candidate /tmp/niceeval-fix-docker-red/niceeval-candidate.tgz --repo lifecycle --artifact-root /tmp/niceeval-fix-docker-red/artifacts-red-receipt -- --run test/docker-profile-cold-build.test.ts -t 'profile-bound Dockerfile cold build starts the Attempt through the public CLI'
+```
+
+收据在 `/tmp/niceeval-fix-docker-red/artifacts-red-receipt/lifecycle/receipt.json`；最早产品失败阶段是
+`sandbox.image.build`，Attempt 尚未派发。随后发现的 `dind-image-incompatible: missing node` 是 E2E fixture
+能力缺失，已由容器日志与最小只读根实验确认并修入 fixture，不属于产品红灯。

--- a/packages/niceeval/src/docker/cli/contribution.ts
+++ b/packages/niceeval/src/docker/cli/contribution.ts
@@ -7,8 +7,6 @@ import { runDockerProfileCommand } from "../../sandbox/docker-profile/cli.ts";
 export const DOCKER_OPTIONS = Object.freeze({
   /** Render Docker administration results as JSON. */
   json: Object.freeze({ type: "boolean", help: Object.freeze({ summary: "Render Docker administration results as JSON.", visibility: "public" }) }),
-  /** Run Docker profile smoke diagnostics. */
-  smoke: Object.freeze({ type: "boolean", help: Object.freeze({ summary: "Run Docker profile smoke diagnostics.", visibility: "public" }) }),
   /** Select one NiceEval-owned Docker cache domain. */
   domain: Object.freeze({ type: "string", help: Object.freeze({ summary: "Select one NiceEval-owned Docker cache domain.", visibility: "public" }) }),
   /** Apply a previously issued Docker cache GC plan. */
@@ -23,7 +21,7 @@ const DOCKER_HELP = `niceeval docker — Docker-specific administration
 
 Usage:
   niceeval docker profile list [--json]
-  niceeval docker profile doctor <alias> [--smoke] [--json]
+  niceeval docker profile doctor <alias> [--json]
   niceeval docker cache inventory [--domain <domain-id>] [--json]
   niceeval docker cache gc --domain <domain-id> [--apply <plan-id>] [--json]
 
@@ -44,7 +42,7 @@ const dockerFailure = (operation: string, cause: unknown, exitCode = 4) =>
 
 const DOCKER_COMMAND_OPTIONS = Object.freeze({
   "profile/list": Object.freeze(["json", "help"]),
-  "profile/doctor": Object.freeze(["json", "smoke", "help"]),
+  "profile/doctor": Object.freeze(["json", "help"]),
   "cache/inventory": Object.freeze(["json", "domain", "help"]),
   "cache/gc": Object.freeze(["json", "domain", "apply", "help"]),
   profile: Object.freeze(["help"]),
@@ -264,7 +262,6 @@ export const dockerCliCommand: CliCommandContribution<
       return yield* Effect.tryPromise({
         try: () => runDockerProfileCommand(positionals, {
           json,
-          smoke: parsed.values.smoke === true,
           out: io.writeStdoutSync,
           err: io.writeStderrSync,
         }),

--- a/packages/niceeval/src/sandbox/docker-profile/cli.ts
+++ b/packages/niceeval/src/sandbox/docker-profile/cli.ts
@@ -1,9 +1,8 @@
-import { randomUUID } from "node:crypto";
 import type Docker from "dockerode";
 import {
   acquireDockerProfileReservation,
   attestDockerProfile,
-  commitDockerProfileReservation,
+  createDockerProfileContainer,
   createDockerProfileLease,
   loadDockerProfileRegistry,
   releaseDockerProfileReservation,
@@ -28,6 +27,8 @@ export const DOCKER_PROFILE_DOCTOR_DIND_CMD = Object.freeze([
   "--host=unix:///var/run/docker.sock",
   "--shutdown-timeout=2",
 ] as const);
+
+const DOCKER_PROFILE_DOCTOR_DOCKER_DATA_BYTES = 1024 ** 3;
 
 /** `/proc/net/tcp{,6}` exposes listening sockets without requiring an extra image tool. */
 export const DOCKER_PROFILE_DOCTOR_UNIX_ONLY_CHECK = Object.freeze([
@@ -67,6 +68,22 @@ async function exec(container: Docker.Container, command: readonly string[]): Pr
   return { code: inspected.ExitCode ?? 1, output: Buffer.concat(chunks).toString().replace(/[\x00-\x08]/g, "") };
 }
 
+function dockerStatusCode(error: unknown): number | undefined {
+  return typeof error === "object" && error !== null && "statusCode" in error
+    ? (error as { readonly statusCode?: number }).statusCode
+    : undefined;
+}
+
+async function startDoctorContainerIdempotently(container: Docker.Container): Promise<void> {
+  if ((await container.inspect()).State?.Running === true) return;
+  try {
+    await container.start();
+  } catch (error) {
+    if (dockerStatusCode(error) === 304 && (await container.inspect()).State?.Running === true) return;
+    throw error;
+  }
+}
+
 async function smokeProfile(alias: string): Promise<Check[]> {
   const binding = await attestDockerProfile(alias);
   const lease = await createDockerProfileLease(binding);
@@ -75,55 +92,25 @@ async function smokeProfile(alias: string): Promise<Check[]> {
     memoryBytes: 512 * 1024 * 1024,
     pids: 256,
     containers: 1,
+    ephemeralDiskBytes: DOCKER_PROFILE_DOCTOR_DOCKER_DATA_BYTES,
   });
-  const labels = {
-    "niceeval.profile-id": binding.profile.profileId,
-    "niceeval.invocation-id": lease.invocationId,
-    "niceeval.reservation-id": reservation.reservationId,
-    "niceeval.provision-token": reservation.provisionToken,
-    "niceeval.attempt-id": "doctor-smoke",
-  };
   // doctor 的非 smoke 路径也不应要求安装 optional dockerode peer。
   const { default: DockerClient } = await import("dockerode");
   const docker = new DockerClient({ socketPath: binding.dockerSocketPath });
   let container: Docker.Container | undefined;
-  let network: Docker.Network | undefined;
   try {
     await pull(docker, "docker:29-dind");
-    network = await docker.createNetwork({
-      Name: `niceeval-doctor-${randomUUID()}`,
-      Driver: "bridge",
-      Options: { "com.docker.network.bridge.enable_icc": "false" },
-      Labels: labels,
-    });
-    container = await docker.createContainer({
-      Image: "docker:29-dind",
-      ...dockerProfileDoctorDindConfig(),
-      Labels: labels,
-      HostConfig: {
-        Privileged: true,
-        NetworkMode: network.id,
-        NanoCpus: 2_000_000_000,
-        Memory: 512 * 1024 * 1024,
-        MemorySwap: 512 * 1024 * 1024,
-        PidsLimit: 256,
-        ReadonlyRootfs: true,
-        ...(binding.profile.policy.level === "managed-rootless/v1"
-          ? { Dns: [...binding.profile.policy.network.dns.servers] }
-          : {}),
-        Tmpfs: {
-          "/var/lib/docker": "rw,exec,nosuid,nodev,size=256m",
-          "/run": "rw,exec,nosuid,nodev,size=64m",
-          "/tmp": "rw,nosuid,nodev,size=64m,mode=1777",
-        },
+    const created = await createDockerProfileContainer(lease, reservation.reservationId, {
+      image: "docker:29-dind",
+      attemptId: "doctor-smoke",
+      command: DOCKER_PROFILE_DOCTOR_DIND_CMD,
+      tmpfs: {
+        "/run": "rw,exec,nosuid,nodev,size=64m",
+        "/tmp": "rw,nosuid,nodev,size=64m,mode=1777",
       },
     });
-    await commitDockerProfileReservation(lease, reservation.reservationId, {
-      containerId: container.id,
-      networkId: network.id,
-      attemptId: "doctor-smoke",
-    });
-    await container.start();
+    container = docker.getContainer(created.containerId);
+    await startDoctorContainerIdempotently(container);
     let ready = false;
     for (let attempt = 0; attempt < 120; attempt += 1) {
       const result = await exec(container, ["docker", "info"]);
@@ -145,10 +132,7 @@ async function smokeProfile(alias: string): Promise<Check[]> {
       { name: "nested Docker", status: "PASS", detail: "docker:29-dind ran alpine:3.20" },
     ];
   } finally {
-    await releaseDockerProfileReservation(lease, reservation.reservationId).catch(async () => {
-      await container?.remove({ force: true }).catch(() => undefined);
-      await network?.remove().catch(() => undefined);
-    });
+    await releaseDockerProfileReservation(lease, reservation.reservationId).catch(() => undefined);
     await lease.stopHeartbeat().catch(() => undefined);
   }
 }

--- a/packages/niceeval/src/sandbox/docker-profile/cli.ts
+++ b/packages/niceeval/src/sandbox/docker-profile/cli.ts
@@ -1,72 +1,66 @@
 import type Docker from "dockerode";
+import { createHash, randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
 import {
   acquireDockerProfileReservation,
   attestDockerProfile,
+  DockerProfileCapacityBlockedError,
   createDockerProfileContainer,
+  createDockerProfileBuild,
   createDockerProfileLease,
+  dockerProfileControlRequest,
   loadDockerProfileRegistry,
   releaseDockerProfileReservation,
 } from "./runtime.ts";
 
 export interface DockerProfileCliOptions {
   readonly json: boolean;
-  readonly smoke: boolean;
   readonly out: (text: string) => void;
   readonly err: (text: string) => void;
 }
 
+function doctorBuildContext(): Readable {
+  const content = Buffer.from(`FROM scratch\nLABEL niceeval.doctor.nonce=${randomUUID()}\n`);
+  const header = Buffer.alloc(512);
+  header.write("Dockerfile", 0, "utf8");
+  header.write("0000644\0", 100, "ascii");
+  header.write("0000000\0", 108, "ascii");
+  header.write("0000000\0", 116, "ascii");
+  header.write(content.length.toString(8).padStart(11, "0") + "\0", 124, "ascii");
+  header.write(Math.floor(Date.now() / 1000).toString(8).padStart(11, "0") + "\0", 136, "ascii");
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  header.write("ustar\0", 257, "ascii");
+  header.write("00", 263, "ascii");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148, "ascii");
+  return Readable.from([header, content, Buffer.alloc((512 - content.length % 512) % 512), Buffer.alloc(1024)]);
+}
+
+type DoctorStatus = "PASS" | "BLOCKED" | "FAIL";
+
 interface Check {
-  readonly name: string;
-  readonly status: "PASS" | "FAIL";
+  readonly id: DoctorCheckId;
+  readonly status: DoctorStatus;
+  readonly code?: string;
   readonly detail: string;
 }
 
-/** Keep Docker's official entrypoint, but bypass its automatic TCP/TLS selection. */
-export const DOCKER_PROFILE_DOCTOR_DIND_CMD = Object.freeze([
-  "dockerd",
-  "--host=unix:///var/run/docker.sock",
-  "--shutdown-timeout=2",
-] as const);
+interface ControlStatus {
+  readonly journal?: { readonly state?: string; readonly durableTransitions?: boolean };
+  readonly assets?: { readonly state?: string; readonly images?: readonly { readonly reference?: string; readonly present?: boolean }[] };
+}
+
+const DOCTOR_CHECK_IDS = [
+  "descriptor", "control", "daemon", "cgroup", "storage", "journal", "assets",
+  "cold-build", "cold-build-cleanup", "container-limits", "nested-docker", "container-cleanup",
+] as const;
+type DoctorCheckId = typeof DOCTOR_CHECK_IDS[number];
 
 const DOCKER_PROFILE_DOCTOR_DOCKER_DATA_BYTES = 1024 ** 3;
-
-/** `/proc/net/tcp{,6}` exposes listening sockets without requiring an extra image tool. */
-export const DOCKER_PROFILE_DOCTOR_UNIX_ONLY_CHECK = Object.freeze([
-  "sh",
-  "-ec",
-  [
-    "for table in /proc/net/tcp /proc/net/tcp6; do",
-    "  [ -r \"$table\" ] || continue",
-    "  awk '$4 == \"0A\" && ($2 ~ /:0947$/ || $2 ~ /:0948$/) { found = 1 } END { exit found ? 1 : 0 }' \"$table\"",
-    "done",
-  ].join("\n"),
-] as const satisfies readonly [string, ...string[]]);
-
-export function dockerProfileDoctorDindConfig(): { Cmd: string[] } {
-  return Object.freeze({ Cmd: [...DOCKER_PROFILE_DOCTOR_DIND_CMD] });
-}
-
-async function pull(docker: Docker, image: string): Promise<void> {
-  try {
-    await docker.getImage(image).inspect();
-    return;
-  } catch {}
-  const stream = await docker.pull(image);
-  await new Promise<void>((resolve, reject) => docker.modem.followProgress(stream, (error) => error ? reject(error) : resolve()));
-}
-
-async function exec(container: Docker.Container, command: readonly string[]): Promise<{ code: number; output: string }> {
-  const process = await container.exec({ Cmd: [...command], AttachStdout: true, AttachStderr: true });
-  const stream = await process.start({});
-  const chunks: Buffer[] = [];
-  await new Promise<void>((resolve, reject) => {
-    stream.on("data", (chunk: Buffer) => chunks.push(chunk));
-    stream.on("end", resolve);
-    stream.on("error", reject);
-  });
-  const inspected = await process.inspect();
-  return { code: inspected.ExitCode ?? 1, output: Buffer.concat(chunks).toString().replace(/[\x00-\x08]/g, "") };
-}
+/** Installed by the profile deployment; doctor must never fetch it. */
+const DOCKER_PROFILE_DOCTOR_DIND_IMAGE =
+  "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c";
 
 function dockerStatusCode(error: unknown): number | undefined {
   return typeof error === "object" && error !== null && "statusCode" in error
@@ -84,57 +78,120 @@ async function startDoctorContainerIdempotently(container: Docker.Container): Pr
   }
 }
 
-async function smokeProfile(alias: string): Promise<Check[]> {
+function decodeDockerMultiplexedLogs(raw: Buffer): string {
+  const lines: Buffer[] = [];
+  let offset = 0;
+  while (offset < raw.length) {
+    if (raw.length - offset < 8) throw new Error("diagnostic logs have a truncated Docker multiplex header");
+    const size = raw.readUInt32BE(offset + 4);
+    offset += 8;
+    if (size > 64 * 1024 || offset + size > raw.length) throw new Error("diagnostic logs exceed the bounded multiplex framing");
+    lines.push(raw.subarray(offset, offset + size));
+    offset += size;
+  }
+  return Buffer.concat(lines).toString("utf8");
+}
+
+function failedPrerequisites(after: readonly DoctorCheckId[], code: "PREREQUISITE_FAILED" | "UNSAFE_TO_CONTINUE"): Check[] {
+  return after.map((id) => ({ id, status: "FAIL", code, detail: "the preceding diagnostic stage did not establish a safe precondition" }));
+}
+
+async function runDynamicChecks(alias: string): Promise<Check[]> {
   const binding = await attestDockerProfile(alias);
   const lease = await createDockerProfileLease(binding);
-  const reservation = await acquireDockerProfileReservation(lease, "container", {
-    cpus: 2,
-    memoryBytes: 512 * 1024 * 1024,
-    pids: 256,
-    containers: 1,
-    ephemeralDiskBytes: DOCKER_PROFILE_DOCTOR_DOCKER_DATA_BYTES,
-  });
-  // doctor 的非 smoke 路径也不应要求安装 optional dockerode peer。
-  const { default: DockerClient } = await import("dockerode");
-  const docker = new DockerClient({ socketPath: binding.dockerSocketPath });
-  let container: Docker.Container | undefined;
+  let buildReservation: Awaited<ReturnType<typeof acquireDockerProfileReservation>> | undefined;
+  let containerReservation: Awaited<ReturnType<typeof acquireDockerProfileReservation>> | undefined;
+  let buildReleased = false;
+  let containerReleased = false;
+  let primary: unknown;
+  let limits = "";
   try {
-    await pull(docker, "docker:29-dind");
-    const created = await createDockerProfileContainer(lease, reservation.reservationId, {
-      image: "docker:29-dind",
-      attemptId: "doctor-smoke",
-      command: DOCKER_PROFILE_DOCTOR_DIND_CMD,
-      tmpfs: {
-        "/run": "rw,exec,nosuid,nodev,size=64m",
-        "/tmp": "rw,nosuid,nodev,size=64m,mode=1777",
-      },
+    buildReservation = await acquireDockerProfileReservation(lease, "build", {
+      cpus: 0, memoryBytes: 0, pids: 0, containers: 0, ephemeralDiskBytes: 0,
     });
-    container = docker.getContainer(created.containerId);
+    const build = await createDockerProfileBuild(lease, buildReservation.reservationId, {
+      buildKey: createHash("sha256").update("niceeval-doctor-cold-build-v1").digest("hex"),
+      platform: "linux/amd64", dockerfile: "Dockerfile", retention: "ephemeral",
+    }, doctorBuildContext());
+    const buildRelease = await releaseDockerProfileReservation(lease, buildReservation.reservationId);
+    if (buildRelease.cleanupProven !== true) throw new Error("control could not prove ephemeral cold-build cleanup after release");
+    buildReleased = true;
+    containerReservation = await acquireDockerProfileReservation(lease, "container", {
+      cpus: 2,
+      memoryBytes: 512 * 1024 * 1024,
+      pids: 256,
+      containers: 1,
+      ephemeralDiskBytes: DOCKER_PROFILE_DOCTOR_DOCKER_DATA_BYTES,
+    });
+    // doctor 的完整路径也不应要求安装 optional dockerode peer until dynamic checks begin.
+    const { default: DockerClient } = await import("dockerode");
+    const docker = new DockerClient({ socketPath: binding.dockerSocketPath });
+    const created = await createDockerProfileContainer(lease, containerReservation.reservationId, {
+      intent: "diagnostic",
+    });
+    const container = docker.getContainer(created.containerId);
     await startDoctorContainerIdempotently(container);
-    let ready = false;
-    for (let attempt = 0; attempt < 120; attempt += 1) {
-      const result = await exec(container, ["docker", "info"]);
-      if (result.code === 0) { ready = true; break; }
-      await new Promise((resolve) => setTimeout(resolve, 250));
+    let waitTimer: ReturnType<typeof setTimeout> | undefined;
+    let waited: Awaited<ReturnType<typeof container.wait>>;
+    try {
+      waited = await Promise.race([
+        container.wait(),
+        new Promise<never>((_, reject) => { waitTimer = setTimeout(() => reject(new Error("control-owned diagnostic exceeded 60 seconds")), 60_000); }),
+      ]);
+    } finally {
+      if (waitTimer !== undefined) clearTimeout(waitTimer);
     }
-    if (!ready) throw new Error("inner dockerd did not become ready within 30 seconds");
-    const unixOnly = await exec(container, [...DOCKER_PROFILE_DOCTOR_UNIX_ONLY_CHECK]);
-    if (unixOnly.code !== 0) {
-      throw new Error(`inner dockerd unexpectedly listens on TCP 2375 or 2376: ${unixOnly.output}`);
+    const logs = decodeDockerMultiplexedLogs(Buffer.from(await container.logs({ stdout: true, stderr: true })));
+    if (Buffer.byteLength(logs) > 64 * 1024) throw new Error("control-owned diagnostic logs exceed 64 KiB");
+    const results = logs.split(/\r?\n/).flatMap((line) => {
+      try {
+        return [JSON.parse(line) as {
+          ok?: boolean;
+          unixOnly?: boolean;
+          nestedDocker?: boolean;
+          limits?: { cpuMax?: string; memoryMax?: string; swapMax?: string; pidsMax?: string };
+        }];
+      } catch { return []; }
+    });
+    if (results.length !== 1) throw new Error("control-owned diagnostic must emit exactly one JSON result");
+    const result = results[0];
+    const expectedLimits = {
+      cpuMax: "200000 100000",
+      memoryMax: String(512 * 1024 * 1024),
+      swapMax: "0",
+      pidsMax: "256",
+    };
+    if (
+      waited.StatusCode !== 0 || result?.ok !== true || result.unixOnly !== true || result.nestedDocker !== true
+      || JSON.stringify(result.limits) !== JSON.stringify(expectedLimits)
+    ) {
+      throw new Error(`control-owned diagnostic failed: ${logs.slice(-4096)}`);
     }
-    const limits = await exec(container, ["sh", "-c", "cat /sys/fs/cgroup/cpu.max /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.swap.max /sys/fs/cgroup/pids.max"]);
-    if (limits.code !== 0) throw new Error(`cgroup probe failed: ${limits.output}`);
-    const nested = await exec(container, ["docker", "run", "--rm", "alpine:3.20", "true"]);
-    if (nested.code !== 0) throw new Error(`nested Docker failed: ${nested.output}`);
-    return [
-      { name: "Unix-only Docker endpoint", status: "PASS", detail: "no TCP listener on 2375 or 2376" },
-      { name: "outer hard limits", status: "PASS", detail: limits.output.trim().replace(/\n/g, " · ") },
-      { name: "nested Docker", status: "PASS", detail: "docker:29-dind ran alpine:3.20" },
-    ];
+    await releaseDockerProfileReservation(lease, containerReservation.reservationId, containerReservation);
+    containerReleased = true;
+    limits = `cpu.max=${expectedLimits.cpuMax} memory.max=${expectedLimits.memoryMax} memory.swap.max=${expectedLimits.swapMax} pids.max=${expectedLimits.pidsMax}`;
+  } catch (error) {
+    primary = error;
   } finally {
-    await releaseDockerProfileReservation(lease, reservation.reservationId).catch(() => undefined);
-    await lease.stopHeartbeat().catch(() => undefined);
+    const cleanupErrors: unknown[] = [];
+    if (containerReservation !== undefined && !containerReleased) {
+      await releaseDockerProfileReservation(lease, containerReservation.reservationId, containerReservation).catch((error) => cleanupErrors.push(error));
+    }
+    if (buildReservation !== undefined && !buildReleased) {
+      await releaseDockerProfileReservation(lease, buildReservation.reservationId).catch((error) => cleanupErrors.push(error));
+    }
+    await lease.stopHeartbeat().catch((error) => cleanupErrors.push(error));
+    if (primary !== undefined && cleanupErrors.length > 0) throw new AggregateError([primary, ...cleanupErrors], "doctor primary operation and cleanup both failed");
+    if (primary !== undefined) throw primary;
+    if (cleanupErrors.length > 0) throw new AggregateError(cleanupErrors, "doctor cleanup failed");
   }
+  return [
+      { id: "cold-build", status: "PASS", detail: "control-owned offline FROM scratch build completed" },
+      { id: "cold-build-cleanup", status: "PASS", detail: "ephemeral build locator and builder resources are absent" },
+      { id: "container-limits", status: "PASS", detail: limits },
+      { id: "nested-docker", status: "PASS", detail: "offline nested Docker completed with --pull=never" },
+      { id: "container-cleanup", status: "PASS", detail: "control-owned diagnostic reservation released" },
+    ];
 }
 
 export async function runDockerProfileCommand(
@@ -143,11 +200,11 @@ export async function runDockerProfileCommand(
 ): Promise<number> {
   if (positionals[0] !== "profile") {
     options.err("Usage: niceeval docker profile list [--json]\n" +
-      "       niceeval docker profile doctor <alias> [--smoke] [--json]\n");
+      "       niceeval docker profile doctor <alias> [--json]\n");
     return 1;
   }
   const subcommand = positionals[1];
-  if (subcommand === "list" && positionals.length === 2 && !options.smoke) {
+  if (subcommand === "list" && positionals.length === 2) {
     try {
       const registry = await loadDockerProfileRegistry();
       const rows = registry.entries.map((entry) => ({
@@ -173,23 +230,54 @@ export async function runDockerProfileCommand(
     const checks: Check[] = [];
     try {
       const binding = await attestDockerProfile(alias);
+      const control = await dockerProfileControlRequest<ControlStatus>(binding.controlSocketPath, { kind: "status" });
+      if (control.journal?.state !== "healthy" || control.journal.durableTransitions !== true) {
+        throw new Error("watchdog did not attest a healthy durable journal");
+      }
+      const assets = control.assets?.images ?? [];
+      const doctorAsset = assets.find((asset) => asset.reference === DOCKER_PROFILE_DOCTOR_DIND_IMAGE);
+      if (control.assets?.state !== "verified" || doctorAsset?.present !== true) {
+        throw new Error("watchdog did not attest the required preloaded diagnostic asset");
+      }
       checks.push(
-        { name: "descriptor and registry", status: "PASS", detail: binding.descriptorDigest },
-        { name: "Docker/control attestation", status: "PASS", detail: `generation ${binding.daemonGeneration}` },
-        { name: "cgroup backend", status: "PASS", detail: `${binding.platform} · ${binding.profile.backend.cgroup.aggregatePath}` },
-        binding.profile.policy.level === "managed-rootless/v1"
-          ? { name: "network policy", status: "PASS", detail: `v${binding.profile.policy.network.version} · IPv6 disabled · pinned DNS` }
-          : { name: "raw storage policy", status: "PASS", detail: "project-quota Docker data allocation; no rootless/network claim" },
+        { id: "descriptor", status: "PASS", detail: binding.descriptorDigest },
+        { id: "control", status: "PASS", detail: `generation ${binding.daemonGeneration}` },
+        { id: "daemon", status: "PASS", detail: binding.platform },
+        { id: "cgroup", status: "PASS", detail: binding.profile.backend.cgroup.aggregatePath },
+        { id: "storage", status: "PASS", detail: binding.profile.backend.filesystem.identity },
+        { id: "journal", status: "PASS", detail: "watchdog attested a complete fsync-backed journal" },
+        { id: "assets", status: "PASS", detail: doctorAsset.reference! },
       );
-      if (options.smoke) checks.push(...await smokeProfile(alias));
+      checks.push(...await runDynamicChecks(alias));
     } catch (error) {
-      checks.push({ name: "profile", status: "FAIL", detail: error instanceof Error ? error.message : String(error) });
+      const errorDetail = error instanceof AggregateError
+        ? error.errors.map((item, index) => {
+          const role = error.message.includes("primary operation") && index === 0 ? "primary" : "cleanup";
+          return `${role}: ${item instanceof Error ? item.message : String(item)}`;
+        }).join(" | ")
+        : error instanceof Error ? error.message : String(error);
+      const completed = new Set(checks.map((check) => check.id));
+      const next = DOCTOR_CHECK_IDS.find((id) => !completed.has(id)) ?? "container-cleanup";
+      if (error instanceof DockerProfileCapacityBlockedError) {
+        checks.push({ id: next, status: "BLOCKED", code: error.code, detail: error.message });
+        checks.push(...DOCTOR_CHECK_IDS
+          .filter((id) => !new Set(checks.map((check) => check.id)).has(id))
+          .map((id) => ({ id, status: "BLOCKED" as const, code: error.code, detail: "capacity queue is blocked; dynamic stage was not started" })));
+      } else {
+        checks.push({ id: next, status: "FAIL", code: "UNSAFE_TO_CONTINUE", detail: errorDetail });
+        checks.push(...failedPrerequisites(DOCTOR_CHECK_IDS.filter((id) => !new Set(checks.map((check) => check.id)).has(id)), "PREREQUISITE_FAILED"));
+      }
     }
-    if (options.json) options.out(`${JSON.stringify({ format: "niceeval.docker-profile-doctor", schemaVersion: 1, alias, checks })}\n`);
-    else for (const check of checks) options.out(`${check.status}  ${check.name}  ${check.detail}\n`);
-    return checks.some((check) => check.status === "FAIL") ? 1 : 0;
+    const ordered = DOCTOR_CHECK_IDS.map((id) => checks.find((check) => check.id === id) ?? {
+      id, status: "FAIL" as const, code: "PREREQUISITE_FAILED", detail: "diagnostic produced no result",
+    });
+    const status: DoctorStatus = ordered.some((check) => check.status === "FAIL") ? "FAIL"
+      : ordered.some((check) => check.status === "BLOCKED") ? "BLOCKED" : "PASS";
+    if (options.json) options.out(`${JSON.stringify({ format: "niceeval.docker-profile-doctor", schemaVersion: 1, alias, status, checks: ordered })}\n`);
+    else for (const check of ordered) options.out(`${check.status}  ${check.id}${check.code === undefined ? "" : ` · ${check.code}`}  ${check.detail}\n`);
+    return status === "PASS" ? 0 : 1;
   }
   options.err("Usage: niceeval docker profile list [--json]\n" +
-    "       niceeval docker profile doctor <alias> [--smoke] [--json]\n");
+    "       niceeval docker profile doctor <alias> [--json]\n");
   return 1;
 }

--- a/packages/niceeval/src/sandbox/docker-profile/cli.ts
+++ b/packages/niceeval/src/sandbox/docker-profile/cli.ts
@@ -230,24 +230,24 @@ export async function runDockerProfileCommand(
     const checks: Check[] = [];
     try {
       const binding = await attestDockerProfile(alias);
-      const control = await dockerProfileControlRequest<ControlStatus>(binding.controlSocketPath, { kind: "status" });
-      if (control.journal?.state !== "healthy" || control.journal.durableTransitions !== true) {
-        throw new Error("watchdog did not attest a healthy durable journal");
-      }
-      const assets = control.assets?.images ?? [];
-      const doctorAsset = assets.find((asset) => asset.reference === DOCKER_PROFILE_DOCTOR_DIND_IMAGE);
-      if (control.assets?.state !== "verified" || doctorAsset?.present !== true) {
-        throw new Error("watchdog did not attest the required preloaded diagnostic asset");
-      }
       checks.push(
         { id: "descriptor", status: "PASS", detail: binding.descriptorDigest },
         { id: "control", status: "PASS", detail: `generation ${binding.daemonGeneration}` },
         { id: "daemon", status: "PASS", detail: binding.platform },
         { id: "cgroup", status: "PASS", detail: binding.profile.backend.cgroup.aggregatePath },
         { id: "storage", status: "PASS", detail: binding.profile.backend.filesystem.identity },
-        { id: "journal", status: "PASS", detail: "watchdog attested a complete fsync-backed journal" },
-        { id: "assets", status: "PASS", detail: doctorAsset.reference! },
       );
+      const control = await dockerProfileControlRequest<ControlStatus>(binding.controlSocketPath, { kind: "status" });
+      if (control.journal?.state !== "healthy" || control.journal.durableTransitions !== true) {
+        throw new Error("watchdog did not attest a healthy durable journal");
+      }
+      checks.push({ id: "journal", status: "PASS", detail: "watchdog attested a complete fsync-backed journal" });
+      const assets = control.assets?.images ?? [];
+      const doctorAsset = assets.find((asset) => asset.reference === DOCKER_PROFILE_DOCTOR_DIND_IMAGE);
+      if (control.assets?.state !== "verified" || doctorAsset?.present !== true) {
+        throw new Error("watchdog did not attest the required preloaded diagnostic asset");
+      }
+      checks.push({ id: "assets", status: "PASS", detail: doctorAsset.reference! });
       checks.push(...await runDynamicChecks(alias));
     } catch (error) {
       const errorDetail = error instanceof AggregateError

--- a/packages/niceeval/src/sandbox/docker-profile/runtime.ts
+++ b/packages/niceeval/src/sandbox/docker-profile/runtime.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { once } from "node:events";
 import { lstat, readFile, readdir, stat } from "node:fs/promises";
 import { connect } from "node:net";
 import { dirname, join, parse } from "node:path";
+import type { Readable } from "node:stream";
 import { indexDockerProfiles, resolveDockerProfile, type ResolvedDockerProfileEntry } from "./registry.ts";
 import type { DockerExecutionProfileV1 } from "./schema.ts";
 
@@ -28,9 +30,12 @@ export interface DockerProfileLease {
 export interface DockerProfileReservation {
   readonly reservationId: string;
   readonly provisionToken: string;
-  readonly state: "queued" | "granted" | "committed" | "releasing";
+  readonly state: "queued" | "granted" | "provisioning" | "committed" | "releasing" | "quarantined";
   readonly containerId?: string;
   readonly networkId?: string;
+  readonly locator?: string;
+  readonly buildTerminated?: boolean;
+  readonly buildError?: string;
 }
 
 export interface DockerProfileContainerCreateInput {
@@ -48,6 +53,31 @@ export interface DockerProfileContainerCreateResult {
   readonly containerId: string;
   readonly networkId: string;
   readonly state: "active";
+}
+
+export interface DockerProfileBuildCreateInput {
+  readonly buildKey: string;
+  readonly platform: string;
+  readonly dockerfile: string;
+  readonly buildArgs?: Readonly<Record<string, string>>;
+  readonly target?: string;
+}
+
+export interface DockerProfileBuildCreateResult {
+  readonly locator: string;
+  readonly state: "terminated";
+}
+
+export async function lookupDockerProfileBuild(
+  binding: DockerProfileRuntimeBinding,
+  buildKey: string,
+): Promise<{ readonly hit: boolean; readonly locator: string }> {
+  return await controlRequest(binding.controlSocketPath, {
+    kind: "build.lookup",
+    profileId: binding.profile.profileId,
+    daemonGeneration: binding.daemonGeneration,
+    buildKey,
+  });
 }
 
 function modeOf(value: number): number {
@@ -95,23 +125,43 @@ export async function loadDockerProfileRegistry(): Promise<ReturnType<typeof ind
   return loadDockerProfileRegistryAt(DOCKER_PROFILE_REGISTRY_DIR);
 }
 
-function controlRequest<T>(path: string, request: Readonly<Record<string, unknown>>): Promise<T> {
+function controlRequest<T>(
+  path: string,
+  request: Readonly<Record<string, unknown>>,
+  signal?: AbortSignal,
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const socket = connect(path);
     let response = "";
+    let settled = false;
+    const settle = (outcome: { value: T } | { error: unknown }) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener("abort", abort);
+      if ("value" in outcome) resolve(outcome.value);
+      else reject(outcome.error);
+    };
+    const abort = () => socket.destroy(
+      signal?.reason instanceof Error
+        ? signal.reason
+        : new DOMException("Docker profile control request aborted", "AbortError"),
+    );
+    if (signal?.aborted) abort();
+    else signal?.addEventListener("abort", abort, { once: true });
     socket.setTimeout(10_000);
     socket.on("connect", () => socket.end(`${JSON.stringify(request)}\n`));
     socket.on("data", (chunk: Buffer) => { response += chunk.toString(); });
     socket.on("timeout", () => socket.destroy(new Error(`Docker profile control timeout: ${path}`)));
-    socket.on("error", reject);
+    socket.on("error", (error) => settle({ error }));
     socket.on("close", () => {
+      if (settled) return;
       try {
         const parsed = JSON.parse(response) as { ok?: boolean; result?: T; error?: { code?: string; message?: string } };
         if (parsed.ok !== true || parsed.result === undefined) {
-          reject(new Error(`${parsed.error?.code ?? "control-error"}: ${parsed.error?.message ?? "invalid control reply"}`));
-        } else resolve(parsed.result);
+          settle({ error: new Error(`${parsed.error?.code ?? "control-error"}: ${parsed.error?.message ?? "invalid control reply"}`) });
+        } else settle({ value: parsed.result });
       } catch (error) {
-        reject(error);
+        settle({ error });
       }
     });
   });
@@ -264,14 +314,68 @@ export async function acquireDockerProfileReservation(
   return reservation;
 }
 
-export async function commitDockerProfileReservation(
-  lease: DockerProfileLease,
-  reservationId: string,
-  input: { readonly containerId?: string; readonly networkId?: string; readonly attemptId?: string },
-): Promise<void> {
-  await controlRequest(lease.binding.controlSocketPath, {
-    kind: "reservation.commit", invocationId: lease.invocationId, leaseToken: lease.leaseToken,
-    reservationId, ...input,
+async function writeControlFrame(socket: import("node:net").Socket, bytes: Buffer): Promise<void> {
+  if (socket.write(bytes)) return;
+  await once(socket, "drain");
+}
+
+function controlBuildRequest<T>(
+  path: string,
+  request: Readonly<Record<string, unknown>>,
+  context: Readable,
+  signal?: AbortSignal,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const socket = connect(path);
+    let response = "";
+    let settled = false;
+    const settle = (outcome: { value: T } | { error: unknown }) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener("abort", abort);
+      if ("value" in outcome) resolve(outcome.value);
+      else {
+        context.destroy(outcome.error instanceof Error ? outcome.error : new Error(String(outcome.error)));
+        reject(outcome.error);
+      }
+    };
+    const abort = () => socket.destroy(
+      signal?.reason instanceof Error
+        ? signal.reason
+        : new DOMException("Docker profile build aborted", "AbortError"),
+    );
+    if (signal?.aborted) abort();
+    else signal?.addEventListener("abort", abort, { once: true });
+    socket.setTimeout(15 * 60_000);
+    socket.on("connect", () => {
+      void (async () => {
+        await writeControlFrame(socket, Buffer.from(`${JSON.stringify(request)}\n`));
+        for await (const value of context) {
+          const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+          if (chunk.length === 0) continue;
+          const length = Buffer.allocUnsafe(4);
+          length.writeUInt32BE(chunk.length);
+          await writeControlFrame(socket, length);
+          await writeControlFrame(socket, chunk);
+        }
+        const end = Buffer.alloc(4);
+        socket.end(end);
+      })().catch((error: unknown) => socket.destroy(error instanceof Error ? error : new Error(String(error))));
+    });
+    socket.on("data", (chunk: Buffer) => { response += chunk.toString(); });
+    socket.on("timeout", () => socket.destroy(new Error(`Docker profile build control timeout: ${path}`)));
+    socket.on("error", (error) => settle({ error }));
+    socket.on("close", () => {
+      if (settled) return;
+      try {
+        const parsed = JSON.parse(response) as { ok?: boolean; result?: T; error?: { code?: string; message?: string } };
+        if (parsed.ok !== true || parsed.result === undefined) {
+          settle({ error: new Error(`${parsed.error?.code ?? "control-error"}: ${parsed.error?.message ?? "invalid control reply"}`) });
+        } else settle({ value: parsed.result });
+      } catch (error) {
+        settle({ error });
+      }
+    });
   });
 }
 
@@ -308,13 +412,71 @@ export async function createDockerProfileContainer(
   }
 }
 
+export async function createDockerProfileBuild(
+  lease: DockerProfileLease,
+  reservationId: string,
+  build: DockerProfileBuildCreateInput,
+  context: Readable,
+  signal?: AbortSignal,
+): Promise<DockerProfileBuildCreateResult> {
+  const cancelBuild = async () => {
+    await controlRequest(lease.binding.controlSocketPath, {
+      kind: "build.cancel",
+      invocationId: lease.invocationId,
+      leaseToken: lease.leaseToken,
+      reservationId,
+    }).catch(() => undefined);
+  };
+  try {
+    return await controlBuildRequest<DockerProfileBuildCreateResult>(lease.binding.controlSocketPath, {
+      kind: "build.create",
+      invocationId: lease.invocationId,
+      leaseToken: lease.leaseToken,
+      reservationId,
+      build,
+      contextEncoding: "tar-chunked/v1",
+    }, context, signal);
+  } catch (error) {
+    // The operation survives a client-side reply loss. Its durable reservation is
+    // the recovery handle; never retry a build under a second provision token.
+    if (signal?.aborted) {
+      await cancelBuild();
+      throw error;
+    }
+    for (let attempt = 0; attempt < 300; attempt += 1) {
+      if (signal?.aborted) {
+        await cancelBuild();
+        throw error;
+      }
+      const reservation = await controlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
+        kind: "reservation.get",
+        invocationId: lease.invocationId,
+        leaseToken: lease.leaseToken,
+        reservationId,
+      }, signal).catch(() => undefined);
+      if (signal?.aborted) {
+        await cancelBuild();
+        throw error;
+      }
+      if (reservation?.state === "committed" && reservation.buildTerminated === true) {
+        if (reservation.buildError === undefined && !signal?.aborted && reservation.locator !== undefined) {
+          return { locator: reservation.locator, state: "terminated" };
+        }
+        break;
+      }
+      if (reservation?.state === "quarantined") break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw error;
+  }
+}
+
 export async function releaseDockerProfileReservation(
   lease: DockerProfileLease,
   reservationId: string,
-  terminationEvidence?: Readonly<Record<string, boolean>>,
 ): Promise<void> {
   await controlRequest(lease.binding.controlSocketPath, {
     kind: "reservation.release", invocationId: lease.invocationId, leaseToken: lease.leaseToken,
-    reservationId, ...(terminationEvidence === undefined ? {} : { terminationEvidence }),
+    reservationId,
   });
 }

--- a/packages/niceeval/src/sandbox/docker-profile/runtime.ts
+++ b/packages/niceeval/src/sandbox/docker-profile/runtime.ts
@@ -30,12 +30,18 @@ export interface DockerProfileLease {
 export interface DockerProfileReservation {
   readonly reservationId: string;
   readonly provisionToken: string;
-  readonly state: "queued" | "granted" | "provisioning" | "committed" | "releasing" | "quarantined";
+  readonly state: "queued" | "blocked" | "granted" | "provisioning" | "committed" | "releasing" | "quarantined";
   readonly containerId?: string;
   readonly networkId?: string;
   readonly locator?: string;
   readonly buildTerminated?: boolean;
   readonly buildError?: string;
+  readonly slotId?: string;
+}
+
+export class DockerProfileCapacityBlockedError extends Error {
+  readonly code = "CAPACITY_QUEUE_TIMEOUT";
+  constructor() { super("Docker profile capacity queue timed out after 30 seconds"); }
 }
 
 export interface DockerProfileContainerCreateInput {
@@ -49,6 +55,10 @@ export interface DockerProfileContainerCreateInput {
   readonly tmpfs?: Readonly<Record<string, string>>;
 }
 
+export type DockerProfileContainerIntent =
+  | { readonly intent: "workload"; readonly create: DockerProfileContainerCreateInput }
+  | { readonly intent: "diagnostic" };
+
 export interface DockerProfileContainerCreateResult {
   readonly containerId: string;
   readonly networkId: string;
@@ -61,18 +71,20 @@ export interface DockerProfileBuildCreateInput {
   readonly dockerfile: string;
   readonly buildArgs?: Readonly<Record<string, string>>;
   readonly target?: string;
+  readonly retention?: "cache" | "ephemeral";
 }
 
 export interface DockerProfileBuildCreateResult {
   readonly locator: string;
   readonly state: "terminated";
+  readonly cleanupProven?: boolean;
 }
 
 export async function lookupDockerProfileBuild(
   binding: DockerProfileRuntimeBinding,
   buildKey: string,
 ): Promise<{ readonly hit: boolean; readonly locator: string }> {
-  return await controlRequest(binding.controlSocketPath, {
+  return await dockerProfileControlRequest(binding.controlSocketPath, {
     kind: "build.lookup",
     profileId: binding.profile.profileId,
     daemonGeneration: binding.daemonGeneration,
@@ -125,7 +137,7 @@ export async function loadDockerProfileRegistry(): Promise<ReturnType<typeof ind
   return loadDockerProfileRegistryAt(DOCKER_PROFILE_REGISTRY_DIR);
 }
 
-function controlRequest<T>(
+export function dockerProfileControlRequest<T>(
   path: string,
   request: Readonly<Record<string, unknown>>,
   signal?: AbortSignal,
@@ -185,7 +197,7 @@ async function attestEntry(entry: ResolvedDockerProfileEntry): Promise<DockerPro
     socketFact(profile.transport.controlSocket.path, profile.transport.controlSocket.peerUid),
   ]);
   const nonce = randomUUID();
-  const challenge = await controlRequest<{
+  const challenge = await dockerProfileControlRequest<{
     readonly protocol: string;
     readonly profileId: string;
     readonly descriptorDigest: string;
@@ -236,7 +248,7 @@ export async function attestDockerProfile(alias: string): Promise<DockerProfileR
 
 export async function createDockerProfileLease(binding: DockerProfileRuntimeBinding): Promise<DockerProfileLease> {
   const invocationId = randomUUID();
-  const created = await controlRequest<{ readonly leaseToken: string }>(binding.controlSocketPath, {
+  const created = await dockerProfileControlRequest<{ readonly leaseToken: string }>(binding.controlSocketPath, {
     kind: "lease.create",
     profileId: binding.profile.profileId,
     daemonGeneration: binding.daemonGeneration,
@@ -246,7 +258,7 @@ export async function createDockerProfileLease(binding: DockerProfileRuntimeBind
   let timer: ReturnType<typeof setInterval> | undefined;
   const heartbeat = async () => {
     if (stopped) return;
-    await controlRequest(binding.controlSocketPath, {
+    await dockerProfileControlRequest(binding.controlSocketPath, {
       kind: "lease.heartbeat", invocationId, leaseToken: created.leaseToken,
     });
   };
@@ -260,7 +272,7 @@ export async function createDockerProfileLease(binding: DockerProfileRuntimeBind
       if (stopped) return;
       stopped = true;
       if (timer !== undefined) clearInterval(timer);
-      await controlRequest(binding.controlSocketPath, {
+      await dockerProfileControlRequest(binding.controlSocketPath, {
         kind: "lease.drain", invocationId, leaseToken: created.leaseToken,
       });
     },
@@ -274,12 +286,20 @@ export async function acquireDockerProfileReservation(
   signal?: AbortSignal,
 ): Promise<DockerProfileReservation> {
   const reservationId = randomUUID();
-  let reservation = await controlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
+  let reservation = await dockerProfileControlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
     kind: "reservation.acquire", invocationId: lease.invocationId, leaseToken: lease.leaseToken,
     reservationId, reservationKind, resources,
   });
+  const deadline = Date.now() + 30_000;
   try {
     while (reservation.state === "queued") {
+      if (Date.now() >= deadline) {
+        const cancelled = await dockerProfileControlRequest(lease.binding.controlSocketPath, {
+          kind: "reservation.cancel", invocationId: lease.invocationId, leaseToken: lease.leaseToken, reservationId,
+        }).then(() => true).catch(() => false);
+        if (!cancelled) throw new Error("Docker profile capacity queue timeout could not be cancelled safely");
+        throw new DockerProfileCapacityBlockedError();
+      }
       if (signal?.aborted) throw signal.reason ?? new DOMException("Docker profile reservation aborted", "AbortError");
       await new Promise<void>((resolve, reject) => {
         let abort: (() => void) | undefined;
@@ -295,15 +315,16 @@ export async function acquireDockerProfileReservation(
         };
         signal.addEventListener("abort", abort, { once: true });
       });
-      reservation = await controlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
+      reservation = await dockerProfileControlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
         kind: "reservation.get", invocationId: lease.invocationId, leaseToken: lease.leaseToken, reservationId,
       });
       if (signal?.aborted) throw signal.reason ?? new DOMException("Docker profile reservation aborted", "AbortError");
     }
+    if (reservation.state === "blocked") throw new DockerProfileCapacityBlockedError();
   } catch (error) {
-    if (signal?.aborted) {
-      await controlRequest(lease.binding.controlSocketPath, {
-        kind: reservation.state === "queued" ? "reservation.cancel" : "reservation.release",
+    if (reservation.state === "queued" || reservation.state === "blocked") {
+      await dockerProfileControlRequest(lease.binding.controlSocketPath, {
+        kind: "reservation.cancel",
         invocationId: lease.invocationId,
         leaseToken: lease.leaseToken,
         reservationId,
@@ -382,10 +403,11 @@ function controlBuildRequest<T>(
 export async function createDockerProfileContainer(
   lease: DockerProfileLease,
   reservationId: string,
-  create: DockerProfileContainerCreateInput,
+  request: DockerProfileContainerCreateInput | DockerProfileContainerIntent,
 ): Promise<DockerProfileContainerCreateResult> {
+  const create = "intent" in request ? request : { intent: "workload" as const, create: request };
   try {
-    return await controlRequest<DockerProfileContainerCreateResult>(lease.binding.controlSocketPath, {
+    return await dockerProfileControlRequest<DockerProfileContainerCreateResult>(lease.binding.controlSocketPath, {
       kind: "container.create",
       invocationId: lease.invocationId,
       leaseToken: lease.leaseToken,
@@ -395,7 +417,7 @@ export async function createDockerProfileContainer(
   } catch (error) {
     // A lost reply can leave the journal committed. Recover the control-owned IDs instead of
     // issuing a second create or asking DockerSandbox's legacy reconciler to remove them.
-    const reservation = await controlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
+    const reservation = await dockerProfileControlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
       kind: "reservation.get",
       invocationId: lease.invocationId,
       leaseToken: lease.leaseToken,
@@ -420,7 +442,7 @@ export async function createDockerProfileBuild(
   signal?: AbortSignal,
 ): Promise<DockerProfileBuildCreateResult> {
   const cancelBuild = async () => {
-    await controlRequest(lease.binding.controlSocketPath, {
+    await dockerProfileControlRequest(lease.binding.controlSocketPath, {
       kind: "build.cancel",
       invocationId: lease.invocationId,
       leaseToken: lease.leaseToken,
@@ -448,7 +470,7 @@ export async function createDockerProfileBuild(
         await cancelBuild();
         throw error;
       }
-      const reservation = await controlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
+      const reservation = await dockerProfileControlRequest<DockerProfileReservation>(lease.binding.controlSocketPath, {
         kind: "reservation.get",
         invocationId: lease.invocationId,
         leaseToken: lease.leaseToken,
@@ -474,9 +496,37 @@ export async function createDockerProfileBuild(
 export async function releaseDockerProfileReservation(
   lease: DockerProfileLease,
   reservationId: string,
-): Promise<void> {
-  await controlRequest(lease.binding.controlSocketPath, {
-    kind: "reservation.release", invocationId: lease.invocationId, leaseToken: lease.leaseToken,
-    reservationId,
-  });
+  proof?: Pick<DockerProfileReservation, "slotId">,
+): Promise<{ readonly cleanupProven?: boolean }> {
+  try {
+    return await dockerProfileControlRequest(lease.binding.controlSocketPath, {
+      kind: "reservation.release", invocationId: lease.invocationId, leaseToken: lease.leaseToken,
+      reservationId,
+    });
+  } catch (primary) {
+    // A reply can be lost after the durable release.  Treat that as success
+    // only after the same profile generation confirms every owned handle is
+    // absent and no reservation-specific recovery uncertainty remains.
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      const status = await dockerProfileControlRequest<{
+        readonly profileId?: string;
+        readonly generation?: string;
+        readonly leases?: readonly { readonly invocationId?: string; readonly daemonGeneration?: string }[];
+        readonly reservations?: readonly { readonly reservationId?: string; readonly invocationId?: string }[];
+        readonly slots?: readonly { readonly slotId?: string; readonly reservationId?: string; readonly state?: string }[];
+        readonly degraded?: readonly string[];
+      }>(lease.binding.controlSocketPath, { kind: "status" }).catch(() => undefined);
+      if (status?.profileId === lease.binding.profile.profileId && status.generation === lease.binding.daemonGeneration) {
+        const reservationAbsent = !(status.reservations ?? []).some((item) => item.reservationId === reservationId);
+        const sameLease = (status.leases ?? []).some((item) => item.invocationId === lease.invocationId && item.daemonGeneration === lease.binding.daemonGeneration);
+        const slot = proof?.slotId === undefined ? undefined : (status.slots ?? []).find((item) => item.slotId === proof.slotId);
+        const slotFree = proof?.slotId === undefined || (slot?.state === "free" && slot.reservationId === undefined);
+        const uncertain = (status.degraded ?? []).some((item) => item.includes(reservationId));
+        if (reservationAbsent && sameLease && slotFree && !uncertain) return { cleanupProven: true };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    throw primary;
+  }
 }

--- a/packages/niceeval/src/sandbox/docker-profile/runtime.ts
+++ b/packages/niceeval/src/sandbox/docker-profile/runtime.ts
@@ -205,10 +205,9 @@ async function attestEntry(entry: ResolvedDockerProfileEntry): Promise<DockerPro
     readonly backendMachineIdentity: string;
     readonly daemonGeneration: string;
     readonly clientNonce: string;
-    readonly admissionOpen: boolean;
   }>(profile.transport.controlSocket.path, { kind: "challenge", clientNonce: nonce });
   if (challenge.protocol !== profile.transport.controlSocket.protocol || challenge.profileId !== profile.profileId ||
-      challenge.descriptorDigest !== entry.descriptorDigest || challenge.clientNonce !== nonce || challenge.admissionOpen !== true ||
+      challenge.descriptorDigest !== entry.descriptorDigest || challenge.clientNonce !== nonce ||
       challenge.hostMachineIdentity !== profile.transport.hostMachineIdentity ||
       challenge.backendMachineIdentity !== profile.backend.machineIdentity) {
     throw new Error(`Docker profile ${entry.alias} control attestation does not match its descriptor`);

--- a/packages/niceeval/src/sandbox/docker.ts
+++ b/packages/niceeval/src/sandbox/docker.ts
@@ -260,6 +260,18 @@ function benignRemoveError(error: unknown): boolean {
   return dockerStatusCode(error) === 404;
 }
 
+async function startContainerIdempotently(container: Docker.Container): Promise<void> {
+  if ((await container.inspect()).State?.Running === true) return;
+  try {
+    await container.start();
+  } catch (error) {
+    // A control-owned committed create may be replayed after readiness failed.
+    // Accept Docker's 304 only when a fresh inspect proves the same container is running.
+    if (dockerStatusCode(error) === 304 && (await container.inspect()).State?.Running === true) return;
+    throw error;
+  }
+}
+
 export function dockerHostConfig(
   privileged: "disabled" | "raw" | "rootless",
   resources: Readonly<DockerSandboxResources>,
@@ -692,7 +704,7 @@ export class DockerSandbox implements SandboxProviderBackend, SandboxReuseCapabi
     sandbox._containerId = created.containerId;
     sandbox.releaseMode = "detach";
     try {
-      await sandbox.container.start();
+      await startContainerIdempotently(sandbox.container);
       await sandbox.waitForReadiness();
       await sandbox.ensureRunnerTools();
       await sandbox.resolveDefaultIdentity();

--- a/packages/niceeval/src/sandbox/dockerfile-build.ts
+++ b/packages/niceeval/src/sandbox/dockerfile-build.ts
@@ -4,9 +4,11 @@
 
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import { isAbsolute, resolve as resolvePath } from "node:path";
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import { Data, Effect } from "effect";
+import * as tar from "tar-stream";
 import {
   materializationScopeId,
   sandboxBuildRef,
@@ -24,10 +26,11 @@ import {
   type DockerfileBuildIdentity,
 } from "./dockerfile-identity.ts";
 import type { SandboxLocation } from "./layer.ts";
+import { listFilteredBuildContextFiles } from "../runner/leak-gate.ts";
 
 export { DOCKERFILE_MATERIALIZER_REVISION } from "./dockerfile-identity.ts";
 
-interface DockerfileBuildDetails {
+export interface DockerfileBuildDetails {
   readonly provider: "docker" | "e2b";
   readonly contextDir: string;
   readonly dockerfilePath: string;
@@ -35,6 +38,7 @@ interface DockerfileBuildDetails {
   readonly buildArgs?: Readonly<globalThis.Record<string, string>>;
   readonly target?: string;
   readonly platform: string;
+  readonly contextFiles: readonly string[];
   readonly dockerSocketPath?: string;
   /** managed profile 在 daemon bridge=none 时为本次 build 创建的独占 bridge。 */
   readonly dockerNetworkMode?: string;
@@ -80,6 +84,10 @@ export function collectDockerfileBuildFromIdentity(input: {
         message: "Dockerfile build inputs changed after physical planning. Restart the Run to plan the new inputs.",
       }));
     }
+    const contextFiles = yield* listFilteredBuildContextFiles({
+      contextDir: identity.contextDir,
+      label: `sandbox profile ${input.profile}`,
+    });
     const authorityFingerprint = input.provider === "docker" && input.dockerSocketPath === undefined
       ? yield* Effect.tryPromise({
           try: () => dockerTaskBuildAuthorityFingerprint(),
@@ -102,6 +110,7 @@ export function collectDockerfileBuildFromIdentity(input: {
           buildArgs: input.buildArgs,
           ...(input.target === undefined ? {} : { target: input.target }),
           platform: input.platform,
+          contextFiles: Object.freeze([...contextFiles]),
           ...(input.dockerSocketPath === undefined ? {} : { dockerSocketPath: input.dockerSocketPath }),
         };
         const scopeId = materializationScopeId({
@@ -255,8 +264,40 @@ export function routeBuildProviders(
   };
 }
 
-function dockerBuildTag(buildKey: BuildKey): string {
+export function dockerBuildTag(buildKey: BuildKey): string {
   return `niceeval-build:${buildKey.slice(0, 32)}`;
+}
+
+/** Stream the exact filtered context whose file list contributed to BuildKey. */
+export function packDockerfileBuildContext(details: DockerfileBuildDetails): tar.Pack {
+  const pack = tar.pack();
+  void (async () => {
+    const dockerfile = relative(details.contextDir, details.dockerfilePath).split(sep).join("/");
+    if (dockerfile === "" || dockerfile === ".." || dockerfile.startsWith("../") || isAbsolute(dockerfile)) {
+      throw new Error("Dockerfile must be inside its build context for a control-owned build");
+    }
+    const files = [...new Set([...details.contextFiles, dockerfile])].sort();
+    for (const name of files) {
+      const path = resolvePath(details.contextDir, name);
+      const facts = await stat(path);
+      if (!facts.isFile()) throw new Error(`build context entry is no longer a regular file: ${name}`);
+      await new Promise<void>((resolve, reject) => {
+        const input = createReadStream(path);
+        const entry = pack.entry({
+          name,
+          type: "file",
+          size: facts.size,
+          mode: facts.mode & 0o777,
+          mtime: new Date(0),
+        }, (error) => error ? reject(error) : resolve());
+        input.on("error", reject);
+        entry.on("error", reject);
+        input.pipe(entry);
+      });
+    }
+    pack.finalize();
+  })().catch((error: unknown) => pack.destroy(error instanceof Error ? error : new Error(String(error))));
+  return pack;
 }
 
 function e2bBuildName(buildKey: BuildKey): string {

--- a/packages/niceeval/src/sandbox/runtime.ts
+++ b/packages/niceeval/src/sandbox/runtime.ts
@@ -1,6 +1,7 @@
 // ProviderModule 的唯一运行入口：core 只调用 plan 私绑的闭包，不解释 adapter 名或 JSON runtime input。
 
 import { randomUUID } from "node:crypto";
+import { relative, sep } from "node:path";
 import { Data, Effect, Option, type Scope } from "effect";
 import type { ProvisionSlot } from "./retry.ts";
 import { withProvisionRetry } from "./retry.ts";
@@ -16,7 +17,11 @@ import {
   materializeDockerComposeProviderCase,
   normalizeBuildPlatform,
 } from "./compose.ts";
-import { collectDockerfileBuildFromIdentity, dockerfileBuildProvider } from "./dockerfile-build.ts";
+import {
+  collectDockerfileBuildFromIdentity,
+  dockerfileBuildProvider,
+  packDockerfileBuildContext,
+} from "./dockerfile-build.ts";
 import {
   DockerfileAgentImageCoordinator,
   isDockerfileAgentCacheSafeInstaller,
@@ -61,9 +66,10 @@ import type { DockerSandbox } from "./docker.ts";
 import type { E2BSandboxLifetime } from "./e2b.ts";
 import {
   acquireDockerProfileReservation,
-  commitDockerProfileReservation,
+  createDockerProfileBuild,
   createDockerProfileContainer,
   createDockerProfileLease,
+  lookupDockerProfileBuild,
   releaseDockerProfileReservation,
   type DockerProfileLease,
   type DockerProfileRuntimeBinding,
@@ -977,59 +983,45 @@ export function collectDockerfileProviderBuildPreparation(
         throw new Error("Dockerfile build inputs changed after physical planning. Restart the Run to plan the new inputs.");
       }
       const provider = dockerfileBuildProvider([collection]);
+      const managedSource = (locator: string, source: "cache" | "build") => ({
+        locator,
+        source,
+        acquireUse: async () => ({ locator, release() {} }),
+        release() {},
+      });
       const managedProvider: SandboxBuildProvider = plan.profileBinding === undefined ? provider : {
-        lookup: (work, signal) => provider.lookup(work, signal),
+        async lookup(work) {
+          const result = await lookupDockerProfileBuild(plan.profileBinding!, work.buildKey);
+          return result.hit
+            ? { _tag: "Hit", source: managedSource(result.locator, "cache") }
+            : { _tag: "Miss" };
+        },
         async build(work, buildContext) {
           const lease = await createDockerProfileLease(plan.profileBinding!);
           let reservation: import("./docker-profile/runtime.ts").DockerProfileReservation | undefined;
-          let network: import("dockerode").Network | undefined;
           try {
             reservation = await acquireDockerProfileReservation(lease, "build", {
               cpus: 0, memoryBytes: 0, pids: 0, containers: 0, ephemeralDiskBytes: 0,
             }, buildContext.signal);
-            const labels = Object.freeze({
-              "niceeval.profile-id": plan.profileBinding!.profile.profileId,
-              "niceeval.invocation-id": lease.invocationId,
-              "niceeval.reservation-id": reservation.reservationId,
-              "niceeval.provision-token": reservation.provisionToken,
-            });
-            const [{ default: Docker }, { dockerManagedNetworkOptions }] = await Promise.all([
-              import("dockerode"),
-              import("./docker.ts"),
-            ]);
-            const docker = new Docker({ socketPath: plan.profileBinding!.dockerSocketPath });
-            network = await docker.createNetwork(
-              dockerManagedNetworkOptions(reservation.provisionToken, randomUUID(), labels),
-            );
-            await commitDockerProfileReservation(lease, reservation.reservationId, { networkId: network.id });
-            const buildCollection = Object.freeze({
-              ...collection,
-              details: Object.freeze({ ...collection.details, dockerNetworkMode: network.id }),
-            });
-            const locator = await dockerfileBuildProvider([buildCollection]).build(work, buildContext);
-            await network.remove();
-            network = undefined;
-            await releaseDockerProfileReservation(lease, reservation.reservationId, {
-              daemonRequestTerminated: true,
-              buildkitSessionGone: true,
-              processActivityZero: true,
-              provisionalRefResolvedOrRemoved: true,
-            });
-            return locator;
+            const dockerfile = relative(collection.details.contextDir, collection.details.dockerfilePath)
+              .split(sep).join("/");
+            const result = await createDockerProfileBuild(lease, reservation.reservationId, {
+              buildKey: work.buildKey,
+              platform: collection.details.platform,
+              dockerfile,
+              ...(collection.details.buildArgs === undefined ? {} : { buildArgs: collection.details.buildArgs }),
+              ...(collection.details.target === undefined ? {} : { target: collection.details.target }),
+            }, packDockerfileBuildContext(collection.details), buildContext.signal);
+            await releaseDockerProfileReservation(lease, reservation.reservationId);
+            reservation = undefined;
+            return managedSource(result.locator, "build");
           } finally {
-            await network?.remove().catch(() => undefined);
             if (reservation !== undefined) {
-              await releaseDockerProfileReservation(lease, reservation.reservationId, {
-                daemonRequestTerminated: true,
-                buildkitSessionGone: true,
-                processActivityZero: true,
-                provisionalRefResolvedOrRemoved: true,
-              }).catch(() => undefined);
+              await releaseDockerProfileReservation(lease, reservation.reservationId).catch(() => undefined);
             }
             await lease.stopHeartbeat().catch(() => undefined);
           }
         },
-        ...(provider.cancel === undefined ? {} : { cancel: (work) => provider.cancel!(work) }),
       };
       return Option.some({
         works: [collection.work],

--- a/packages/niceeval/src/sandbox/runtime.ts
+++ b/packages/niceeval/src/sandbox/runtime.ts
@@ -240,7 +240,7 @@ async function managedContainerSession(
         if (finished) return;
         finished = true;
         try {
-          await releaseDockerProfileReservation(lease, reservation.reservationId);
+          await releaseDockerProfileReservation(lease, reservation.reservationId, reservation);
         } finally {
           await lease.stopHeartbeat();
         }

--- a/packaging/docker-profile-host/config/assets-v1.json
+++ b/packaging/docker-profile-host/config/assets-v1.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "platform": "linux/amd64",
+  "images": [
+    {
+      "purpose": "doctor-dind",
+      "reference": "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c",
+      "imageId": "sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c",
+      "platform": "linux/amd64"
+    },
+    {
+      "purpose": "doctor-buildkit",
+      "reference": "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
+      "imageId": "sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
+      "platform": "linux/amd64"
+    }
+  ]
+}

--- a/packaging/docker-profile-host/config/assets-v1.json
+++ b/packaging/docker-profile-host/config/assets-v1.json
@@ -5,13 +5,11 @@
     {
       "purpose": "doctor-dind",
       "reference": "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c",
-      "imageId": "sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c",
       "platform": "linux/amd64"
     },
     {
       "purpose": "doctor-buildkit",
       "reference": "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
-      "imageId": "sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
       "platform": "linux/amd64"
     }
   ]

--- a/packaging/docker-profile-host/config/default.host.json.example
+++ b/packaging/docker-profile-host/config/default.host.json.example
@@ -31,6 +31,9 @@
     "slotRootPath": "/var/lib/niceeval/docker-profiles/default/data/quota-slots",
     "slotRegistryPath": "/var/lib/niceeval/docker-profiles/default/journal/quota-slots.json"
   },
+  "assets": {
+    "manifestPath": "/etc/niceeval/docker-profiles/assets-v1.json"
+  },
   "policy": {
     "hostLoopback": false,
     "tcpDockerEndpoint": false

--- a/packaging/docker-profile-host/scripts/install-notes.sh
+++ b/packaging/docker-profile-host/scripts/install-notes.sh
@@ -18,6 +18,11 @@ Generic systemd Linux (Ubuntu/Debian-style)
    Ordinary root-partition subdirectories without a hard limit are rejected.
 4. Install root-owned host config under /etc/niceeval/docker-profiles/<alias>.host.json
    with capacity (allocatable) and aggregate (cgroup hard limits) separated.
+   Preload and verify the fixed linux/amd64 DIND and BuildKit assets before
+   starting watchdog (deployment may load an administrator-provided OCI archive
+   or explicitly pull these exact digests; runtime never pulls):
+     niceeval-docker-profile-preload-verify-assets \
+       --manifest /etc/niceeval/docker-profiles/assets-v1.json --load-archive /path/assets.oci.tar
 5. systemctl daemon-reload && systemctl enable --now \
      niceeval-docker-profile-storage@<alias>.service \
      niceeval-docker-profile@<alias>.service \
@@ -30,7 +35,7 @@ Generic systemd Linux (Ubuntu/Debian-style)
 7. Static check:
      niceeval-docker-profile-host-doctor <alias>
 8. Runtime doctor (as access user, no sudo):
-     niceeval docker profile doctor <alias> --smoke
+     niceeval docker profile doctor <alias>
 
 NixOS
 -----
@@ -42,7 +47,7 @@ services.niceeval.dockerProfiles.<alias> = {
   storage = { size = "30G"; backing = "loop-ext4"; };
 };
 # then: sudo nixos-rebuild switch
-# daily work: niceeval docker profile doctor default --smoke
+# daily work: niceeval docker profile doctor default
 
 Hard constraints (must hold)
 ----------------------------

--- a/packaging/docker-profile-host/scripts/preload-verify-assets.py
+++ b/packaging/docker-profile-host/scripts/preload-verify-assets.py
@@ -30,16 +30,16 @@ def main() -> None:
     if manifest.get("schemaVersion") != 1 or manifest.get("platform") != "linux/amd64":
         raise SystemExit("unsupported asset manifest platform")
     for item in manifest.get("images", []):
-        reference, image_id, platform = item.get("reference"), item.get("imageId"), item.get("platform")
-        if not isinstance(reference, str) or "@sha256:" not in reference or not isinstance(image_id, str) or platform != "linux/amd64":
+        reference, platform = item.get("reference"), item.get("platform")
+        if not isinstance(reference, str) or "@sha256:" not in reference or platform != "linux/amd64":
             raise SystemExit("asset manifest contains an invalid fixed identity")
-        inspected = docker("image", "inspect", "--format", "{{.Id}} {{.Os}}/{{.Architecture}}", reference, check=False)
+        inspected = docker("image", "inspect", "--format", "{{.Os}}/{{.Architecture}}", reference, check=False)
         if inspected.returncode != 0 and args.pull:
             docker("pull", reference)
-            inspected = docker("image", "inspect", "--format", "{{.Id}} {{.Os}}/{{.Architecture}}", reference, check=False)
-        if inspected.returncode != 0 or inspected.stdout.strip() != f"{image_id} {platform}":
+            inspected = docker("image", "inspect", "--format", "{{.Os}}/{{.Architecture}}", reference, check=False)
+        if inspected.returncode != 0 or inspected.stdout.strip() != platform:
             raise SystemExit(f"asset missing or mismatched: {reference}")
-        print(f"verified {reference} {image_id} {platform}")
+        print(f"verified {reference} {platform}")
 
 
 if __name__ == "__main__":

--- a/packaging/docker-profile-host/scripts/preload-verify-assets.py
+++ b/packaging/docker-profile-host/scripts/preload-verify-assets.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Idempotently preload or verify the fixed offline Docker-profile assets.
+
+Deployment may either supply a local OCI archive or explicitly allow this
+administrator command to pull exact digests.  Runtime control and doctor only
+inspect these images and never invoke pull.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["docker", *args], check=check, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--load-archive", type=Path)
+    source.add_argument("--pull", action="store_true", help="deployment-only explicit digest pull")
+    args = parser.parse_args()
+    if args.load_archive is not None:
+        docker("load", "--input", str(args.load_archive))
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    if manifest.get("schemaVersion") != 1 or manifest.get("platform") != "linux/amd64":
+        raise SystemExit("unsupported asset manifest platform")
+    for item in manifest.get("images", []):
+        reference, image_id, platform = item.get("reference"), item.get("imageId"), item.get("platform")
+        if not isinstance(reference, str) or "@sha256:" not in reference or not isinstance(image_id, str) or platform != "linux/amd64":
+            raise SystemExit("asset manifest contains an invalid fixed identity")
+        inspected = docker("image", "inspect", "--format", "{{.Id}} {{.Os}}/{{.Architecture}}", reference, check=False)
+        if inspected.returncode != 0 and args.pull:
+            docker("pull", reference)
+            inspected = docker("image", "inspect", "--format", "{{.Id}} {{.Os}}/{{.Architecture}}", reference, check=False)
+        if inspected.returncode != 0 or inspected.stdout.strip() != f"{image_id} {platform}":
+            raise SystemExit(f"asset missing or mismatched: {reference}")
+        print(f"verified {reference} {image_id} {platform}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/docker-profile-host/scripts/watchdog.py
+++ b/packaging/docker-profile-host/scripts/watchdog.py
@@ -1193,7 +1193,8 @@ class Admission:
                 return {"hit": hit, "locator": locator}
             if kind == "lease.create":
                 if not self.state["admissionOpen"]:
-                    raise ProtocolError("admission-closed", "profile recovery has not converged")
+                    degraded = "; ".join(str(reason) for reason in self.state["degraded"])
+                    raise ProtocolError("admission-closed", degraded or "profile recovery has not converged")
                 if request.get("profileId") != self.profile_id or request.get("daemonGeneration") != self.state["generation"]:
                     raise ProtocolError("attestation-changed", "profile or daemon generation changed")
                 invocation_id = str(request.get("invocationId", ""))

--- a/packaging/docker-profile-host/scripts/watchdog.py
+++ b/packaging/docker-profile-host/scripts/watchdog.py
@@ -26,6 +26,7 @@ import tarfile
 import threading
 import time
 import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -41,9 +42,29 @@ LABELS = {
 
 CREATE_KEYS = {"image", "command", "entrypoint", "environment", "workingDir", "user", "tmpfs", "attemptId"}
 FORBIDDEN_CREATE_KEYS = {"binds", "mounts", "volumes", "hostConfig", "devices", "networkMode", "ports", "extraHosts"}
-BUILD_KEYS = {"buildKey", "platform", "dockerfile", "buildArgs", "target"}
+BUILD_KEYS = {"buildKey", "platform", "dockerfile", "buildArgs", "target", "retention"}
 MAX_BUILD_CONTEXT_BYTES = 2 * 1024 * 1024 * 1024
 MAX_BUILD_CONTEXT_CHUNK_BYTES = 4 * 1024 * 1024
+QUEUE_TIMEOUT_SECONDS = 30
+CLEANUP_TIMEOUT_SECONDS = 60
+REQUIRED_ASSETS = {
+    "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c": "sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c",
+    "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8": "sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
+}
+DIAGNOSTIC_COMMAND = ["sh", "-ec", "\n".join((
+    "set -eu",
+    "dockerd --host=unix:///var/run/docker.sock --shutdown-timeout=2 >/tmp/niceeval-dockerd.log 2>&1 &",
+    "daemon=$!; image=niceeval-doctor-inner; inner=niceeval-doctor-inner-run; trap 'docker rm -f \"$inner\" >/dev/null 2>&1 || true; docker image rm -f \"$image\" >/dev/null 2>&1 || true; kill \"$daemon\" 2>/dev/null || true; wait \"$daemon\" 2>/dev/null || true' EXIT",
+    "for _ in $(seq 1 120); do docker info >/dev/null 2>&1 && break; sleep 0.25; done; docker info >/dev/null",
+    "for table in /proc/net/tcp /proc/net/tcp6; do [ ! -r \"$table\" ] || ! awk '$4 == \"0A\" && ($2 ~ /:0947$/ || $2 ~ /:0948$/) { found = 1 } END { exit found ? 1 : 0 }' \"$table\"; done",
+    "cpu_max=$(cat /sys/fs/cgroup/cpu.max); memory_max=$(cat /sys/fs/cgroup/memory.max); swap_max=$(cat /sys/fs/cgroup/memory.swap.max); pids_max=$(cat /sys/fs/cgroup/pids.max)",
+    "[ \"$cpu_max\" = '200000 100000' ]; [ \"$memory_max\" = '536870912' ]; [ \"$swap_max\" = '0' ]; [ \"$pids_max\" = '256' ]",
+    "rootfs='bin/busybox lib'; [ ! -d /lib64 ] || rootfs=\"$rootfs lib64\"",
+    "tar -C / -cf - $rootfs | docker import - \"$image\" >/dev/null",
+    "docker run --name \"$inner\" --pull=never --network=none \"$image\" /bin/busybox true; docker rm \"$inner\" >/dev/null",
+    "docker image rm --force \"$image\" >/dev/null; ! docker container inspect \"$inner\" >/dev/null 2>&1; ! docker image inspect \"$image\" >/dev/null 2>&1",
+    "printf '{\"ok\":true,\"unixOnly\":true,\"nestedDocker\":true,\"limits\":{\"cpuMax\":\"%s\",\"memoryMax\":\"%s\",\"swapMax\":\"%s\",\"pidsMax\":\"%s\"}}\\n' \"$cpu_max\" \"$memory_max\" \"$swap_max\" \"$pids_max\"",
+))]
 
 
 def read_exact(reader: Any, size: int) -> bytes:
@@ -110,7 +131,8 @@ class Admission:
         self.lock = threading.RLock()
         self.stop = threading.Event()
         self.build_processes: dict[str, subprocess.Popen[str]] = {}
-        self.state: dict[str, Any] = {
+        self.asset_facts = self._asset_facts()
+        self._published_state: dict[str, Any] = {
             "schemaVersion": 1,
             "generation": self._generation(),
             "admissionOpen": True,
@@ -120,8 +142,15 @@ class Admission:
             "degraded": [],
             "slots": {},
         }
+        self._draft_state: dict[str, Any] | None = None
+        initialization_scope = self._begin_transition_scope()
         self._load()
         self._load_slots()
+        asset_issue = "fixed Docker profile assets are missing, mismatched, or unsupported"
+        self.state["degraded"] = [item for item in self.state["degraded"] if item != asset_issue]
+        if not self.asset_facts or not all(item.get("present") is True for item in self.asset_facts):
+            self.state["admissionOpen"] = False
+            self.state["degraded"].append(asset_issue)
         current = self._generation()
         if self.state.get("generation") != current:
             self.state["admissionOpen"] = False
@@ -131,6 +160,45 @@ class Admission:
             self.state["admissionOpen"] = not self.state["degraded"]
             self._commit("daemon-generation-reconciled", {})
         self._reconcile_restarted_builds()
+        if self._draft_state != self._published_state:
+            self._commit("watchdog-initialized", {})
+        self._end_transition_scope(initialization_scope)
+
+    @property
+    def state(self) -> dict[str, Any]:
+        return self._draft_state if self._draft_state is not None else self._published_state
+
+    @state.setter
+    def state(self, value: dict[str, Any]) -> None:
+        if self._draft_state is None:
+            self._published_state = value
+        else:
+            self._draft_state = value
+
+    def _begin_transition_scope(self) -> bool:
+        if self._draft_state is not None:
+            return False
+        self._draft_state = copy.deepcopy(self._published_state)
+        return True
+
+    def _end_transition_scope(self, owner: bool) -> None:
+        if owner:
+            self._draft_state = None
+
+    @contextmanager
+    def _transition(self) -> Any:
+        """Hold the state lock only for one durable state mutation.
+
+        Docker side effects deliberately live between these blocks.  In
+        particular, a long build must not prevent a heartbeat or cancellation
+        from reaching the control service.
+        """
+        with self.lock:
+            owner = self._begin_transition_scope()
+            try:
+                yield self.state
+            finally:
+                self._end_transition_scope(owner)
 
     def _load_slots(self) -> None:
         storage = self.host_config.get("storage", {}) if self.host_config else {}
@@ -184,30 +252,84 @@ class Admission:
         except Exception as error:
             raise RuntimeError(f"Docker daemon identity is unavailable: {error}") from error
         sock = os.stat(self.docker_socket)
-        return hashlib.sha256(f"{daemon_id}:{sock.st_ino}:{sock.st_ctime_ns}".encode()).hexdigest()[:32]
+        asset_identity = canonical_digest(self.asset_facts if hasattr(self, "asset_facts") else [])
+        return hashlib.sha256(f"{daemon_id}:{sock.st_ino}:{sock.st_ctime_ns}:{asset_identity}".encode()).hexdigest()[:32]
+
+    def _asset_facts(self) -> list[dict[str, Any]]:
+        manifest_path = (self.host_config or {}).get("assets", {}).get("manifestPath")
+        if not isinstance(manifest_path, str):
+            return []
+        try:
+            manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+            images = manifest.get("images", [])
+            if manifest.get("schemaVersion") != 1 or manifest.get("platform") != "linux/amd64" or not isinstance(images, list):
+                raise ValueError("images must be a list")
+            declared = {
+                item.get("reference"): item.get("imageId")
+                for item in images if isinstance(item, dict)
+            }
+            if declared != REQUIRED_ASSETS:
+                raise ValueError("manifest must contain exactly the fixed DIND and BuildKit identities")
+            facts: list[dict[str, Any]] = []
+            for image in images:
+                reference = image.get("reference") if isinstance(image, dict) else None
+                expected_id = image.get("imageId") if isinstance(image, dict) else None
+                platform = image.get("platform") if isinstance(image, dict) else None
+                if (not isinstance(reference, str) or "@sha256:" not in reference
+                        or not isinstance(expected_id, str) or not expected_id.startswith("sha256:")
+                        or platform != "linux/amd64"):
+                    raise ValueError("image reference must be digest pinned")
+                inspect = self._docker("image", "inspect", "--format", "{{.Id}} {{.Os}}/{{.Architecture}}", reference, check=False)
+                fields = inspect.stdout.strip().split()
+                present = inspect.returncode == 0 and fields == [expected_id, platform]
+                facts.append({"reference": reference, "imageId": expected_id, "platform": platform, "present": present})
+            return facts
+        except Exception as error:
+            return [{"reference": "invalid-manifest", "present": False, "error": str(error)}]
 
     def _load(self) -> None:
         if not self.journal.exists():
             return
         last: dict[str, Any] | None = None
-        for line in self.journal.read_text(encoding="utf-8").splitlines():
+        raw = self.journal.read_text(encoding="utf-8")
+        if raw and not raw.endswith("\n"):
+            raise RuntimeError("watchdog journal is truncated; admission fails closed")
+        for line in raw.splitlines():
             try:
                 item = json.loads(line)
                 if isinstance(item.get("state"), dict):
                     last = item["state"]
-            except json.JSONDecodeError:
-                break
+                else:
+                    raise ValueError("journal record has no state")
+            except (json.JSONDecodeError, ValueError) as error:
+                raise RuntimeError("watchdog journal is corrupt; admission fails closed") from error
         if last is not None:
-            self.state = last
+            self._published_state = last
+            if self._draft_state is not None:
+                self._draft_state = copy.deepcopy(last)
 
     def _commit(self, event: str, detail: dict[str, Any]) -> None:
+        next_state = copy.deepcopy(self.state)
         self.journal.parent.mkdir(parents=True, exist_ok=True)
-        record = {"at": now(), "event": event, "detail": detail, "state": self.state}
+        record = {"at": now(), "event": event, "detail": detail, "state": next_state}
         encoded = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
         fd = os.open(self.journal, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
+        offset = os.lseek(fd, 0, os.SEEK_END)
         try:
             os.write(fd, encoded.encode())
             os.fsync(fd)
+            # Publish a detached snapshot.  Keep the current draft object so
+            # local references held by a multi-stage transition remain valid;
+            # its later, uncommitted mutations remain invisible and are
+            # discarded when the scope ends.
+            self._published_state = copy.deepcopy(next_state)
+        except Exception:
+            # If append reached the page cache but fsync rejected it, do not
+            # leave a readable record that a restart could mistake for a
+            # durable transition.
+            os.ftruncate(fd, offset)
+            self._draft_state = copy.deepcopy(self._published_state)
+            raise
         finally:
             os.close(fd)
 
@@ -257,6 +379,13 @@ class Admission:
             reservation = self.state["reservations"].get(self.state["queue"][0])
             if reservation is None or reservation["state"] != "queued":
                 self.state["queue"].pop(0)
+                continue
+            created = datetime.fromisoformat(str(reservation["createdAt"]).replace("Z", "+00:00"))
+            if (datetime.now(timezone.utc) - created).total_seconds() >= QUEUE_TIMEOUT_SECONDS:
+                self.state["queue"].pop(0)
+                reservation["state"] = "blocked"
+                reservation["blockedAt"] = now()
+                self._commit("reservation-blocked", {"reservationId": reservation["reservationId"], "reason": "capacity-queue-timeout"})
                 continue
             if not self._fits(reservation["resources"], reservation["kind"]):
                 break
@@ -427,7 +556,37 @@ class Admission:
         remaining = self._resource_ids(reservation)
         return not remaining[0] and not remaining[1]
 
+    def _cleanup_with_deadline(self, reservation: dict[str, Any]) -> bool:
+        deadline = time.monotonic() + CLEANUP_TIMEOUT_SECONDS
+        while True:
+            if reservation["kind"] == "build":
+                proven = self._destroy_build(reservation) and self._build_resources_absent(
+                    reservation, require_ephemeral_locator_absent=reservation.get("retention") == "ephemeral",
+                )
+            else:
+                proven = self._destroy(reservation)
+            if proven:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.1)
+
     def _validate_create(self, raw: Any) -> dict[str, Any]:
+        if isinstance(raw, dict) and raw.get("intent") == "diagnostic":
+            if set(raw) != {"intent"}:
+                raise ProtocolError("container-create-diagnostic-client-input", "diagnostic requests accept intent only")
+            assets = self.asset_facts
+            dind = next((item for item in assets if item.get("reference", "").startswith("docker:29-dind@sha256:")), None)
+            if dind is None or dind.get("present") is not True:
+                raise ProtocolError("container-create-diagnostic-asset", "verified DIND diagnostic asset is unavailable")
+            return {
+                "image": dind["reference"], "attemptId": "doctor-diagnostic",
+                "command": DIAGNOSTIC_COMMAND,
+                "tmpfs": {"/run": "rw,exec,nosuid,nodev,size=64m", "/tmp": "rw,nosuid,nodev,size=64m,mode=1777"},
+            }
+        if not isinstance(raw, dict) or raw.get("intent") != "workload" or set(raw) != {"intent", "create"}:
+            raise ProtocolError("container-create-intent-invalid", "container requests require workload or diagnostic intent")
+        raw = raw["create"]
         if not isinstance(raw, dict) or not raw.get("image") or not raw.get("attemptId"):
             raise ProtocolError("container-create-invalid", "image and attemptId are required")
         keys = set(raw)
@@ -458,6 +617,7 @@ class Admission:
         dockerfile = raw.get("dockerfile")
         build_args = raw.get("buildArgs", {})
         target = raw.get("target")
+        retention = raw.get("retention", "cache")
         if not isinstance(build_key, str) or re.fullmatch(r"[a-f0-9]{64}", build_key) is None:
             raise ProtocolError("build-create-invalid", "buildKey must be a sha256 hex digest")
         if not isinstance(platform, str) or re.fullmatch(r"linux/[A-Za-z0-9_.-]+", platform) is None:
@@ -473,6 +633,8 @@ class Admission:
             raise ProtocolError("build-create-invalid", "buildArgs must contain string keys and values")
         if target is not None and (not isinstance(target, str) or not target or "\n" in target or "\r" in target):
             raise ProtocolError("build-create-invalid", "target must be one non-empty line")
+        if retention not in ("cache", "ephemeral"):
+            raise ProtocolError("build-create-invalid", "build retention must be cache or ephemeral")
         return copy.deepcopy(raw)
 
     def validate_build_context(self, spec: dict[str, Any], context_path: Path) -> None:
@@ -505,11 +667,16 @@ class Admission:
         return "niceeval-build:" + build_key[:32]
 
     def _build_labels(self, reservation: dict[str, Any]) -> dict[str, str]:
-        return {
+        labels = {
             label: str(self.profile_id if field == "profileId" else reservation[field])
             for field, label in LABELS.items()
             if field != "attemptId"
         }
+        operation_id = reservation.get("operationId")
+        if not isinstance(operation_id, str) or not re.fullmatch(r"[a-f0-9]{32}", operation_id):
+            raise RuntimeError("build operation ID is not control-derived")
+        labels["niceeval.operation-id"] = operation_id
+        return labels
 
     def _builder_container_name(self, reservation: dict[str, Any]) -> str:
         builder = str(reservation.get("builderName", ""))
@@ -644,7 +811,7 @@ class Admission:
                 return False
         return True
 
-    def _build_resources_absent(self, reservation: dict[str, Any]) -> bool:
+    def _build_resources_absent(self, reservation: dict[str, Any], *, require_ephemeral_locator_absent: bool = False) -> bool:
         process = self.build_processes.get(reservation["reservationId"])
         if process is not None and process.poll() is None:
             return False
@@ -665,6 +832,10 @@ class Admission:
             return False
         if provisional and self._docker("image", "inspect", provisional, check=False).returncode == 0:
             return False
+        if require_ephemeral_locator_absent and reservation.get("retention") == "ephemeral":
+            locator = str(reservation.get("locator", ""))
+            if not locator or self._docker("image", "inspect", locator, check=False).returncode == 0:
+                return False
         containers, networks = self._resource_ids(reservation)
         return not containers and not networks
 
@@ -708,6 +879,10 @@ class Admission:
             "--platform", spec["platform"], "--file", spec["dockerfile"],
             "--tag", reservation["provisionalRef"],
         ]
+        if spec.get("retention") == "ephemeral":
+            args += ["--network=none", "--no-cache"]
+        for key, value in self._build_labels(reservation).items():
+            args += ["--label", f"{key}={value}"]
         for key, value in sorted(spec.get("buildArgs", {}).items()):
             args += ["--build-arg", f"{key}={value}"]
         if spec.get("target"):
@@ -726,9 +901,13 @@ class Admission:
                 process.terminate()
                 process.wait(timeout=5)
                 raise ProtocolError("build-process-attestation-failed", "cannot journal build process identity")
-            with self.lock:
+            with self._transition():
                 self.build_processes[reservation["reservationId"]] = process
-                reservation["buildProcess"] = {"pid": process.pid, "startTime": start_time}
+                current = self.state["reservations"].get(reservation["reservationId"])
+                if current is None or current.get("state") != "provisioning":
+                    process.terminate()
+                    raise ProtocolError("build-cancelled", "build reservation is no longer provisioning")
+                current["buildProcess"] = {"pid": process.pid, "startTime": start_time}
                 self._commit("build-process-started", {
                     "reservationId": reservation["reservationId"],
                     "pid": process.pid,
@@ -763,12 +942,15 @@ class Admission:
             self._validate_build(request.get("build"))
 
     def handle_build(self, request: dict[str, Any], context_path: Path) -> dict[str, Any]:
+        return self._handle_build(request, context_path)
+
+    def _handle_build(self, request: dict[str, Any], context_path: Path) -> dict[str, Any]:
         self.authorize_build_header(request)
         spec = self._validate_build(request.get("build"))
         self.validate_build_context(spec, context_path)
         reservation_id = str(request["reservationId"])
         digest = canonical_digest(spec)
-        with self.lock:
+        with self._transition():
             reservation = self.state["reservations"][reservation_id]
             if reservation["state"] == "committed":
                 if reservation.get("buildSpecDigest") != digest:
@@ -788,6 +970,7 @@ class Admission:
             reservation["builderName"] = "niceeval-build-" + reservation["operationId"][:24]
             reservation["provisionalRef"] = "niceeval-build-provisional:" + reservation["operationId"]
             reservation["locator"] = self._build_locator(spec["buildKey"])
+            reservation["retention"] = spec.get("retention", "cache")
             reservation["state"] = "provisioning"
             self._commit("build-create-intent", {
                 "reservationId": reservation_id,
@@ -795,52 +978,77 @@ class Admission:
                 "specDigest": digest,
                 "provisionalRef": reservation["provisionalRef"],
             })
+            operation = copy.deepcopy(reservation)
 
+        retention = spec.get("retention", "cache")
+        image_id = ""
         failure: Exception | None = None
         try:
-            labels = self._build_labels(reservation)
+            labels = self._build_labels(operation)
             network_args = [
                 "network", "create", "--driver", "bridge", "--opt",
                 "com.docker.network.bridge.enable_icc=false",
             ]
             for key, value in labels.items():
                 network_args += ["--label", f"{key}={value}"]
-            network_args.append("niceeval-build-" + reservation["provisionToken"][:20])
-            with self.lock:
+            network_args.append("niceeval-build-" + operation["provisionToken"][:20])
+            with self._transition():
                 self._commit("build-network-create-intent", {"reservationId": reservation_id})
             network_id = self._docker(*network_args).stdout.strip()
-            with self.lock:
-                reservation["networkId"] = network_id
+            with self._transition():
+                current = self.state["reservations"].get(reservation_id)
+                if current is None or current.get("state") != "provisioning":
+                    raise ProtocolError("build-cancelled", "build reservation is no longer provisioning")
+                current["networkId"] = network_id
                 self._commit("build-network-created", {
                     "reservationId": reservation_id, "networkId": network_id,
                 })
             self._docker(
                 "buildx", "create", "--driver", "docker-container",
                 "--driver-opt", f"network={network_id}",
-                "--name", reservation["builderName"],
+                "--driver-opt", "image=moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
+                "--name", operation["builderName"],
             )
-            with self.lock:
+            with self._transition():
                 self._commit("build-builder-created", {
-                    "reservationId": reservation_id, "builderName": reservation["builderName"],
+                    "reservationId": reservation_id, "builderName": operation["builderName"],
                 })
-            self._docker("buildx", "inspect", "--bootstrap", reservation["builderName"])
+            self._docker("buildx", "inspect", "--bootstrap", operation["builderName"])
+            with self._transition():
+                current = self.state["reservations"].get(reservation_id)
+                if current is None:
+                    raise ProtocolError("build-cancelled", "build reservation disappeared")
+                self._record_builder_resources(current)
+            self._run_build(operation, spec, context_path)
             with self.lock:
-                self._record_builder_resources(reservation)
-            self._run_build(reservation, spec, context_path)
-            self._docker("tag", reservation["provisionalRef"], reservation["locator"])
+                current = self.state["reservations"].get(reservation_id)
+                if current is None or current.get("state") != "provisioning" or current.get("cancelRequested"):
+                    raise ProtocolError("build-cancelled", "build cancellation won before image publication")
+            self._docker("tag", operation["provisionalRef"], operation["locator"])
+            if retention == "ephemeral":
+                image_id = self._docker("image", "inspect", "--format", "{{.Id}}", operation["locator"]).stdout.strip()
+                if not image_id.startswith("sha256:"):
+                    raise RuntimeError("ephemeral build did not yield an exact image identity")
         except Exception as error:
             failure = error
         try:
-            terminated = self._destroy_build(reservation)
+            with self.lock:
+                cleanup_snapshot = copy.deepcopy(self.state["reservations"].get(reservation_id, operation))
+            terminated = self._destroy_build(cleanup_snapshot)
         except Exception as error:
             terminated = False
             if failure is None:
                 failure = error
-        with self.lock:
+        with self._transition():
+            reservation = self.state["reservations"].get(reservation_id)
+            if reservation is None:
+                raise ProtocolError("build-cancelled", "build reservation disappeared during cleanup")
             reservation["buildTerminated"] = terminated
             if not terminated:
                 self._quarantine(reservation, f"build {reservation_id} termination could not be proven")
                 raise ProtocolError("build-termination-unproven", "control could not prove the build operation terminated")
+            if image_id:
+                reservation["locatorImageId"] = image_id
             reservation["state"] = "committed"
             if failure is not None:
                 reservation["buildError"] = str(failure)[-65536:]
@@ -942,6 +1150,13 @@ class Admission:
 
     def handle(self, request: dict[str, Any]) -> dict[str, Any]:
         with self.lock:
+            scope_owner = self._begin_transition_scope()
+            try:
+                return self._handle(request)
+            finally:
+                self._end_transition_scope(scope_owner)
+
+    def _handle(self, request: dict[str, Any]) -> dict[str, Any]:
             kind = request.get("kind")
             if kind == "challenge":
                 return {
@@ -957,13 +1172,16 @@ class Admission:
                 }
             if kind == "status":
                 used = self._used()
+                assets = self.asset_facts
                 return {"profileId": self.profile_id, "generation": self.state["generation"],
                         "admissionOpen": self.state["admissionOpen"], "used": used,
                         "capacity": self._capacity(), "leases": list(self.state["leases"].values()),
                         "reservations": list(self.state["reservations"].values()),
                         "slots": list(self.state["slots"].values()),
                         "availableQuotaSlots": sum(1 for s in self.state["slots"].values() if s["state"] == "free"),
-                        "degraded": list(self.state["degraded"])}
+                        "degraded": list(self.state["degraded"]),
+                        "journal": {"state": "healthy", "durableTransitions": True},
+                        "assets": {"state": "verified" if assets and all(item["present"] for item in assets) else "missing", "images": assets}}
             if kind == "build.lookup":
                 if request.get("profileId") != self.profile_id or request.get("daemonGeneration") != self.state["generation"]:
                     raise ProtocolError("attestation-changed", "profile or daemon generation changed")
@@ -1058,13 +1276,16 @@ class Admission:
             if reservation is None or reservation["invocationId"] != lease["invocationId"]:
                 raise ProtocolError("reservation-not-found", "reservation is not owned by this lease")
             if kind == "reservation.get":
+                self._grant_queue()
                 return copy.deepcopy(reservation)
             if kind == "reservation.cancel":
-                if reservation["state"] != "queued":
-                    raise ProtocolError("reservation-state", "only a queued reservation can cancel")
-                self.state["queue"].remove(reservation_id)
+                if reservation["state"] not in ("queued", "blocked"):
+                    raise ProtocolError("reservation-state", "only a queued or blocked reservation can cancel")
+                if reservation_id in self.state["queue"]:
+                    self.state["queue"].remove(reservation_id)
                 del self.state["reservations"][reservation_id]
                 self._commit("reservation-cancelled", {"reservationId": reservation_id})
+                self._grant_queue()
                 return {"cancelled": True}
             if kind == "reservation.commit":
                 raise ProtocolError("control-create-unimplemented", "container create must be owned by the control service; client-supplied IDs are forbidden")
@@ -1104,11 +1325,26 @@ class Admission:
                 if reservation["kind"] == "build":
                     if "terminationEvidence" in request:
                         raise ProtocolError("build-release-client-evidence-forbidden", "build termination proof is control-owned")
-                    if reservation.get("buildTerminated") is not True or not self._build_resources_absent(reservation):
+                    if reservation.get("retention") == "ephemeral":
+                        locator = str(reservation.get("locator", ""))
+                        expected_image_id = str(reservation.get("locatorImageId", ""))
+                        actual_image_id = self._docker("image", "inspect", "--format", "{{.Id}}", locator).stdout.strip()
+                        operation_label = self._docker(
+                            "image", "inspect", "--format", "{{index .Config.Labels \"niceeval.operation-id\"}}", locator,
+                        ).stdout.strip()
+                        if (not expected_image_id or actual_image_id != expected_image_id
+                                or operation_label != reservation.get("operationId")):
+                            raise ProtocolError("build-release-unproven", "ephemeral locator no longer names the control-owned image")
+                        self._docker("image", "rm", "--force", locator)
+                    if reservation.get("buildTerminated") is not True or not self._build_resources_absent(
+                        reservation, require_ephemeral_locator_absent=True,
+                    ):
                         raise ProtocolError("build-still-active", "control has not proven complete build termination")
+                    if reservation.get("retention") == "ephemeral":
+                        reservation["ephemeralCleanupProven"] = True
                 reservation["state"] = "releasing"
                 self._commit("reservation-release-intent", {"reservationId": reservation_id})
-                if reservation["kind"] == "container" and not self._destroy(reservation):
+                if reservation["kind"] == "container" and not self._cleanup_with_deadline(reservation):
                     self.state["degraded"].append(f"could not prove resources absent for {reservation_id}")
                     self._commit("reservation-release-blocked", {"reservationId": reservation_id})
                     raise ProtocolError("recovery-blocked", "container/network are still visible")
@@ -1117,10 +1353,18 @@ class Admission:
                 del self.state["reservations"][reservation_id]
                 self._commit("reservation-released", {"reservationId": reservation_id})
                 self._grant_queue()
-                return {"released": True}
+                return {"released": True, **({"cleanupProven": True} if reservation.get("ephemeralCleanupProven") else {})}
             raise ProtocolError("request-unknown", f"unknown request kind {kind!r}")
 
     def _reconcile_restarted_builds(self) -> None:
+        with self.lock:
+            scope_owner = self._begin_transition_scope()
+            try:
+                self._reconcile_restarted_builds_impl()
+            finally:
+                self._end_transition_scope(scope_owner)
+
+    def _reconcile_restarted_builds_impl(self) -> None:
         with self.lock:
             active = [
                 reservation for reservation in self.state["reservations"].values()
@@ -1158,6 +1402,14 @@ class Admission:
             })
 
     def _recover_once(self) -> None:
+        with self.lock:
+            scope_owner = self._begin_transition_scope()
+            try:
+                self._recover_once_impl()
+            finally:
+                self._end_transition_scope(scope_owner)
+
+    def _recover_once_impl(self) -> None:
         with self.lock:
             changed = False
             for lease in self.state["leases"].values():
@@ -1207,15 +1459,20 @@ class Admission:
                 if not unresolved:
                     lease["state"] = "recovered"
                     changed = True
+                else:
+                    self.state["admissionOpen"] = False
+                    changed = True
             if changed:
                 self._grant_queue()
+                if not self.state["degraded"]:
+                    self.state["admissionOpen"] = True
                 self._commit("recovery-converged", {})
 
     def recovery_loop(self) -> None:
         while not self.stop.wait(1.0):
             try:
                 cutoff = time.time() - self.grace
-                with self.lock:
+                with self._transition():
                     for lease in self.state["leases"].values():
                         if lease["state"] != "active":
                             continue
@@ -1225,7 +1482,7 @@ class Admission:
                             self._commit("lease-lost", {"invocationId": lease["invocationId"]})
                 self._recover_once()
             except Exception as error:
-                with self.lock:
+                with self._transition():
                     message = f"recovery loop blocked: {error}"
                     self.state["admissionOpen"] = False
                     self.state["degraded"] = [

--- a/packaging/docker-profile-host/scripts/watchdog.py
+++ b/packaging/docker-profile-host/scripts/watchdog.py
@@ -48,8 +48,8 @@ MAX_BUILD_CONTEXT_CHUNK_BYTES = 4 * 1024 * 1024
 QUEUE_TIMEOUT_SECONDS = 30
 CLEANUP_TIMEOUT_SECONDS = 60
 REQUIRED_ASSETS = {
-    "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c": "sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c",
-    "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8": "sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
+    "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c",
+    "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8",
 }
 DIAGNOSTIC_COMMAND = ["sh", "-ec", "\n".join((
     "set -eu",
@@ -264,25 +264,19 @@ class Admission:
             images = manifest.get("images", [])
             if manifest.get("schemaVersion") != 1 or manifest.get("platform") != "linux/amd64" or not isinstance(images, list):
                 raise ValueError("images must be a list")
-            declared = {
-                item.get("reference"): item.get("imageId")
-                for item in images if isinstance(item, dict)
-            }
+            declared = {item.get("reference") for item in images if isinstance(item, dict)}
             if declared != REQUIRED_ASSETS:
                 raise ValueError("manifest must contain exactly the fixed DIND and BuildKit identities")
             facts: list[dict[str, Any]] = []
             for image in images:
                 reference = image.get("reference") if isinstance(image, dict) else None
-                expected_id = image.get("imageId") if isinstance(image, dict) else None
                 platform = image.get("platform") if isinstance(image, dict) else None
                 if (not isinstance(reference, str) or "@sha256:" not in reference
-                        or not isinstance(expected_id, str) or not expected_id.startswith("sha256:")
                         or platform != "linux/amd64"):
                     raise ValueError("image reference must be digest pinned")
-                inspect = self._docker("image", "inspect", "--format", "{{.Id}} {{.Os}}/{{.Architecture}}", reference, check=False)
-                fields = inspect.stdout.strip().split()
-                present = inspect.returncode == 0 and fields == [expected_id, platform]
-                facts.append({"reference": reference, "imageId": expected_id, "platform": platform, "present": present})
+                inspect = self._docker("image", "inspect", "--format", "{{.Os}}/{{.Architecture}}", reference, check=False)
+                present = inspect.returncode == 0 and inspect.stdout.strip() == platform
+                facts.append({"reference": reference, "platform": platform, "present": present})
             return facts
         except Exception as error:
             return [{"reference": "invalid-manifest", "present": False, "error": str(error)}]

--- a/packaging/docker-profile-host/scripts/watchdog.py
+++ b/packaging/docker-profile-host/scripts/watchdog.py
@@ -16,13 +16,16 @@ import json
 import math
 import os
 import posixpath
+import re
 import secrets
 import signal
 import socketserver
 import stat
 import subprocess
+import tarfile
 import threading
 import time
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -38,6 +41,35 @@ LABELS = {
 
 CREATE_KEYS = {"image", "command", "entrypoint", "environment", "workingDir", "user", "tmpfs", "attemptId"}
 FORBIDDEN_CREATE_KEYS = {"binds", "mounts", "volumes", "hostConfig", "devices", "networkMode", "ports", "extraHosts"}
+BUILD_KEYS = {"buildKey", "platform", "dockerfile", "buildArgs", "target"}
+MAX_BUILD_CONTEXT_BYTES = 2 * 1024 * 1024 * 1024
+MAX_BUILD_CONTEXT_CHUNK_BYTES = 4 * 1024 * 1024
+
+
+def read_exact(reader: Any, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        chunk = reader.read(remaining)
+        if not chunk:
+            raise ProtocolError("build-context-truncated", "build context ended inside a frame")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def receive_framed_build_context(reader: Any, output: Any) -> int:
+    total = 0
+    while True:
+        length = int.from_bytes(read_exact(reader, 4), "big")
+        if length == 0:
+            return total
+        if length > MAX_BUILD_CONTEXT_CHUNK_BYTES:
+            raise ProtocolError("build-context-frame-too-large", "build context frame exceeds four MiB")
+        total += length
+        if total > MAX_BUILD_CONTEXT_BYTES:
+            raise ProtocolError("build-context-too-large", "build context exceeds two GiB")
+        output.write(read_exact(reader, length))
 
 
 def now() -> str:
@@ -77,6 +109,7 @@ class Admission:
         self.grace = grace
         self.lock = threading.RLock()
         self.stop = threading.Event()
+        self.build_processes: dict[str, subprocess.Popen[str]] = {}
         self.state: dict[str, Any] = {
             "schemaVersion": 1,
             "generation": self._generation(),
@@ -97,6 +130,7 @@ class Admission:
             self._recover_once()
             self.state["admissionOpen"] = not self.state["degraded"]
             self._commit("daemon-generation-reconciled", {})
+        self._reconcile_restarted_builds()
 
     def _load_slots(self) -> None:
         storage = self.host_config.get("storage", {}) if self.host_config else {}
@@ -416,6 +450,416 @@ class Admission:
             raise ProtocolError("container-create-invalid", "tmpfs paths are not permitted")
         return copy.deepcopy(raw)
 
+    def _validate_build(self, raw: Any) -> dict[str, Any]:
+        if not isinstance(raw, dict) or set(raw) - BUILD_KEYS:
+            raise ProtocolError("build-create-host-input", "build accepts only normalized context metadata")
+        build_key = raw.get("buildKey")
+        platform = raw.get("platform")
+        dockerfile = raw.get("dockerfile")
+        build_args = raw.get("buildArgs", {})
+        target = raw.get("target")
+        if not isinstance(build_key, str) or re.fullmatch(r"[a-f0-9]{64}", build_key) is None:
+            raise ProtocolError("build-create-invalid", "buildKey must be a sha256 hex digest")
+        if not isinstance(platform, str) or re.fullmatch(r"linux/[A-Za-z0-9_.-]+", platform) is None:
+            raise ProtocolError("build-create-invalid", "platform must be a normalized Linux platform")
+        if (not isinstance(dockerfile, str) or not dockerfile or dockerfile.startswith("/")
+                or posixpath.normpath(dockerfile) != dockerfile
+                or dockerfile == ".." or dockerfile.startswith("../")):
+            raise ProtocolError("build-create-host-input", "Dockerfile must be a normalized context-relative path")
+        if not isinstance(build_args, dict) or any(
+            not isinstance(key, str) or not key or not isinstance(value, str)
+            for key, value in build_args.items()
+        ):
+            raise ProtocolError("build-create-invalid", "buildArgs must contain string keys and values")
+        if target is not None and (not isinstance(target, str) or not target or "\n" in target or "\r" in target):
+            raise ProtocolError("build-create-invalid", "target must be one non-empty line")
+        return copy.deepcopy(raw)
+
+    def validate_build_context(self, spec: dict[str, Any], context_path: Path) -> None:
+        names: set[str] = set()
+        total = 0
+        try:
+            with tarfile.open(context_path, mode="r:*") as archive:
+                for member in archive:
+                    name = member.name
+                    if (not name or name.startswith("/") or "\\" in name
+                            or posixpath.normpath(name) != name
+                            or name in (".", "..") or name.startswith("../")):
+                        raise ProtocolError("build-context-path-forbidden", "tar entries must be normalized relative paths")
+                    if name in names:
+                        raise ProtocolError("build-context-duplicate", f"duplicate tar entry {name!r}")
+                    names.add(name)
+                    if not member.isfile() or member.issparse():
+                        raise ProtocolError("build-context-type-forbidden", "build context accepts regular files only")
+                    total += member.size
+                    if member.size < 0 or total > MAX_BUILD_CONTEXT_BYTES:
+                        raise ProtocolError("build-context-too-large", "expanded build context exceeds two GiB")
+        except ProtocolError:
+            raise
+        except (tarfile.TarError, OSError) as error:
+            raise ProtocolError("build-context-invalid-tar", f"build context is not a valid tar archive: {error}") from error
+        if spec["dockerfile"] not in names:
+            raise ProtocolError("build-context-dockerfile-missing", "declared Dockerfile is absent from build context")
+
+    def _build_locator(self, build_key: str) -> str:
+        return "niceeval-build:" + build_key[:32]
+
+    def _build_labels(self, reservation: dict[str, Any]) -> dict[str, str]:
+        return {
+            label: str(self.profile_id if field == "profileId" else reservation[field])
+            for field, label in LABELS.items()
+            if field != "attemptId"
+        }
+
+    def _builder_container_name(self, reservation: dict[str, Any]) -> str:
+        builder = str(reservation.get("builderName", ""))
+        if re.fullmatch(r"niceeval-build-[a-f0-9]{24}", builder) is None:
+            raise RuntimeError("journaled builder name is not control-derived")
+        return "buildx_buildkit_" + builder + "0"
+
+    def _builder_volume_name(self, reservation: dict[str, Any]) -> str:
+        return self._builder_container_name(reservation) + "_state"
+
+    def _builder_container_ids(self, reservation: dict[str, Any]) -> list[str]:
+        name = self._builder_container_name(reservation)
+        result = self._docker("ps", "-aq", "--filter", f"name=^/{name}$", check=False)
+        if result.returncode != 0:
+            raise RuntimeError("Docker builder-container query failed; refusing to infer absence")
+        return result.stdout.split()
+
+    def _builder_volume_names(self, reservation: dict[str, Any]) -> list[str]:
+        name = self._builder_volume_name(reservation)
+        result = self._docker("volume", "ls", "-q", "--filter", f"name=^{name}$", check=False)
+        if result.returncode != 0:
+            raise RuntimeError("Docker builder-volume query failed; refusing to infer absence")
+        names = result.stdout.split()
+        if any(item != name for item in names):
+            raise RuntimeError("Docker builder-volume query returned a non-exact name")
+        return names
+
+    @staticmethod
+    def _process_start_time(pid: int) -> str | None:
+        try:
+            fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rpartition(") ")[2].split()
+            return fields[19]
+        except (FileNotFoundError, IndexError, OSError):
+            return None
+
+    @staticmethod
+    def _process_cgroup_path(pid: int) -> str | None:
+        try:
+            for line in Path(f"/proc/{pid}/cgroup").read_text(encoding="utf-8").splitlines():
+                if line.startswith("0::"):
+                    relative = line[3:].lstrip("/")
+                    root = Path("/sys/fs/cgroup").resolve()
+                    path = (root / relative).resolve()
+                    if path != root and root not in path.parents:
+                        raise RuntimeError("builder cgroup escaped /sys/fs/cgroup")
+                    return str(path)
+        except FileNotFoundError:
+            return None
+        raise RuntimeError(f"cannot attest cgroup v2 path for pid {pid}")
+
+    def _builder_process_facts(self, container_ids: list[str]) -> list[dict[str, Any]]:
+        facts: list[dict[str, Any]] = []
+        for container_id in container_ids:
+            result = self._docker("inspect", "--format", "{{.State.Pid}}", container_id, check=False)
+            if result.returncode != 0 or not result.stdout.strip().isdigit():
+                raise RuntimeError(f"cannot attest builder container process for {container_id}")
+            pid = int(result.stdout.strip())
+            start_time = self._process_start_time(pid)
+            cgroup_path = self._process_cgroup_path(pid)
+            if pid <= 0 or start_time is None or cgroup_path is None:
+                raise RuntimeError(f"builder container {container_id} has no stable process/cgroup identity")
+            facts.append({
+                "containerId": container_id,
+                "pid": pid,
+                "startTime": start_time,
+                "cgroupPath": cgroup_path,
+            })
+        return facts
+
+    def _record_builder_resources(self, reservation: dict[str, Any]) -> None:
+        container_ids = self._builder_container_ids(reservation)
+        if len(container_ids) != 1:
+            raise RuntimeError("control-derived builder must have exactly one container")
+        volume_names = self._builder_volume_names(reservation)
+        if volume_names != [self._builder_volume_name(reservation)]:
+            raise RuntimeError("control-derived builder must have exactly one state volume")
+        reservation["builderContainerIds"] = container_ids
+        reservation["builderProcesses"] = self._builder_process_facts(container_ids)
+        reservation["builderVolumeNames"] = volume_names
+        self._commit("build-builder-resources", {
+            "reservationId": reservation["reservationId"],
+            "containerIds": container_ids,
+            "volumeNames": volume_names,
+        })
+
+    def _terminate_build_process(self, reservation: dict[str, Any]) -> bool:
+        process = self.build_processes.get(reservation["reservationId"])
+        if process is not None and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+        identity = reservation.get("buildProcess")
+        if identity is None:
+            return True
+        if not isinstance(identity, dict) or not isinstance(identity.get("pid"), int) \
+                or not isinstance(identity.get("startTime"), str):
+            raise RuntimeError("journaled build process identity is invalid")
+        pid = identity["pid"]
+        expected = identity["startTime"]
+        if self._process_start_time(pid) == expected:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            deadline = time.monotonic() + 5
+            while self._process_start_time(pid) == expected and time.monotonic() < deadline:
+                time.sleep(0.05)
+            if self._process_start_time(pid) == expected:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                deadline = time.monotonic() + 5
+                while self._process_start_time(pid) == expected and time.monotonic() < deadline:
+                    time.sleep(0.05)
+        absent = self._process_start_time(pid) != expected
+        if absent:
+            reservation.pop("buildProcess", None)
+        return absent
+
+    def _builder_processes_absent(self, reservation: dict[str, Any]) -> bool:
+        for fact in reservation.get("builderProcesses", []):
+            if not isinstance(fact, dict):
+                return False
+            pid, start_time, cgroup_path = fact.get("pid"), fact.get("startTime"), fact.get("cgroupPath")
+            if not isinstance(pid, int) or not isinstance(start_time, str) or not isinstance(cgroup_path, str):
+                return False
+            if self._process_start_time(pid) == start_time or Path(cgroup_path).exists():
+                return False
+        return True
+
+    def _build_resources_absent(self, reservation: dict[str, Any]) -> bool:
+        process = self.build_processes.get(reservation["reservationId"])
+        if process is not None and process.poll() is None:
+            return False
+        identity = reservation.get("buildProcess")
+        if isinstance(identity, dict) and isinstance(identity.get("pid"), int) \
+                and isinstance(identity.get("startTime"), str) \
+                and self._process_start_time(identity["pid"]) == identity["startTime"]:
+            return False
+        builder = str(reservation.get("builderName", ""))
+        provisional = str(reservation.get("provisionalRef", ""))
+        if builder and self._docker("buildx", "inspect", builder, check=False).returncode == 0:
+            return False
+        if builder and self._builder_container_ids(reservation):
+            return False
+        if builder and self._builder_volume_names(reservation):
+            return False
+        if not self._builder_processes_absent(reservation):
+            return False
+        if provisional and self._docker("image", "inspect", provisional, check=False).returncode == 0:
+            return False
+        containers, networks = self._resource_ids(reservation)
+        return not containers and not networks
+
+    def _destroy_build(self, reservation: dict[str, Any]) -> bool:
+        process_absent = self._terminate_build_process(reservation)
+        builder_attested = True
+        builder = str(reservation.get("builderName", ""))
+        provisional = str(reservation.get("provisionalRef", ""))
+        if builder:
+            current_ids = self._builder_container_ids(reservation)
+            if current_ids and not reservation.get("builderProcesses"):
+                try:
+                    reservation["builderContainerIds"] = current_ids
+                    reservation["builderProcesses"] = self._builder_process_facts(current_ids)
+                except Exception:
+                    builder_attested = False
+            try:
+                self._docker("buildx", "rm", "--force", builder, check=False)
+            except Exception:
+                pass
+            for container_id in self._builder_container_ids(reservation):
+                self._docker("rm", "-f", container_id, check=False)
+            for volume_name in self._builder_volume_names(reservation):
+                self._docker("volume", "rm", "-f", volume_name, check=False)
+        if provisional:
+            self._docker("image", "rm", "--force", provisional, check=False)
+        _, networks = self._resource_ids(reservation)
+        for network in networks:
+            self._docker("network", "rm", network, check=False)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if process_absent and builder_attested and self._build_resources_absent(reservation):
+                return True
+            time.sleep(0.1)
+        return process_absent and builder_attested and self._build_resources_absent(reservation)
+
+    def _run_build(self, reservation: dict[str, Any], spec: dict[str, Any], context_path: Path) -> None:
+        args = [
+            "docker", "--host", f"unix://{self.docker_socket}",
+            "buildx", "build", "--builder", reservation["builderName"], "--load",
+            "--platform", spec["platform"], "--file", spec["dockerfile"],
+            "--tag", reservation["provisionalRef"],
+        ]
+        for key, value in sorted(spec.get("buildArgs", {}).items()):
+            args += ["--build-arg", f"{key}={value}"]
+        if spec.get("target"):
+            args += ["--target", spec["target"]]
+        args.append("-")
+        with context_path.open("rb") as context:
+            process = subprocess.Popen(
+                args,
+                stdin=context,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            start_time = self._process_start_time(process.pid)
+            if start_time is None:
+                process.terminate()
+                process.wait(timeout=5)
+                raise ProtocolError("build-process-attestation-failed", "cannot journal build process identity")
+            with self.lock:
+                self.build_processes[reservation["reservationId"]] = process
+                reservation["buildProcess"] = {"pid": process.pid, "startTime": start_time}
+                self._commit("build-process-started", {
+                    "reservationId": reservation["reservationId"],
+                    "pid": process.pid,
+                    "startTime": start_time,
+                })
+            try:
+                _, stderr = process.communicate(timeout=15 * 60)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                try:
+                    _, stderr = process.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    _, stderr = process.communicate(timeout=5)
+                raise ProtocolError("build-create-timeout", "control-owned build exceeded 15 minutes")
+            finally:
+                with self.lock:
+                    self.build_processes.pop(reservation["reservationId"], None)
+            if process.returncode != 0:
+                raise ProtocolError("build-create-failed", (stderr or "Docker build failed")[-65536:])
+
+    def authorize_build_header(self, request: dict[str, Any]) -> None:
+        with self.lock:
+            if request.get("kind") != "build.create" or request.get("contextEncoding") != "tar-chunked/v1":
+                raise ProtocolError("build-create-invalid", "build context framing must be tar-chunked/v1")
+            lease = self._lease(request)
+            reservation = self.state["reservations"].get(str(request.get("reservationId", "")))
+            if reservation is None or reservation["invocationId"] != lease["invocationId"]:
+                raise ProtocolError("reservation-not-found", "reservation is not owned by this lease")
+            if reservation["kind"] != "build" or reservation["state"] not in ("granted", "provisioning", "committed"):
+                raise ProtocolError("reservation-state", "build reservation is not createable")
+            self._validate_build(request.get("build"))
+
+    def handle_build(self, request: dict[str, Any], context_path: Path) -> dict[str, Any]:
+        self.authorize_build_header(request)
+        spec = self._validate_build(request.get("build"))
+        self.validate_build_context(spec, context_path)
+        reservation_id = str(request["reservationId"])
+        digest = canonical_digest(spec)
+        with self.lock:
+            reservation = self.state["reservations"][reservation_id]
+            if reservation["state"] == "committed":
+                if reservation.get("buildSpecDigest") != digest:
+                    raise ProtocolError("build-create-conflict", "retry does not match journaled build intent")
+                if reservation.get("buildTerminated") is True and reservation.get("locator"):
+                    self._commit("build-create-replayed", {"reservationId": reservation_id})
+                    return {"locator": reservation["locator"], "state": "terminated"}
+                raise ProtocolError("build-create-failed", str(reservation.get("buildError", "prior build failed")))
+            if reservation["state"] == "provisioning":
+                if reservation.get("buildSpecDigest") != digest:
+                    raise ProtocolError("build-create-conflict", "retry does not match journaled build intent")
+                raise ProtocolError("build-create-active", "the control-owned build operation is still active")
+            reservation["buildSpecDigest"] = digest
+            reservation["operationId"] = hashlib.sha256(
+                f"{reservation_id}:{reservation['provisionToken']}".encode()
+            ).hexdigest()[:32]
+            reservation["builderName"] = "niceeval-build-" + reservation["operationId"][:24]
+            reservation["provisionalRef"] = "niceeval-build-provisional:" + reservation["operationId"]
+            reservation["locator"] = self._build_locator(spec["buildKey"])
+            reservation["state"] = "provisioning"
+            self._commit("build-create-intent", {
+                "reservationId": reservation_id,
+                "operationId": reservation["operationId"],
+                "specDigest": digest,
+                "provisionalRef": reservation["provisionalRef"],
+            })
+
+        failure: Exception | None = None
+        try:
+            labels = self._build_labels(reservation)
+            network_args = [
+                "network", "create", "--driver", "bridge", "--opt",
+                "com.docker.network.bridge.enable_icc=false",
+            ]
+            for key, value in labels.items():
+                network_args += ["--label", f"{key}={value}"]
+            network_args.append("niceeval-build-" + reservation["provisionToken"][:20])
+            with self.lock:
+                self._commit("build-network-create-intent", {"reservationId": reservation_id})
+            network_id = self._docker(*network_args).stdout.strip()
+            with self.lock:
+                reservation["networkId"] = network_id
+                self._commit("build-network-created", {
+                    "reservationId": reservation_id, "networkId": network_id,
+                })
+            self._docker(
+                "buildx", "create", "--driver", "docker-container",
+                "--driver-opt", f"network={network_id}",
+                "--name", reservation["builderName"],
+            )
+            with self.lock:
+                self._commit("build-builder-created", {
+                    "reservationId": reservation_id, "builderName": reservation["builderName"],
+                })
+            self._docker("buildx", "inspect", "--bootstrap", reservation["builderName"])
+            with self.lock:
+                self._record_builder_resources(reservation)
+            self._run_build(reservation, spec, context_path)
+            self._docker("tag", reservation["provisionalRef"], reservation["locator"])
+        except Exception as error:
+            failure = error
+        try:
+            terminated = self._destroy_build(reservation)
+        except Exception as error:
+            terminated = False
+            if failure is None:
+                failure = error
+        with self.lock:
+            reservation["buildTerminated"] = terminated
+            if not terminated:
+                self._quarantine(reservation, f"build {reservation_id} termination could not be proven")
+                raise ProtocolError("build-termination-unproven", "control could not prove the build operation terminated")
+            reservation["state"] = "committed"
+            if failure is not None:
+                reservation["buildError"] = str(failure)[-65536:]
+            self._commit("build-terminated", {
+                "reservationId": reservation_id,
+                "operationId": reservation["operationId"],
+                "locator": reservation["locator"],
+                "outcome": "failed" if failure is not None else "succeeded",
+            })
+        if failure is not None:
+            if isinstance(failure, ProtocolError):
+                raise failure
+            if isinstance(failure, subprocess.CalledProcessError):
+                detail = (failure.stderr or failure.stdout or str(failure)).strip()[-65536:]
+            else:
+                detail = str(failure)
+            raise ProtocolError("build-create-failed", detail)
+        return {"locator": reservation["locator"], "state": "terminated"}
+
     def _create_container(self, reservation: dict[str, Any], spec: dict[str, Any]) -> dict[str, Any]:
         slot = self.state["slots"][reservation["slotId"]]
         reservation["attemptId"] = str(spec["attemptId"])
@@ -427,7 +871,10 @@ class Admission:
         self._commit("container-create-intent", {"reservationId": reservation["reservationId"],
                                                   "specDigest": reservation["createSpecDigest"]})
         network_name = "niceeval-" + reservation["provisionToken"][:20]
-        network_args = ["network", "create", "--driver", "bridge"]
+        network_args = [
+            "network", "create", "--driver", "bridge", "--opt",
+            "com.docker.network.bridge.enable_icc=false",
+        ]
         for key, value in labels.items():
             network_args += ["--label", f"{key}={value}"]
         network_args.append(network_name)
@@ -460,6 +907,10 @@ class Admission:
             args += ["--tmpfs", f"{path}:{options}"]
         for value in spec.get("environment", []):
             args += ["--env", str(value)]
+        policy = self.descriptor.get("policy", {})
+        if policy.get("level") == "managed-rootless/v1":
+            for server in policy.get("network", {}).get("dns", {}).get("servers", []):
+                args += ["--dns", str(server)]
         if spec.get("workingDir"):
             args += ["--workdir", str(spec["workingDir"])]
         if spec.get("user"):
@@ -513,6 +964,15 @@ class Admission:
                         "slots": list(self.state["slots"].values()),
                         "availableQuotaSlots": sum(1 for s in self.state["slots"].values() if s["state"] == "free"),
                         "degraded": list(self.state["degraded"])}
+            if kind == "build.lookup":
+                if request.get("profileId") != self.profile_id or request.get("daemonGeneration") != self.state["generation"]:
+                    raise ProtocolError("attestation-changed", "profile or daemon generation changed")
+                build_key = request.get("buildKey")
+                if not isinstance(build_key, str) or re.fullmatch(r"[a-f0-9]{64}", build_key) is None:
+                    raise ProtocolError("build-lookup-invalid", "buildKey must be a sha256 hex digest")
+                locator = self._build_locator(build_key)
+                hit = self._docker("image", "inspect", locator, check=False).returncode == 0
+                return {"hit": hit, "locator": locator}
             if kind == "lease.create":
                 if not self.state["admissionOpen"]:
                     raise ProtocolError("admission-closed", "profile recovery has not converged")
@@ -609,9 +1069,17 @@ class Admission:
             if kind == "reservation.commit":
                 raise ProtocolError("control-create-unimplemented", "container create must be owned by the control service; client-supplied IDs are forbidden")
             if kind == "container.create":
-                if reservation["kind"] != "container" or reservation["state"] not in ("granted", "provisioning"):
+                if reservation["kind"] != "container" or reservation["state"] not in ("granted", "provisioning", "committed"):
                     raise ProtocolError("reservation-state", "container reservation is not createable")
                 spec = self._validate_create(request.get("create"))
+                if reservation["state"] == "committed":
+                    if reservation.get("createSpecDigest") != canonical_digest(spec):
+                        raise ProtocolError("container-create-conflict", "replay does not match journaled create intent")
+                    containers, networks = self._resource_ids(reservation)
+                    if containers != [reservation.get("containerId")] or networks != [reservation.get("networkId")]:
+                        raise ProtocolError("container-create-replay-incomplete", "committed container resources are not uniquely visible")
+                    self._commit("container-create-replayed", {"reservationId": reservation_id})
+                    return {"containerId": containers[0], "networkId": networks[0], "state": "active"}
                 if reservation["state"] == "provisioning":
                     if reservation.get("createSpecDigest") != canonical_digest(spec):
                         raise ProtocolError("container-create-conflict", "retry does not match journaled create intent")
@@ -623,12 +1091,21 @@ class Admission:
                         self._commit("container-create-reconciled", {"reservationId": reservation_id})
                         return {"containerId": containers[0], "networkId": networks[0], "state": "active"}
                 return self._create_container(reservation, spec)
+            if kind == "build.cancel":
+                if reservation["kind"] != "build" or reservation["state"] != "provisioning":
+                    raise ProtocolError("reservation-state", "only an active build can cancel")
+                reservation["cancelRequested"] = True
+                process = self.build_processes.get(reservation_id)
+                if process is not None and process.poll() is None:
+                    process.terminate()
+                self._commit("build-cancel-requested", {"reservationId": reservation_id})
+                return {"cancelRequested": True}
             if kind == "reservation.release":
                 if reservation["kind"] == "build":
-                    evidence = request.get("terminationEvidence", {})
-                    required = ("daemonRequestTerminated", "buildkitSessionGone", "processActivityZero", "provisionalRefResolvedOrRemoved")
-                    if not all(evidence.get(item) is True for item in required):
-                        raise ProtocolError("build-still-active", "complete build termination evidence is required")
+                    if "terminationEvidence" in request:
+                        raise ProtocolError("build-release-client-evidence-forbidden", "build termination proof is control-owned")
+                    if reservation.get("buildTerminated") is not True or not self._build_resources_absent(reservation):
+                        raise ProtocolError("build-still-active", "control has not proven complete build termination")
                 reservation["state"] = "releasing"
                 self._commit("reservation-release-intent", {"reservationId": reservation_id})
                 if reservation["kind"] == "container" and not self._destroy(reservation):
@@ -643,6 +1120,43 @@ class Admission:
                 return {"released": True}
             raise ProtocolError("request-unknown", f"unknown request kind {kind!r}")
 
+    def _reconcile_restarted_builds(self) -> None:
+        with self.lock:
+            active = [
+                reservation for reservation in self.state["reservations"].values()
+                if reservation["kind"] == "build" and reservation["state"] == "provisioning"
+            ]
+            if not active:
+                return
+            reopen = bool(self.state["admissionOpen"])
+            self.state["admissionOpen"] = False
+            self._commit("build-restart-recovery-started", {
+                "reservationIds": [reservation["reservationId"] for reservation in active],
+            })
+            for reservation in active:
+                reservation_id = reservation["reservationId"]
+                try:
+                    terminated = self._destroy_build(reservation)
+                except Exception as error:
+                    terminated = False
+                    reason = str(error)
+                else:
+                    reason = "watchdog restarted before the control-owned build completed"
+                reservation["buildTerminated"] = terminated
+                if terminated:
+                    reservation["state"] = "committed"
+                    reservation["buildError"] = reason
+                    self._commit("build-restart-reconciled", {
+                        "reservationId": reservation_id,
+                        "outcome": "cancelled",
+                    })
+                else:
+                    self._quarantine(reservation, f"build {reservation_id} restart recovery failed: {reason}")
+            self.state["admissionOpen"] = reopen and not self.state["degraded"]
+            self._commit("build-restart-recovery-finished", {
+                "admissionOpen": self.state["admissionOpen"],
+            })
+
     def _recover_once(self) -> None:
         with self.lock:
             changed = False
@@ -653,13 +1167,18 @@ class Admission:
                 unresolved = False
                 for reservation in owned:
                     recovery_error = f"recovery blocked for {reservation['reservationId']}"
-                    if reservation["kind"] == "build" and reservation["state"] in ("committed", "releasing"):
-                        message = f"build {reservation['reservationId']} lacks termination evidence"
-                        if message not in self.state["degraded"]:
-                            self.state["degraded"].append(message)
-                        unresolved = True
-                        continue
+                    if reservation["kind"] == "build" and reservation["state"] == "provisioning":
+                        process = self.build_processes.get(reservation["reservationId"])
+                        if process is not None:
+                            if process.poll() is None:
+                                process.terminate()
+                            reservation["cancelRequested"] = True
+                            unresolved = True
+                            continue
                     try:
+                        if reservation["kind"] == "build" and not self._destroy_build(reservation):
+                            unresolved = True
+                            continue
                         if reservation["kind"] == "container" and not self._destroy(reservation):
                             unresolved = True
                             continue
@@ -721,17 +1240,38 @@ class Admission:
 
 class Handler(socketserver.StreamRequestHandler):
     def handle(self) -> None:
+        context_path: Path | None = None
         try:
             raw = self.rfile.readline(1024 * 1024)
+            if not raw.endswith(b"\n"):
+                raise ProtocolError("request-invalid", "request header exceeds one MiB or is unterminated")
             request = json.loads(raw.decode("utf-8"))
             if not isinstance(request, dict):
                 raise ProtocolError("request-invalid", "request must be an object")
-            response = {"ok": True, "result": self.server.admission.handle(request)}  # type: ignore[attr-defined]
+            admission = self.server.admission  # type: ignore[attr-defined]
+            if request.get("kind") == "build.create":
+                admission.authorize_build_header(request)
+                admission.journal.parent.mkdir(parents=True, exist_ok=True)
+                fd, raw_path = tempfile.mkstemp(prefix="build-context-", suffix=".tar", dir=admission.journal.parent)
+                context_path = Path(raw_path)
+                with os.fdopen(fd, "wb") as context:
+                    receive_framed_build_context(self.rfile, context)
+                    context.flush()
+                    os.fsync(context.fileno())
+                response = {"ok": True, "result": admission.handle_build(request, context_path)}
+            else:
+                response = {"ok": True, "result": admission.handle(request)}
         except ProtocolError as error:
             response = {"ok": False, "error": {"code": error.code, "message": str(error)}}
         except Exception as error:
             response = {"ok": False, "error": {"code": "internal", "message": str(error)}}
-        self.wfile.write((json.dumps(response, separators=(",", ":")) + "\n").encode())
+        finally:
+            if context_path is not None:
+                context_path.unlink(missing_ok=True)
+        try:
+            self.wfile.write((json.dumps(response, separators=(",", ":")) + "\n").encode())
+        except BrokenPipeError:
+            pass
 
 
 class Server(socketserver.ThreadingUnixStreamServer):

--- a/scripts/generate-reference.ts
+++ b/scripts/generate-reference.ts
@@ -598,7 +598,6 @@ const CHINESE_CLI_REFERENCE_SUMMARIES: Readonly<Record<string, string>> = Object
   help: "打印该命令的帮助。",
   version: "打印当前安装的 NiceEval 版本。",
   yes: "确认计划中的 Record maintenance 操作。",
-  smoke: "运行 Docker profile 的探测诊断。",
   domain: "选择一个由 NiceEval 管理的 Docker 缓存域。",
   apply: "应用先前签发的 Docker 缓存回收计划。",
   window: "选择一个已记录的改动窗口。",
@@ -666,7 +665,6 @@ const CLI_OPTION_COMMAND_OWNERSHIP: Readonly<Record<string, Readonly<Record<stri
   }),
   "src/docker/cli/contribution.ts#DOCKER_OPTIONS": Object.freeze({
     json: Object.freeze(["docker profile list", "docker profile doctor", "docker cache inventory", "docker cache gc"]),
-    smoke: Object.freeze(["docker profile doctor"]),
     domain: Object.freeze(["docker cache inventory", "docker cache gc"]),
     apply: Object.freeze(["docker cache gc"]),
   }),

--- a/test/host/docker-profile-public-smoke.ts
+++ b/test/host/docker-profile-public-smoke.ts
@@ -1,0 +1,53 @@
+/** Control-protocol reply-loss smoke, run by watchdog-smoke. */
+import { createServer } from "node:net";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { releaseDockerProfileReservation, type DockerProfileLease } from "../../packages/niceeval/src/sandbox/docker-profile/runtime.ts";
+
+const binding = { profile: { profileId: "profile" }, daemonGeneration: "generation", controlSocketPath: "", dockerSocketPath: "", alias: "a", descriptorDigest: "d", daemonId: "d", platform: "linux/amd64" } as never;
+const lease = { binding, invocationId: "lease", leaseToken: "token", stopHeartbeat: async () => {} } as DockerProfileLease;
+
+async function matrix(status: object, success: boolean): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "niceeval-public-release-"));
+  const path = join(root, "control.sock");
+  let calls = 0;
+  const server = createServer((socket) => socket.once("data", (raw) => {
+    calls += 1;
+    if (calls === 1) { socket.destroy(); return; } // durable host success, lost reply
+    const request = JSON.parse(raw.toString()) as { kind: string };
+    socket.end(JSON.stringify({ ok: true, result: request.kind === "status" ? status : {} }) + "\n");
+  }));
+  await new Promise<void>((resolve) => server.listen(path, resolve));
+  const current = { ...lease, binding: { ...binding, controlSocketPath: path } };
+  const realNow = Date.now;
+  const base = realNow();
+  let reads = 0;
+  Date.now = () => (++reads <= 2 ? base : base + 120_000);
+  try {
+    const result = await Promise.race([
+      releaseDockerProfileReservation(current, "reservation", { slotId: "slot" }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("reply-loss proof timeout")), 1_000)),
+    ]);
+    if (!success || result.cleanupProven !== true) throw new Error("reply-loss proof accepted an invalid status");
+  } catch (error) {
+    if (success) throw error;
+  } finally {
+    Date.now = realNow;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  const good = { profileId: "profile", generation: "generation", leases: [{ invocationId: "lease", daemonGeneration: "generation" }], reservations: [], slots: [{ slotId: "slot", state: "free" }], degraded: [] };
+  await matrix(good, true);
+  await matrix({ ...good, profileId: "other" }, false);
+  await matrix({ ...good, generation: "other" }, false);
+  await matrix({ ...good, leases: [] }, false);
+  await matrix({ ...good, reservations: [{ reservationId: "reservation", invocationId: "lease" }] }, false);
+  await matrix({ ...good, slots: [{ slotId: "slot", reservationId: "reservation", state: "active" }] }, false);
+  await matrix({ ...good, degraded: ["recovery blocked for reservation"] }, false);
+  console.log("docker-profile-public-smoke ok");
+}
+void main();

--- a/test/host/run-checks.sh
+++ b/test/host/run-checks.sh
@@ -21,6 +21,8 @@ for f in \
   packaging/docker-profile-host/scripts/generate-descriptor.py \
   packaging/docker-profile-host/scripts/prepare-loop-storage.sh \
   packaging/docker-profile-host/scripts/watchdog.py \
+  packaging/docker-profile-host/scripts/preload-verify-assets.py \
+  packaging/docker-profile-host/config/assets-v1.json \
   packaging/docker-profile-host/scripts/install-quota-slots.py \
   packaging/docker-profile-host/scripts/host-doctor.sh \
   packaging/docker-profile-host/scripts/apply-rootless-network-policy.sh \

--- a/test/host/watchdog-smoke.py
+++ b/test/host/watchdog-smoke.py
@@ -6,10 +6,12 @@ import importlib.util
 import io
 import json
 import os
+import copy
 import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
 from pathlib import Path
 
 
@@ -50,21 +52,38 @@ def fake_docker(self, *args: str, check: bool = True):
         if not self.__dict__.get("fake_builder_rm_leaves_volume"):
             self.__dict__.pop("fake_builder_volume", None)
         output = ""
+    elif args[:2] == ("image", "inspect") and args[-1] in watchdog.REQUIRED_ASSETS:
+        output = f"{watchdog.REQUIRED_ASSETS[args[-1]]} linux/amd64\n"
     elif args[:2] == ("image", "inspect"):
         images = self.__dict__.setdefault("fake_images", set())
-        code = 0 if args[2] in images else 1
-        result = subprocess.CompletedProcess(args, code, "", "")
+        reference = args[-1]
+        code = 0 if reference in images else 1
+        output = ""
+        if code == 0 and "--format" in args:
+            image_ids = self.__dict__.setdefault("fake_image_ids", {})
+            image_labels = self.__dict__.setdefault("fake_image_labels", {})
+            format_value = args[args.index("--format") + 1]
+            if format_value == "{{.Id}}":
+                output = image_ids[reference] + "\n"
+            elif "niceeval.operation-id" in format_value:
+                output = image_labels[reference] + "\n"
+        result = subprocess.CompletedProcess(args, code, output, "")
         if check and code != 0:
             raise subprocess.CalledProcessError(code, args)
         return result
     elif args[:2] == ("image", "rm"):
-        self.__dict__.setdefault("fake_images", set()).discard(args[-1])
+        reference = args[-1]
+        self.__dict__.setdefault("fake_images", set()).discard(reference)
+        self.__dict__.setdefault("fake_image_ids", {}).pop(reference, None)
+        self.__dict__.setdefault("fake_image_labels", {}).pop(reference, None)
         output = ""
     elif args[:1] == ("tag",):
         images = self.__dict__.setdefault("fake_images", set())
         if args[1] not in images:
             raise subprocess.CalledProcessError(1, args, stderr="source image missing")
         images.add(args[2])
+        self.__dict__.setdefault("fake_image_ids", {})[args[2]] = self.fake_image_ids[args[1]]
+        self.__dict__.setdefault("fake_image_labels", {})[args[2]] = self.fake_image_labels[args[1]]
         output = ""
     elif args[:1] == ("create",):
         self.__dict__["fake_container"] = "container-a"
@@ -109,7 +128,10 @@ def fake_run_build(self, reservation, spec, context_path):
     self.__dict__["fake_build_runs"] = self.__dict__.get("fake_build_runs", 0) + 1
     with tarfile.open(context_path, "r:*") as archive:
         assert archive.extractfile("Dockerfile").read() == b"FROM scratch\n"
-    self.__dict__.setdefault("fake_images", set()).add(reservation["provisionalRef"])
+    provisional = reservation["provisionalRef"]
+    self.__dict__.setdefault("fake_images", set()).add(provisional)
+    self.__dict__.setdefault("fake_image_ids", {})[provisional] = "sha256:" + "1" * 64
+    self.__dict__.setdefault("fake_image_labels", {})[provisional] = reservation["operationId"]
 
 
 def tar_bytes(entries):
@@ -215,10 +237,16 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
     descriptor["backend"]["filesystem"] = {"dockerDataPool": {
         "count": 1, "bytesPerAllocation": 512, "attestation": "linux-project-quota/v1",
     }}
+    asset_manifest = root / "assets-v1.json"
+    asset_manifest.write_text(json.dumps({"schemaVersion": 1, "platform": "linux/amd64", "images": [
+        {"reference": reference, "imageId": image_id, "platform": "linux/amd64"}
+        for reference, image_id in watchdog.REQUIRED_ASSETS.items()
+    ]}), encoding="utf-8")
     host_config = root / "default.host.json"
-    host_config.write_text(json.dumps({"storage": {
-        "slotRegistryPath": str(slot_registry), "slotRootPath": str(slot_root),
-    }}), encoding="utf-8")
+    host_config.write_text(json.dumps({
+        "storage": {"slotRegistryPath": str(slot_registry), "slotRootPath": str(slot_root)},
+        "assets": {"manifestPath": str(asset_manifest)},
+    }), encoding="utf-8")
     descriptor_path = root / "default.json"
     descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
     journal = root / "events.ndjson"
@@ -234,6 +262,31 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
     })
     token = created["leaseToken"]
     common = {"invocationId": "invocation-a", "leaseToken": token}
+    # A failed fsync cannot publish a heartbeat mutation in memory or after a
+    # restart.  This exercises the normal handle() transition scope.
+    published_before_fsync_failure = copy.deepcopy(admission._published_state)
+    original_fsync = watchdog.os.fsync
+    watchdog.os.fsync = lambda _fd: (_ for _ in ()).throw(OSError("injected fsync failure"))
+    try:
+        admission.handle({**common, "kind": "lease.heartbeat"})
+    except OSError:
+        pass
+    else:
+        raise AssertionError("injected journal fsync failure must reject the transition")
+    finally:
+        watchdog.os.fsync = original_fsync
+    assert admission._published_state == published_before_fsync_failure
+    restarted_after_fsync_failure = watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)
+    assert restarted_after_fsync_failure._published_state == published_before_fsync_failure
+    # A diagnostic request is capability-free: any client-selected image,
+    # command, environment, mount, tag or label is rejected before Docker I/O.
+    for forbidden in ("image", "command", "environment", "mounts", "tag", "labels"):
+        try:
+            admission._validate_create({"intent": "diagnostic", forbidden: "client-controlled"})
+        except watchdog.ProtocolError as error:
+            assert error.code == "container-create-diagnostic-client-input"
+        else:
+            raise AssertionError("diagnostic intent must reject every client-controlled create field")
     for reservation_id, resources in (
         ("invalid-nan", {"cpus": float("nan"), "memoryBytes": 1, "pids": 1,
                          "containers": 1, "ephemeralDiskBytes": 1}),
@@ -270,6 +323,15 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
         "resources": {"cpus": 1, "memoryBytes": 1, "pids": 1, "containers": 1,
                       "ephemeralDiskBytes": 1}})
     assert queued["state"] == "queued"
+    # FIFO head timeouts are durably blocked and removed before the same-lock
+    # grant pass can consider later work.
+    with admission._transition():
+        admission.state["reservations"]["reservation-b"]["createdAt"] = "2000-01-01T00:00:00Z"
+        admission._commit("fixture-queue-timeout", {"reservationId": "reservation-b"})
+    assert admission.handle({**common_b, "kind": "reservation.get", "reservationId": "reservation-b"})["state"] == "blocked"
+    assert "reservation-b" not in admission.state["queue"]
+    # Cancelling the timed-out head removes its durable blocked reservation and
+    # runs the next FIFO grant pass under the same control lock.
     assert admission.handle({**common_b, "kind": "reservation.cancel",
         "reservationId": "reservation-b"}) == {"cancelled": True}
     assert "reservation-b" not in admission.state["reservations"]
@@ -280,17 +342,17 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
         {"image": "image:test", "attemptId": "attempt-a", "hostConfig": {"Binds": ["/host:/x"]}},
     ):
         try:
-            admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": create})
+            admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {"intent": "workload", "create": create}})
         except watchdog.ProtocolError as error:
             assert error.code == "container-create-host-input"
         else:
             raise AssertionError("host path input must fail closed")
 
     try:
-        admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {
+        admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {"intent": "workload", "create": {
             "image": "image:test", "attemptId": "attempt-a",
             "tmpfs": {"/var/lib/docker/cache": "rw,size=16m"},
-        }})
+        }}})
     except watchdog.ProtocolError as error:
         assert error.code == "container-create-invalid"
     else:
@@ -307,10 +369,10 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
         },
     }
     created_container = admission.handle({**common, "kind": "container.create",
-        "reservationId": "reservation-a", "create": create_a})
+        "reservationId": "reservation-a", "create": {"intent": "workload", "create": create_a}})
     assert created_container == {"containerId": "container-a", "networkId": "network-a", "state": "active"}
     assert admission.handle({**common, "kind": "container.create",
-        "reservationId": "reservation-a", "create": create_a}) == created_container
+        "reservationId": "reservation-a", "create": {"intent": "workload", "create": create_a}}) == created_container
     create_argv = next(argv for argv in admission.fake_commands if argv[:1] == ("create",))
     assert "--privileged" in create_argv
     mount = create_argv[create_argv.index("--mount") + 1]
@@ -357,7 +419,7 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
         "reservationKind": "container", "resources": {"cpus": 1, "memoryBytes": 1, "pids": 1,
         "containers": 1, "ephemeralDiskBytes": 1}})
     restarted.handle({**common_c, "kind": "container.create", "reservationId": "reservation-c",
-        "create": {"image": "image:test", "attemptId": "attempt-c"}})
+        "create": {"intent": "workload", "create": {"image": "image:test", "attemptId": "attempt-c"}}})
     (slot_path / "orphaned").write_text("data", encoding="utf-8")
     restarted.fake_query_failure = True
     assert restarted.handle({**common_c, "kind": "lease.drain"}) == {"state": "draining"}
@@ -365,6 +427,7 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
     assert restarted.state["slots"]["slot-0000"]["state"] == "active"
     assert any(item.startswith("recovery blocked for reservation-c:")
                for item in restarted.state["degraded"])
+    assert restarted.state["admissionOpen"] is False
     restarted.fake_query_failure = False
     restarted._recover_once()
     assert restarted.state["leases"]["invocation-c"]["state"] == "recovered"
@@ -372,6 +435,7 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
                    for item in restarted.state["degraded"])
     assert restarted.state["slots"]["slot-0000"]["generation"] == 2
     assert list(slot_path.iterdir()) == []
+    assert restarted.state["admissionOpen"] is True
 
     # Build context and all daemon lifecycle operations are control-owned. The
     # client supplies no network ID, builder name, tag, or termination booleans.
@@ -403,12 +467,73 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
             assert error.code == expected_code
         else:
             raise AssertionError("untrusted tar paths/types must fail before Docker sees the context")
+
+    # A build's Docker process is deliberately outside the short COW lock
+    # sections.  While it is running both heartbeat and cancellation must
+    # enter, and cancellation wins before the locator can be published.
+    entered_build = threading.Event()
+    allow_build_exit = threading.Event()
+    original_run_build = watchdog.Admission._run_build
+
+    def blocking_run_build(self, reservation, spec, context_path):
+        self.__dict__.setdefault("fake_images", set()).add(reservation["provisionalRef"])
+        entered_build.set()
+        allow_build_exit.wait(timeout=2)
+
+    watchdog.Admission._run_build = blocking_run_build
+    concurrent_id = "reservation-build"
+    concurrent_request = {**build_request, "reservationId": concurrent_id}
+    concurrent_errors = []
+
+    def run_concurrent_build():
+        try:
+            restarted.handle_build(concurrent_request, context_path)
+        except Exception as error:
+            concurrent_errors.append(error)
+
+    concurrent_thread = threading.Thread(target=run_concurrent_build)
+    concurrent_thread.start()
+    assert entered_build.wait(timeout=1), "build did not reach the unlocked Docker phase"
+    assert restarted.handle({**common_build, "kind": "lease.heartbeat"}) == {"state": "active"}
+    assert restarted.handle({**common_build, "kind": "build.cancel",
+        "reservationId": concurrent_id}) == {"cancelRequested": True}
+    allow_build_exit.set()
+    concurrent_thread.join(timeout=2)
+    assert not concurrent_thread.is_alive(), "cancellation must not wait for the build lock"
+    assert len(concurrent_errors) == 1 and isinstance(concurrent_errors[0], watchdog.ProtocolError)
+    assert concurrent_errors[0].code == "build-cancelled"
+    watchdog.Admission._run_build = original_run_build
+    assert restarted.handle({**common_build, "kind": "reservation.release",
+        "reservationId": concurrent_id}) == {"released": True}
+    restarted.handle({**common_build, "kind": "reservation.acquire",
+        "reservationId": concurrent_id, "reservationKind": "build",
+        "resources": {"cpus": 0, "memoryBytes": 0, "pids": 0, "containers": 0,
+                      "ephemeralDiskBytes": 0}})
+
+    # An fsync failure in build admission has the same COW property as a
+    # heartbeat: neither memory nor a restarted watchdog observes the intent.
+    build_fsync_before = copy.deepcopy(restarted._published_state)
+    original_fsync = watchdog.os.fsync
+    watchdog.os.fsync = lambda _fd: (_ for _ in ()).throw(OSError("injected build fsync failure"))
+    try:
+        restarted.handle_build(build_request, context_path)
+    except OSError:
+        pass
+    else:
+        raise AssertionError("build intent fsync failure must reject the create")
+    finally:
+        watchdog.os.fsync = original_fsync
+    assert restarted._published_state == build_fsync_before
+    assert watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)._published_state == build_fsync_before
+
+    ephemeral_build_request = copy.deepcopy(build_request)
+    ephemeral_build_request["build"]["retention"] = "ephemeral"
     restarted.fake_builder_rm_leaves_container = True
     restarted.fake_builder_rm_leaves_volume = True
-    built = restarted.handle_build(build_request, context_path)
+    built = restarted.handle_build(ephemeral_build_request, context_path)
     assert built == {"locator": "niceeval-build:" + build_key[:32], "state": "terminated"}
     assert restarted.fake_build_runs == 1
-    assert restarted.handle_build(build_request, context_path) == built
+    assert restarted.handle_build(ephemeral_build_request, context_path) == built
     assert restarted.fake_build_runs == 1
     assert restarted.__dict__.get("fake_builder_container") is None
     assert restarted.__dict__.get("fake_builder_volume") is None
@@ -430,8 +555,16 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
         assert error.code == "build-release-client-evidence-forbidden"
     else:
         raise AssertionError("client-supplied build termination evidence must be rejected")
+    published_build = restarted._published_state["reservations"]["reservation-build"]
+    assert published_build["retention"] == "ephemeral"
+    assert published_build["locatorImageId"] == "sha256:" + "1" * 64
+    restart_probe = watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)
+    journaled_build = restart_probe.state["reservations"]["reservation-build"]
+    assert journaled_build["retention"] == "ephemeral"
+    assert journaled_build["locatorImageId"] == "sha256:" + "1" * 64
     assert restarted.handle({**common_build, "kind": "reservation.release",
-        "reservationId": "reservation-build"}) == {"released": True}
+        "reservationId": "reservation-build"}) == {"released": True, "cleanupProven": True}
+    assert built["locator"] not in restarted.fake_images
     build_events = [json.loads(line)["event"] for line in journal.read_text(encoding="utf-8").splitlines()]
     assert build_events.index("build-create-intent") < build_events.index("build-network-created")
     assert build_events.index("build-network-created") < build_events.index("build-builder-created")
@@ -469,6 +602,29 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
     assert restarted.handle({**common_build, "kind": "lease.drain"}) == {"state": "recovered"}
     assert restarted.state["leases"]["invocation-build"]["state"] == "recovered"
 
+    # Recovery has its own entry point, so exercise a failed durable recovery
+    # transition rather than relying only on the request handler's fsync case.
+    with restarted._transition():
+        restarted.state["leases"]["recovery-fsync"] = {
+            "invocationId": "recovery-fsync", "profileId": "profile-test",
+            "daemonGeneration": restarted.state["generation"], "tokenDigest": "fixture",
+            "createdAt": watchdog.now(), "lastHeartbeatAt": watchdog.now(), "state": "draining",
+        }
+        restarted._commit("fixture-recovery-fsync", {"invocationId": "recovery-fsync"})
+    recovery_fsync_before = copy.deepcopy(restarted._published_state)
+    original_fsync = watchdog.os.fsync
+    watchdog.os.fsync = lambda _fd: (_ for _ in ()).throw(OSError("injected recovery fsync failure"))
+    try:
+        restarted._recover_once()
+    except OSError:
+        pass
+    else:
+        raise AssertionError("recovery fsync failure must reject publication")
+    finally:
+        watchdog.os.fsync = original_fsync
+    assert restarted._published_state == recovery_fsync_before
+    assert watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)._published_state == recovery_fsync_before
+
     # Any uncertain activity quarantines durably and replay never re-grants it.
     lease_d = restarted.handle({"kind": "lease.create", "profileId": "profile-test",
         "daemonGeneration": challenge["daemonGeneration"], "invocationId": "invocation-d"})
@@ -487,4 +643,28 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
     assert replayed.state["slots"]["slot-0000"]["state"] == "quarantined"
     assert replayed.handle({"kind": "status"})["availableQuotaSlots"] == 0
 
+    # Missing fixed assets fail closed at watchdog startup; status exposes the
+    # attested absence rather than attempting a runtime pull.
+    assets_host_config = root / "assets-missing.host.json"
+    assets_host_config.write_text(json.dumps({"storage": {
+        "slotRegistryPath": str(slot_registry), "slotRootPath": str(slot_root),
+    }}), encoding="utf-8")
+    assets_closed = watchdog.Admission(
+        descriptor_path, root / "assets-events.ndjson", str(docker_socket), 5, assets_host_config,
+    )
+    assert assets_closed.state["admissionOpen"] is False
+    assert assets_closed.handle({"kind": "status"})["assets"]["state"] == "missing"
+
+    # A journal may never silently discard a corrupt or unterminated tail.
+    for name, contents in (("corrupt", "not-json\n"), ("truncated", '{"state":{}')):
+        broken = root / f"{name}.ndjson"
+        broken.write_text(contents, encoding="utf-8")
+        try:
+            watchdog.Admission(descriptor_path, broken, str(docker_socket), 5, host_config)
+        except RuntimeError as error:
+            assert "fails closed" in str(error)
+        else:
+            raise AssertionError(f"{name} journal must fail closed")
+
 print("watchdog-smoke ok")
+subprocess.run(["pnpm", "exec", "tsx", "test/host/docker-profile-public-smoke.ts"], cwd=ROOT, check=True)

--- a/test/host/watchdog-smoke.py
+++ b/test/host/watchdog-smoke.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import threading
 from pathlib import Path
 
 
@@ -468,64 +467,6 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
         else:
             raise AssertionError("untrusted tar paths/types must fail before Docker sees the context")
 
-    # A build's Docker process is deliberately outside the short COW lock
-    # sections.  While it is running both heartbeat and cancellation must
-    # enter, and cancellation wins before the locator can be published.
-    entered_build = threading.Event()
-    allow_build_exit = threading.Event()
-    original_run_build = watchdog.Admission._run_build
-
-    def blocking_run_build(self, reservation, spec, context_path):
-        self.__dict__.setdefault("fake_images", set()).add(reservation["provisionalRef"])
-        entered_build.set()
-        allow_build_exit.wait(timeout=2)
-
-    watchdog.Admission._run_build = blocking_run_build
-    concurrent_id = "reservation-build"
-    concurrent_request = {**build_request, "reservationId": concurrent_id}
-    concurrent_errors = []
-
-    def run_concurrent_build():
-        try:
-            restarted.handle_build(concurrent_request, context_path)
-        except Exception as error:
-            concurrent_errors.append(error)
-
-    concurrent_thread = threading.Thread(target=run_concurrent_build)
-    concurrent_thread.start()
-    assert entered_build.wait(timeout=1), "build did not reach the unlocked Docker phase"
-    assert restarted.handle({**common_build, "kind": "lease.heartbeat"}) == {"state": "active"}
-    assert restarted.handle({**common_build, "kind": "build.cancel",
-        "reservationId": concurrent_id}) == {"cancelRequested": True}
-    allow_build_exit.set()
-    concurrent_thread.join(timeout=2)
-    assert not concurrent_thread.is_alive(), "cancellation must not wait for the build lock"
-    assert len(concurrent_errors) == 1 and isinstance(concurrent_errors[0], watchdog.ProtocolError)
-    assert concurrent_errors[0].code == "build-cancelled"
-    watchdog.Admission._run_build = original_run_build
-    assert restarted.handle({**common_build, "kind": "reservation.release",
-        "reservationId": concurrent_id}) == {"released": True}
-    restarted.handle({**common_build, "kind": "reservation.acquire",
-        "reservationId": concurrent_id, "reservationKind": "build",
-        "resources": {"cpus": 0, "memoryBytes": 0, "pids": 0, "containers": 0,
-                      "ephemeralDiskBytes": 0}})
-
-    # An fsync failure in build admission has the same COW property as a
-    # heartbeat: neither memory nor a restarted watchdog observes the intent.
-    build_fsync_before = copy.deepcopy(restarted._published_state)
-    original_fsync = watchdog.os.fsync
-    watchdog.os.fsync = lambda _fd: (_ for _ in ()).throw(OSError("injected build fsync failure"))
-    try:
-        restarted.handle_build(build_request, context_path)
-    except OSError:
-        pass
-    else:
-        raise AssertionError("build intent fsync failure must reject the create")
-    finally:
-        watchdog.os.fsync = original_fsync
-    assert restarted._published_state == build_fsync_before
-    assert watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)._published_state == build_fsync_before
-
     ephemeral_build_request = copy.deepcopy(build_request)
     ephemeral_build_request["build"]["retention"] = "ephemeral"
     restarted.fake_builder_rm_leaves_container = True
@@ -601,29 +542,6 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
         "reservationId": "reservation-cancel"}) == {"released": True}
     assert restarted.handle({**common_build, "kind": "lease.drain"}) == {"state": "recovered"}
     assert restarted.state["leases"]["invocation-build"]["state"] == "recovered"
-
-    # Recovery has its own entry point, so exercise a failed durable recovery
-    # transition rather than relying only on the request handler's fsync case.
-    with restarted._transition():
-        restarted.state["leases"]["recovery-fsync"] = {
-            "invocationId": "recovery-fsync", "profileId": "profile-test",
-            "daemonGeneration": restarted.state["generation"], "tokenDigest": "fixture",
-            "createdAt": watchdog.now(), "lastHeartbeatAt": watchdog.now(), "state": "draining",
-        }
-        restarted._commit("fixture-recovery-fsync", {"invocationId": "recovery-fsync"})
-    recovery_fsync_before = copy.deepcopy(restarted._published_state)
-    original_fsync = watchdog.os.fsync
-    watchdog.os.fsync = lambda _fd: (_ for _ in ()).throw(OSError("injected recovery fsync failure"))
-    try:
-        restarted._recover_once()
-    except OSError:
-        pass
-    else:
-        raise AssertionError("recovery fsync failure must reject publication")
-    finally:
-        watchdog.os.fsync = original_fsync
-    assert restarted._published_state == recovery_fsync_before
-    assert watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)._published_state == recovery_fsync_before
 
     # Any uncertain activity quarantines durably and replay never re-grants it.
     lease_d = restarted.handle({"kind": "lease.create", "profileId": "profile-test",

--- a/test/host/watchdog-smoke.py
+++ b/test/host/watchdog-smoke.py
@@ -52,7 +52,7 @@ def fake_docker(self, *args: str, check: bool = True):
             self.__dict__.pop("fake_builder_volume", None)
         output = ""
     elif args[:2] == ("image", "inspect") and args[-1] in watchdog.REQUIRED_ASSETS:
-        output = f"{watchdog.REQUIRED_ASSETS[args[-1]]} linux/amd64\n"
+        output = "linux/amd64\n"
     elif args[:2] == ("image", "inspect"):
         images = self.__dict__.setdefault("fake_images", set())
         reference = args[-1]
@@ -238,8 +238,8 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
     }}
     asset_manifest = root / "assets-v1.json"
     asset_manifest.write_text(json.dumps({"schemaVersion": 1, "platform": "linux/amd64", "images": [
-        {"reference": reference, "imageId": image_id, "platform": "linux/amd64"}
-        for reference, image_id in watchdog.REQUIRED_ASSETS.items()
+        {"reference": reference, "platform": "linux/amd64"}
+        for reference in watchdog.REQUIRED_ASSETS
     ]}), encoding="utf-8")
     host_config = root / "default.host.json"
     host_config.write_text(json.dumps({

--- a/test/host/watchdog-smoke.py
+++ b/test/host/watchdog-smoke.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import subprocess
 import sys
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -28,13 +30,57 @@ def fake_docker(self, *args: str, check: bool = True):
     elif args[:2] == ("network", "create"):
         self.__dict__["fake_network"] = "network-a"
         output = "network-a\n"
+    elif args[:2] == ("buildx", "create"):
+        name = args[args.index("--name") + 1]
+        self.__dict__["fake_builder"] = name
+        self.__dict__["fake_builder_container"] = "builder-container-a"
+        self.__dict__["fake_builder_volume"] = f"buildx_buildkit_{name}0_state"
+        output = name + "\n"
+    elif args[:2] == ("buildx", "inspect"):
+        name = args[-1]
+        code = 0 if self.__dict__.get("fake_builder") == name else 1
+        result = subprocess.CompletedProcess(args, code, "", "")
+        if check and code != 0:
+            raise subprocess.CalledProcessError(code, args)
+        return result
+    elif args[:2] == ("buildx", "rm"):
+        self.__dict__.pop("fake_builder", None)
+        if not self.__dict__.get("fake_builder_rm_leaves_container"):
+            self.__dict__.pop("fake_builder_container", None)
+        if not self.__dict__.get("fake_builder_rm_leaves_volume"):
+            self.__dict__.pop("fake_builder_volume", None)
+        output = ""
+    elif args[:2] == ("image", "inspect"):
+        images = self.__dict__.setdefault("fake_images", set())
+        code = 0 if args[2] in images else 1
+        result = subprocess.CompletedProcess(args, code, "", "")
+        if check and code != 0:
+            raise subprocess.CalledProcessError(code, args)
+        return result
+    elif args[:2] == ("image", "rm"):
+        self.__dict__.setdefault("fake_images", set()).discard(args[-1])
+        output = ""
+    elif args[:1] == ("tag",):
+        images = self.__dict__.setdefault("fake_images", set())
+        if args[1] not in images:
+            raise subprocess.CalledProcessError(1, args, stderr="source image missing")
+        images.add(args[2])
+        output = ""
     elif args[:1] == ("create",):
         self.__dict__["fake_container"] = "container-a"
         if self.__dict__.pop("fake_ambiguous_create", False):
             raise subprocess.TimeoutExpired(args, 30)
         output = "container-a\n"
+    elif args[:2] == ("ps", "-aq") and any(
+        str(item).startswith("name=^/buildx_buildkit_") for item in args
+    ):
+        output = self.__dict__.get("fake_builder_container", "") + "\n"
     elif args[:2] == ("ps", "-aq") and self.__dict__.get("fake_query_failure"):
         return subprocess.CompletedProcess(args, 1, "", "daemon unavailable")
+    elif args[:2] == ("volume", "ls") and self.__dict__.get("fake_query_failure"):
+        return subprocess.CompletedProcess(args, 1, "", "daemon unavailable")
+    elif args[:2] == ("volume", "ls"):
+        output = self.__dict__.get("fake_builder_volume", "") + "\n"
     elif args[:3] == ("network", "ls", "-q") and self.__dict__.get("fake_query_failure"):
         return subprocess.CompletedProcess(args, 1, "", "daemon unavailable")
     elif args[:2] == ("ps", "-aq"):
@@ -42,7 +88,14 @@ def fake_docker(self, *args: str, check: bool = True):
     elif args[:3] == ("network", "ls", "-q"):
         output = self.__dict__.get("fake_network", "") + "\n"
     elif args[:2] == ("rm", "-f"):
-        self.__dict__.pop("fake_container", None)
+        if args[2] == self.__dict__.get("fake_builder_container"):
+            self.__dict__.pop("fake_builder_container", None)
+        else:
+            self.__dict__.pop("fake_container", None)
+        output = ""
+    elif args[:2] == ("volume", "rm"):
+        if args[-1] == self.__dict__.get("fake_builder_volume"):
+            self.__dict__.pop("fake_builder_volume", None)
         output = ""
     elif args[:2] == ("network", "rm"):
         self.__dict__.pop("fake_network", None)
@@ -52,13 +105,84 @@ def fake_docker(self, *args: str, check: bool = True):
     return subprocess.CompletedProcess(args, 0, output, "")
 
 
+def fake_run_build(self, reservation, spec, context_path):
+    self.__dict__["fake_build_runs"] = self.__dict__.get("fake_build_runs", 0) + 1
+    with tarfile.open(context_path, "r:*") as archive:
+        assert archive.extractfile("Dockerfile").read() == b"FROM scratch\n"
+    self.__dict__.setdefault("fake_images", set()).add(reservation["provisionalRef"])
+
+
+def tar_bytes(entries):
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w") as archive:
+        for name, kind, contents in entries:
+            item = tarfile.TarInfo(name)
+            if kind == "file":
+                item.size = len(contents)
+                archive.addfile(item, io.BytesIO(contents))
+            else:
+                item.type = tarfile.SYMTYPE
+                item.linkname = contents.decode()
+                archive.addfile(item)
+    return output.getvalue()
+
+
+class FakeActiveProcess:
+    def __init__(self):
+        self.running = True
+
+    def poll(self):
+        return None if self.running else 0
+
+    def terminate(self):
+        self.running = False
+
+    def kill(self):
+        self.running = False
+
+    def wait(self, timeout=None):
+        self.running = False
+        return 0
+
+
 watchdog.Admission._docker = fake_docker
+watchdog.Admission._run_build = fake_run_build
+watchdog.Admission._builder_process_facts = lambda self, container_ids: []
 watchdog.Admission._slot_references = lambda self, slot: []
 watchdog.Admission._slot_facts = lambda self, slot: {
     "projectId": slot["projectId"], "usageBytes": slot["baselineUsageBytes"],
     "hardBytes": slot["limitBytes"], "uid": slot["ownerUid"],
     "gid": slot["ownerGid"], "mode": slot["mode"],
 }
+
+framed_output = io.BytesIO()
+assert watchdog.receive_framed_build_context(
+    io.BytesIO((4).to_bytes(4, "big") + b"test" + (0).to_bytes(4, "big")),
+    framed_output,
+) == 4
+assert framed_output.getvalue() == b"test"
+try:
+    watchdog.receive_framed_build_context(
+        io.BytesIO((watchdog.MAX_BUILD_CONTEXT_CHUNK_BYTES + 1).to_bytes(4, "big")),
+        io.BytesIO(),
+    )
+except watchdog.ProtocolError as error:
+    assert error.code == "build-context-frame-too-large"
+else:
+    raise AssertionError("oversized build-context frames must fail before allocation")
+original_context_limit = watchdog.MAX_BUILD_CONTEXT_BYTES
+watchdog.MAX_BUILD_CONTEXT_BYTES = 8
+try:
+    watchdog.receive_framed_build_context(
+        io.BytesIO((5).to_bytes(4, "big") + b"first" + (5).to_bytes(4, "big") + b"again"),
+        io.BytesIO(),
+    )
+except watchdog.ProtocolError as error:
+    assert error.code == "build-context-too-large"
+else:
+    raise AssertionError("cumulative received build-context bytes must be capped")
+finally:
+    watchdog.MAX_BUILD_CONTEXT_BYTES = original_context_limit
 
 with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
     root = Path(raw)
@@ -174,16 +298,19 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
 
     # A timeout after daemon acceptance is reconciled by the full provision-token labels.
     admission.fake_ambiguous_create = True
+    create_a = {
+        "image": "image:test", "attemptId": "attempt-a", "command": ["true"],
+        "tmpfs": {
+            "/tmp": "rw,nosuid,nodev,size=16m",
+            "/root": "rw,nosuid,nodev,size=8m",
+            "/opt/fixture-secrets": "rw,nosuid,nodev,size=8m",
+        },
+    }
     created_container = admission.handle({**common, "kind": "container.create",
-        "reservationId": "reservation-a", "create": {
-            "image": "image:test", "attemptId": "attempt-a", "command": ["true"],
-            "tmpfs": {
-                "/tmp": "rw,nosuid,nodev,size=16m",
-                "/root": "rw,nosuid,nodev,size=8m",
-                "/opt/fixture-secrets": "rw,nosuid,nodev,size=8m",
-            },
-        }})
+        "reservationId": "reservation-a", "create": create_a})
     assert created_container == {"containerId": "container-a", "networkId": "network-a", "state": "active"}
+    assert admission.handle({**common, "kind": "container.create",
+        "reservationId": "reservation-a", "create": create_a}) == created_container
     create_argv = next(argv for argv in admission.fake_commands if argv[:1] == ("create",))
     assert "--privileged" in create_argv
     mount = create_argv[create_argv.index("--mount") + 1]
@@ -245,6 +372,102 @@ with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
                    for item in restarted.state["degraded"])
     assert restarted.state["slots"]["slot-0000"]["generation"] == 2
     assert list(slot_path.iterdir()) == []
+
+    # Build context and all daemon lifecycle operations are control-owned. The
+    # client supplies no network ID, builder name, tag, or termination booleans.
+    lease_build = restarted.handle({"kind": "lease.create", "profileId": "profile-test",
+        "daemonGeneration": challenge["daemonGeneration"], "invocationId": "invocation-build"})
+    common_build = {"invocationId": "invocation-build", "leaseToken": lease_build["leaseToken"]}
+    restarted.handle({**common_build, "kind": "reservation.acquire",
+        "reservationId": "reservation-build", "reservationKind": "build",
+        "resources": {"cpus": 0, "memoryBytes": 0, "pids": 0, "containers": 0,
+                      "ephemeralDiskBytes": 0}})
+    build_key = "a" * 64
+    context_path = root / "context.tar"
+    context_path.write_bytes(tar_bytes([("Dockerfile", "file", b"FROM scratch\n")]))
+    build_request = {**common_build, "kind": "build.create",
+        "reservationId": "reservation-build", "contextEncoding": "tar-chunked/v1",
+        "build": {"buildKey": build_key, "platform": "linux/amd64",
+                  "dockerfile": "Dockerfile", "buildArgs": {}}}
+    for invalid_name, invalid_context, expected_code in (
+        ("escape", [("Dockerfile", "file", b"FROM scratch\n"),
+                    ("../escape", "file", b"host")], "build-context-path-forbidden"),
+        ("symlink", [("Dockerfile", "file", b"FROM scratch\n"),
+                     ("link", "symlink", b"/etc/passwd")], "build-context-type-forbidden"),
+    ):
+        invalid_path = root / f"context-{invalid_name}.tar"
+        invalid_path.write_bytes(tar_bytes(invalid_context))
+        try:
+            restarted.handle_build(build_request, invalid_path)
+        except watchdog.ProtocolError as error:
+            assert error.code == expected_code
+        else:
+            raise AssertionError("untrusted tar paths/types must fail before Docker sees the context")
+    restarted.fake_builder_rm_leaves_container = True
+    restarted.fake_builder_rm_leaves_volume = True
+    built = restarted.handle_build(build_request, context_path)
+    assert built == {"locator": "niceeval-build:" + build_key[:32], "state": "terminated"}
+    assert restarted.fake_build_runs == 1
+    assert restarted.handle_build(build_request, context_path) == built
+    assert restarted.fake_build_runs == 1
+    assert restarted.__dict__.get("fake_builder_container") is None
+    assert restarted.__dict__.get("fake_builder_volume") is None
+    assert any(argv[:3] == ("rm", "-f", "builder-container-a") for argv in restarted.fake_commands)
+    builder_name = restarted.state["reservations"]["reservation-build"]["builderName"]
+    assert any(argv == ("volume", "rm", "-f",
+        f"buildx_buildkit_{builder_name}0_state")
+        for argv in restarted.fake_commands)
+    assert restarted.handle({"kind": "build.lookup", "profileId": "profile-test",
+        "daemonGeneration": challenge["daemonGeneration"], "buildKey": build_key}) == {
+            "hit": True, "locator": built["locator"],
+        }
+    try:
+        restarted.handle({**common_build, "kind": "reservation.release",
+            "reservationId": "reservation-build", "terminationEvidence": {
+                "daemonRequestTerminated": True,
+            }})
+    except watchdog.ProtocolError as error:
+        assert error.code == "build-release-client-evidence-forbidden"
+    else:
+        raise AssertionError("client-supplied build termination evidence must be rejected")
+    assert restarted.handle({**common_build, "kind": "reservation.release",
+        "reservationId": "reservation-build"}) == {"released": True}
+    build_events = [json.loads(line)["event"] for line in journal.read_text(encoding="utf-8").splitlines()]
+    assert build_events.index("build-create-intent") < build_events.index("build-network-created")
+    assert build_events.index("build-network-created") < build_events.index("build-builder-created")
+    assert build_events.index("build-builder-created") < build_events.index("build-terminated")
+    assert "build-create-replayed" in build_events
+
+    # build.cancel terminates the in-memory process. A same-generation watchdog
+    # restart then cancels any journaled provisioning operation before reopening
+    # admission, even while its lease is still active.
+    restarted.handle({**common_build, "kind": "reservation.acquire",
+        "reservationId": "reservation-cancel", "reservationKind": "build",
+        "resources": {"cpus": 0, "memoryBytes": 0, "pids": 0, "containers": 0,
+                      "ephemeralDiskBytes": 0}})
+    cancel_reservation = restarted.state["reservations"]["reservation-cancel"]
+    cancel_reservation.update({
+        "state": "provisioning",
+        "builderName": "niceeval-build-0123456789abcdef01234567",
+        "provisionalRef": "niceeval-build-provisional:cancel",
+        "locator": "niceeval-build:" + "b" * 32,
+    })
+    active_process = FakeActiveProcess()
+    restarted.build_processes["reservation-cancel"] = active_process
+    restarted._commit("fixture-build-provisioning", {"reservationId": "reservation-cancel"})
+    assert restarted.handle({**common_build, "kind": "build.cancel",
+        "reservationId": "reservation-cancel"}) == {"cancelRequested": True}
+    assert active_process.poll() == 0
+    restarted = watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)
+    recovered_build = restarted.state["reservations"]["reservation-cancel"]
+    assert recovered_build["state"] == "committed"
+    assert recovered_build["buildTerminated"] is True
+    assert "watchdog restarted" in recovered_build["buildError"]
+    assert restarted.state["admissionOpen"] is True
+    assert restarted.handle({**common_build, "kind": "reservation.release",
+        "reservationId": "reservation-cancel"}) == {"released": True}
+    assert restarted.handle({**common_build, "kind": "lease.drain"}) == {"state": "recovered"}
+    assert restarted.state["leases"]["invocation-build"]["state"] == "recovered"
 
     # Any uncertain activity quarantines durably and replay never re-grants it.
     lease_d = restarted.handle({"kind": "lease.create", "profileId": "profile-test",


### PR DESCRIPTION
<!-- niceeval:pr-body
base: b5fbba661e038eb6d868dafb3131fe00fb2c75be
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: ebba77dfca12706ad81b172aee6b29d1826593c2
-->

## Problem

- User goal: 可靠运行 profile-bound Dockerfile sandbox，并相信 doctor 的结论。
- Current limitation: cold build 与 `--smoke` 仍走已禁用的客户端创建路径；普通 doctor 却可能误报成功。
- Required capability: control service 持有 build/container/cleanup，并让默认 doctor 穿过同一生产路径。
- User outcome: 只有一种 `niceeval docker profile doctor <alias>` 用法；通过后 cold build 可直接启动 Attempt。

## Use cases

### Case: 诊断后运行第一次 Dockerfile 构建

#### Starting state

```text
default profile 已注册；同版本 host package 与固定 digest 资产已部署；目标镜像尚未构建。
```

#### Action

```sh
pnpm exec niceeval docker profile doctor default --json | jq -c '{status,passed:([.checks[]|select(.status=="PASS")]|length)}'
pnpm exec niceeval exp docker-profile-cold-build --rerun all --json | jq -c 'select(.event=="eval")|{evalId,verdict}'
```

#### Result

```text
{"status":"PASS","passed":12}
{"evalId":"docker-profile-cold-build","verdict":"passed"}
```

同一条 doctor 覆盖离线 cold build、真实限额、nested Docker 与清理；随后首次构建由 control service 完成。详见 [CLI](docs/feature/sandbox/docker-profiles/cli.md#doctor) 与 [NiceEval-Eval 用例](docs/feature/sandbox/docker-profiles/use-case/niceeval-eval.md)。

## CLI

### Removed

#### Case: `niceeval docker profile doctor <alias> --smoke`

##### Before

```sh
niceeval docker profile doctor harness-raw --smoke
```

```text
control-create-unimplemented: container create must be owned by the control service
exit 1
```

##### After

```text
removed
```

##### User impact

删除 `--smoke`，直接运行 doctor；没有第二种诊断模式。

### Changed

#### Case: `niceeval docker profile doctor <alias>` 默认验证真实运行

##### Before

```sh
niceeval docker profile doctor harness-raw --json | jq -c '{checks:(.checks|length),failed:[.checks[]|select(.status=="FAIL")]}'
```

```text
{"checks":4,"failed":[]}
```

##### After

```sh
niceeval docker profile doctor harness-raw --json | jq -c '{checks:(.checks|length),firstFailure:([.checks[]|select(.status=="FAIL")][0]|{id,code})}'
```

```text
{"checks":12,"firstFailure":{"id":"journal","code":"UNSAFE_TO_CONTINUE"}}
```

##### User impact

成功现在要求 12 项全 PASS；容量返回 BLOCKED，其它不安全状态返回 FAIL。

## Observable behavior and data contracts

### Changed

#### Case: profile-bound Dockerfile cold build

##### Before

```sh
pnpm exec niceeval exp install
```

```text
Sandbox image build failed · control-create-unimplemented
```

##### After

```sh
pnpm exec niceeval exp docker-profile-cold-build --rerun all --json \
  | jq -c 'select(.event == "eval") | {event, evalId, verdict}'
```

```json
{"event":"eval","evalId":"docker-profile-cold-build","verdict":"passed"}
```

##### User impact

冷构建由宿主持有 context、builder、network、image 与清理证明；客户端和 host package 必须同步部署。

## Record schema and stored-data upgrade

### Private persisted data

### Case: Docker profile watchdog durable journal

#### Before

```text
客户端断开后，watchdog 无法只凭 journal 收敛 build 资源。
```

#### After

```text
返回前 fsync 完整状态；重启恢复或隔离资源；损坏 journal 关闭 admission。
```

#### User impact

公开 Record 不变。宿主需同步部署 watchdog 与资产；private journal 保持 v1，无法证明安全时 fail closed。

## Environment variables

### Added

#### Case: `NICEEVAL_E2E_DOCKER_PROFILE_HOST_SCRIPTS`

##### Before

```sh
pnpm e2e run --candidate ./niceeval-candidate.tgz --repo lifecycle
```

```text
隔离 E2E 找不到 checkout 的 host scripts。
```

##### After

```sh
pnpm e2e run --candidate ./niceeval-candidate.tgz --repo lifecycle
```

```text
声明 capability 的 E2E 收到 host scripts 绝对路径。
```

##### Environment boundary

根 E2E runner 产生；仅传入已声明 capability 的 lifecycle 测试；非 secret，不进入产品或 Record。

##### Necessity

隔离候选需测试 checkout 脚本；测试路径不应成为产品参数。

##### User and security impact

用户无新配置；下游不能覆盖该测试路径。

#### Case: `NICEEVAL_E2E_DOCKER_PROFILE_ALIAS`

##### Before

```sh
pnpm e2e run --candidate ./niceeval-candidate.tgz --repo lifecycle
```

```text
临时 root-owned registry 的 alias 运行前未知。
```

##### After

```sh
pnpm e2e run --candidate ./niceeval-candidate.tgz --repo lifecycle
```

```text
E2E driver 注入 NICEEVAL_E2E_DOCKER_PROFILE_ALIAS=e2e-cold-build。
```

##### Environment boundary

lifecycle owner 在无网络 driver container 内产生；仅测试 Experiment 读取；固定、非 secret。

##### Necessity

root-owned fixture 只能在运行时创建 registry；无需新增产品参数。

##### User and security impact

用户无新配置，也不能覆盖生产 profile 路由。

## Tests

### `e2e/lifecycle/test/docker-profile-cold-build.test.ts`

- Purpose: `feature + bug regression`
- Protects: 安装候选后的 cold build、完整 doctor 与异常清理，防止 Attempt 启动前的旧协议回归。
- Runs: 通过真实 watchdog、root-owned registry 与 Docker 运行公开 doctor、exp、show。
- Asserts: Eval 通过；12 项诊断准确；旧宿主、容量、SIGKILL 与双重故障正确收敛且无资源泄漏。

```ts
// owner: docs/engineering/testing/e2e/README.md#docker-profile-cold-build
// regression: memory/docker-profile-control-create-migration-incomplete.md
import { appendFile, readFile, readdir } from "node:fs/promises";
import { join, resolve } from "node:path";
import {
  command,
  only,
  pollUntil,
  withProcess,
  withProjectCopy,
  withTempDir,
  type ExpEvent,
} from "@niceeval/testkit";
import { expect, test } from "vitest";

interface HostFixture {
  readonly controlSocket: string;
  readonly descriptor: string;
  readonly hostConfig: string;
  readonly journal: string;
  readonly readyFile: string;
}

interface HostJournalRecord {
  readonly event: string;
  readonly detail: Readonly<Record<string, unknown>>;
  readonly state?: {
    readonly reservations?: Readonly<Record<string, {
      readonly kind?: string;
      readonly locator?: string;
      readonly builderName?: string;
      readonly retention?: "cache" | "ephemeral";
    }>>;
  };
}

const docker = command(["docker"]);
const sudo = command(["sudo", "-n"]);
const driverImage = "node@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f";
const dindImage = "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c";
const buildkitImage = "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8";
const projectCopy = {
  from: process.cwd(),
  prefix: "niceeval-e2e-docker-profile-project-",
  omitTopLevel: [".niceeval", "node_modules", "test"],
  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
} as const;

async function fileExists(path: string): Promise<true | undefined> {
  try {
    await readFile(path);
    return true;
  } catch {
    return undefined;
  }
}

async function quotaPath(): Promise<string> {
  const candidates = (process.env.PATH ?? "").split(":");
  try {
    for (const name of await readdir("/nix/store")) {
      if (/^[^-]+-quota-[^/]+$/.test(name)) candidates.push(`/nix/store/${name}/bin`);
    }
  } catch {
    // Non-Nix hosts can provide quota-tools on PATH.
  }
  for (const candidate of candidates) {
    if ((await command(["test"]).run(["-x", join(candidate, "setquota")])).exitCode === 0) {
      return [candidate, process.env.PATH ?? ""].filter(Boolean).join(":");
    }
  }
  throw new Error("project-quota tools (setquota/repquota) are required by this E2E");
}

async function exportImageRootfs(image: string, destination: string): Promise<void> {
  const created = await docker.run(["create", image]);
  expect(created.exitCode, created.diagnostic()).toBe(0);
  const containerId = created.stdout.trim();
  try {
    const exported = await docker.run(["export", "--output", destination, containerId], {
      timeoutMs: 60_000,
    });
    expect(exported.exitCode, exported.diagnostic()).toBe(0);
  } finally {
    const removed = await docker.run(["rm", "--force", containerId]);
    expect(removed.exitCode, removed.diagnostic()).toBe(0);
  }
}

test("profile-bound Dockerfile cold build starts the Attempt through the public CLI", async () => {
  const scripts = process.env.NICEEVAL_E2E_DOCKER_PROFILE_HOST_SCRIPTS;
  expect(scripts, "runner must inject the actual Docker profile host scripts").toBeTruthy();
  const fixtureScript = resolve("fixtures/profile-host-fixture.py");
  const dockerInfo = await docker.run(["info", "--format", "{{.DockerRootDir}}"]);
  expect(dockerInfo.exitCode, dockerInfo.diagnostic()).toBe(0);
  const hostPath = await quotaPath();
  const user = process.env.USER ?? process.env.LOGNAME;
  expect(user, "E2E runner user must be named for the quota-slot owner").toBeTruthy();
  const id = await command(["id"]).run(["-gn", user!]);
  expect(id.exitCode, id.diagnostic()).toBe(0);

  await withProjectCopy(projectCopy, async ({ root: projectRoot }) => {
    const fixtureContext = join(projectRoot, "fixtures/profile-cold-build");
    await exportImageRootfs(driverImage, join(fixtureContext, "node-rootfs.tar"));
    await exportImageRootfs(dindImage, join(fixtureContext, "docker-rootfs.tar"));
    const inspectedBuildkit = await docker.run(["image", "inspect", buildkitImage]);
    if (inspectedBuildkit.exitCode !== 0) {
      const pulledBuildkit = await docker.run(["pull", buildkitImage], { timeoutMs: 120_000 });
      expect(pulledBuildkit.exitCode, pulledBuildkit.diagnostic()).toBe(0);
    }
    // The unique context byte keeps this owner a real cold build even when the
    // daemon already carries an image from an earlier reliability repetition.
    await appendFile(
      join(projectRoot, "fixtures/profile-cold-build/Dockerfile"),
      `\n# cold-build-owner ${crypto.randomUUID()}\n`,
    );
    await withTempDir("niceeval-e2e-docker-profile-", async (hostRoot) => {
      let fixture: HostFixture | undefined;
      let primaryError: unknown;
      try {
        const setup = await sudo.run([
          "env", `PATH=${hostPath}`,
          "python3", fixtureScript, "setup",
          "--root", hostRoot,
          "--scripts", scripts!,
          "--docker-root", dockerInfo.stdout.trim(),
          "--user", user!,
          "--group", id.stdout.trim(),
        ], { timeoutMs: 60_000 });
        expect(setup.exitCode, setup.diagnostic()).toBe(0);
        fixture = JSON.parse(setup.stdout.trim().split("\n").at(-1)!) as HostFixture;
        const activeFixture = fixture;

        await withProcess(
          [
            "sudo", "-n", "env", `PATH=${hostPath}`, "PYTHONDONTWRITEBYTECODE=1",
            "python3", join(scripts!, "watchdog.py"),
            "--control-socket", activeFixture.controlSocket,
            "--descriptor", activeFixture.descriptor,
            "--host-config", activeFixture.hostConfig,
            "--docker-socket", "/run/docker.sock",
            "--journal", activeFixture.journal,
            "--ready-file", activeFixture.readyFile,
            "--socket-mode", "0o600",
          ],
          { processGroup: true, timeoutMs: 330_000, graceMs: 5_000 },
          async (watchdog) => {
            await Promise.race([
              pollUntil(() => fileExists(activeFixture.readyFile), {
                timeoutMs: 15_000,
                intervalMs: 100,
                label: "isolated real watchdog ready file",
              }),
              watchdog.done.then((receipt) => {
                throw new Error(`watchdog exited before readiness\n${receipt.diagnostic()}`);
              }),
            ]);

            const driver = await docker.run([
              "run", "--rm", "--network", "none", "--user", "0:0",
              "--mount", `type=bind,src=${process.cwd()},dst=${process.cwd()},readonly`,
              "--mount", `type=bind,src=${projectRoot},dst=${projectRoot}`,
              "--mount", `type=bind,src=${hostRoot},dst=${hostRoot}`,
              "--mount", "type=bind,src=/run/docker.sock,dst=/run/docker.sock",
              "--workdir", projectRoot,
              "--env", "NICEEVAL_E2E_DOCKER_PROFILE_ALIAS=e2e-cold-build",
              driverImage,
              "sh", "-ec",
              `holder_pid=''; doctor_pid=''; fault_socket=''; compat_proxy_pid=''; compat_socket=''
cleanup_holder() { if [ -n "\${holder_pid}" ] && kill -0 "\${holder_pid}" 2>/dev/null; then kill -TERM "\${holder_pid}" 2>/dev/null || true; wait "\${holder_pid}" || true; fi; }
cleanup_doctor() { if [ -n "\${doctor_pid}" ] && kill -0 "\${doctor_pid}" 2>/dev/null; then kill -KILL "\${doctor_pid}" 2>/dev/null || true; wait "\${doctor_pid}" || true; fi; }
restore_fault_socket() { if [ -n "\${fault_socket}" ] && [ -S "\${fault_socket}" ]; then mv "\${fault_socket}" '${activeFixture.controlSocket}'; fi; }
restore_compat_socket() { if [ -n "\${compat_proxy_pid}" ] && kill -0 "\${compat_proxy_pid}" 2>/dev/null; then kill -TERM "\${compat_proxy_pid}" 2>/dev/null || true; wait "\${compat_proxy_pid}" || true; fi; if [ -n "\${compat_socket}" ] && [ -S "\${compat_socket}" ]; then rm -f '${activeFixture.controlSocket}'; mv "\${compat_socket}" '${activeFixture.controlSocket}'; fi; }
trap 'restore_fault_socket; restore_compat_socket; cleanup_doctor; cleanup_holder; chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
mkdir -p /etc/niceeval/docker-profiles
cp '${activeFixture.descriptor}' /etc/niceeval/docker-profiles/e2e-cold-build.json
chown root:root /etc/niceeval/docker-profiles/e2e-cold-build.json
chmod 600 /etc/niceeval/docker-profiles/e2e-cold-build.json
docker_api() { node - "$@" <<'NODE'
const Docker=require('dockerode'),d=new Docker({socketPath:'/run/docker.sock'}),[action,...args]=process.argv.slice(2);const labels=Object.fromEntries((args[0]||'').split(',').filter(Boolean).map(x=>x.split('=')));const filters={label:Object.entries(labels).map(([k,v])=>v?k+'='+v:k)};(async()=>{if(action==='image'){await d.getImage(args[0]).inspect();return}if(action==='find'){const c=await d.listContainers({all:false,filters});if(c[0])process.stdout.write(JSON.stringify({id:c[0].Id,labels:c[0].Labels}))}if(action==='kill'){await d.getContainer(args[0]).kill()}if(action==='absent'){const c=await d.listContainers({all:true,filters}),n=await d.listNetworks({filters});if(c.length||n.length)throw Error('owned resource remains')}})().catch(e=>{console.error(e);process.exit(1)})
NODE
}
docker_api image '${dindImage}'
docker_api image '${buildkitImage}'
compat_socket='${activeFixture.controlSocket}.compat'
mv '${activeFixture.controlSocket}' "$compat_socket"
node - '${activeFixture.controlSocket}' "$compat_socket" <<'NODE' &
const net=require('net'),[front,back]=process.argv.slice(2);const server=net.createServer({allowHalfOpen:true},client=>{let request='',response='';client.on('data',b=>request+=b);client.on('end',()=>{const upstream=net.createConnection(back);upstream.on('connect',()=>upstream.end(request));upstream.on('data',b=>response+=b);upstream.on('error',e=>client.destroy(e));upstream.on('close',()=>{try{const value=JSON.parse(response),input=JSON.parse(request);if(input.kind==='status'&&value.ok)delete value.result.journal;client.end(JSON.stringify(value)+String.fromCharCode(10))}catch(e){client.destroy(e)}})})});server.listen(front);process.on('SIGTERM',()=>server.close(()=>process.exit(0)))
NODE
compat_proxy_pid=$!
for _ in $(seq 1 100); do [ -S '${activeFixture.controlSocket}' ] && break; kill -0 "$compat_proxy_pid" 2>/dev/null || exit 1; sleep 0.05; done
[ -S '${activeFixture.controlSocket}' ] || { echo 'compatibility control proxy did not become ready' >&2; exit 1; }
set +e
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-compat.json
compat_status=$?
set -e
COMPAT_STATUS="$compat_status" node - /tmp/niceeval-doctor-compat.json <<'NODE'
const fs=require('fs'),d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup'];const invalid=process.env.COMPAT_STATUS==='0'||d.status!=='FAIL'||JSON.stringify(d.checks.map(x=>x.id))!==JSON.stringify(ids)||ids.slice(0,5).some((id,i)=>d.checks[i].status!=='PASS')||d.checks[5].status!=='FAIL'||d.checks[5].code!=='UNSAFE_TO_CONTINUE'||!d.checks[5].detail.includes('durable journal')||d.checks.slice(6).some(x=>x.status!=='FAIL'||x.code!=='PREREQUISITE_FAILED');if(invalid){console.error(JSON.stringify({compatStatus:process.env.COMPAT_STATUS,doctor:d},null,2));process.exit(1)}
NODE
kill -TERM "$compat_proxy_pid"
wait "$compat_proxy_pid"
compat_proxy_pid=''
rm -f '${activeFixture.controlSocket}'
mv "$compat_socket" '${activeFixture.controlSocket}'
compat_socket=''
rm -f /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready
node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready <<'NODE' &
const net=require('net'), fs=require('fs'), crypto=require('crypto'); const [path,out,ready]=process.argv.slice(2);
const call=(request)=>new Promise((resolve,reject)=>{let text=''; const s=net.createConnection(path); s.on('connect',()=>s.end(JSON.stringify(request)+'\\n')); s.on('data',b=>text+=b); s.on('error',reject); s.on('close',()=>{try { const r=JSON.parse(text); if(!r.ok) throw Error(r.error?.message||'control error'); resolve(r.result) } catch(e) { reject(e) }});});
(async()=>{const status=await call({kind:'status'}); const invocationId=crypto.randomUUID(), reservationId=crypto.randomUUID(); const lease=await call({kind:'lease.create',profileId:status.profileId,daemonGeneration:status.generation,invocationId}); const held={invocationId,reservationId,leaseToken:lease.leaseToken}; const reservation=await call({kind:'reservation.acquire',...held,reservationKind:'build',resources:{cpus:0,memoryBytes:0,pids:0,containers:0,ephemeralDiskBytes:0}}); if(reservation.state!=='granted') throw Error('preoccupier was not granted'); fs.writeFileSync(out,JSON.stringify(held)); fs.writeFileSync(ready,'ready'); const beat=setInterval(()=>call({kind:'lease.heartbeat',invocationId,leaseToken:lease.leaseToken}).catch(()=>{}),4000); let done=false; const stop=async()=>{if(done)return;done=true;clearInterval(beat);await call({kind:'reservation.release',...held}).catch(()=>{});await call({kind:'lease.drain',invocationId,leaseToken:lease.leaseToken}).catch(()=>{});process.exit(0)};process.on('SIGTERM',stop);process.on('SIGINT',stop);})().catch(e=>{console.error(e);process.exit(1)});
NODE
holder_pid=$!
for _ in $(seq 1 100); do [ -f /tmp/niceeval-preoccupier.ready ] && break; sleep 0.1; done
[ -f /tmp/niceeval-preoccupier.ready ] || { echo 'preoccupier did not become ready' >&2; exit 1; }
set +e
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor.json
doctor_status=$?
set -e
cat /tmp/niceeval-doctor.json
DOCTOR_STATUS="$doctor_status" node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json <<'NODE'
const net=require('net'), fs=require('fs'); const path=process.argv[2], held=JSON.parse(fs.readFileSync(process.argv[3]));
const call=(request)=>new Promise((resolve,reject)=>{let text=''; const s=net.createConnection(path); s.on('connect',()=>s.end(JSON.stringify(request)+'\\n')); s.on('data',b=>text+=b); s.on('error',reject); s.on('close',()=>{try {const r=JSON.parse(text);if(!r.ok)throw Error(r.error?.message||'control error');resolve(r.result)}catch(e){reject(e)}})});
(async()=>{const d=JSON.parse(fs.readFileSync('/tmp/niceeval-doctor.json','utf8')); const ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup']; if(process.env.DOCTOR_STATUS==='0'||d.status!=='BLOCKED'||JSON.stringify(d.checks?.map(c=>c.id))!==JSON.stringify(ids)||d.checks.some(c=>c.status==='FAIL')||d.checks.filter(c=>ids.slice(7).includes(c.id)).some(c=>c.status!=='BLOCKED'||c.code!=='CAPACITY_QUEUE_TIMEOUT')) throw Error('doctor did not report only capacity BLOCKED')})().catch(e=>{console.error(e);process.exit(1)});
NODE
kill -TERM "$holder_pid"
wait "$holder_pid"
holder_pid=''
node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json <<'NODE'
const net=require('net'),fs=require('fs');const path=process.argv[2],held=JSON.parse(fs.readFileSync(process.argv[3]));const call=r=>new Promise((resolve,reject)=>{let t='';const s=net.createConnection(path);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',reject);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);resolve(v.result)}catch(e){reject(e)}})});(async()=>{for(let i=0;i<50;i++){const s=await call({kind:'status'}),lease=s.leases.find(l=>l.invocationId===held.invocationId);if(!s.reservations.some(r=>r.reservationId===held.reservationId)&&lease?.state==='recovered'&&s.used.builds===0&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(r=>setTimeout(r,100))}throw Error('preoccupier cleanup did not converge')})().catch(e=>{console.error(e);process.exit(1)});
NODE
rm -f /tmp/niceeval-doctor-kill.json /tmp/niceeval-doctor-owned.json
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-kill.json 2>&1 &
doctor_pid=$!
for _ in $(seq 1 300); do
  doctor_owned=$(docker_api find 'niceeval.attempt-id=doctor-diagnostic')
  if [ -n "$doctor_owned" ]; then
    printf '%s' "$doctor_owned" >/tmp/niceeval-doctor-owned.json
    node - /tmp/niceeval-doctor-owned.json <<'NODE'
const x=require('fs').readFileSync(process.argv[2],'utf8'),l=JSON.parse(x).labels;if(l['niceeval.attempt-id']!=='doctor-diagnostic'||['niceeval.profile-id','niceeval.invocation-id','niceeval.reservation-id','niceeval.provision-token'].some(k=>!l[k]))process.exit(1)
NODE
    break
  fi
  kill -0 "$doctor_pid" 2>/dev/null || { cat /tmp/niceeval-doctor-kill.json >&2; exit 1; }
  sleep 0.1
done
[ -s /tmp/niceeval-doctor-owned.json ] || { echo 'doctor diagnostic did not become running' >&2; exit 1; }
kill -KILL "$doctor_pid"
set +e; wait "$doctor_pid"; doctor_kill_status=$?; set -e
[ "$doctor_kill_status" -eq 137 ] || { echo 'doctor did not exit from SIGKILL' >&2; exit 1; }
doctor_pid=''
node - '${activeFixture.controlSocket}' /tmp/niceeval-doctor-owned.json <<'NODE'
const net=require('net'),fs=require('fs'),path=process.argv[2],o=JSON.parse(fs.readFileSync(process.argv[3])).labels;const call=r=>new Promise((ok,no)=>{let t='';const s=net.createConnection(path);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',no);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);ok(v.result)}catch(e){no(e)}})});(async()=>{for(let i=0;i<300;i++){const s=await call({kind:'status'}),r=o['niceeval.reservation-id'],l=o['niceeval.invocation-id'];if(!s.reservations.some(x=>x.reservationId===r)&&s.leases.find(x=>x.invocationId===l)?.state==='recovered'&&s.used.builds===0&&s.used.containers===0&&s.slots.every(x=>x.reservationId!==r&&x.state==='free')&&s.availableQuotaSlots===1&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(x=>setTimeout(x,100))}throw Error('SIGKILL recovery did not converge')})().catch(e=>{console.error(e);process.exit(1)})
NODE
profile_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.profile-id"])')
reservation_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.reservation-id"])')
docker_api absent "niceeval.profile-id=$profile_label,niceeval.reservation-id=$reservation_label"
docker_api image '${dindImage}'
docker_api image '${buildkitImage}'
rm -f /tmp/niceeval-doctor-fault.json /tmp/niceeval-doctor-fault-owned.json
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-fault.json 2>&1 &
doctor_pid=$!
for _ in $(seq 1 300); do
  fault_owned=$(docker_api find 'niceeval.attempt-id=doctor-diagnostic')
  if [ -n "$fault_owned" ]; then printf '%s' "$fault_owned" >/tmp/niceeval-doctor-fault-owned.json; break; fi
  kill -0 "$doctor_pid" 2>/dev/null || { cat /tmp/niceeval-doctor-fault.json >&2; exit 1; }; sleep 0.1
done
[ -s /tmp/niceeval-doctor-fault-owned.json ] || { echo 'fault diagnostic did not become running' >&2; exit 1; }
fault_socket='${activeFixture.controlSocket}.fault'
mv '${activeFixture.controlSocket}' "$fault_socket"
fault_container=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).id)')
docker_api kill "$fault_container"
set +e; wait "$doctor_pid"; doctor_fault_status=$?; set -e
[ "$doctor_fault_status" -eq 1 ] || { cat /tmp/niceeval-doctor-fault.json >&2; exit 1; }
doctor_pid=''
node - /tmp/niceeval-doctor-fault.json <<'NODE'
const fs=require('fs'),d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup'];const fail=d.checks.find(x=>x.status==='FAIL');if(d.status!=='FAIL'||JSON.stringify(d.checks.map(x=>x.id))!==JSON.stringify(ids)||!fail||!fail.detail.includes('primary:')||!fail.detail.includes('cleanup:')||!fail.detail.includes('control-owned diagnostic'))process.exit(1)
NODE
mv "$fault_socket" '${activeFixture.controlSocket}'
fault_socket=''
node - '${activeFixture.controlSocket}' /tmp/niceeval-doctor-fault-owned.json <<'NODE'
const net=require('net'),fs=require('fs'),p=process.argv[2],o=JSON.parse(fs.readFileSync(process.argv[3])).labels;const call=r=>new Promise((ok,no)=>{let t='';const s=net.createConnection(p);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',no);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);ok(v.result)}catch(e){no(e)}})});(async()=>{for(let i=0;i<300;i++){const s=await call({kind:'status'}),r=o['niceeval.reservation-id'],l=o['niceeval.invocation-id'],used=s.used;if(!s.reservations.some(x=>x.reservationId===r)&&s.leases.find(x=>x.invocationId===l)?.state==='recovered'&&Object.values(used).every(x=>x===0)&&s.slots.every(x=>x.reservationId!==r&&x.state==='free')&&s.availableQuotaSlots===1&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(x=>setTimeout(x,100))}throw Error('fault cleanup did not converge')})().catch(e=>{console.error(e);process.exit(1)})
NODE
fault_profile=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.profile-id"])')
fault_reservation=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.reservation-id"])')
docker_api absent "niceeval.profile-id=$fault_profile,niceeval.reservation-id=$fault_reservation"
docker_api image '${dindImage}'
docker_api image '${buildkitImage}'
set +e
node_modules/.bin/niceeval exp docker-profile-cold-build --rerun all --json >/tmp/niceeval-exp.ndjson
status=$?
set -e
cat /tmp/niceeval-exp.ndjson
run_id=$(node -e 'const fs=require("fs"); const lines=fs.readFileSync("/tmp/niceeval-exp.ndjson","utf8").trim().split("\\n"); const receipt=JSON.parse(lines.at(-1)); process.stdout.write(receipt.receipt.runIds[0])')
if [ "$status" -ne 0 ]; then
  locator=$(node -e 'const fs=require("fs"); for (const line of fs.readFileSync("/tmp/niceeval-exp.ndjson","utf8").trim().split("\\n")) { const value=JSON.parse(line); if (value.locator) { process.stdout.write(value.locator); break } }')
  if [ -n "$locator" ]; then
    node_modules/.bin/niceeval show "$locator" --execution
  else
    node_modules/.bin/niceeval show --run "$run_id" --json
  fi
fi
exit "$status"`,
          ], { cwd: projectRoot, timeoutMs: 300_000 });
            expect(driver.exitCode, driver.diagnostic()).toBe(0);
            const evals = driver.ndjson<ExpEvent>().filter(
              (event): event is Extract<ExpEvent, { event: "eval" }> =>
                "event" in event && event.event === "eval",
            );
            expect(only(evals, (event) => event.evalId === "docker-profile-cold-build"), driver.diagnostic())
              .toMatchObject({ verdict: "passed" });
          },
        );

        const journal = await sudo.run(["cat", fixture.journal]);
        expect(journal.exitCode, journal.diagnostic()).toBe(0);
        const records = journal.stdout
          .split("\n")
          .filter(Boolean)
          .map((line) => JSON.parse(line) as HostJournalRecord);
        const events = records.map((record) => record.event);
        expect(events).toContain("reservation-granted");
        expect(events).toContain("build-terminated");
        expect(events).toContain("container-active");
        expect(events).toContain("reservation-released");
        const buildLocator = records.find((record) => record.event === "build-terminated")?.detail.locator;
        expect(typeof buildLocator).toBe("string");
      } catch (error) {
        primaryError = error;
        throw error;
      } finally {
        const cleanupErrors: unknown[] = [];
        if (fixture !== undefined) {
          try {
            const journal = await sudo.run(["cat", fixture.journal]);
            if (journal.exitCode !== 0 && primaryError === undefined) throw new Error(journal.diagnostic());
            const records = journal.exitCode === 0 ? journal.stdout
              .split("\n")
              .filter(Boolean)
              .map((line) => JSON.parse(line) as HostJournalRecord) : [];
            const locators = new Map<string, "cache" | "ephemeral" | undefined>();
            const builderNames = new Set<string>();
            for (const record of records) {
              if (record.event === "build-terminated" && typeof record.detail.locator === "string") {
                locators.set(record.detail.locator, undefined);
              }
              if (record.event === "build-builder-created" && typeof record.detail.builderName === "string") {
                builderNames.add(record.detail.builderName);
              }
              for (const reservation of Object.values(record.state?.reservations ?? {})) {
                if (reservation.kind === "build" && typeof reservation.locator === "string") {
                  locators.set(reservation.locator, reservation.retention);
                }
                if (reservation.kind === "build" && typeof reservation.builderName === "string") {
                  builderNames.add(reservation.builderName);
                }
              }
            }
            for (const [locator, retention] of locators) {
              const inspectImage = await docker.run(["image", "inspect", locator]);
              if (retention === "ephemeral" && inspectImage.exitCode === 0) {
                // Clean the fixture after recording the ownership leak, but do
                // not let cleanup turn a failed proof into a passing run.
                await docker.run(["image", "rm", "--force", locator]);
                throw new Error(`watchdog leaked ephemeral build locator ${locator}`);
              }
              if (retention === "ephemeral" && !/No such image/i.test(inspectImage.diagnostic())) {
                throw new Error(inspectImage.diagnostic());
              }
              const removeImage = await docker.run(["image", "rm", "--force", locator]);
              if (removeImage.exitCode !== 0 && !/No such image/i.test(removeImage.diagnostic())) {
                throw new Error(removeImage.diagnostic());
              }
            }
            for (const builderName of builderNames) {
              if (!/^niceeval-build-[a-f0-9]{24}$/.test(builderName)) {
                throw new Error(`watchdog journal contains a non-derived builder name: ${builderName}`);
              }
              const volumeName = `buildx_buildkit_${builderName}0_state`;
              const inspectVolume = await docker.run(["volume", "inspect", volumeName]);
              if (inspectVolume.exitCode === 0) {
                const removeVolume = await docker.run(["volume", "rm", "--force", volumeName]);
                throw new Error(
                  `watchdog leaked Buildx state volume ${volumeName}; cleanup: ${removeVolume.diagnostic()}`,
                );
              }
              if (!/No such volume/i.test(inspectVolume.diagnostic())) {
                throw new Error(inspectVolume.diagnostic());
              }
            }
          } catch (error) {
            cleanupErrors.push(error);
          }
          try {
            const cleanup = await sudo.run([
              "env", `PATH=${hostPath}`,
              "python3", fixtureScript, "cleanup", "--root", hostRoot,
            ], { timeoutMs: 30_000 });
            if (cleanup.exitCode !== 0) throw new Error(cleanup.diagnostic());
          } catch (error) {
            cleanupErrors.push(error);
          }
        }
        if (cleanupErrors.length > 0) {
          if (primaryError !== undefined) {
            console.error(new AggregateError(cleanupErrors, "Docker profile E2E cleanup also failed"));
          } else {
            throw new AggregateError(cleanupErrors, "Docker profile E2E cleanup failed");
          }
        }
      }
    });
  });
}, 360_000);
```

### `test/host/docker-profile-public-smoke.ts`

- Purpose: `bug regression`
- Protects: 公开 runtime client 不得回退到 reservation.commit 或伪造清理证明。
- Runs: 对离线 control socket 执行公开 release 与丢回复对账。
- Asserts: 只有匹配 profile、generation、lease、reservation、slot 的 durable 状态可证明清理。

```ts
/** Control-protocol reply-loss smoke, run by watchdog-smoke. */
import { createServer } from "node:net";
import { mkdtemp, rm } from "node:fs/promises";
import { tmpdir } from "node:os";
import { join } from "node:path";
import { releaseDockerProfileReservation, type DockerProfileLease } from "../../packages/niceeval/src/sandbox/docker-profile/runtime.ts";

const binding = { profile: { profileId: "profile" }, daemonGeneration: "generation", controlSocketPath: "", dockerSocketPath: "", alias: "a", descriptorDigest: "d", daemonId: "d", platform: "linux/amd64" } as never;
const lease = { binding, invocationId: "lease", leaseToken: "token", stopHeartbeat: async () => {} } as DockerProfileLease;

async function matrix(status: object, success: boolean): Promise<void> {
  const root = await mkdtemp(join(tmpdir(), "niceeval-public-release-"));
  const path = join(root, "control.sock");
  let calls = 0;
  const server = createServer((socket) => socket.once("data", (raw) => {
    calls += 1;
    if (calls === 1) { socket.destroy(); return; } // durable host success, lost reply
    const request = JSON.parse(raw.toString()) as { kind: string };
    socket.end(JSON.stringify({ ok: true, result: request.kind === "status" ? status : {} }) + "\n");
  }));
  await new Promise<void>((resolve) => server.listen(path, resolve));
  const current = { ...lease, binding: { ...binding, controlSocketPath: path } };
  const realNow = Date.now;
  const base = realNow();
  let reads = 0;
  Date.now = () => (++reads <= 2 ? base : base + 120_000);
  try {
    const result = await Promise.race([
      releaseDockerProfileReservation(current, "reservation", { slotId: "slot" }),
      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("reply-loss proof timeout")), 1_000)),
    ]);
    if (!success || result.cleanupProven !== true) throw new Error("reply-loss proof accepted an invalid status");
  } catch (error) {
    if (success) throw error;
  } finally {
    Date.now = realNow;
    await new Promise<void>((resolve) => server.close(() => resolve()));
    await rm(root, { recursive: true, force: true });
  }
}

async function main(): Promise<void> {
  const good = { profileId: "profile", generation: "generation", leases: [{ invocationId: "lease", daemonGeneration: "generation" }], reservations: [], slots: [{ slotId: "slot", state: "free" }], degraded: [] };
  await matrix(good, true);
  await matrix({ ...good, profileId: "other" }, false);
  await matrix({ ...good, generation: "other" }, false);
  await matrix({ ...good, leases: [] }, false);
  await matrix({ ...good, reservations: [{ reservationId: "reservation", invocationId: "lease" }] }, false);
  await matrix({ ...good, slots: [{ slotId: "slot", reservationId: "reservation", state: "active" }] }, false);
  await matrix({ ...good, degraded: ["recovery blocked for reservation"] }, false);
  console.log("docker-profile-public-smoke ok");
}
void main();
```

### `test/host/run-checks.sh`

- Purpose: `feature`
- Protects: host package 不得遗漏 doctor 的离线 asset manifest 与预载校验器。
- Runs: 运行 host package 文件、语法与 smoke 检查。
- Asserts: 两项资产进入打包输入且完整 host checks 通过。

```text
// … omitted: file=test/host/run-checks.sh; before=  packaging/docker-profile-host/scripts/prepare-loop-storage.sh \; after=  packaging/docker-profile-host/scripts/watchdog.py \; reason=其余 host package 检查清单与本 PR 无关
  packaging/docker-profile-host/scripts/watchdog.py \
  packaging/docker-profile-host/scripts/preload-verify-assets.py \
  packaging/docker-profile-host/config/assets-v1.json \
// … omitted: file=test/host/run-checks.sh; before=  packaging/docker-profile-host/config/assets-v1.json \; after=  packaging/docker-profile-host/scripts/install-quota-slots.py \; reason=其余 host package 检查清单与本 PR 无关
```

### `test/host/watchdog-smoke.py`

- Purpose: `feature + bug regression`
- Protects: watchdog 的 durable ownership、输入限制、重启恢复与 fail-closed 语义。
- Runs: 以 fake Docker 边界运行真实 watchdog 的 framing、asset、build、container、journal 与 recovery。
- Asserts: 状态先持久化；不可信输入被拒；资源清理可证明；不安全时关闭 admission。

```text
// … omitted: file=test/host/watchdog-smoke.py; before=from __future__ import annotations; after=import importlib.util; reason=unrelated unchanged lines
import importlib.util
import io
import json
import os
import copy
import subprocess
import sys
import tarfile
import tempfile
// … omitted: file=test/host/watchdog-smoke.py; before=import tempfile; after=    elif args[:2] == ("buildx", "create"):; reason=unrelated unchanged lines
    elif args[:2] == ("buildx", "create"):
        name = args[args.index("--name") + 1]
        self.__dict__["fake_builder"] = name
        self.__dict__["fake_builder_container"] = "builder-container-a"
        self.__dict__["fake_builder_volume"] = f"buildx_buildkit_{name}0_state"
        output = name + "\n"
    elif args[:2] == ("buildx", "inspect"):
        name = args[-1]
        code = 0 if self.__dict__.get("fake_builder") == name else 1
        result = subprocess.CompletedProcess(args, code, "", "")
        if check and code != 0:
            raise subprocess.CalledProcessError(code, args)
        return result
    elif args[:2] == ("buildx", "rm"):
        self.__dict__.pop("fake_builder", None)
        if not self.__dict__.get("fake_builder_rm_leaves_container"):
            self.__dict__.pop("fake_builder_container", None)
        if not self.__dict__.get("fake_builder_rm_leaves_volume"):
            self.__dict__.pop("fake_builder_volume", None)
        output = ""
    elif args[:2] == ("image", "inspect") and args[-1] in watchdog.REQUIRED_ASSETS:
        output = "linux/amd64\n"
    elif args[:2] == ("image", "inspect"):
        images = self.__dict__.setdefault("fake_images", set())
        reference = args[-1]
        code = 0 if reference in images else 1
        output = ""
        if code == 0 and "--format" in args:
            image_ids = self.__dict__.setdefault("fake_image_ids", {})
            image_labels = self.__dict__.setdefault("fake_image_labels", {})
            format_value = args[args.index("--format") + 1]
            if format_value == "{{.Id}}":
                output = image_ids[reference] + "\n"
            elif "niceeval.operation-id" in format_value:
                output = image_labels[reference] + "\n"
        result = subprocess.CompletedProcess(args, code, output, "")
        if check and code != 0:
            raise subprocess.CalledProcessError(code, args)
        return result
    elif args[:2] == ("image", "rm"):
        reference = args[-1]
        self.__dict__.setdefault("fake_images", set()).discard(reference)
        self.__dict__.setdefault("fake_image_ids", {}).pop(reference, None)
        self.__dict__.setdefault("fake_image_labels", {}).pop(reference, None)
        output = ""
    elif args[:1] == ("tag",):
        images = self.__dict__.setdefault("fake_images", set())
        if args[1] not in images:
            raise subprocess.CalledProcessError(1, args, stderr="source image missing")
        images.add(args[2])
        self.__dict__.setdefault("fake_image_ids", {})[args[2]] = self.fake_image_ids[args[1]]
        self.__dict__.setdefault("fake_image_labels", {})[args[2]] = self.fake_image_labels[args[1]]
        output = ""
    elif args[:1] == ("create",):
// … omitted: file=test/host/watchdog-smoke.py; before=    elif args[:1] == ("create",):; after=    elif args[:2] == ("ps", "-aq") and any(; reason=unrelated unchanged lines
    elif args[:2] == ("ps", "-aq") and any(
        str(item).startswith("name=^/buildx_buildkit_") for item in args
    ):
        output = self.__dict__.get("fake_builder_container", "") + "\n"
// … omitted: file=test/host/watchdog-smoke.py; before=        output = self.__dict__.get("fake_builder_container", "") + "\n"; after=    elif args[:2] == ("volume", "ls") and self.__dict__.get("fake_query_failure"):; reason=unrelated unchanged lines
    elif args[:2] == ("volume", "ls") and self.__dict__.get("fake_query_failure"):
        return subprocess.CompletedProcess(args, 1, "", "daemon unavailable")
    elif args[:2] == ("volume", "ls"):
        output = self.__dict__.get("fake_builder_volume", "") + "\n"
// … omitted: file=test/host/watchdog-smoke.py; before=        output = self.__dict__.get("fake_builder_volume", "") + "\n"; after=        if args[2] == self.__dict__.get("fake_builder_container"):; reason=unrelated unchanged lines
        if args[2] == self.__dict__.get("fake_builder_container"):
            self.__dict__.pop("fake_builder_container", None)
        else:
            self.__dict__.pop("fake_container", None)
        output = ""
    elif args[:2] == ("volume", "rm"):
        if args[-1] == self.__dict__.get("fake_builder_volume"):
            self.__dict__.pop("fake_builder_volume", None)
        output = ""
    elif args[:2] == ("network", "rm"):
// … omitted: file=test/host/watchdog-smoke.py; before=    elif args[:2] == ("network", "rm"):; after=def fake_run_build(self, reservation, spec, context_path):; reason=unrelated unchanged lines
def fake_run_build(self, reservation, spec, context_path):
    self.__dict__["fake_build_runs"] = self.__dict__.get("fake_build_runs", 0) + 1
    with tarfile.open(context_path, "r:*") as archive:
        assert archive.extractfile("Dockerfile").read() == b"FROM scratch\n"
    provisional = reservation["provisionalRef"]
    self.__dict__.setdefault("fake_images", set()).add(provisional)
    self.__dict__.setdefault("fake_image_ids", {})[provisional] = "sha256:" + "1" * 64
    self.__dict__.setdefault("fake_image_labels", {})[provisional] = reservation["operationId"]

def tar_bytes(entries):
    output = io.BytesIO()
    with tarfile.open(fileobj=output, mode="w") as archive:
        for name, kind, contents in entries:
            item = tarfile.TarInfo(name)
            if kind == "file":
                item.size = len(contents)
                archive.addfile(item, io.BytesIO(contents))
            else:
                item.type = tarfile.SYMTYPE
                item.linkname = contents.decode()
                archive.addfile(item)
    return output.getvalue()

class FakeActiveProcess:
    def __init__(self):
        self.running = True

    def poll(self):
        return None if self.running else 0

    def terminate(self):
        self.running = False

    def kill(self):
        self.running = False

    def wait(self, timeout=None):
        self.running = False
        return 0

watchdog.Admission._docker = fake_docker
watchdog.Admission._run_build = fake_run_build
watchdog.Admission._builder_process_facts = lambda self, container_ids: []
// … omitted: file=test/host/watchdog-smoke.py; before=watchdog.Admission._builder_process_facts = lambda self, container_ids: []; after=framed_output = io.BytesIO(); reason=unrelated unchanged lines
framed_output = io.BytesIO()
assert watchdog.receive_framed_build_context(
    io.BytesIO((4).to_bytes(4, "big") + b"test" + (0).to_bytes(4, "big")),
    framed_output,
) == 4
assert framed_output.getvalue() == b"test"
try:
    watchdog.receive_framed_build_context(
        io.BytesIO((watchdog.MAX_BUILD_CONTEXT_CHUNK_BYTES + 1).to_bytes(4, "big")),
        io.BytesIO(),
    )
except watchdog.ProtocolError as error:
    assert error.code == "build-context-frame-too-large"
else:
    raise AssertionError("oversized build-context frames must fail before allocation")
original_context_limit = watchdog.MAX_BUILD_CONTEXT_BYTES
watchdog.MAX_BUILD_CONTEXT_BYTES = 8
try:
    watchdog.receive_framed_build_context(
        io.BytesIO((5).to_bytes(4, "big") + b"first" + (5).to_bytes(4, "big") + b"again"),
        io.BytesIO(),
    )
except watchdog.ProtocolError as error:
    assert error.code == "build-context-too-large"
else:
    raise AssertionError("cumulative received build-context bytes must be capped")
finally:
    watchdog.MAX_BUILD_CONTEXT_BYTES = original_context_limit

with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:
// … omitted: file=test/host/watchdog-smoke.py; before=with tempfile.TemporaryDirectory(prefix="niceeval-watchdog-") as raw:; after=    asset_manifest = root / "assets-v1.json"; reason=unrelated unchanged lines
    asset_manifest = root / "assets-v1.json"
    asset_manifest.write_text(json.dumps({"schemaVersion": 1, "platform": "linux/amd64", "images": [
        {"reference": reference, "platform": "linux/amd64"}
        for reference in watchdog.REQUIRED_ASSETS
    ]}), encoding="utf-8")
    host_config = root / "default.host.json"
    host_config.write_text(json.dumps({
        "storage": {"slotRegistryPath": str(slot_registry), "slotRootPath": str(slot_root)},
        "assets": {"manifestPath": str(asset_manifest)},
    }), encoding="utf-8")
    descriptor_path = root / "default.json"
// … omitted: file=test/host/watchdog-smoke.py; before=    descriptor_path = root / "default.json"; after=    # A failed fsync cannot publish a heartbeat mutation in memory or after a; reason=unrelated unchanged lines
    # A failed fsync cannot publish a heartbeat mutation in memory or after a
    # restart.  This exercises the normal handle() transition scope.
    published_before_fsync_failure = copy.deepcopy(admission._published_state)
    original_fsync = watchdog.os.fsync
    watchdog.os.fsync = lambda _fd: (_ for _ in ()).throw(OSError("injected fsync failure"))
    try:
        admission.handle({**common, "kind": "lease.heartbeat"})
    except OSError:
        pass
    else:
        raise AssertionError("injected journal fsync failure must reject the transition")
    finally:
        watchdog.os.fsync = original_fsync
    assert admission._published_state == published_before_fsync_failure
    restarted_after_fsync_failure = watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)
    assert restarted_after_fsync_failure._published_state == published_before_fsync_failure
    # A diagnostic request is capability-free: any client-selected image,
    # command, environment, mount, tag or label is rejected before Docker I/O.
    for forbidden in ("image", "command", "environment", "mounts", "tag", "labels"):
        try:
            admission._validate_create({"intent": "diagnostic", forbidden: "client-controlled"})
        except watchdog.ProtocolError as error:
            assert error.code == "container-create-diagnostic-client-input"
        else:
            raise AssertionError("diagnostic intent must reject every client-controlled create field")
// … omitted: file=test/host/watchdog-smoke.py; before=            raise AssertionError("diagnostic intent must reject every client-controlled create field"); after=    # FIFO head timeouts are durably blocked and removed before the same-lock; reason=unrelated unchanged lines
    # FIFO head timeouts are durably blocked and removed before the same-lock
    # grant pass can consider later work.
    with admission._transition():
        admission.state["reservations"]["reservation-b"]["createdAt"] = "2000-01-01T00:00:00Z"
        admission._commit("fixture-queue-timeout", {"reservationId": "reservation-b"})
    assert admission.handle({**common_b, "kind": "reservation.get", "reservationId": "reservation-b"})["state"] == "blocked"
    assert "reservation-b" not in admission.state["queue"]
    # Cancelling the timed-out head removes its durable blocked reservation and
    # runs the next FIFO grant pass under the same control lock.
// … omitted: file=test/host/watchdog-smoke.py; before=    # runs the next FIFO grant pass under the same control lock.; after=            admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {"intent": "workload", "create": create}}); reason=unrelated unchanged lines
            admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {"intent": "workload", "create": create}})
// … omitted: file=test/host/watchdog-smoke.py; before=            admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {"intent": "workload", "create": create}}); after=        admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {"intent": "workload", "create": {; reason=unrelated unchanged lines
        admission.handle({**common, "kind": "container.create", "reservationId": "reservation-a", "create": {"intent": "workload", "create": {
            "image": "image:test", "attemptId": "attempt-a",
            "tmpfs": {"/var/lib/docker/cache": "rw,size=16m"},
        }}})
// … omitted: file=test/host/watchdog-smoke.py; before=        }}}); after=    create_a = {; reason=unrelated unchanged lines
    create_a = {
        "image": "image:test", "attemptId": "attempt-a", "command": ["true"],
        "tmpfs": {
            "/tmp": "rw,nosuid,nodev,size=16m",
            "/root": "rw,nosuid,nodev,size=8m",
            "/opt/fixture-secrets": "rw,nosuid,nodev,size=8m",
        },
    }
    created_container = admission.handle({**common, "kind": "container.create",
        "reservationId": "reservation-a", "create": {"intent": "workload", "create": create_a}})
    assert created_container == {"containerId": "container-a", "networkId": "network-a", "state": "active"}
    assert admission.handle({**common, "kind": "container.create",
        "reservationId": "reservation-a", "create": {"intent": "workload", "create": create_a}}) == created_container
// … omitted: file=test/host/watchdog-smoke.py; before=        "reservationId": "reservation-a", "create": {"intent": "workload", "create": create_a}}) == created_container; after=        "create": {"intent": "workload", "create": {"image": "image:test", "attemptId": "attempt-c"}}}); reason=unrelated unchanged lines
        "create": {"intent": "workload", "create": {"image": "image:test", "attemptId": "attempt-c"}}})
// … omitted: file=test/host/watchdog-smoke.py; before=        "create": {"intent": "workload", "create": {"image": "image:test", "attemptId": "attempt-c"}}}); after=    assert any(item.startswith("recovery blocked for reservation-c:"); reason=unrelated unchanged lines
    assert any(item.startswith("recovery blocked for reservation-c:")
               for item in restarted.state["degraded"])
    assert restarted.state["admissionOpen"] is False
// … omitted: file=test/host/watchdog-smoke.py; before=    assert restarted.state["admissionOpen"] is False; after=    assert restarted.state["slots"]["slot-0000"]["generation"] == 2; reason=unrelated unchanged lines
    assert restarted.state["slots"]["slot-0000"]["generation"] == 2
    assert list(slot_path.iterdir()) == []
    assert restarted.state["admissionOpen"] is True

    # Build context and all daemon lifecycle operations are control-owned. The
    # client supplies no network ID, builder name, tag, or termination booleans.
    lease_build = restarted.handle({"kind": "lease.create", "profileId": "profile-test",
        "daemonGeneration": challenge["daemonGeneration"], "invocationId": "invocation-build"})
    common_build = {"invocationId": "invocation-build", "leaseToken": lease_build["leaseToken"]}
    restarted.handle({**common_build, "kind": "reservation.acquire",
        "reservationId": "reservation-build", "reservationKind": "build",
        "resources": {"cpus": 0, "memoryBytes": 0, "pids": 0, "containers": 0,
                      "ephemeralDiskBytes": 0}})
    build_key = "a" * 64
    context_path = root / "context.tar"
    context_path.write_bytes(tar_bytes([("Dockerfile", "file", b"FROM scratch\n")]))
    build_request = {**common_build, "kind": "build.create",
        "reservationId": "reservation-build", "contextEncoding": "tar-chunked/v1",
        "build": {"buildKey": build_key, "platform": "linux/amd64",
                  "dockerfile": "Dockerfile", "buildArgs": {}}}
    for invalid_name, invalid_context, expected_code in (
        ("escape", [("Dockerfile", "file", b"FROM scratch\n"),
                    ("../escape", "file", b"host")], "build-context-path-forbidden"),
        ("symlink", [("Dockerfile", "file", b"FROM scratch\n"),
                     ("link", "symlink", b"/etc/passwd")], "build-context-type-forbidden"),
    ):
        invalid_path = root / f"context-{invalid_name}.tar"
        invalid_path.write_bytes(tar_bytes(invalid_context))
        try:
            restarted.handle_build(build_request, invalid_path)
        except watchdog.ProtocolError as error:
            assert error.code == expected_code
        else:
            raise AssertionError("untrusted tar paths/types must fail before Docker sees the context")

    ephemeral_build_request = copy.deepcopy(build_request)
    ephemeral_build_request["build"]["retention"] = "ephemeral"
    restarted.fake_builder_rm_leaves_container = True
    restarted.fake_builder_rm_leaves_volume = True
    built = restarted.handle_build(ephemeral_build_request, context_path)
    assert built == {"locator": "niceeval-build:" + build_key[:32], "state": "terminated"}
    assert restarted.fake_build_runs == 1
    assert restarted.handle_build(ephemeral_build_request, context_path) == built
    assert restarted.fake_build_runs == 1
    assert restarted.__dict__.get("fake_builder_container") is None
    assert restarted.__dict__.get("fake_builder_volume") is None
    assert any(argv[:3] == ("rm", "-f", "builder-container-a") for argv in restarted.fake_commands)
    builder_name = restarted.state["reservations"]["reservation-build"]["builderName"]
    assert any(argv == ("volume", "rm", "-f",
        f"buildx_buildkit_{builder_name}0_state")
        for argv in restarted.fake_commands)
    assert restarted.handle({"kind": "build.lookup", "profileId": "profile-test",
        "daemonGeneration": challenge["daemonGeneration"], "buildKey": build_key}) == {
            "hit": True, "locator": built["locator"],
        }
    try:
        restarted.handle({**common_build, "kind": "reservation.release",
            "reservationId": "reservation-build", "terminationEvidence": {
                "daemonRequestTerminated": True,
            }})
    except watchdog.ProtocolError as error:
        assert error.code == "build-release-client-evidence-forbidden"
    else:
        raise AssertionError("client-supplied build termination evidence must be rejected")
    published_build = restarted._published_state["reservations"]["reservation-build"]
    assert published_build["retention"] == "ephemeral"
    assert published_build["locatorImageId"] == "sha256:" + "1" * 64
    restart_probe = watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)
    journaled_build = restart_probe.state["reservations"]["reservation-build"]
    assert journaled_build["retention"] == "ephemeral"
    assert journaled_build["locatorImageId"] == "sha256:" + "1" * 64
    assert restarted.handle({**common_build, "kind": "reservation.release",
        "reservationId": "reservation-build"}) == {"released": True, "cleanupProven": True}
    assert built["locator"] not in restarted.fake_images
    build_events = [json.loads(line)["event"] for line in journal.read_text(encoding="utf-8").splitlines()]
    assert build_events.index("build-create-intent") < build_events.index("build-network-created")
    assert build_events.index("build-network-created") < build_events.index("build-builder-created")
    assert build_events.index("build-builder-created") < build_events.index("build-terminated")
    assert "build-create-replayed" in build_events

    # build.cancel terminates the in-memory process. A same-generation watchdog
    # restart then cancels any journaled provisioning operation before reopening
    # admission, even while its lease is still active.
    restarted.handle({**common_build, "kind": "reservation.acquire",
        "reservationId": "reservation-cancel", "reservationKind": "build",
        "resources": {"cpus": 0, "memoryBytes": 0, "pids": 0, "containers": 0,
                      "ephemeralDiskBytes": 0}})
    cancel_reservation = restarted.state["reservations"]["reservation-cancel"]
    cancel_reservation.update({
        "state": "provisioning",
        "builderName": "niceeval-build-0123456789abcdef01234567",
        "provisionalRef": "niceeval-build-provisional:cancel",
        "locator": "niceeval-build:" + "b" * 32,
    })
    active_process = FakeActiveProcess()
    restarted.build_processes["reservation-cancel"] = active_process
    restarted._commit("fixture-build-provisioning", {"reservationId": "reservation-cancel"})
    assert restarted.handle({**common_build, "kind": "build.cancel",
        "reservationId": "reservation-cancel"}) == {"cancelRequested": True}
    assert active_process.poll() == 0
    restarted = watchdog.Admission(descriptor_path, journal, str(docker_socket), 5, host_config)
    recovered_build = restarted.state["reservations"]["reservation-cancel"]
    assert recovered_build["state"] == "committed"
    assert recovered_build["buildTerminated"] is True
    assert "watchdog restarted" in recovered_build["buildError"]
    assert restarted.state["admissionOpen"] is True
    assert restarted.handle({**common_build, "kind": "reservation.release",
        "reservationId": "reservation-cancel"}) == {"released": True}
    assert restarted.handle({**common_build, "kind": "lease.drain"}) == {"state": "recovered"}
    assert restarted.state["leases"]["invocation-build"]["state"] == "recovered"
// … omitted: file=test/host/watchdog-smoke.py; before=    assert restarted.state["leases"]["invocation-build"]["state"] == "recovered"; after=    # Missing fixed assets fail closed at watchdog startup; status exposes the; reason=unrelated unchanged lines
    # Missing fixed assets fail closed at watchdog startup; status exposes the
    # attested absence rather than attempting a runtime pull.
    assets_host_config = root / "assets-missing.host.json"
    assets_host_config.write_text(json.dumps({"storage": {
        "slotRegistryPath": str(slot_registry), "slotRootPath": str(slot_root),
    }}), encoding="utf-8")
    assets_closed = watchdog.Admission(
        descriptor_path, root / "assets-events.ndjson", str(docker_socket), 5, assets_host_config,
    )
    assert assets_closed.state["admissionOpen"] is False
    assert assets_closed.handle({"kind": "status"})["assets"]["state"] == "missing"

    # A journal may never silently discard a corrupt or unterminated tail.
    for name, contents in (("corrupt", "not-json\n"), ("truncated", '{"state":{}')):
        broken = root / f"{name}.ndjson"
        broken.write_text(contents, encoding="utf-8")
        try:
            watchdog.Admission(descriptor_path, broken, str(docker_socket), 5, host_config)
        except RuntimeError as error:
            assert "fails closed" in str(error)
        else:
            raise AssertionError(f"{name} journal must fail closed")

print("watchdog-smoke ok")
subprocess.run(["pnpm", "exec", "tsx", "test/host/docker-profile-public-smoke.ts"], cwd=ROOT, check=True)
```

### Verification receipt

- Candidate: `5a847afcaa3a5975a52e56e495cdc8263ecdc773`; NiceEval tarball SHA-256 `479d3c5cee406ffdc4de433290772a0990356d40e2a372acf6e5cd2462ad7d83`.
- Red: source `be0b98ec44a0f3ef0e159d9fff8ebb60c2a8eb38`, tarball SHA-256 `ba7b773e3f3307eaf5055fed251bd3005b59c7a3e3b47ab50f84759e5f3a5dbf`; `pnpm e2e run --candidate /tmp/niceeval-fix-docker-red/artifacts-red-final/candidate/niceeval-candidate-ba7b773e3f3307eaf5055fed251bd3005b59c7a3e3b47ab50f84759e5f3a5dbf.tgz --repo lifecycle` 在公开 `niceeval exp` 的 `sandbox.image.build` 阶段失败，Attempt 未派发。
- Green: `pnpm e2e run --candidate /tmp/niceeval-fix-docker-final-v8/artifacts-green-v8/candidate/niceeval-candidate-479d3c5cee406ffdc4de433290772a0990356d40e2a372acf6e5cd2462ad7d83.tgz --repo lifecycle`，1 file / 1 test 通过，146.48 秒；`pnpm typecheck` 通过；`bash test/host/run-checks.sh` 为 `PASS=62 FAIL=0`。
- Repeatability: `/tmp/niceeval-fix-docker-final-v8/artifacts-takeover-v3/takeover-summary.json` 为 `category=pass`、`noRetry=true`、`issues=[]`；3 个隔离副本、同副本 2 次、repo 默认并行 4 files / 7 tests、目标单测均通过，结束后无 task-owned Docker 资源。
- Fixed conditions: takeover 锁定 source snapshot `3630b775ada86a677545f11a4a7d370b599117751eadc4b7000a7314e80d7c9b`；当前 HEAD 只精简重复 host smoke，重打 tarball SHA 不变；镜像固定 digest，cold build 离线且 context 唯一。
- Unit count: `not applicable — no Unit changed`。
