### PR TITLE
fix: 修正评分汇总与托管 Docker profile 诊断

### DIFF
--- a/apps/docs-site/zh/explanation/drive.mdx
+++ b/apps/docs-site/zh/explanation/drive.mdx
@@ -102,7 +102,7 @@ t.calledTool("send_email").label("已发送");
 
 `t.requireInputRequest(filter)` 把一个待处理的 HITL 请求变成可检查、可回应的具体值。如果匹配到 0 个或超过 1 个待处理请求就会抛出,所以尽量把能填的 filter 字段都填上(`id` / `prompt` / `display` / `action` / `optionIds` / `input`)来消歧。
 
-`t.respond(...)` 回答它并发出下一轮;每个参数是一条回答:字符串按待处理请求的顺序对位,`{ request, optionId }` 对象形式显式指名(多个请求并停时用它)。在底层它只是又一次普通的 `send`:回答文本进 `input.text`,同时以结构化形式逐条进 `input.responses`。命中请求选项的回答带 `{ requestId, optionId }`,自由文本回答带 `{ requestId, text }`,adapter 不用解析文本,按 `requestId` 就能对上"哪个回答给哪个请求"。每种回答到 adapter 长什么样,见[不同回答的入参](/zh/explanation/adapter#不同回答的入参)。
+`t.respond(...)` 回答它并发出下一轮;每个参数是一条回答。字符串形式只用于当前恰好有一个待处理请求的情况;多个请求并停时必须用 `{ request, optionId }` 或 `{ request, text }` 显式指名,不能靠参数顺序猜。在底层它只是又一次普通的 `send`:回答文本进 `input.text`,同时以结构化形式逐条进 `input.responses`。命中请求选项的回答带 `{ requestId, optionId }`,自由文本回答带 `{ requestId, text }`,adapter 不用解析文本,按 `requestId` 就能对上"哪个回答给哪个请求"。每种回答到 Adapter 长什么样,见[不同回答的入参](/zh/explanation/adapter#不同回答的入参)。
 
 如果当前轮有多个同类待处理请求、都该给同一个答案(比如逐个批准一批文件改动),用 `t.respondAll(optionId)` 一次性处理,不用挨个解。`optionId` 会先对每条待处理请求校验——不在请求的 `options` 里就直接抛错,打错的字不会被静默当成别的答案发出去：
 

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -402,8 +402,8 @@ ledger 与 reason data types 同样仅以 type-only export 提供。精确调用
 
 `ExperimentTable` 与 `ExperimentScatter` 是具名比较组件。它们只接受 `ExperimentComparisonScope` 或该 scope 产生的同组 branded projection，不接受普通 Sample 或任意 rows。多组输入以 `analysis-comparison-group-mismatch` 失败；同组 member 即使 Eval population 不同也正常渲染，各自指标使用实际运行的 Slot 和自己的分母。没有运行的 Eval 不合成为失败，也不进入共同交集。中立 `Table` 与 `Scatter` 仍可显示任意已闭合值，不承担实验组语义。
 
-`ExperimentTable` 的每个实验行只在实验名后显示一次 `samples/total`；耗时、Tokens、成本与主结果格不重复同一比值。展开后的 Eval、分组与 Attempt 行仍各自保留自己的读数完整度，因为它们回答的是下钻范围而不是实验行的重复摘要。
-计分制的实验、分组与 Eval 行把 earned score 和未挣满的得分项数放在主结果格。未挣满的得分项指已封口且 `earned < points` 的 score contribution；计数为零也是有意义的完整结果。正常 Score Attempt 的 `passed` 不显示；非零的 `failed`、`errored` 与 `skipped` 仍单独显示，不与丢分项合并。
+`ExperimentTable` 的每个实验行只在实验名后显示一次 Eval 结果数，格式为已有结果的 Eval 数／本实验 Eval 总数。它不使用 Attempt 样本数替代 Eval 数；耗时、Tokens、成本与主结果格也不重复这一比值。展开后的 Eval、分组与 Attempt 行仍各自保留自己的读数完整度，因为它们回答的是下钻范围而不是实验行的重复摘要。
+计分制的实验、分组与 Eval 行只把 earned score 放在主结果格。评分项是否挣满属于展开后的评分证据，不在汇总分数旁重复计数。正常 Score Attempt 的 `passed` 不显示；非零的 `failed`、`errored` 与 `skipped` 仍单独显示。
 
 `AttemptDetails` 把 source navigation 精确关联的每次物理 `send` 嵌回对应源码行。Assertion 展开区先把 matcher 或检查名、sealed 状态与有界 diagnostic children 投影成可逐层展开的状态树；它不重新执行 matcher。
 

--- a/docs/feature/sandbox/docker-profiles/cli.md
+++ b/docs/feature/sandbox/docker-profiles/cli.md
@@ -55,6 +55,9 @@ niceeval docker profile list --json
 显示本地别名、稳定 ID缩写、security level、policy revision、endpoint kind与健康摘要；JSON输出
 稳定 schema。
 
+registry目录中的 `*.host.json`、`*.daemon.json`与版本化 `assets-vN.json`属于宿主部署材料，不是 profile descriptor，
+发现时必须忽略。它们可以与 `<alias>.json`并存，不能占用 alias或让整个 registry失效。
+
 别名可以随机器不同，也可以改名。stable profile ID来自宿主部署，让 detached operation找回原
 endpoint。以下任一情形会把条目标为 invalid并禁止使用：
 

--- a/e2e/lifecycle/fixtures/profile-host-fixture.py
+++ b/e2e/lifecycle/fixtures/profile-host-fixture.py
@@ -139,6 +139,7 @@ def setup(args: argparse.Namespace) -> None:
         os.chmod(descriptor, 0o600)
         run(sys.executable, str(scripts / "install-quota-slots.py"), "--host-config", str(host_config))
         print(json.dumps({
+            "assets": str(assets),
             "controlSocket": str(root / "control.sock"),
             "descriptor": str(descriptor),
             "hostConfig": str(host_config),

--- a/e2e/lifecycle/test/docker-profile-cold-build.test.ts
+++ b/e2e/lifecycle/test/docker-profile-cold-build.test.ts
@@ -1,5 +1,7 @@
 // owner: docs/engineering/testing/e2e/README.md#docker-profile-cold-build
 // regression: memory/docker-profile-control-create-migration-incomplete.md
+// regression: memory/docker-profile-assets-manifest-registry-collision.md
+// regression: memory/docker-profile-doctor-inherits-dind-docker-host.md
 import { appendFile, readFile, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
@@ -14,6 +16,7 @@ import {
 import { expect, test } from "vitest";
 
 interface HostFixture {
+  readonly assets: string;
   readonly controlSocket: string;
   readonly descriptor: string;
   readonly hostConfig: string;
@@ -174,8 +177,11 @@ restore_compat_socket() { if [ -n "\${compat_proxy_pid}" ] && kill -0 "\${compat
 trap 'restore_fault_socket; restore_compat_socket; cleanup_doctor; cleanup_holder; chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
 mkdir -p /etc/niceeval/docker-profiles
 cp '${activeFixture.descriptor}' /etc/niceeval/docker-profiles/e2e-cold-build.json
+cp '${activeFixture.assets}' /etc/niceeval/docker-profiles/assets-v1.json
 chown root:root /etc/niceeval/docker-profiles/e2e-cold-build.json
+chown root:root /etc/niceeval/docker-profiles/assets-v1.json
 chmod 600 /etc/niceeval/docker-profiles/e2e-cold-build.json
+chmod 644 /etc/niceeval/docker-profiles/assets-v1.json
 docker_api() { node - "$@" <<'NODE'
 const Docker=require('dockerode'),d=new Docker({socketPath:'/run/docker.sock'}),[action,...args]=process.argv.slice(2);const labels=Object.fromEntries((args[0]||'').split(',').filter(Boolean).map(x=>x.split('=')));const filters={label:Object.entries(labels).map(([k,v])=>v?k+'='+v:k)};(async()=>{if(action==='image'){await d.getImage(args[0]).inspect();return}if(action==='find'){const c=await d.listContainers({all:false,filters});if(c[0])process.stdout.write(JSON.stringify({id:c[0].Id,labels:c[0].Labels}))}if(action==='kill'){await d.getContainer(args[0]).kill()}if(action==='absent'){const c=await d.listContainers({all:true,filters}),n=await d.listNetworks({filters});if(c.length||n.length)throw Error('owned resource remains')}})().catch(e=>{console.error(e);process.exit(1)})
 NODE
@@ -285,6 +291,14 @@ fault_reservation=$(node -e 'process.stdout.write(JSON.parse(require("fs").readF
 docker_api absent "niceeval.profile-id=$fault_profile,niceeval.reservation-id=$fault_reservation"
 docker_api image '${dindImage}'
 docker_api image '${buildkitImage}'
+set +e
+node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-pass.json
+doctor_pass_status=$?
+set -e
+cat /tmp/niceeval-doctor-pass.json
+DOCTOR_PASS_STATUS="$doctor_pass_status" node - /tmp/niceeval-doctor-pass.json <<'NODE'
+const d=JSON.parse(require('fs').readFileSync(process.argv[2],'utf8'));if(process.env.DOCTOR_PASS_STATUS!=='0'||d.status!=='PASS'||d.checks.length!==12||d.checks.some(x=>x.status!=='PASS')){console.error(JSON.stringify(d,null,2));process.exit(1)}
+NODE
 set +e
 node_modules/.bin/niceeval exp docker-profile-cold-build --rerun all --json >/tmp/niceeval-exp.ndjson
 status=$?

--- a/e2e/report/experiments/classic/incompatible.ts
+++ b/e2e/report/experiments/classic/incompatible.ts
@@ -8,5 +8,6 @@ export default defineExperiment({
   evals: ["score"],
   flags: { memory: "incompatible" },
   labels: { line: "classic", memory: "incompatible" },
-  attempts: 1,
+  // Two Attempts make Eval coverage observably different from Attempt samples.
+  attempts: 2,
 });

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -123,7 +123,9 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
           hasText: /^classic\/incompatible /,
         });
         await expect(scoreExperimentSummary).toHaveCount(1);
-        await expect(scoreExperimentSummary).toContainText("7 · 1 missed check");
+        await expect(scoreExperimentSummary).toContainText("classic/incompatible (1/1)");
+        await expect(scoreExperimentSummary).toContainText("7");
+        await expect(scoreExperimentSummary).not.toContainText("missed check");
         await expect(scoreExperimentSummary).not.toContainText("passed");
         await experiment.click();
         await expect(page).toHaveURL(/#\/experiment\//);

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -51,6 +51,8 @@ memory 的召回全靠这份索引:漏索引的条目等于不存在。维护规
 ### 台账
 
 - 已修 [docker-profile-control-create-migration-incomplete](docker-profile-control-create-migration-incomplete.md) — profile-bound Dockerfile cold build 与 doctor smoke 仍由客户端 create/commit，遇到拒绝旧语义的新 watchdog 会在 Attempt 前报 control-create-unimplemented；改为 control 持有 build context、network/container create 与终止证明
+- 已修 [docker-profile-assets-manifest-registry-collision](docker-profile-assets-manifest-registry-collision.md) — host package 把 `assets-v1.json` 放进 profile registry 后，客户端误把它当成 alias descriptor，doctor 与 experiment 在 descriptor 阶段失败；改为 registry 明确忽略版本化资产清单，并补齐 host package 的预载验证入口
+- 已修 [docker-profile-doctor-inherits-dind-docker-host](docker-profile-doctor-inherits-dind-docker-host.md) — doctor 的 DIND 诊断容器继承镜像自带 `DOCKER_HOST=tcp://docker:2375`，因而始终探测错误 endpoint、无法产出结果；固定到本容器的 Unix socket，并让 lifecycle owner 验收完整 PASS
 - 已修 [group-wave-barrier-starves-fast-lanes](group-wave-barrier-starves-fast-lanes.md) — 连续跨 lane wave 闸让慢 Group 的下一槽挡住快 Group 后继，出现真实空闲与 timing 空白；公平闸收窄为只保护各 lane 首槽
 - 已修 [interrupted-run-completed-attempt-hidden](interrupted-run-completed-attempt-hidden.md) — 同 Run 的快 Attempt 已完成并有 locator，慢 Attempt 在飞时 SIGINT 却让整 Run 无 complete、全部不可见；受控中断改为关闭在飞 Attempt 后正常 seal
 - [compose-project-namespace-escape-destabilizes-case-identity](compose-project-namespace-escape-destabilizes-case-identity.md) — 10 个 Terminal-Bench Compose Eval 把逐次随机容器名塞进 fingerprinted env,导致 CaseKey/private identity 每次规划漂移；修法是 Provider 规划期拒绝受管资源逃逸 project namespace,下游删除 `container_name` nonce

--- a/memory/docker-profile-assets-manifest-registry-collision.md
+++ b/memory/docker-profile-assets-manifest-registry-collision.md
@@ -1,0 +1,53 @@
+# Docker profile 资产清单被误当成 profile descriptor
+
+## 现象
+
+新版 Docker profile host package 按部署文档把 `assets-v1.json` 放进
+`/etc/niceeval/docker-profiles/`。安装后的 `niceeval docker profile doctor <alias> --json`
+却在第一个 `descriptor` check 失败，并把资产清单报告为 alias `assets-v1`：
+
+```text
+Docker profile alias "assets-v1": profile.platform is unexpected
+```
+
+同一 registry 被 `niceeval exp` 读取时也会在任何 build、container 或 Attempt 开始前失败。
+
+## 根因
+
+宿主部署契约把 `<alias>.json`、`*.host.json`、`*.daemon.json` 与版本化 `assets-vN.json`
+放在同一目录。Node registry loader 只排除了 host 与 daemon 文件，仍把每个其它 `.json`
+交给 profile schema。因此 host package 新增的资产清单与客户端发现规则互相冲突。
+
+同一轮还发现 Nix host package 的安装说明公开了
+`niceeval-docker-profile-preload-verify-assets`，derivation 却没有安装对应 Python helper 与 binary。
+这会让管理员无法按随包说明完成固定镜像的离线预载验证。
+
+## 修法与长期不变量
+
+- profile registry 只把 descriptor 候选交给 profile schema；`*.host.json`、`*.daemon.json` 与
+  `assets-vN.json` 是保留的宿主部署材料，发现时忽略。
+- 资产清单可以与 `<alias>.json` 并存，不占用 alias，也不能让无关 profile 失效。
+- host package 安装 `preload-verify-assets` helper，并提供安装说明声明的
+  `niceeval-docker-profile-preload-verify-assets` binary。
+- doctor 继续从 watchdog 的 attested status 验证资产，不从 registry 拉取或修改镜像。
+
+## 回归 kill 收据
+
+加强既有 lifecycle owner `e2e/lifecycle/test/docker-profile-cold-build.test.ts`：隔离消费容器按真实
+host package 布局，把 descriptor 与 `assets-v1.json` 一起安装到 root-owned registry，再从安装后
+CLI 运行 doctor 与 cold-build experiment。
+
+旧候选 source HEAD `55483c0a6`，tarball SHA-256
+`93413100f611512db3f28ac278156a65cfea2893ba125b53f41ec9d957bb76cf`。命令：
+
+```sh
+PATH=/nix/store/0rw27f8ism3y0hyqpcnhsd49h9a9xadf-quota-4.11/bin:$PATH \
+pnpm e2e run \
+  --candidate /tmp/niceeval-e2e-artifacts-wksYAo/candidate/niceeval-candidate-93413100f611512db3f28ac278156a65cfea2893ba125b53f41ec9d957bb76cf.tgz \
+  --repo lifecycle -- \
+  --run test/docker-profile-cold-build.test.ts \
+  -t 'profile-bound Dockerfile cold build starts the Attempt through the public CLI'
+```
+
+收据位于 `/tmp/niceeval-e2e-artifacts-P3zv8M/lifecycle/receipt.json`。最早失败阶段是公开 doctor 的
+`descriptor` check；`control` 及之后的 check 全部为 `PREREQUISITE_FAILED`，没有发生 provider side effect。

--- a/memory/docker-profile-doctor-inherits-dind-docker-host.md
+++ b/memory/docker-profile-doctor-inherits-dind-docker-host.md
@@ -1,0 +1,39 @@
+# Docker profile doctor 继承了 DIND 镜像的远端 DOCKER_HOST
+
+## 现象
+
+宿主 watchdog、journal 与固定资产升级后，`niceeval docker profile doctor harness-raw --json` 的前七项
+全部 PASS，动态诊断却报告：
+
+```text
+control-owned diagnostic must emit exactly one JSON result
+```
+
+同一 digest 的最小容器复现显示，嵌套 `dockerd` 已在 `/var/run/docker.sock` 启动成功，循环中的
+`docker info` 却持续连接 `http://docker:2375`，最终没有执行到 JSON 输出。
+
+## 根因
+
+固定 `docker:29-dind` 镜像带有 `DOCKER_HOST=tcp://docker:2375`。watchdog 的诊断脚本显式把 daemon
+绑定到 Unix socket，却没有覆盖镜像环境；后续所有 `docker info`、`import`、`run`、`rm` 与 `image rm`
+仍选择远端 TCP endpoint。诊断容器的隔离网络中没有名为 `docker` 的服务，因此脚本超时退出。
+
+## 修法与长期不变量
+
+- control-owned 诊断脚本在启动 daemon 前固定
+  `DOCKER_HOST=unix:///var/run/docker.sock`；镜像默认环境不能改变 doctor 的 endpoint。
+- 诊断继续检查容器内不存在 2375/2376 listener，不能为了适配镜像默认值开启 TCP daemon。
+- lifecycle cold-build owner 必须包含一次未注入故障、未预占 capacity 的完整 doctor，并要求 12 项全为
+  PASS；BLOCKED、只测强杀与只测 cleanup 都不能替代 happy path。
+
+## 回归 kill 收据
+
+既有 owner `e2e/lifecycle/test/docker-profile-cold-build.test.ts` 增加完整 doctor happy path。旧实现使用
+安装后候选与真实 checkout watchdog，在前置 capacity、SIGKILL 与 fault cleanup 全部收敛后，仍在该 doctor
+命令非零退出。
+
+旧候选 source HEAD `55483c0a6`，tarball SHA-256
+`ac3f22b9c075bd8d84e8ef4029046f3fee2af0d17e74d110f561bb89493d7697`。收据位于
+`/tmp/niceeval-e2e-artifacts-NMt5wz/lifecycle/receipt.json`，test invocation ID 为
+`6535695e-ff68-4cd9-b4f9-1a368f81f9bf`。真实宿主上的公开 doctor 同时保存了前七项 PASS、动态诊断失败的
+可复现观察。

--- a/nix/packages/docker-profile-host.nix
+++ b/nix/packages/docker-profile-host.nix
@@ -37,6 +37,7 @@ stdenvNoCC.mkDerivation {
     for pair in \
       generate-descriptor.py:generate-descriptor \
       validate-capacity.py:validate-capacity \
+      preload-verify-assets.py:preload-verify-assets \
       watchdog.py:docker-profile-watchdog \
       install-quota-slots.py:install-quota-slots
     do
@@ -73,6 +74,7 @@ stdenvNoCC.mkDerivation {
     ln -s $out/libexec/niceeval/validate-capacity $out/bin/niceeval-docker-profile-validate-capacity
     ln -s $out/libexec/niceeval/generate-descriptor $out/bin/niceeval-docker-profile-generate-descriptor
     ln -s $out/libexec/niceeval/docker-profile-host-doctor $out/bin/niceeval-docker-profile-host-doctor
+    ln -s $out/libexec/niceeval/preload-verify-assets $out/bin/niceeval-docker-profile-preload-verify-assets
     ln -s $out/libexec/niceeval/apply-rootless-network-policy $out/bin/niceeval-docker-profile-apply-network-policy
     ln -s $out/libexec/niceeval/verify-sibling-isolation $out/bin/niceeval-docker-profile-verify-sibling-isolation
 

--- a/packages/niceeval/src/report/components/entity-lists/content.ts
+++ b/packages/niceeval/src/report/components/entity-lists/content.ts
@@ -99,22 +99,8 @@ function exceptionalVerdictCountsCell(attempts: readonly AttemptListItem[]): Cel
   return { kind: "verdict", counts: { ...counts, passed: 0 } };
 }
 
-/** 只有所有 Score Attempt 都给出完整计数时才汇总；未知不冒充零。 */
-function missedScoreItems(attempts: readonly AttemptListItem[]): number | undefined {
-  const scoreAttempts = attempts.filter((attempt) => attempt.evaluationKind === "points");
-  if (scoreAttempts.length === 0 || scoreAttempts.some((attempt) => attempt.missedScoreItems === undefined)) {
-    return undefined;
-  }
-  return scoreAttempts.reduce((total, attempt) => total + attempt.missedScoreItems!, 0);
-}
-
-function scoreCell(earned: number, attempts: readonly AttemptListItem[]): Cell {
-  const missed = missedScoreItems(attempts);
-  return {
-    kind: "score",
-    earned,
-    ...(missed === undefined ? {} : { missedScoreItems: missed }),
-  };
+function scoreCell(earned: number): Cell {
+  return { kind: "score", earned };
 }
 
 function evalVerdictCell(attempts: readonly AttemptListItem[]): Cell {
@@ -266,7 +252,7 @@ function evalRow(
       : stackCell(
           row.totalScore === undefined
             ? { kind: "notApplicable" }
-            : scoreCell(row.totalScore, row.attempts),
+            : scoreCell(row.totalScore),
           exceptionalVerdictCountsCell(row.attempts),
         ),
     ...(row.costUSD === undefined ? {} : { costUSD: measureCell(row.costUSD) }),
@@ -328,7 +314,7 @@ function groupTableRow(
   const primary = evalRows.every((row) => row.evaluationKind === "pass")
     ? groupMetricValue(metrics, "passRate")
     : evalRows.some((row) => row.totalScore !== undefined)
-    ? scoreCell(evalRows.reduce((sum, row) => sum + (row.totalScore ?? 0), 0), attempts)
+    ? scoreCell(evalRows.reduce((sum, row) => sum + (row.totalScore ?? 0), 0))
     : { kind: "notApplicable" } as const;
 
   const bag: CellBag = {
@@ -381,11 +367,13 @@ function experimentRow(item: ExperimentListItem, view: HierarchyView): TableCont
     ? measureCell(item.endToEndPassRate, false)
     : item.totalScore === undefined
     ? { kind: "notApplicable" } as const
-    : scoreCell(item.totalScore, attempts);
+    : scoreCell(item.totalScore);
+  const coveredEvalCount = item.evalRows.length;
+  const totalEvalCount = coveredEvalCount + item.missingEvalIds.length;
   const bag: CellBag = {
     entity: identityCell(
       item.experimentId,
-      `${item.endToEndPassRate.samples}/${item.endToEndPassRate.total}`,
+      `${coveredEvalCount}/${totalEvalCount}`,
     ),
     model: item.model === null ? { kind: "notApplicable" } : textCell(item.model),
     agent: item.agent === null ? { kind: "notApplicable" } : textCell(item.agent),

--- a/packages/niceeval/src/sandbox/docker-profile/runtime.ts
+++ b/packages/niceeval/src/sandbox/docker-profile/runtime.ts
@@ -113,7 +113,10 @@ export async function loadDockerProfileRegistryAt(
   registryDir: string,
 ): Promise<ReturnType<typeof indexDockerProfiles>> {
   const names = (await readdir(registryDir)).filter((name) =>
-    name.endsWith(".json") && !name.endsWith(".host.json") && !name.endsWith(".daemon.json")
+    name.endsWith(".json")
+    && !name.endsWith(".host.json")
+    && !name.endsWith(".daemon.json")
+    && !/^assets-v[1-9]\d*\.json$/.test(name)
   ).sort();
   const entries = await Promise.all(names.map(async (name) => {
     const source = join(registryDir, name);

--- a/packaging/docker-profile-host/scripts/watchdog.py
+++ b/packaging/docker-profile-host/scripts/watchdog.py
@@ -53,6 +53,7 @@ REQUIRED_ASSETS = {
 }
 DIAGNOSTIC_COMMAND = ["sh", "-ec", "\n".join((
     "set -eu",
+    "export DOCKER_HOST=unix:///var/run/docker.sock",
     "dockerd --host=unix:///var/run/docker.sock --shutdown-timeout=2 >/tmp/niceeval-dockerd.log 2>&1 &",
     "daemon=$!; image=niceeval-doctor-inner; inner=niceeval-doctor-inner-run; trap 'docker rm -f \"$inner\" >/dev/null 2>&1 || true; docker image rm -f \"$image\" >/dev/null 2>&1 || true; kill \"$daemon\" 2>/dev/null || true; wait \"$daemon\" 2>/dev/null || true' EXIT",
     "for _ in $(seq 1 120); do docker info >/dev/null 2>&1 && break; sleep 0.25; done; docker info >/dev/null",


### PR DESCRIPTION
<!-- niceeval:pr-body
base: bddd946758c4ea0ba06efba5e2e8036affb6daf6
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: 6f042b9587ce5f55677545eb96a52aa9196b2d68
-->

## Problem

- User goal: 用户需要从评分制报告直接比较各 Experiment 的得分，也需要在托管 Docker profile 上可靠完成部署检查、doctor 与 cold build。
- Current limitation: 报告把 Attempt 样本数写成 Eval 数，并在得分旁重复显示未挣满项；profile registry 又会把 `assets-vN.json` 当成 descriptor，doctor 的 DinD 探针还会继承镜像里的远端 `DOCKER_HOST`。此外，HITL 文档错误暗示多个待处理请求可以用字符串按顺序回答。
- Required capability: 报告必须按 Eval 身份计数并保持评分汇总简洁；宿主部署材料必须与 profile descriptor 共存，doctor 必须固定探测本容器的 Unix socket；多请求回答必须显式指名 request。
- User outcome: 评分报告标题与可见 Eval 一致、结果列只保留得分；管理员可以安装资产清单后取得 12 项全 PASS 的 doctor，并使用随包资产预载验证入口。

## Use cases

### Case: `阅读评分制 Experiment 比较`

#### Starting state

```text
install/canary 含 2 个 Eval；其中一次历史复用使当前 Sample 含 3 个 Attempt。
```

#### Action

```sh
pnpm exec niceeval show --experiment install/canary
```

#### Result

```text
Experiments    1
Evals          2
Attempts       3

install/canary (2/2) ... 49
```

标题的分子与分母都按 Eval 计算，不再因复用或多次 Attempt 显示成 `3/3`；评分制结果只显示 earned score，丢分原因仍可在展开后的评分证据中阅读。

### Case: `验证带资产清单的托管 Docker profile`

#### Starting state

```text
/etc/niceeval/docker-profiles/
├── e2e-cold-build.json
└── assets-v1.json
```

#### Action

```sh
niceeval docker profile doctor e2e-cold-build --json
niceeval exp docker-profile-cold-build --rerun all --json
```

#### Result

```text
doctor exit: 0
doctor status: PASS
doctor checks: 12/12 PASS
experiment completion: completed
```

资产清单不会占用 alias 或破坏 descriptor discovery。control-owned 诊断固定连接 `/var/run/docker.sock`，cold build 与 nested Docker 继续在同一受管 profile 中完成并清理资源。

### Case: `回答多个并行 HITL 请求`

#### Starting state

```text
当前轮同时存在 approvalRequest 与 destinationRequest。
```

#### Action

```ts
t.respond(
  { request: approvalRequest, optionId: "approve" },
  { request: destinationRequest, text: "staging" },
);
```

#### Result

```text
每条回答都以 requestId 关联原请求；多个请求不依赖参数顺序猜测。
```

公开文档现在明确：字符串形式只用于恰好一个待处理请求；多个请求必须使用对象形式显式指名。

## CLI

### Changed

#### Case: `docker profile doctor 忽略版本化资产清单`

##### Before

```sh
niceeval docker profile doctor e2e-cold-build --json
```

```text
Docker profile alias "assets-v1": profile.platform is unexpected
exit: non-zero
```

##### After

```sh
niceeval docker profile doctor e2e-cold-build --json
```

```text
status: PASS
checks: 12/12 PASS
exit: 0
```

##### User impact

管理员可以按宿主部署说明把 `assets-v1.json` 与 `<alias>.json` 放在同一 registry；`list`、`doctor` 与 `exp` 都只把真正的 descriptor 当作 profile。

#### Case: `doctor 的 DinD 探针使用本地 Unix socket`

##### Before

```sh
niceeval docker profile doctor e2e-cold-build --json
```

```text
control-owned diagnostic must emit exactly one JSON result
exit: non-zero
```

##### After

```sh
niceeval docker profile doctor e2e-cold-build --json
```

```text
status: PASS
checks: 12/12 PASS
exit: 0
```

##### User impact

固定 DIND 镜像即使自带 `DOCKER_HOST=tcp://docker:2375`，doctor 也只探测自己启动的 `/var/run/docker.sock`，不会等待不存在的远端服务。

## Report components

### Changed

#### Case: `ExperimentTable 的评分制实验行`

##### Before

```tsx
<ExperimentTable scope={ctx.scope} />
```

```text
classic/incompatible (2/2) ... 7 · 2 missed checks
```

##### After

```tsx
<ExperimentTable scope={ctx.scope} />
```

```text
classic/incompatible (1/1) ... 7
```

##### User impact

括号表达已有结果的 Eval 数／本实验 Eval 总数，不再表达 Attempt 样本数。评分制的 Experiment、分组与 Eval 汇总只显示 earned score；异常 `failed`、`errored` 与 `skipped` 仍会单独显示。

## Observable behavior and data contracts

### Changed

#### Case: `niceeval-docker-profile-host 资产预载验证入口`

##### Before

```sh
host=$(nix build --no-link --print-out-paths .#docker-profile-host)
test -x "$host/bin/niceeval-docker-profile-preload-verify-assets"
echo $?
```

```text
1
```

##### After

```sh
host=$(nix build --no-link --print-out-paths .#docker-profile-host)
test -x "$host/bin/niceeval-docker-profile-preload-verify-assets"
echo $?
```

```text
0
```

##### User impact

随包安装说明公开的命令现在真实存在于 Nix host package；管理员可以在启动 watchdog 前验证 digest-pinned DIND 与 BuildKit 资产。

## Tests

### `e2e/lifecycle/test/docker-profile-cold-build.test.ts`

- Purpose: `feature + bug regression`
- Protects: 带 `assets-v1.json` 的 root-owned registry 可运行完整 doctor，DinD 探针使用本地 Unix socket，并且 cold build 与资源清理继续完成。
- Runs: 安装后 `niceeval docker profile doctor ... --json` 与 `niceeval exp docker-profile-cold-build --rerun all --json`，并通过真实 Docker daemon 与 watchdog 验证终态。
- Asserts: doctor 退出 0、12 项全部 PASS；Experiment 完成；DIND/BuildKit 资产存在；container、network、allocation 与 journal 资源全部清理。

### `e2e/lifecycle/test/docker-profile-cold-build.test.ts`

- Purpose: `feature + bug regression`
- Protects: 带资产清单的托管 Docker profile 可通过完整 doctor，并完成 cold build 与资源清理。
- Runs: 安装后 docker profile doctor 与 exp 命令，以及真实 Docker/watchdog 生命周期。
- Asserts: 12 项 doctor 全 PASS、Experiment completed、固定资产存在且受管资源终态干净。

```ts
// owner: docs/engineering/testing/e2e/README.md#docker-profile-cold-build
// regression: memory/docker-profile-control-create-migration-incomplete.md
// regression: memory/docker-profile-assets-manifest-registry-collision.md
// regression: memory/docker-profile-doctor-inherits-dind-docker-host.md
import { appendFile, readFile, readdir } from "node:fs/promises";
import { join, resolve } from "node:path";
import {
  command,
  only,
  pollUntil,
  withProcess,
  withProjectCopy,
  withTempDir,
  type ExpEvent,
} from "@niceeval/testkit";
import { expect, test } from "vitest";

interface HostFixture {
  readonly assets: string;
  readonly controlSocket: string;
  readonly descriptor: string;
  readonly hostConfig: string;
  readonly journal: string;
  readonly readyFile: string;
}

interface HostJournalRecord {
  readonly event: string;
  readonly detail: Readonly<Record<string, unknown>>;
  readonly state?: {
    readonly reservations?: Readonly<Record<string, {
      readonly kind?: string;
      readonly locator?: string;
      readonly builderName?: string;
      readonly retention?: "cache" | "ephemeral";
    }>>;
  };
}

const docker = command(["docker"]);
const sudo = command(["sudo", "-n"]);
const driverImage = "node@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f";
const dindImage = "docker:29-dind@sha256:e8faad5a8dc5279dff929afc5449f2791736912fff9f99351d742db2fad01b4c";
const buildkitImage = "moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8";
const projectCopy = {
  from: process.cwd(),
  prefix: "niceeval-e2e-docker-profile-project-",
  omitTopLevel: [".niceeval", "node_modules", "test"],
  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
} as const;

async function fileExists(path: string): Promise<true | undefined> {
  try {
    await readFile(path);
    return true;
  } catch {
    return undefined;
  }
}

async function quotaPath(): Promise<string> {
  const candidates = (process.env.PATH ?? "").split(":");
  try {
    for (const name of await readdir("/nix/store")) {
      if (/^[^-]+-quota-[^/]+$/.test(name)) candidates.push(`/nix/store/${name}/bin`);
    }
  } catch {
    // Non-Nix hosts can provide quota-tools on PATH.
  }
  for (const candidate of candidates) {
    if ((await command(["test"]).run(["-x", join(candidate, "setquota")])).exitCode === 0) {
      return [candidate, process.env.PATH ?? ""].filter(Boolean).join(":");
    }
  }
  throw new Error("project-quota tools (setquota/repquota) are required by this E2E");
}

async function exportImageRootfs(image: string, destination: string): Promise<void> {
  const created = await docker.run(["create", image]);
  expect(created.exitCode, created.diagnostic()).toBe(0);
  const containerId = created.stdout.trim();
  try {
    const exported = await docker.run(["export", "--output", destination, containerId], {
      timeoutMs: 60_000,
    });
    expect(exported.exitCode, exported.diagnostic()).toBe(0);
  } finally {
    const removed = await docker.run(["rm", "--force", containerId]);
    expect(removed.exitCode, removed.diagnostic()).toBe(0);
  }
}

test("profile-bound Dockerfile cold build starts the Attempt through the public CLI", async () => {
  const scripts = process.env.NICEEVAL_E2E_DOCKER_PROFILE_HOST_SCRIPTS;
  expect(scripts, "runner must inject the actual Docker profile host scripts").toBeTruthy();
  const fixtureScript = resolve("fixtures/profile-host-fixture.py");
  const dockerInfo = await docker.run(["info", "--format", "{{.DockerRootDir}}"]);
  expect(dockerInfo.exitCode, dockerInfo.diagnostic()).toBe(0);
  const hostPath = await quotaPath();
  const user = process.env.USER ?? process.env.LOGNAME;
  expect(user, "E2E runner user must be named for the quota-slot owner").toBeTruthy();
  const id = await command(["id"]).run(["-gn", user!]);
  expect(id.exitCode, id.diagnostic()).toBe(0);

  await withProjectCopy(projectCopy, async ({ root: projectRoot }) => {
    const fixtureContext = join(projectRoot, "fixtures/profile-cold-build");
    await exportImageRootfs(driverImage, join(fixtureContext, "node-rootfs.tar"));
    await exportImageRootfs(dindImage, join(fixtureContext, "docker-rootfs.tar"));
    const inspectedBuildkit = await docker.run(["image", "inspect", buildkitImage]);
    if (inspectedBuildkit.exitCode !== 0) {
      const pulledBuildkit = await docker.run(["pull", buildkitImage], { timeoutMs: 120_000 });
      expect(pulledBuildkit.exitCode, pulledBuildkit.diagnostic()).toBe(0);
    }
    // The unique context byte keeps this owner a real cold build even when the
    // daemon already carries an image from an earlier reliability repetition.
    await appendFile(
      join(projectRoot, "fixtures/profile-cold-build/Dockerfile"),
      `\n# cold-build-owner ${crypto.randomUUID()}\n`,
    );
    await withTempDir("niceeval-e2e-docker-profile-", async (hostRoot) => {
      let fixture: HostFixture | undefined;
      let primaryError: unknown;
      try {
        const setup = await sudo.run([
          "env", `PATH=${hostPath}`,
          "python3", fixtureScript, "setup",
          "--root", hostRoot,
          "--scripts", scripts!,
          "--docker-root", dockerInfo.stdout.trim(),
          "--user", user!,
          "--group", id.stdout.trim(),
        ], { timeoutMs: 60_000 });
        expect(setup.exitCode, setup.diagnostic()).toBe(0);
        fixture = JSON.parse(setup.stdout.trim().split("\n").at(-1)!) as HostFixture;
        const activeFixture = fixture;

        await withProcess(
          [
            "sudo", "-n", "env", `PATH=${hostPath}`, "PYTHONDONTWRITEBYTECODE=1",
            "python3", join(scripts!, "watchdog.py"),
            "--control-socket", activeFixture.controlSocket,
            "--descriptor", activeFixture.descriptor,
            "--host-config", activeFixture.hostConfig,
            "--docker-socket", "/run/docker.sock",
            "--journal", activeFixture.journal,
            "--ready-file", activeFixture.readyFile,
            "--socket-mode", "0o600",
          ],
          { processGroup: true, timeoutMs: 330_000, graceMs: 5_000 },
          async (watchdog) => {
            await Promise.race([
              pollUntil(() => fileExists(activeFixture.readyFile), {
                timeoutMs: 15_000,
                intervalMs: 100,
                label: "isolated real watchdog ready file",
              }),
              watchdog.done.then((receipt) => {
                throw new Error(`watchdog exited before readiness\n${receipt.diagnostic()}`);
              }),
            ]);

            const driver = await docker.run([
              "run", "--rm", "--network", "none", "--user", "0:0",
              "--mount", `type=bind,src=${process.cwd()},dst=${process.cwd()},readonly`,
              "--mount", `type=bind,src=${projectRoot},dst=${projectRoot}`,
              "--mount", `type=bind,src=${hostRoot},dst=${hostRoot}`,
              "--mount", "type=bind,src=/run/docker.sock,dst=/run/docker.sock",
              "--workdir", projectRoot,
              "--env", "NICEEVAL_E2E_DOCKER_PROFILE_ALIAS=e2e-cold-build",
              driverImage,
              "sh", "-ec",
              `holder_pid=''; doctor_pid=''; fault_socket=''; compat_proxy_pid=''; compat_socket=''
cleanup_holder() { if [ -n "\${holder_pid}" ] && kill -0 "\${holder_pid}" 2>/dev/null; then kill -TERM "\${holder_pid}" 2>/dev/null || true; wait "\${holder_pid}" || true; fi; }
cleanup_doctor() { if [ -n "\${doctor_pid}" ] && kill -0 "\${doctor_pid}" 2>/dev/null; then kill -KILL "\${doctor_pid}" 2>/dev/null || true; wait "\${doctor_pid}" || true; fi; }
restore_fault_socket() { if [ -n "\${fault_socket}" ] && [ -S "\${fault_socket}" ]; then mv "\${fault_socket}" '${activeFixture.controlSocket}'; fi; }
restore_compat_socket() { if [ -n "\${compat_proxy_pid}" ] && kill -0 "\${compat_proxy_pid}" 2>/dev/null; then kill -TERM "\${compat_proxy_pid}" 2>/dev/null || true; wait "\${compat_proxy_pid}" || true; fi; if [ -n "\${compat_socket}" ] && [ -S "\${compat_socket}" ]; then rm -f '${activeFixture.controlSocket}'; mv "\${compat_socket}" '${activeFixture.controlSocket}'; fi; }
trap 'restore_fault_socket; restore_compat_socket; cleanup_doctor; cleanup_holder; chown -R ${process.getuid!()}:${process.getgid!()} ${projectRoot}/.niceeval 2>/dev/null || true' EXIT
mkdir -p /etc/niceeval/docker-profiles
cp '${activeFixture.descriptor}' /etc/niceeval/docker-profiles/e2e-cold-build.json
cp '${activeFixture.assets}' /etc/niceeval/docker-profiles/assets-v1.json
chown root:root /etc/niceeval/docker-profiles/e2e-cold-build.json
chown root:root /etc/niceeval/docker-profiles/assets-v1.json
chmod 600 /etc/niceeval/docker-profiles/e2e-cold-build.json
chmod 644 /etc/niceeval/docker-profiles/assets-v1.json
docker_api() { node - "$@" <<'NODE'
const Docker=require('dockerode'),d=new Docker({socketPath:'/run/docker.sock'}),[action,...args]=process.argv.slice(2);const labels=Object.fromEntries((args[0]||'').split(',').filter(Boolean).map(x=>x.split('=')));const filters={label:Object.entries(labels).map(([k,v])=>v?k+'='+v:k)};(async()=>{if(action==='image'){await d.getImage(args[0]).inspect();return}if(action==='find'){const c=await d.listContainers({all:false,filters});if(c[0])process.stdout.write(JSON.stringify({id:c[0].Id,labels:c[0].Labels}))}if(action==='kill'){await d.getContainer(args[0]).kill()}if(action==='absent'){const c=await d.listContainers({all:true,filters}),n=await d.listNetworks({filters});if(c.length||n.length)throw Error('owned resource remains')}})().catch(e=>{console.error(e);process.exit(1)})
NODE
}
docker_api image '${dindImage}'
docker_api image '${buildkitImage}'
compat_socket='${activeFixture.controlSocket}.compat'
mv '${activeFixture.controlSocket}' "$compat_socket"
node - '${activeFixture.controlSocket}' "$compat_socket" <<'NODE' &
const net=require('net'),[front,back]=process.argv.slice(2);const server=net.createServer({allowHalfOpen:true},client=>{let request='',response='';client.on('data',b=>request+=b);client.on('end',()=>{const upstream=net.createConnection(back);upstream.on('connect',()=>upstream.end(request));upstream.on('data',b=>response+=b);upstream.on('error',e=>client.destroy(e));upstream.on('close',()=>{try{const value=JSON.parse(response),input=JSON.parse(request);if(input.kind==='status'&&value.ok)delete value.result.journal;client.end(JSON.stringify(value)+String.fromCharCode(10))}catch(e){client.destroy(e)}})})});server.listen(front);process.on('SIGTERM',()=>server.close(()=>process.exit(0)))
NODE
compat_proxy_pid=$!
for _ in $(seq 1 100); do [ -S '${activeFixture.controlSocket}' ] && break; kill -0 "$compat_proxy_pid" 2>/dev/null || exit 1; sleep 0.05; done
[ -S '${activeFixture.controlSocket}' ] || { echo 'compatibility control proxy did not become ready' >&2; exit 1; }
set +e
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-compat.json
compat_status=$?
set -e
COMPAT_STATUS="$compat_status" node - /tmp/niceeval-doctor-compat.json <<'NODE'
const fs=require('fs'),d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup'];const invalid=process.env.COMPAT_STATUS==='0'||d.status!=='FAIL'||JSON.stringify(d.checks.map(x=>x.id))!==JSON.stringify(ids)||ids.slice(0,5).some((id,i)=>d.checks[i].status!=='PASS')||d.checks[5].status!=='FAIL'||d.checks[5].code!=='UNSAFE_TO_CONTINUE'||!d.checks[5].detail.includes('durable journal')||d.checks.slice(6).some(x=>x.status!=='FAIL'||x.code!=='PREREQUISITE_FAILED');if(invalid){console.error(JSON.stringify({compatStatus:process.env.COMPAT_STATUS,doctor:d},null,2));process.exit(1)}
NODE
kill -TERM "$compat_proxy_pid"
wait "$compat_proxy_pid"
compat_proxy_pid=''
rm -f '${activeFixture.controlSocket}'
mv "$compat_socket" '${activeFixture.controlSocket}'
compat_socket=''
rm -f /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready
node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json /tmp/niceeval-preoccupier.ready <<'NODE' &
const net=require('net'), fs=require('fs'), crypto=require('crypto'); const [path,out,ready]=process.argv.slice(2);
const call=(request)=>new Promise((resolve,reject)=>{let text=''; const s=net.createConnection(path); s.on('connect',()=>s.end(JSON.stringify(request)+'\\n')); s.on('data',b=>text+=b); s.on('error',reject); s.on('close',()=>{try { const r=JSON.parse(text); if(!r.ok) throw Error(r.error?.message||'control error'); resolve(r.result) } catch(e) { reject(e) }});});
(async()=>{const status=await call({kind:'status'}); const invocationId=crypto.randomUUID(), reservationId=crypto.randomUUID(); const lease=await call({kind:'lease.create',profileId:status.profileId,daemonGeneration:status.generation,invocationId}); const held={invocationId,reservationId,leaseToken:lease.leaseToken}; const reservation=await call({kind:'reservation.acquire',...held,reservationKind:'build',resources:{cpus:0,memoryBytes:0,pids:0,containers:0,ephemeralDiskBytes:0}}); if(reservation.state!=='granted') throw Error('preoccupier was not granted'); fs.writeFileSync(out,JSON.stringify(held)); fs.writeFileSync(ready,'ready'); const beat=setInterval(()=>call({kind:'lease.heartbeat',invocationId,leaseToken:lease.leaseToken}).catch(()=>{}),4000); let done=false; const stop=async()=>{if(done)return;done=true;clearInterval(beat);await call({kind:'reservation.release',...held}).catch(()=>{});await call({kind:'lease.drain',invocationId,leaseToken:lease.leaseToken}).catch(()=>{});process.exit(0)};process.on('SIGTERM',stop);process.on('SIGINT',stop);})().catch(e=>{console.error(e);process.exit(1)});
NODE
holder_pid=$!
for _ in $(seq 1 100); do [ -f /tmp/niceeval-preoccupier.ready ] && break; sleep 0.1; done
[ -f /tmp/niceeval-preoccupier.ready ] || { echo 'preoccupier did not become ready' >&2; exit 1; }
set +e
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor.json
doctor_status=$?
set -e
cat /tmp/niceeval-doctor.json
DOCTOR_STATUS="$doctor_status" node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json <<'NODE'
const net=require('net'), fs=require('fs'); const path=process.argv[2], held=JSON.parse(fs.readFileSync(process.argv[3]));
const call=(request)=>new Promise((resolve,reject)=>{let text=''; const s=net.createConnection(path); s.on('connect',()=>s.end(JSON.stringify(request)+'\\n')); s.on('data',b=>text+=b); s.on('error',reject); s.on('close',()=>{try {const r=JSON.parse(text);if(!r.ok)throw Error(r.error?.message||'control error');resolve(r.result)}catch(e){reject(e)}})});
(async()=>{const d=JSON.parse(fs.readFileSync('/tmp/niceeval-doctor.json','utf8')); const ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup']; if(process.env.DOCTOR_STATUS==='0'||d.status!=='BLOCKED'||JSON.stringify(d.checks?.map(c=>c.id))!==JSON.stringify(ids)||d.checks.some(c=>c.status==='FAIL')||d.checks.filter(c=>ids.slice(7).includes(c.id)).some(c=>c.status!=='BLOCKED'||c.code!=='CAPACITY_QUEUE_TIMEOUT')) throw Error('doctor did not report only capacity BLOCKED')})().catch(e=>{console.error(e);process.exit(1)});
NODE
kill -TERM "$holder_pid"
wait "$holder_pid"
holder_pid=''
node - '${activeFixture.controlSocket}' /tmp/niceeval-preoccupier.json <<'NODE'
const net=require('net'),fs=require('fs');const path=process.argv[2],held=JSON.parse(fs.readFileSync(process.argv[3]));const call=r=>new Promise((resolve,reject)=>{let t='';const s=net.createConnection(path);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',reject);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);resolve(v.result)}catch(e){reject(e)}})});(async()=>{for(let i=0;i<50;i++){const s=await call({kind:'status'}),lease=s.leases.find(l=>l.invocationId===held.invocationId);if(!s.reservations.some(r=>r.reservationId===held.reservationId)&&lease?.state==='recovered'&&s.used.builds===0&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(r=>setTimeout(r,100))}throw Error('preoccupier cleanup did not converge')})().catch(e=>{console.error(e);process.exit(1)});
NODE
rm -f /tmp/niceeval-doctor-kill.json /tmp/niceeval-doctor-owned.json
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-kill.json 2>&1 &
doctor_pid=$!
for _ in $(seq 1 300); do
  doctor_owned=$(docker_api find 'niceeval.attempt-id=doctor-diagnostic')
  if [ -n "$doctor_owned" ]; then
    printf '%s' "$doctor_owned" >/tmp/niceeval-doctor-owned.json
    node - /tmp/niceeval-doctor-owned.json <<'NODE'
const x=require('fs').readFileSync(process.argv[2],'utf8'),l=JSON.parse(x).labels;if(l['niceeval.attempt-id']!=='doctor-diagnostic'||['niceeval.profile-id','niceeval.invocation-id','niceeval.reservation-id','niceeval.provision-token'].some(k=>!l[k]))process.exit(1)
NODE
    break
  fi
  kill -0 "$doctor_pid" 2>/dev/null || { cat /tmp/niceeval-doctor-kill.json >&2; exit 1; }
  sleep 0.1
done
[ -s /tmp/niceeval-doctor-owned.json ] || { echo 'doctor diagnostic did not become running' >&2; exit 1; }
kill -KILL "$doctor_pid"
set +e; wait "$doctor_pid"; doctor_kill_status=$?; set -e
[ "$doctor_kill_status" -eq 137 ] || { echo 'doctor did not exit from SIGKILL' >&2; exit 1; }
doctor_pid=''
node - '${activeFixture.controlSocket}' /tmp/niceeval-doctor-owned.json <<'NODE'
const net=require('net'),fs=require('fs'),path=process.argv[2],o=JSON.parse(fs.readFileSync(process.argv[3])).labels;const call=r=>new Promise((ok,no)=>{let t='';const s=net.createConnection(path);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',no);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);ok(v.result)}catch(e){no(e)}})});(async()=>{for(let i=0;i<300;i++){const s=await call({kind:'status'}),r=o['niceeval.reservation-id'],l=o['niceeval.invocation-id'];if(!s.reservations.some(x=>x.reservationId===r)&&s.leases.find(x=>x.invocationId===l)?.state==='recovered'&&s.used.builds===0&&s.used.containers===0&&s.slots.every(x=>x.reservationId!==r&&x.state==='free')&&s.availableQuotaSlots===1&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(x=>setTimeout(x,100))}throw Error('SIGKILL recovery did not converge')})().catch(e=>{console.error(e);process.exit(1)})
NODE
profile_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.profile-id"])')
reservation_label=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-owned.json")).labels["niceeval.reservation-id"])')
docker_api absent "niceeval.profile-id=$profile_label,niceeval.reservation-id=$reservation_label"
docker_api image '${dindImage}'
docker_api image '${buildkitImage}'
rm -f /tmp/niceeval-doctor-fault.json /tmp/niceeval-doctor-fault-owned.json
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-fault.json 2>&1 &
doctor_pid=$!
for _ in $(seq 1 300); do
  fault_owned=$(docker_api find 'niceeval.attempt-id=doctor-diagnostic')
  if [ -n "$fault_owned" ]; then printf '%s' "$fault_owned" >/tmp/niceeval-doctor-fault-owned.json; break; fi
  kill -0 "$doctor_pid" 2>/dev/null || { cat /tmp/niceeval-doctor-fault.json >&2; exit 1; }; sleep 0.1
done
[ -s /tmp/niceeval-doctor-fault-owned.json ] || { echo 'fault diagnostic did not become running' >&2; exit 1; }
fault_socket='${activeFixture.controlSocket}.fault'
mv '${activeFixture.controlSocket}' "$fault_socket"
fault_container=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).id)')
docker_api kill "$fault_container"
set +e; wait "$doctor_pid"; doctor_fault_status=$?; set -e
[ "$doctor_fault_status" -eq 1 ] || { cat /tmp/niceeval-doctor-fault.json >&2; exit 1; }
doctor_pid=''
node - /tmp/niceeval-doctor-fault.json <<'NODE'
const fs=require('fs'),d=JSON.parse(fs.readFileSync(process.argv[2],'utf8')),ids=['descriptor','control','daemon','cgroup','storage','journal','assets','cold-build','cold-build-cleanup','container-limits','nested-docker','container-cleanup'];const fail=d.checks.find(x=>x.status==='FAIL');if(d.status!=='FAIL'||JSON.stringify(d.checks.map(x=>x.id))!==JSON.stringify(ids)||!fail||!fail.detail.includes('primary:')||!fail.detail.includes('cleanup:')||!fail.detail.includes('control-owned diagnostic'))process.exit(1)
NODE
mv "$fault_socket" '${activeFixture.controlSocket}'
fault_socket=''
node - '${activeFixture.controlSocket}' /tmp/niceeval-doctor-fault-owned.json <<'NODE'
const net=require('net'),fs=require('fs'),p=process.argv[2],o=JSON.parse(fs.readFileSync(process.argv[3])).labels;const call=r=>new Promise((ok,no)=>{let t='';const s=net.createConnection(p);s.on('connect',()=>s.end(JSON.stringify(r)+'\\n'));s.on('data',b=>t+=b);s.on('error',no);s.on('close',()=>{try{const v=JSON.parse(t);if(!v.ok)throw Error(v.error?.message);ok(v.result)}catch(e){no(e)}})});(async()=>{for(let i=0;i<300;i++){const s=await call({kind:'status'}),r=o['niceeval.reservation-id'],l=o['niceeval.invocation-id'],used=s.used;if(!s.reservations.some(x=>x.reservationId===r)&&s.leases.find(x=>x.invocationId===l)?.state==='recovered'&&Object.values(used).every(x=>x===0)&&s.slots.every(x=>x.reservationId!==r&&x.state==='free')&&s.availableQuotaSlots===1&&s.admissionOpen&&s.degraded.length===0)return;await new Promise(x=>setTimeout(x,100))}throw Error('fault cleanup did not converge')})().catch(e=>{console.error(e);process.exit(1)})
NODE
fault_profile=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.profile-id"])')
fault_reservation=$(node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/tmp/niceeval-doctor-fault-owned.json")).labels["niceeval.reservation-id"])')
docker_api absent "niceeval.profile-id=$fault_profile,niceeval.reservation-id=$fault_reservation"
docker_api image '${dindImage}'
docker_api image '${buildkitImage}'
set +e
node_modules/.bin/niceeval docker profile doctor e2e-cold-build --json >/tmp/niceeval-doctor-pass.json
doctor_pass_status=$?
set -e
cat /tmp/niceeval-doctor-pass.json
DOCTOR_PASS_STATUS="$doctor_pass_status" node - /tmp/niceeval-doctor-pass.json <<'NODE'
const d=JSON.parse(require('fs').readFileSync(process.argv[2],'utf8'));if(process.env.DOCTOR_PASS_STATUS!=='0'||d.status!=='PASS'||d.checks.length!==12||d.checks.some(x=>x.status!=='PASS')){console.error(JSON.stringify(d,null,2));process.exit(1)}
NODE
set +e
node_modules/.bin/niceeval exp docker-profile-cold-build --rerun all --json >/tmp/niceeval-exp.ndjson
status=$?
set -e
cat /tmp/niceeval-exp.ndjson
run_id=$(node -e 'const fs=require("fs"); const lines=fs.readFileSync("/tmp/niceeval-exp.ndjson","utf8").trim().split("\\n"); const receipt=JSON.parse(lines.at(-1)); process.stdout.write(receipt.receipt.runIds[0])')
if [ "$status" -ne 0 ]; then
  locator=$(node -e 'const fs=require("fs"); for (const line of fs.readFileSync("/tmp/niceeval-exp.ndjson","utf8").trim().split("\\n")) { const value=JSON.parse(line); if (value.locator) { process.stdout.write(value.locator); break } }')
  if [ -n "$locator" ]; then
    node_modules/.bin/niceeval show "$locator" --execution
  else
    node_modules/.bin/niceeval show --run "$run_id" --json
  fi
fi
exit "$status"`,
          ], { cwd: projectRoot, timeoutMs: 300_000 });
            expect(driver.exitCode, driver.diagnostic()).toBe(0);
            const evals = driver.ndjson<ExpEvent>().filter(
              (event): event is Extract<ExpEvent, { event: "eval" }> =>
                "event" in event && event.event === "eval",
            );
            expect(only(evals, (event) => event.evalId === "docker-profile-cold-build"), driver.diagnostic())
              .toMatchObject({ verdict: "passed" });
          },
        );

        const journal = await sudo.run(["cat", fixture.journal]);
        expect(journal.exitCode, journal.diagnostic()).toBe(0);
        const records = journal.stdout
          .split("\n")
          .filter(Boolean)
          .map((line) => JSON.parse(line) as HostJournalRecord);
        const events = records.map((record) => record.event);
        expect(events).toContain("reservation-granted");
        expect(events).toContain("build-terminated");
        expect(events).toContain("container-active");
        expect(events).toContain("reservation-released");
        const buildLocator = records.find((record) => record.event === "build-terminated")?.detail.locator;
        expect(typeof buildLocator).toBe("string");
      } catch (error) {
        primaryError = error;
        throw error;
      } finally {
        const cleanupErrors: unknown[] = [];
        if (fixture !== undefined) {
          try {
            const journal = await sudo.run(["cat", fixture.journal]);
            if (journal.exitCode !== 0 && primaryError === undefined) throw new Error(journal.diagnostic());
            const records = journal.exitCode === 0 ? journal.stdout
              .split("\n")
              .filter(Boolean)
              .map((line) => JSON.parse(line) as HostJournalRecord) : [];
            const locators = new Map<string, "cache" | "ephemeral" | undefined>();
            const builderNames = new Set<string>();
            for (const record of records) {
              if (record.event === "build-terminated" && typeof record.detail.locator === "string") {
                locators.set(record.detail.locator, undefined);
              }
              if (record.event === "build-builder-created" && typeof record.detail.builderName === "string") {
                builderNames.add(record.detail.builderName);
              }
              for (const reservation of Object.values(record.state?.reservations ?? {})) {
                if (reservation.kind === "build" && typeof reservation.locator === "string") {
                  locators.set(reservation.locator, reservation.retention);
                }
                if (reservation.kind === "build" && typeof reservation.builderName === "string") {
                  builderNames.add(reservation.builderName);
                }
              }
            }
            for (const [locator, retention] of locators) {
              const inspectImage = await docker.run(["image", "inspect", locator]);
              if (retention === "ephemeral" && inspectImage.exitCode === 0) {
                // Clean the fixture after recording the ownership leak, but do
                // not let cleanup turn a failed proof into a passing run.
                await docker.run(["image", "rm", "--force", locator]);
                throw new Error(`watchdog leaked ephemeral build locator ${locator}`);
              }
              if (retention === "ephemeral" && !/No such image/i.test(inspectImage.diagnostic())) {
                throw new Error(inspectImage.diagnostic());
              }
              const removeImage = await docker.run(["image", "rm", "--force", locator]);
              if (removeImage.exitCode !== 0 && !/No such image/i.test(removeImage.diagnostic())) {
                throw new Error(removeImage.diagnostic());
              }
            }
            for (const builderName of builderNames) {
              if (!/^niceeval-build-[a-f0-9]{24}$/.test(builderName)) {
                throw new Error(`watchdog journal contains a non-derived builder name: ${builderName}`);
              }
              const volumeName = `buildx_buildkit_${builderName}0_state`;
              const inspectVolume = await docker.run(["volume", "inspect", volumeName]);
              if (inspectVolume.exitCode === 0) {
                const removeVolume = await docker.run(["volume", "rm", "--force", volumeName]);
                throw new Error(
                  `watchdog leaked Buildx state volume ${volumeName}; cleanup: ${removeVolume.diagnostic()}`,
                );
              }
              if (!/No such volume/i.test(inspectVolume.diagnostic())) {
                throw new Error(inspectVolume.diagnostic());
              }
            }
          } catch (error) {
            cleanupErrors.push(error);
          }
          try {
            const cleanup = await sudo.run([
              "env", `PATH=${hostPath}`,
              "python3", fixtureScript, "cleanup", "--root", hostRoot,
            ], { timeoutMs: 30_000 });
            if (cleanup.exitCode !== 0) throw new Error(cleanup.diagnostic());
          } catch (error) {
            cleanupErrors.push(error);
          }
        }
        if (cleanupErrors.length > 0) {
          if (primaryError !== undefined) {
            console.error(new AggregateError(cleanupErrors, "Docker profile E2E cleanup also failed"));
          } else {
            throw new AggregateError(cleanupErrors, "Docker profile E2E cleanup failed");
          }
        }
      }
    });
  });
}, 360_000);
```

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `feature + bug regression`
- Protects: 评分制 Experiment 标题按 Eval 数计数，主结果只显示 earned score，Attempt overlay 仍可导航并保持历史。
- Runs: 安装后候选生成真实 Report，启动 `niceeval view`，再由 Chromium 从公开页面展开实验并打开 Attempt overlay。
- Asserts: 1 个 Eval、2 个 Attempt 显示为 `1/1`；结果含 `7` 且不含 `missed check` 或 `passed`；详情 URL、fragment、历史与源码证据继续可读。

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `feature + bug regression`
- Protects: 评分制 Experiment 汇总按 Eval 数计数且只显示 earned score，同时保持公开 overlay 导航。
- Runs: 安装后 view/static、HTTP 与 Chromium 浏览器动作。
- Asserts: 评分实验显示 1/1 和 7，不显示 missed check/passed，并保持详情、历史与源码交互。

```ts
// owner: docs/engineering/testing/e2e/report.md#report-browser-journey
// rerun: pnpm e2e test --repo report -- --run test/report.browser.spec.ts
//
// This Journey observes only the installed candidate, exported files, HTTP,
// hash navigation, and browser-visible content. It never reads Record files.

import { pollUntil, waitForOutput } from "@niceeval/testkit";
import { createServer, type Server } from "node:http";
import { readFile, readdir, stat } from "node:fs/promises";
import { join, relative, resolve } from "node:path";
import { pathToFileURL } from "node:url";
import { expect, test } from "@playwright/test";
import { reportCaseArtifacts, reportE2E } from "./support.ts";

test("静态站与 view 只交付 SPA shell；普通页面使用 hash 和 fragment，缺少 JavaScript 时明确报错", async ({ browser }) => {
  test.setTimeout(120_000);
  await reportE2E.case(
    "browser-static-spa-site",
    { artifacts: reportCaseArtifacts(["site-export"]) },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      for (const id of ["main", "source"] as const) {
        const run = await niceeval.run(["exp", id, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const exported = await niceeval.run(["view", "--report", "./reports/site.tsx", "--out", "site-export", "--no-open"]);
      expect(exported.exitCode, exported.diagnostic()).toBe(0);

      const exportRoot = join(projectRoot, "site-export");
      await expect(readFile(join(exportRoot, "index.html"), "utf8")).resolves.toContain('src="_niceeval/app.js"');
      expect(await htmlFiles(exportRoot)).toEqual(["index.html"]);

      const live = niceeval.start(
        ["view", "--report", "./reports/site.tsx", "--host", "127.0.0.1", "--port", "0", "--no-open"],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(live, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000, label: "SPA view URL",
      });
      const liveOrigin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(liveOrigin, startup).toBeDefined();
      await waitForHttp(liveOrigin!, "SPA view readiness");
      await expectSameBody(new URL(liveOrigin!), pathToFileURL(join(exportRoot, "index.html")));

      // Exact-file-only HTTP: no /source rewrite exists or is needed for a hash route.
      const staticServer = await serveStaticDirectory(exportRoot);
      try {
        const page = await browser.newPage();
        try {
          await page.goto(new URL("index.html", staticServer.origin).href);
          await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
          const fragment = page.waitForRequest((request) =>
            request.url() === new URL("_niceeval/fragments/source.json", staticServer.origin).href,
          );
          await page.getByRole("link", { name: "Source detail" }).click();
          await expect(page).toHaveURL(/#\/source$/);
          await fragment;
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();

          const copiedUrl = page.url();
          await page.reload();
          expect(page.url()).toBe(copiedUrl);
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();
        } finally {
          await page.close();
        }
        const offline = await browser.newContext({ javaScriptEnabled: false });
        try {
          const page = await offline.newPage();
          await page.goto(new URL("index.html#/source", staticServer.origin).href);
          await expect(page.getByRole("heading", { name: "JavaScript required" })).toBeVisible();
          await expect(page.getByRole("alert")).toContainText("Enable JavaScript to view this NiceEval report.");
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).not.toBeVisible();
        } finally {
          await offline.close();
        }
      } finally {
        await staticServer.close();
      }
    },
  );
});

test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 overlay", async ({ browser }) => {
  test.setTimeout(180_000);
  await reportE2E.case(
    "browser-classic-attempt-overlay",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      for (const id of [
        "classic/baseline",
        "classic/memory-a",
        "classic/incompatible",
      ] as const) {
        const run = await niceeval.run(["exp", id, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const view = niceeval.start(["view", "--host", "127.0.0.1", "--port", "0", "--no-open"], { timeoutMs: 60_000 });
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000, label: "classic SPA view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "classic SPA view readiness");

      const page = await browser.newPage();
      try {
        await page.goto(origin!);
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        const experiment = page.locator('a[href^="#/experiment/"]').filter({
          has: page.locator("title").filter({ hasText: "classic/memory-a" }),
        });
        const experimentSummary = page.locator("summary").filter({
          has: page.getByText("classic/memory-a (9/9)", { exact: true }),
        });
        await expect(experimentSummary).toHaveCount(1);
        await expect(experimentSummary).toContainText("classic/memory-a (9/9)");
        expect((await experimentSummary.textContent())?.match(/9\/9/g)).toHaveLength(1);
        const expandedExperiment = experimentSummary.locator("..");
        await experimentSummary.click();
        await expect(expandedExperiment).toHaveAttribute("open", "");
        const dialog = page.getByRole("dialog");
        const scoreExperimentSummary = page.locator("summary.niceeval-table-hierarchy-summary").filter({
          hasText: /^classic\/incompatible /,
        });
        await expect(scoreExperimentSummary).toHaveCount(1);
        await expect(scoreExperimentSummary).toContainText("classic/incompatible (1/1)");
        await expect(scoreExperimentSummary).toContainText("7");
        await expect(scoreExperimentSummary).not.toContainText("missed check");
        await expect(scoreExperimentSummary).not.toContainText("passed");
        await experiment.click();
        await expect(page).toHaveURL(/#\/experiment\//);
        await expect(dialog).toBeVisible();
        // regression: memory/react19-dangerously-set-inner-html-identity.md
        await expect(expandedExperiment).toHaveAttribute("open", "");

        const attempt = page.locator('a[href^="#/attempt/"]').filter({ visible: true }).first();
        await expect(attempt).toBeVisible();
        const href = await attempt.getAttribute("href");
        expect(href).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);
        const route = href!.slice(1);
        const detail = new URL(`_niceeval/fragments${route}.json`, origin!);

        const overlayRequests: string[] = [];
        page.on("request", (request) => {
          if (new URL(request.url()).pathname.includes("/_niceeval/fragments/"))
            overlayRequests.push(request.url());
        });

        let detailRequested!: () => void;
        const requested = new Promise<void>((done) => { detailRequested = done; });
        let releaseDetail!: () => void;
        const released = new Promise<void>((done) => { releaseDetail = done; });
        let detailContinued!: () => void;
        const continued = new Promise<void>((done) => { detailContinued = done; });
        await page.route(detail.href, async (request) => {
          detailRequested();
          await released;
          await request.continue();
          detailContinued();
        });
        try {
          await attempt.click();
          await requested;
          await expect(page).toHaveURL(new RegExp(`#${route}$`));
          await expect(dialog).toBeVisible();
          await expect(dialog.getByRole("status")).toContainText("Loading details…");
          await expect(
            page.locator("h1", { hasText: "NiceEval overview" }),
          ).toBeVisible();
        } finally {
          releaseDetail();
          await continued;
          await page.unroute(detail.href);
        }
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();

        const assertionLine = dialog.locator("summary").filter({ hasText: "t.check(t.reply" }).first();
        await assertionLine.click();
        const rootMatch = dialog.getByLabel(/^and\(includes.+: matched$/).first();
        await expect(rootMatch).toBeVisible();
        await rootMatch.click();
        const orMatch = dialog.getByLabel(/^or\(includes.+: matched$/).first();
        await expect(orMatch).toBeVisible();
        await orMatch.click();
        const orNode = orMatch.locator("xpath=..");
        await expect(orNode.getByLabel('includes("RECALL_OK"): matched')).toBeVisible();
        await expect(orNode.getByLabel('includes("NEVER_PRESENT"): mismatched')).toBeVisible();

        const copiedUrl = page.url();
        await page.getByRole("button", { name: "Close" }).click();
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("");
        expect(overlayRequests).toEqual([detail.href]);

        await page.goForward();
        await expect(dialog).toBeVisible();
        await page.goBack();
        await expect(dialog).not.toBeVisible();
        await page.goForward();
        await expect(dialog).toBeVisible();
        await page.reload();
        expect(page.url()).toBe(copiedUrl);
        await expect(dialog).toBeVisible();

        // Pasting the copied hash restores an overlay over the report, never a
        // separate Attempt document.
        const shared = await browser.newPage();
        try {
          await shared.goto(copiedUrl);
          await expect(shared.getByRole("dialog")).toBeVisible();
          await expect(shared.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
        } finally {
          await shared.close();
        }

        await page.mouse.click(5, 5);
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("");

        const baselineSummary = page.locator("summary").filter({ hasText: /^classic\/baseline \(9\/9\)/ }).first();
        if (await baselineSummary.locator("xpath=..").getAttribute("open") === null) await baselineSummary.click();
        const classicSummary = page.locator("summary").filter({ hasText: /^classic \(8 evals\)/ }).first();
        if (await classicSummary.locator("xpath=..").getAttribute("open") === null) await classicSummary.click();
        const toolEvalSummary = page.locator("summary").filter({ hasText: /^tool-note/ }).first();
        if (await toolEvalSummary.locator("xpath=..").getAttribute("open") === null) await toolEvalSummary.click();
        const toolAttemptHref = await toolEvalSummary.locator("xpath=..").locator('a[href^="#/attempt/"]').first().getAttribute("href");
        expect(toolAttemptHref).toMatch(/^#\/attempt\//);
        await page.goto(new URL(toolAttemptHref!, origin!).href);
        await expect(dialog).toBeVisible({ timeout: 10_000 });

        const toolAssertion = dialog.locator("summary").filter({ hasText: 'calledTool("write_note"' }).first();
        await expect(toolAssertion).toBeVisible({ timeout: 5_000 });
        if (await toolAssertion.locator("xpath=..").getAttribute("open") === null) await toolAssertion.click();
        const toolMatcher = dialog.getByLabel(/calledTool.+: mismatched$/).filter({ visible: true }).first();
        await expect(toolMatcher).toBeVisible({ timeout: 5_000 });
        await toolMatcher.click();
        await expect(dialog.getByRole("heading", { name: "Tool calls" })).toBeVisible({ timeout: 5_000 });
        await expect(dialog.getByText('exactly 1 × toolMatch("write_note")', { exact: true })).toBeVisible();
        await expect(dialog.getByText("0 definite matches", { exact: true })).toBeVisible();

        const commandAssertion = dialog.locator("summary").filter({ hasText: "t.check({" }).first();
        await expect(commandAssertion).toBeVisible({ timeout: 5_000 });
        if (await commandAssertion.locator("xpath=..").getAttribute("open") === null) await commandAssertion.click();
        const commandMatcher = dialog.getByLabel("commandSucceeded(): matched").filter({ visible: true });
        await expect(commandMatcher).toBeVisible({ timeout: 5_000 });
        await commandMatcher.click();
        await expect(dialog.getByRole("heading", { name: "Command result" })).toBeVisible();
        await expect(dialog.getByText("pnpm test", { exact: true })).toBeVisible();
        await expect(dialog.getByText("Exit code 0", { exact: true })).toBeVisible();
        await expect(dialog.getByText("PASS src/example.test.ts", { exact: true })).not.toBeVisible();

      } finally {
        await page.close();
      }
    },
  );
});

async function expectSameBody(liveUrl: URL, staticUrl: URL): Promise<void> {
  const expected = await readFile(staticUrl);
  const response = await fetch(liveUrl);
  expect(response.status, `${liveUrl} should serve the exported shell`).toBe(200);
  expect(Buffer.from(await response.arrayBuffer()), `${liveUrl} body`).toEqual(expected);
}

async function htmlFiles(root: string): Promise<readonly string[]> {
  const paths: string[] = [];
  async function visit(directory: string): Promise<void> {
    for (const entry of await readdir(directory, { withFileTypes: true })) {
      const file = join(directory, entry.name);
      if (entry.isDirectory()) await visit(file);
      else if (entry.isFile() && entry.name.endsWith(".html")) paths.push(relative(root, file));
    }
  }
  await visit(root);
  return paths.sort();
}

async function waitForHttp(origin: string, label: string): Promise<void> {
  await pollUntil(async () => {
    try {
      return (await fetch(origin)).status === 200 ? true : undefined;
    } catch {
      return undefined;
    }
  }, { timeoutMs: 15_000, intervalMs: 100, label });
}

async function serveStaticDirectory(root: string): Promise<{ readonly origin: string; readonly close: () => Promise<void> }> {
  const absoluteRoot = resolve(root);
  const server = createServer(async (request, response) => {
    const pathname = decodeURIComponent(new URL(request.url ?? "/", "http://static.invalid").pathname);
    const file = resolve(absoluteRoot, `.${pathname === "/" ? "/index.html" : pathname}`);
    if (file !== absoluteRoot && !file.startsWith(`${absoluteRoot}/`)) return void response.writeHead(403).end();
    try {
      if (!(await stat(file)).isFile()) throw new Error("not a file");
      const mediaType = file.endsWith(".html") ? "text/html; charset=utf-8"
        : file.endsWith(".js") ? "text/javascript; charset=utf-8"
        : file.endsWith(".css") ? "text/css; charset=utf-8"
        : file.endsWith(".json") ? "application/json; charset=utf-8"
        : "application/octet-stream";
      response.writeHead(200, { "content-type": mediaType }).end(await readFile(file));
    } catch {
      response.writeHead(404).end();
    }
  });
  await new Promise<void>((done, reject) => {
    server.once("error", reject);
    server.listen(0, "127.0.0.1", done);
  });
  const address = server.address();
  if (address === null || typeof address === "string") throw new Error("static server did not expose a TCP address");
  return { origin: `http://127.0.0.1:${address.port}/`, close: () => closeServer(server) };
}

async function closeServer(server: Server): Promise<void> {
  await new Promise<void>((done, reject) => server.close((error) => error === undefined ? done() : reject(error)));
}
```

### Verification receipt

- Candidate: `6f042b958`；NiceEval tarball SHA-256 `bc8c965a87a1d8fcfa73ec815a2e654a1e6f2204f10aaa071301d08608729de1`。
- Red: Report 旧候选 SHA-256 `ada9d21514130bfa08951680086faebf82a43820b3d39f150a1f0a3d37b6589c` 在浏览器 owner 输出 `classic/incompatible (2/2) ... 7 · 2 missed checks`；Docker 两条旧候选收据分别在 descriptor check 与 control-owned diagnostic 阶段红灯，详见对应 memory 条目。
- Green: Report 目标浏览器 E2E 1 passed；`pnpm e2e takeover --repo report -- --run test/report.browser.spec.ts -t '经典报告将 Attempt 作为可分享、可关闭并保留历史的 overlay'` 完整通过。`nix build --no-link --print-out-paths .#docker-profile-host` 通过，产物中的 `niceeval-docker-profile-preload-verify-assets` 可执行。
- Repeatability: Report takeover 的 3 个全新副本、同安装副本连续 2 次、Repo 默认并行与单项重跑全部 PASS，cleanup 全部成功。Docker lifecycle owner 本机重跑在 test invocation 前以 `configuration` 停止：宿主缺 `linux-loop-project-quota` capability；Docker 29.6.2 可用且 scratch cleanup 成功，具备该 capability 的 CI 必须实际运行 owner 后才能合并。
- Fixed conditions: Report 使用同一候选、签入 fixture、Chromium 1.61.1 与确定性 Agent；Docker 使用 fixture 固定的 DIND/BuildKit digest、真实 Docker daemon、root-owned registry 与 invocation-local 结果根。
- Unit count: `not applicable — no Unit changed`。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790079887&installation_model_id=431746&pr_number=106&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F106&signature=f462c762e9a9f4a75cde3ccf8a9408a04f868cea8303d50ab00d3124c60d22db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->