### PR TITLE
ci(preview): 用全功能示例交付可切换实验的预览

### DIFF
--- a/.agents/friction-log/20260823230837-experiment-数值-labels/friction.md
+++ b/.agents/friction-log/20260823230837-experiment-数值-labels/friction.md
@@ -1,0 +1,32 @@
+---
+title: 'Experiment 数值 labels 使 plan 退化为 [object Object]'
+severity: 'major'
+---
+
+## Expected Behavior
+
+`defineExperiment({ labels: { rank: 0 } })` matches the documented and typed `Record<string, string | number>` contract. `niceeval exp <id> --dry` should plan successfully and persist or normalize the numeric coordinate.
+
+## Current Behavior
+
+`niceeval exp list` discovers and prints the numeric label, but `niceeval exp <id> --dry` fails during planning with only `ExperimentHostError: [object Object]`. Replacing the number with an equivalent string makes the same experiment plan and run.
+
+## Possible Solution
+
+Close numeric labels consistently at the Runner-to-Record boundary, and preserve the structured typed failure when the host maps planning errors so invalid input never degrades to `[object Object]`.
+
+## Minimal Reproducible Example
+
+```ts
+export default defineExperiment({
+  agent: deterministicAgent,
+  labels: { rank: 0 },
+  evals: ["states/pass"],
+});
+```
+
+Run `niceeval exp <experiment-id> --dry`. The current candidate rejects the numeric label even though `packages/niceeval/src/runner/types.ts` and `docs/feature/experiments/README.md` allow it. Change `rank` to `"0"`; planning succeeds.
+
+## Context
+
+Building the deterministic Report preview fixture hit this at the first clean plan. The string workaround is safe for that fixture, but the contract mismatch and opaque error made a valid public Experiment shape unusable and substantially harder to diagnose.

--- a/.agents/friction-log/20260824102608-pr-body-check/friction.md
+++ b/.agents/friction-log/20260824102608-pr-body-check/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'pr:body check 拒绝仓库规则要求的 --no-remote'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+仓库 AGENTS.md 要求创建 PR 前运行 `pnpm pr:body check --source <draft.md> --no-remote`。当前 CLI 应接受该显式本地模式参数，或仓库规则应与 CLI help 一致地省略它。
+
+## Current Behavior
+
+`pnpm pr:body check --source <draft.md> --no-remote` 立即失败为 `Received unknown argument: --no-remote`。与此同时，`pnpm pr:body check --help` 只列出正向 `--remote`，并说明 local validation is the default。
+
+## Possible Solution
+
+让布尔参数支持 `--no-remote`，或把 AGENTS.md 和其它示例统一改成不带该参数的默认本地检查命令，并为命令示例加一个可执行校验。
+
+## Minimal Reproducible Example
+
+先运行 `pnpm pr:body init --source <draft.md> --base main`，再运行 `pnpm pr:body check --source <draft.md> --no-remote`。当前候选在解析参数阶段以 exit code 1 退出；删除 `--no-remote` 后进入正常校验。
+
+## Context
+
+为确定性 Report preview 创建 PR 时，严格执行仓库级 Git 协作规则触发。它会让自动化 agent 在已明确要求的发布门上停住，并需要人工判断 CLI help 优先于规则示例。

--- a/.agents/friction-log/20260824122121-judge-虚拟时钟-timeout/friction.md
+++ b/.agents/friction-log/20260824122121-judge-虚拟时钟-timeout/friction.md
@@ -1,0 +1,30 @@
+---
+title: 'Judge 虚拟时钟 timeout issue 在 unit 套件中稳定缺失'
+severity: 'major'
+---
+
+## Expected Behavior
+
+`pnpm exec vitest run --project unit` 应在未触及 Judge 的 Report 改动上稳定通过，Judge 虚拟时钟用例应在 999ms 保持 pending、到 1000ms 返回带 timeout issue 的 unavailable。
+
+## Current Behavior
+
+全量 unit 在 `packages/niceeval/src/assertions/judge.test.ts:120` 稳定失败；同文件窄重跑也立即复现。结果仍是 `state: unavailable` / `reason: source-unavailable`，但缺少断言期待的 timeout issue，因此 7 files 中 1 file、15 tests 中 1 test 失败。当前 Report 变更未触及 Judge 源码或测试。
+
+## Possible Solution
+
+核对 Effect 3.22.1 下 TestClock、timeout 与 provider interruption 的调度顺序，确保 Fiber 在边界前确实挂起，并让 timeout failure 在 source-unavailable 归一时保留预期 issue；随后让该用例连续与全量都稳定通过。
+
+## Minimal Reproducible Example
+
+在仓库根运行：
+
+```bash
+pnpm exec vitest run --project unit packages/niceeval/src/assertions/judge.test.ts
+```
+
+当前稳定得到 `packages/niceeval/src/assertions/judge.test.ts:120` 的 `toMatchObject` 失败，3 passed / 1 failed。
+
+## Context
+
+在修复 Report Header 实验选择器并完成 Report E2E reliability takeover 后执行全仓 unit 验收时发现。该红灯独立于本次 Report 路径，但会阻止把全仓 unit 宣称为全绿。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@
 | `../terminal-bench/` | 用真实 Terminal-Bench 题目验证 NiceEval 的运行、查看、诊断与实验工作流 |
 | `../MemoryBench/` | 验证 memory 条件、agent/model 对比实验与报告能力 |
 | `../NiceEval-Eval/` | 评估 NiceEval 的 INIT、随包索引、安装/分享场景及文档对 coding agent 的实际效果 |
+| `../NiceEval-Preview/` | 用确定性的全功能 Eval 与已封存 Record 为 CI 提供 Report preview 数据 |
 
 - 当任务要求下游实验，或 NiceEval 的 API、CLI、报告、provider、INIT、随包文档等变更需要真实消费验证时，进入相应兄弟仓库工作；这不是单纯切换到上级目录，而是把下游项目作为产品验收环境。
 - 进入下游前先读取该仓库最近的 `AGENTS.md`、`README.md` 或实验入口，并在每个涉及的仓库分别检查 Git 状态。父目录没有统一依赖或测试入口，不在父目录运行仓库级安装、测试、格式化或批量改写。

--- a/docs/engineering/testing/e2e/report.md
+++ b/docs/engineering/testing/e2e/report.md
@@ -60,7 +60,7 @@ niceeval view --report <fixture> --no-open
 每对 response body 与文件 body 必须逐字节相同；固定 Host asset 也必须来自同一 revision。下载字节合同仍属于产品契约，但这个
 不发布 public Download 的代表 fixture 不为它伪造作者入口。
 
-浏览器默认进入稳定排序的第一个实验组 Page；多组 Header 实验 selector 始终有当前值，语言也由原生 selector 切换。
+浏览器默认进入稳定排序的第一个实验组 Page；单组直接进入且不显示单项控件，多组 Header 实验 selector 始终有当前值并位于语言 selector 之前。named 与 singleton identity 同名时，公开 option 文本仍能无歧义区分。组间切换、详情 overlay、Back/Forward 与直接深链都从基础 Page route 恢复同一当前值，语言由独立的原生 selector 切换。
 同组实验命中不同 Eval population 时，表格和详情入口仍可用。各实验指标保留自己的实际分母；内建机器文档同时给出各 member 的 distinct Eval coverage 与组内并集大小。
 
 完整 Page router

--- a/docs/feature/reports/README.md
+++ b/docs/feature/reports/README.md
@@ -28,9 +28,9 @@ Report 有两条明确不同的执行路径。它们共享同一份作者定义�
 
 `show` 不调用参数 Page 的 `enumerate()`，不建立 `ClosedSiteRevision`，也不为未选 route 执行作者 callback。
 
-`project-current` 仍是整个项目的 Sample。只有一个实验组范围时，标准 Overview 直接从父 Sample 形成该范围的 `ExperimentComparisonScope`。有多个范围时，标准 Report 内容交付各范围的普通 Page 链接；通用 Header 不理解实验组。Hero、通知、Summary、图表和 Table 都消费目标 Page 背后的同一 narrowed Sample。
+`project-current` 仍是整个项目的 Sample。只有一个实验组范围时，标准 Overview 直接从父 Sample 形成该范围的 `ExperimentComparisonScope`。有一个或多个范围时，Host 在站点关闭阶段把显式实验组 Page role 形成纯 route/label 导航投影；浏览器根入口默认进入稳定排序的第一个组 Page。两个及以上范围在 Header 显示原生实验选择器，一个范围则直接进入且不显示无意义的单项控件。Hero、通知、Summary、图表和 Table 都消费目标 Page 背后的同一 narrowed Sample。
 
-切换选项只改变根 document 的 hash，不新增 CLI 参数或 HTTP 路径。`show` 的多组默认输出仍是可复制命令的实验索引。每个 Page 把唯一 scope 交给具名比较组件；任何比较组件都不能跨范围。
+切换选项只改变根 document 的 hash，不新增 CLI 参数或 HTTP 路径。当前实验由基础组 Page 的 canonical route 唯一决定；详情 overlay 沿用其 background Page，真正的非组 Page 不伪造实验选择。`show` 的多组默认输出仍是可复制命令的实验索引。每个 Page 把唯一 scope 交给具名比较组件；任何比较组件都不能跨范围。
 `view` 与静态导出则必须完成全站枚举、链接校验、资源闭包和限额检查；它们只从同一个 revision 读取最终 bytes。
 
 [Report 成本投影](cost-projections/README.md) 是完整的成本契约。它只经 `ReportDefinition.pricing` 接入 Report，并以同一只读值暴露为
@@ -93,7 +93,7 @@ view 不注入只在本机有效的作者脚本。
 单组默认输出 `experiment-group`，多组 Overview 输出 `groups`，不建立跨组 leaderboard；实验组 Page 的 `comparison` 输出成员、各成员 distinct Eval coverage 与组内 Eval 并集大小。population 不同不会产生另一种状态。
 
 报告样式只有一个产品 owner：Report CSS 负责 reset、基础排版、theme token 消费和所有报告组件。View shell 左侧放品牌，中间居中整个
-Page router，右侧放实验与语言两个原生选择器；Page router 无论含一个还是多个 Page 都作为整体居中。Shell 不重绘 Report 内容。
+Page router，右侧先放 Host 已关闭的实验导航选择器、再放语言选择器；两者都是原生控件。Page router 无论含一个还是多个 Page 都作为整体居中。Shell 不解释 raw role、params 或 Analysis，也不重绘 Report 内容。
 
 每个报告只有一个根 document。作者可声明多个业务 Page；Hash router 把它们呈现在同一 document 中。Page 的 `presentation` 明确为 `page` 或 `overlay`。Attempt、Source 和 Diff 使用 `overlay`，不是独立业务 Page。overlay 使用半透明黑色 backdrop，保留当前业务 Page 作为可见上下文，内容面板保持不透明。点击内容外侧、按 Escape、点击关闭按钮或浏览器返回都会关闭 overlay 并恢复前一 hash。
 完整边界见 [Architecture](architecture.md#css、theme-与-view-shell)。

--- a/docs/feature/reports/architecture.md
+++ b/docs/feature/reports/architecture.md
@@ -24,7 +24,7 @@ enumerate every Page instance → execute every Page → validate site → Close
 `show` 只执行目标 Page。省略 `--page` 时使用 Report 的默认 route；带 `--page` 时使用精确 route。它不枚举参数 Page，
 不执行其它 Page，也不创建 site revision。
 
-`--experiment <selector>` 与 `niceeval exp <selector>` 使用同一实验选择规则并形成固定 Sample；Report 不增加另一套实验组 CLI selector。浏览器只沿 Report 内容交付的 Page 链接导航，不重新选择 Sample；通用 shell 不识别实验组。
+`--experiment <selector>` 与 `niceeval exp <selector>` 使用同一实验选择规则并形成固定 Sample；Report 不增加另一套实验组 CLI selector。浏览器不重新选择 Sample。全站关闭时，Host 把显式实验组 Page role 与已验证的 parameter identity 一次性投影成纯 route/label 选项；通用 shell 只呈现这份闭合导航值，不读取 raw role、params 或 Analysis。
 
 `view` 和 `view --out` 先要求固定 Sample 至少选中一个 logical Slot，再枚举全部普通 Page 与参数 Page 实例。零选中结果是
 `report-sample-empty` 输入错误，不形成 revision。只有所有页面、route、链接、下载、asset、问题表和预算通过校验，Host 才形成
@@ -82,7 +82,7 @@ target-execution manifest；它不能借用或伪造 revision identity。
 `theme.ts` 只定义 theme token 与 token 值；它不新增 reset、布局 selector 或组件样式。`styles.css` 是 token 的唯一消费者。
 作者通过结构化 `head` 提供的样式只能服务自己的具名内容，不能建立另一套 reset、theme 或 View shell。
 
-View shell 只拥有浏览器语言切换、reload 状态、Host 错误提示和通用 Page 导航。品牌位于左侧，完整 Page router 作为一个整体居中，右侧只承载语言选择。实验组选择属于标准 Report 的已闭合内容与链接，不由通用 shell 读取 `role` 或生成 selector。
+View shell 只拥有浏览器语言切换、reload 状态、Host 错误提示和通用 Page 导航。品牌位于左侧，完整 Page router 作为一个整体居中；右侧先呈现可选的闭合实验导航，再呈现语言选择。实验 selector 仅在至少两个选项且当前基础 Page 精确命中一个 option route 时出现。通用 shell 不读取 `role`、parameter identity 或 Analysis，也不自行生成实验分组。
 
 Shell 不读取 Analysis、不在浏览器计算比较范围、
 不注入第二份产品 CSS，也不重绘已关闭的 Report 内容。

--- a/docs/feature/reports/library.md
+++ b/docs/feature/reports/library.md
@@ -214,9 +214,9 @@ type Page<Params extends JsonValue | void = void, Input = Sample> =
     : ParameterizedPage<Extract<Params, JsonValue>, Input>;
 ```
 
-`role.kind: "experiment-group"` 只参与标准 Report 在关闭阶段形成 `ExperimentComparisonScope`；它不进入通用客户端 manifest，也不驱动 Host shell UI。实验组访问入口由标准 Report 自己渲染为普通 Page 链接。未声明该 role 时不补造 Page、route 或选择器。
+`role.kind: "experiment-group"` 在最后一个同时拥有 Page declaration 与已关闭 parameter instance 的 Host 边界形成实验导航投影。role 和 raw params 不进入客户端 manifest；manifest 只携带按 canonical route 排序的 `{ route, label }` 闭合选项，通用 Header 据此呈现原生 selector。未声明该 role 时不补造 Page、route 或选择器，也不从 title、page id 或 path 猜测。
 
-参数 Page 仍只消费一个 canonical key segment。标准 Report 因此显式声明 `path: "/group/named"` 和 `path: "/group/singleton"` 两个 Page，并用它们形成 canonical hash。标准 Report 内容链接直接指向这些最终 hash route；禁用 JavaScript 时根 shell 明确报错。
+参数 Page 仍只消费一个 canonical key segment。标准 Report 因此显式声明 `path: "/group/named"` 和 `path: "/group/singleton"` 两个 Page，并用它们形成 canonical hash。named role 的 `groupId`、singleton role 的 `experimentId` 必须与本轮已经验证的 canonical key 原文相同；无效或歧义 role 使整站关闭失败。根入口进入稳定排序的第一组，禁用 JavaScript 时根 shell 明确报错。
 
 标准实验组 Page 是完整的 scoped Overview，不是只替换 Experiment Table。它把 `ExperimentComparisonScope` 的 backing Sample 显式交给 Hero、`SampleNotices` 与 `SampleSummary`，再把同一 scope 交给 `ExperimentScatter` 和 `ExperimentTable`。因此告警数、Pass rate、Experiments、Evals、Attempts、Eval results、Total cost 与 Run range 都随选择范围变化。
 

--- a/e2e/report/test/report.browser.spec.ts
+++ b/e2e/report/test/report.browser.spec.ts
@@ -1,4 +1,5 @@
 // owner: docs/engineering/testing/e2e/report.md#report-browser-journey
+// regression: memory/report-header-experiment-selector-regression.md
 // rerun: pnpm e2e test --repo report -- --run test/report.browser.spec.ts
 //
 // This Journey observes only the installed candidate, exported files, HTTP,
@@ -6,7 +7,7 @@
 
 import { pollUntil, waitForOutput } from "@niceeval/testkit";
 import { createServer, type Server } from "node:http";
-import { readFile, readdir, stat } from "node:fs/promises";
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { expect, test } from "@playwright/test";
@@ -48,6 +49,7 @@ test("静态站与 view 只交付 SPA shell；普通页面使用 hash 和 fragme
         try {
           await page.goto(new URL("index.html", staticServer.origin).href);
           await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
+          await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);
           const fragment = page.waitForRequest((request) =>
             request.url() === new URL("_niceeval/fragments/source.json", staticServer.origin).href,
           );
@@ -80,12 +82,28 @@ test("静态站与 view 只交付 SPA shell；普通页面使用 hash 和 fragme
   );
 });
 
-test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 overlay", async ({ browser }) => {
+test("经典报告默认并切换实验组，Attempt 作为可分享、可关闭并保留历史的 overlay", async ({ browser }) => {
   test.setTimeout(180_000);
   await reportE2E.case(
     "browser-classic-attempt-overlay",
     { artifacts: reportCaseArtifacts() },
-    async ({ commands: { niceeval } }) => {
+    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
+      await writeFile(
+        join(projectRoot, "experiments", "classic.ts"),
+        `import { defineExperiment } from "niceeval";
+import { deterministicAgent } from "../agents/deterministic.ts";
+
+const agent = deterministicAgent("report-group-label-collision", 0.00002);
+
+export default defineExperiment({
+  description: "classic: root Experiment that shares a label with the classic/* named group",
+  agent,
+  model: "report-fixture-v1",
+  evals: ["deliberate-fail"],
+});
+`,
+        "utf8",
+      );
       for (const id of [
         "classic/baseline",
         "classic/memory-a",
@@ -105,7 +123,60 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
       const page = await browser.newPage();
       try {
         await page.goto(origin!);
+        await expect(page).toHaveURL(/#\/group\/named\/classic$/);
         await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
+
+        // A single group is still the default comparison, without wasting
+        // Header space on a one-option selector.
+        await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);
+
+        // Adding a root Experiment creates a legal label collision with the
+        // classic/* named group. The live revision exposes two unambiguous,
+        // stable options and keeps the current group selected.
+        const collisionRun = await niceeval.run(["exp", "classic", "--rerun", "all", "--json"]);
+        expect(collisionRun.expReceipt(), collisionRun.diagnostic()).toMatchObject({ completion: "completed" });
+        const experimentSelector = page.getByRole("combobox", { name: "Experiments" });
+        await expect(experimentSelector).toBeVisible({ timeout: 15_000 });
+        await expect(experimentSelector.getByRole("option")).toHaveText([
+          "named/classic",
+          "singleton/classic",
+        ]);
+        await expect(experimentSelector).toHaveValue("/group/named/classic");
+
+        const comboboxes = page.getByRole("combobox");
+        await expect(comboboxes).toHaveCount(2);
+        await expect(comboboxes.nth(0)).toHaveAccessibleName("Experiments");
+        await expect(comboboxes.nth(1)).toHaveAccessibleName("Language");
+
+        const overview = page.getByRole("link", { name: "Overview" });
+        await expect(overview).toHaveAttribute("href", "#/group/named/classic");
+        await expect(overview).toHaveAttribute("aria-current", "page");
+
+        await experimentSelector.selectOption("/group/singleton/classic");
+        await expect(page).toHaveURL(/#\/group\/singleton\/classic$/);
+        await expect(experimentSelector).toHaveValue("/group/singleton/classic");
+        await expect(page.getByText("classic (1/1)", { exact: true })).toBeVisible();
+
+        await page.goBack();
+        await expect(page).toHaveURL(/#\/group\/named\/classic$/);
+        await expect(experimentSelector).toHaveValue("/group/named/classic");
+        await expect(page.getByText("classic/memory-a (9/9)", { exact: true })).toBeVisible();
+        await page.goForward();
+        await expect(page).toHaveURL(/#\/group\/singleton\/classic$/);
+        await expect(experimentSelector).toHaveValue("/group/singleton/classic");
+
+        await experimentSelector.selectOption("/group/named/classic");
+        await expect(page).toHaveURL(/#\/group\/named\/classic$/);
+        const englishRoute = page.url();
+        const languageSelector = page.getByRole("combobox", { name: "Language" });
+        await languageSelector.selectOption("zh-CN");
+        expect(page.url()).toBe(englishRoute);
+        await expect(page.locator("html")).toHaveAttribute("lang", "zh-CN");
+        await expect(page.getByRole("combobox", { name: "实验" })).toHaveValue("/group/named/classic");
+        await expect(page.getByRole("link", { name: "总览" })).toHaveAttribute("href", "#/group/named/classic");
+        await languageSelector.selectOption("en");
+        await expect(page.locator("html")).toHaveAttribute("lang", "en");
+
         const experiment = page.locator('a[href^="#/experiment/"]').filter({
           has: page.locator("title").filter({ hasText: "classic/memory-a" }),
         });
@@ -127,6 +198,7 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
         await expect(scoreExperimentSummary).toContainText("7");
         await expect(scoreExperimentSummary).not.toContainText("missed check");
         await expect(scoreExperimentSummary).not.toContainText("passed");
+
         await experiment.click();
         await expect(page).toHaveURL(/#\/experiment\//);
         await expect(dialog).toBeVisible();
@@ -189,7 +261,7 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
         const copiedUrl = page.url();
         await page.getByRole("button", { name: "Close" }).click();
         await expect(dialog).not.toBeVisible();
-        expect(new URL(page.url()).hash).toBe("");
+        expect(new URL(page.url()).hash).toBe("#/group/named/classic");
         expect(overlayRequests).toEqual([detail.href]);
 
         await page.goForward();
@@ -209,13 +281,21 @@ test("经典报告将 Attempt 作为可分享、可关闭并保留历史的 over
           await shared.goto(copiedUrl);
           await expect(shared.getByRole("dialog")).toBeVisible();
           await expect(shared.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
+          await shared.getByRole("button", { name: "Close" }).click();
+          await expect(shared.getByRole("dialog")).not.toBeVisible();
+          await expect(shared).toHaveURL(/#\/group\/named\/classic$/);
+          const directSelector = shared.getByRole("combobox", { name: "Experiments" });
+          await expect(directSelector).toHaveValue("/group/named/classic");
+          await directSelector.selectOption("/group/singleton/classic");
+          await expect(shared).toHaveURL(/#\/group\/singleton\/classic$/);
+          await expect(shared.getByRole("dialog")).not.toBeVisible();
         } finally {
           await shared.close();
         }
 
         await page.mouse.click(5, 5);
         await expect(dialog).not.toBeVisible();
-        expect(new URL(page.url()).hash).toBe("");
+        expect(new URL(page.url()).hash).toBe("#/group/named/classic");
 
         const baselineSummary = page.locator("summary").filter({ hasText: /^classic\/baseline \(9\/9\)/ }).first();
         if (await baselineSummary.locator("xpath=..").getAttribute("open") === null) await baselineSummary.click();

--- a/feedback/20260824111930-report-header-experiment-selector/README.md
+++ b/feedback/20260824111930-report-header-experiment-selector/README.md
@@ -1,0 +1,29 @@
+---
+format: niceeval.feedback/v1
+id: 20260824111930-report-header-experiment-selector
+title: Report Header 实验选择器回归为未选择索引
+state: open
+reportedAt: 2026-08-24T11:19:30+08:00
+source:
+  kind: dogfood
+  repository: NiceEval/NiceEval-Preview
+  originId: preview-pr-108-header-experiment-selector
+  commit: 587f07590bb8f1883b30feade86c5af6220b58f2
+subject: product
+claim: defect
+observation: 这里有一个回归bug吧，之前说实验选择应该是在head在语言选择的左边，没有选的时候默认选第一个，什么时候又回归成这种了
+impact: 包含多个实验组的 Report 打开根 URL 后显示未选择范围的实验链接索引，Header 只有语言选择器。读者不能立即看到一个具体实验范围，也不能从语言选择左侧直接切换实验。
+adoptedContract:
+  path: docs/engineering/testing/e2e/report.md
+  anchor: report-browser-journey
+memoryRelations:
+  - kind: root-cause
+    memory: report-header-experiment-selector-regression
+---
+## Reporter observation
+
+> 这里有一个回归bug吧，之前说实验选择应该是在head在语言选择的左边，没有选的时候默认选第一个，什么时候又回归成这种了
+
+## Provenance
+
+在 NiceEval PR #108 的 Netlify Report preview 根页面观察到。公开页面包含 gallery、judge-unavailable、sandbox-group、sandbox-reuse 与 states 五个实验范围，却只显示正文链接索引；Header 右侧只有语言选择。

--- a/feedback/20260824111930-report-header-experiment-selector/README.md
+++ b/feedback/20260824111930-report-header-experiment-selector/README.md
@@ -2,7 +2,7 @@
 format: niceeval.feedback/v1
 id: 20260824111930-report-header-experiment-selector
 title: Report Header 实验选择器回归为未选择索引
-state: open
+state: closed
 reportedAt: 2026-08-24T11:19:30+08:00
 source:
   kind: dogfood
@@ -19,6 +19,12 @@ adoptedContract:
 memoryRelations:
   - kind: root-cause
     memory: report-header-experiment-selector-regression
+closure:
+  kind: fixed
+  memory: report-header-experiment-selector-regression
+  proof:
+    - Public Netlify preview https://deploy-preview-108--niceeval-report-preview.netlify.app on commit 3756e5c479762f76dc5c6d499dd57b5781decd13 defaults to gallery, renders the Experiments selector immediately before Language, exposes five stable options, and switches to the scoped states page.
+    - Installed-candidate E2E and reliability takeover passed for e2e/report/test/report.browser.spec.ts with candidate SHA-256 4c26ab7f9a42890dfe2a3e37e1e353baab56e262f026a5c92967b07b8e5ec693.
 ---
 ## Reporter observation
 

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -309,6 +309,7 @@ memory 的召回全靠这份索引:漏索引的条目等于不存在。维护规
 
 ### 台账
 
+- [report-header-experiment-selector-regression](report-header-experiment-selector-regression.md) — Report SPA 合并时丢掉实验组导航投影，根页退化成未选范围的链接索引且 Header 只剩语言；修法是 closure 交付闭合 route/label、根入口默认第一组并恢复语言左侧原生 selector
 - 已修 [record-only-assertions-labeled-soft](record-only-assertions-labeled-soft.md) — Attempt 展开把未计分 Assertion 标成 `soft`，正常 `notCalledTool` 看不出这是已记录的零命中结果；改为 `recorded passed/failed/unavailable`，并由浏览器 E2E 守住零命中与决定性见证
 - 已修 [commandsucceeded-received-excerpt-not-tail](commandsucceeded-received-excerpt-not-tail.md) — commandSucceeded 失败摘录曾落在输出中段:合并顺序(stdout 前置让 stderr 装包噪声占末尾)+ 摘录窗口宽过终端行预算被从头收口,双因叠加;修为 stderr 在前合并 + 76 字符窗口(src/context/context.ts),合并顺序钉进 display.md;同批裁决 commands.json 落盘不截
 - 已修 [show-locator-scoped-to-current-sample](show-locator-scoped-to-current-sample.md) — `show @<locator>` 曾在 resolveLocator 之后拿 `currentSample().attempts`(现刻水位,同 evalId 只留最新)二次筛,`--history` 印出的历史 attempt 一律报「outside the selected record scope」这第四种失败,违反「作用域是一个记录根」契约;修为删掉二次筛(src/show/index.ts),身份直达不复核范围

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -309,7 +309,7 @@ memory 的召回全靠这份索引:漏索引的条目等于不存在。维护规
 
 ### 台账
 
-- [report-header-experiment-selector-regression](report-header-experiment-selector-regression.md) — Report SPA 合并时丢掉实验组导航投影，根页退化成未选范围的链接索引且 Header 只剩语言；修法是 closure 交付闭合 route/label、根入口默认第一组并恢复语言左侧原生 selector
+- 已修 [report-header-experiment-selector-regression](report-header-experiment-selector-regression.md) — Report SPA 合并时丢掉实验组导航投影，根页退化成未选范围的链接索引且 Header 只剩语言；修法是 closure 交付闭合 route/label、根入口默认第一组并恢复语言左侧原生 selector
 - 已修 [record-only-assertions-labeled-soft](record-only-assertions-labeled-soft.md) — Attempt 展开把未计分 Assertion 标成 `soft`，正常 `notCalledTool` 看不出这是已记录的零命中结果；改为 `recorded passed/failed/unavailable`，并由浏览器 E2E 守住零命中与决定性见证
 - 已修 [commandsucceeded-received-excerpt-not-tail](commandsucceeded-received-excerpt-not-tail.md) — commandSucceeded 失败摘录曾落在输出中段:合并顺序(stdout 前置让 stderr 装包噪声占末尾)+ 摘录窗口宽过终端行预算被从头收口,双因叠加;修为 stderr 在前合并 + 76 字符窗口(src/context/context.ts),合并顺序钉进 display.md;同批裁决 commands.json 落盘不截
 - 已修 [show-locator-scoped-to-current-sample](show-locator-scoped-to-current-sample.md) — `show @<locator>` 曾在 resolveLocator 之后拿 `currentSample().attempts`(现刻水位,同 evalId 只留最新)二次筛,`--history` 印出的历史 attempt 一律报「outside the selected record scope」这第四种失败,违反「作用域是一个记录根」契约;修为删掉二次筛(src/show/index.ts),身份直达不复核范围

--- a/memory/report-header-experiment-selector-regression.md
+++ b/memory/report-header-experiment-selector-regression.md
@@ -5,7 +5,14 @@ title: Report SPA 丢失 Header 实验选择器与默认实验组
 createdAt: 2026-08-24T11:19:30+08:00
 kind:
   type: problem
-  state: open
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - "E2E red: fix-parent dc3f89c243de2214555960dc9e48d7356a48157f installed candidate 3465f8f1fa110c0303c3efd4f9478247f46438e83e51fe059a14670286aaf4f2 failed e2e/report/test/report.browser.spec.ts at the earliest public root URL assertion: received /, expected #/group/named/classic."
+      - "E2E green: candidate 4c26ab7f9a42890dfe2a3e37e1e353baab56e262f026a5c92967b07b8e5ec693 ran pnpm e2e test --repo report -- --run test/report.browser.spec.ts with 2 passed; the selector Journey covered default route, Header order, group switching, Back/Forward, locale, overlay, and deep link."
+      - "E2E reliability takeover: /tmp/niceeval-report-selector-takeover.PHx3Hw completed 3 isolated copies, same-copy repeat, repo-default-parallel 6 files / 13 tests, and target-single with category pass and scratch cleanup ok."
+      - "Public regression check: https://deploy-preview-108--niceeval-report-preview.netlify.app at NiceEval commit 3756e5c479762f76dc5c6d499dd57b5781decd13 defaulted to #/group/named/gallery, exposed Experiments=gallery before Language=EN with five options, and switching states produced #/group/singleton/states plus the scoped 1 experiment / 5 eval results."
 promotions: []
 ---
 ## Problem

--- a/memory/report-header-experiment-selector-regression.md
+++ b/memory/report-header-experiment-selector-regression.md
@@ -1,0 +1,34 @@
+---
+format: niceeval.memory/v1
+id: report-header-experiment-selector-regression
+title: Report SPA 丢失 Header 实验选择器与默认实验组
+createdAt: 2026-08-24T11:19:30+08:00
+kind:
+  type: problem
+  state: open
+promotions: []
+---
+## Problem
+
+包含多个实验组的标准 Report 应在 Header 的语言选择左侧显示原生实验选择器，并在根 URL 没有显式 hash 时稳定进入第一组。当前 SPA 打开 `/`，显示一个未选择范围的实验链接索引；Header 只显示语言选择。
+
+长期 owner `docs/engineering/testing/e2e/report.md#report-browser-journey` 仍明确要求默认第一组与始终有值的 Header selector。`docs/feature/reports/README.md` 的 CSS/View shell 摘要也仍写两个原生选择器，但同页前文和 `architecture.md` 被改成内容链接与只显示语言，形成互相矛盾的目标。
+
+## Root cause
+
+提交 `e077c1c15e9f25a2b8959be9cd1da3fc044fed09`（PR #85）统一 Report SPA 时，没有把旧静态 shell 的 experiment-group 导航迁入新 manifest/client：
+
+- 新 `App.tsx` 只渲染语言 selector；
+- `landingPage()` 改为第一个普通 `presentation: page`，使标准 Overview `/` 成为默认 route；
+- manifest 不再携带客户端形成实验选择所需的已闭合 group route/label；
+- 同一 PR 删除了浏览器 owner 对 `Experiments` combobox、默认第一组和切换后 scoped 内容的断言。
+
+旧 CSS selector 仍在，说明退化不是样式隐藏，而是产品控件和默认路由语义被移除。
+
+## Regression proof
+
+修复必须先加强既有 `e2e/report/test/report.browser.spec.ts`，从安装后的 fix-parent candidate 经真实 `niceeval view` 与 Chromium 取得红灯。断言只观察根 URL、Header combobox、真实 option/href 导航和 scoped Page 内容，不读取 Record 或 manifest 私有实现。
+
+## Repair boundary
+
+恢复行为时只把 Host 已闭合的实验组 route 与显示标签交付给 app client；浏览器不读取 Analysis、不重新分组，也不执行作者 callback。根 URL 的默认 route 与 selector options 必须来自同一次已验证 revision，稳定排序规则只有 Host 一处 owner。

--- a/netlify-preview/build-report-preview.sh
+++ b/netlify-preview/build-report-preview.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 readonly SCRIPT_DIRECTORY="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly NICEEVAL_ROOT="$(cd -- "$SCRIPT_DIRECTORY/.." && pwd)"
-readonly MEMORYBENCH_REPOSITORY="https://github.com/NiceEval/MemoryBench.git"
-readonly MEMORYBENCH_BRANCH="2-0"
+readonly PREVIEW_REPOSITORY="${NICEEVAL_PREVIEW_REPOSITORY:-https://github.com/NiceEval/NiceEval-Preview.git}"
+readonly PREVIEW_REF="${NICEEVAL_PREVIEW_REF:-main}"
 readonly PUBLISH_DIRECTORY="$NICEEVAL_ROOT/netlify-report-preview"
 
 if [[ "${CONTEXT:-}" != "deploy-preview" ]]; then
@@ -21,21 +21,22 @@ PREVIEW_SCRATCH="$(mktemp -d)"
 mkdir -p "$NICEEVAL_ROOT/.netlify"
 PACKAGE_SCRATCH="$(mktemp -d "$NICEEVAL_ROOT/.netlify/package-runtime.XXXXXX")"
 trap 'rm -rf "$PREVIEW_SCRATCH" "$PACKAGE_SCRATCH"' EXIT
-readonly MEMORYBENCH_ROOT="$PREVIEW_SCRATCH/MemoryBench"
+readonly PREVIEW_ROOT="$PREVIEW_SCRATCH/NiceEval-Preview"
 
-git clone --filter=blob:none --single-branch --branch "$MEMORYBENCH_BRANCH" \
-  "$MEMORYBENCH_REPOSITORY" "$MEMORYBENCH_ROOT"
+git clone --filter=blob:none --single-branch --branch "$PREVIEW_REF" \
+  "$PREVIEW_REPOSITORY" "$PREVIEW_ROOT"
+echo "NiceEval preview fixture: $(git -C "$PREVIEW_ROOT" rev-parse HEAD)"
 
 # Netlify installs the isolated netlify-preview base, not the repository root.
 # Build the linked candidate from the root lockfile rather than a stale cache.
 corepack pnpm@11.18.0 --dir "$NICEEVAL_ROOT" install --frozen-lockfile --ignore-scripts
-corepack pnpm@11.10.0 --dir "$MEMORYBENCH_ROOT" install --frozen-lockfile
+corepack pnpm@11.18.0 --dir "$PREVIEW_ROOT" install --frozen-lockfile
 TMPDIR="$PACKAGE_SCRATCH" \
-corepack pnpm@11.18.0 --dir "$NICEEVAL_ROOT" consumer:link apply "$MEMORYBENCH_ROOT"
+corepack pnpm@11.18.0 --dir "$NICEEVAL_ROOT" consumer:link apply "$PREVIEW_ROOT"
 
-corepack pnpm@11.10.0 --dir "$MEMORYBENCH_ROOT" exec niceeval --version
+corepack pnpm@11.18.0 --dir "$PREVIEW_ROOT" exec niceeval --version
+# Keep V8's old-space collector inside the preview's fixed Report RSS budget;
+# the product budget remains unchanged and still rejects real excess output.
 NODE_OPTIONS="--max-old-space-size=1024" \
-CODEX_BASE_URL="https://preview.invalid/v1" \
-CODEX_API_KEY="netlify-report-preview-no-secret" \
-corepack pnpm@11.10.0 --dir "$MEMORYBENCH_ROOT" exec niceeval view \
+corepack pnpm@11.18.0 --dir "$PREVIEW_ROOT" exec niceeval view \
   --out "$PUBLISH_DIRECTORY"

--- a/packages/niceeval/src/report/client/App.tsx
+++ b/packages/niceeval/src/report/client/App.tsx
@@ -234,6 +234,11 @@ export function App({
   const pages = manifest.pages.filter(
     (page) => page.presentation === "page" && page.navigation,
   );
+  const experimentOptions = manifest.experimentSelection?.options ?? [];
+  const currentExperiment = experimentOptions.find(
+    (option) => option.route === visible?.route,
+  );
+  const experimentLabel = locale === "zh-CN" ? "实验" : "Experiments";
   return (
     <div onClickCapture={onDocumentClick}>
       <header className="niceeval-view-shell">
@@ -255,9 +260,14 @@ export function App({
               {pages.map((page) => (
                 <li key={page.pageId}>
                   <a
-                    href={`#${page.route}`}
+                    href={`#${page.route === "/" && currentExperiment !== undefined
+                      ? currentExperiment.route
+                      : page.route}`}
                     aria-current={
-                      visible?.route === page.route ? "page" : undefined
+                      visible?.route === page.route ||
+                        (page.route === "/" && currentExperiment !== undefined)
+                        ? "page"
+                        : undefined
                     }
                   >
                     {localized(page.title, locale)}
@@ -268,6 +278,31 @@ export function App({
           </nav>
         </div>
         <div className="niceeval-view-controls">
+          {experimentOptions.length >= 2 && currentExperiment !== undefined && (
+            <div className="niceeval-view-experiment">
+              <label>
+                <span>{experimentLabel}</span>
+                <select
+                  aria-label={experimentLabel}
+                  value={currentExperiment.route}
+                  onChange={(event) => {
+                    const route = event.target.value;
+                    if (route !== currentExperiment.route) {
+                      navigate(route, {
+                        replace: current?.presentation === "overlay",
+                      });
+                    }
+                  }}
+                >
+                  {experimentOptions.map((option) => (
+                    <option key={option.route} value={option.route}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          )}
           <label className="niceeval-view-language">
             <select
               aria-label="Language"

--- a/packages/niceeval/src/report/client/types.ts
+++ b/packages/niceeval/src/report/client/types.ts
@@ -17,6 +17,12 @@ export interface ReportPageManifest {
 export interface ReportManifest {
   readonly title: LocalizedText;
   readonly defaultRoute: string;
+  readonly experimentSelection?: {
+    readonly options: readonly {
+      readonly route: string;
+      readonly label: string;
+    }[];
+  };
   readonly pages: readonly ReportPageManifest[];
 }
 

--- a/packages/niceeval/src/report/host/execute.ts
+++ b/packages/niceeval/src/report/host/execute.ts
@@ -107,6 +107,13 @@ export interface ReportSiteRouteConflict {
   readonly pageIds: readonly [string, string];
 }
 
+export interface ReportExperimentSelectionInvalid {
+  readonly code: "report-experiment-selection-invalid";
+  readonly pageId: string;
+  readonly route: string;
+  readonly reason: string;
+}
+
 export type ReportExecutionError =
   | SampleClosedError
   | AnalysisRequestError
@@ -115,6 +122,7 @@ export type ReportExecutionError =
   | ReportTargetRouteInvalid
   | ReportPageExecutionFailed
   | ReportSiteRouteConflict
+  | ReportExperimentSelectionInvalid
   | ReportProjectionBuildFailure
   | ReportBuildBudgetExceeded;
 
@@ -130,6 +138,13 @@ export interface ClosedSitePage {
   readonly presentation: "page" | "overlay";
 }
 
+export interface ClosedExperimentSelection {
+  readonly options: readonly {
+    readonly route: string;
+    readonly label: string;
+  }[];
+}
+
 /** Host-private complete page closure used only while forming a revision. */
 export interface ClosedReportSite {
   /** Monotonic-enough wall clock anchor for the full Sample-open + byte build budget. */
@@ -141,6 +156,7 @@ export interface ClosedReportSite {
   readonly title: import("../model/locale.ts").LocalizedText;
   readonly theme?: ThemeDefinition;
   readonly pages: readonly ClosedSitePage[];
+  readonly experimentSelection?: ClosedExperimentSelection;
   readonly projections: ReportProjections;
   readonly problems: readonly ReportProblem[];
 }
@@ -209,6 +225,7 @@ export function executeReportSite(input: {
     return yield* Effect.ensuring(
       Effect.gen(function* () {
         const pages: ClosedSitePage[] = [];
+        const experimentSelectionCandidates: ExperimentSelectionCandidate[] = [];
         const routeOwners = new Map<string, string>();
         const siteProblems: ReportProblem[] = [];
         const projectionCosts: ReportProjectionCostInput[] = [];
@@ -288,6 +305,16 @@ export function executeReportSite(input: {
               capturePage: (capture) => capturedProjectionCosts(capture, route, definition.id),
             });
             yield* addSitePage(pages, routeOwners, page, false, definition.presentation);
+            const candidate = experimentSelectionCandidate({
+              role: definition.role,
+              presentation: definition.presentation,
+              key,
+              page,
+            });
+            if (candidate !== undefined && "code" in candidate) {
+              return yield* Effect.fail(candidate);
+            }
+            if (candidate !== undefined) experimentSelectionCandidates.push(candidate);
             yield* registerProjectionCosts(pricingProfile, projectionCosts, pageCosts);
             siteProblems.push(...analysisProblems(issues, page.target.pageId));
             yield* checkBuildBudgets(input.budget);
@@ -295,6 +322,10 @@ export function executeReportSite(input: {
         }
 
         siteProblems.push(...analysisProblems(outerCapture.issues()));
+        const experimentSelection = closeExperimentSelection(experimentSelectionCandidates);
+        if (experimentSelection !== undefined && "code" in experimentSelection) {
+          return yield* Effect.fail(experimentSelection);
+        }
 
         return Object.freeze({
           startedAtMs,
@@ -304,6 +335,7 @@ export function executeReportSite(input: {
           title: resolveReportTitle(input.report),
           ...(input.report.theme === undefined ? {} : { theme: input.report.theme }),
           pages: Object.freeze(pages),
+          ...(experimentSelection === undefined ? {} : { experimentSelection }),
           projections: buildReportProjections({
             pricingProfile,
             costs: projectionCosts,
@@ -552,6 +584,102 @@ function invokeAuthor<Value>(
   });
 }
 
+interface ExperimentSelectionCandidate {
+  readonly pageId: string;
+  readonly route: string;
+  readonly identity: string;
+  readonly taggedIdentity: string;
+}
+
+function experimentSelectionCandidate(input: {
+  readonly role?: {
+    readonly kind: "experiment-group";
+    readonly groupKind: "named" | "singleton";
+  };
+  readonly presentation: "page" | "overlay";
+  readonly key: string;
+  readonly page: ResolvedPage;
+}): ExperimentSelectionCandidate | ReportExperimentSelectionInvalid | undefined {
+  if (input.role === undefined) return undefined;
+  if (input.presentation !== "page") {
+    return experimentSelectionInvalid(input.page, "an experiment-group Page must use page presentation");
+  }
+  const params = input.page.target.params;
+  const field = input.role.groupKind === "named" ? "groupId" : "experimentId";
+  const identity = typeof params === "object" && params !== null && !Array.isArray(params)
+    ? Reflect.get(params, field)
+    : undefined;
+  if (typeof identity !== "string" || identity.length === 0) {
+    return experimentSelectionInvalid(
+      input.page,
+      `an ${input.role.groupKind} experiment-group Page requires a non-empty ${field}`,
+    );
+  }
+  if (identity !== input.key) {
+    return experimentSelectionInvalid(
+      input.page,
+      `${field} must equal the canonical parameter key`,
+    );
+  }
+  return Object.freeze({
+    pageId: input.page.target.pageId,
+    route: input.page.target.route,
+    identity,
+    taggedIdentity: `${input.role.groupKind}/${identity}`,
+  });
+}
+
+function closeExperimentSelection(
+  candidates: readonly ExperimentSelectionCandidate[],
+): ClosedExperimentSelection | ReportExperimentSelectionInvalid | undefined {
+  if (candidates.length === 0) return undefined;
+  const byTaggedIdentity = new Map<string, ExperimentSelectionCandidate>();
+  for (const candidate of candidates) {
+    const prior = byTaggedIdentity.get(candidate.taggedIdentity);
+    if (prior !== undefined) {
+      return experimentSelectionInvalid(
+        candidate,
+        `${candidate.taggedIdentity} is already owned by ${prior.pageId} at ${prior.route}`,
+      );
+    }
+    byTaggedIdentity.set(candidate.taggedIdentity, candidate);
+  }
+  const labelCounts = new Map<string, number>();
+  for (const candidate of candidates) {
+    labelCounts.set(candidate.identity, (labelCounts.get(candidate.identity) ?? 0) + 1);
+  }
+  const options = candidates.map((candidate) => Object.freeze({
+    route: candidate.route,
+    label: labelCounts.get(candidate.identity) === 1
+      ? candidate.identity
+      : candidate.taggedIdentity,
+  })).sort((left, right) => compareUtf8(left.route, right.route));
+  const labels = new Set<string>();
+  for (const option of options) {
+    if (labels.has(option.label)) {
+      const candidate = candidates.find((entry) => entry.route === option.route)!;
+      return experimentSelectionInvalid(candidate, `closed experiment label ${option.label} is ambiguous`);
+    }
+    labels.add(option.label);
+  }
+  return Object.freeze({ options: Object.freeze(options) });
+}
+
+function experimentSelectionInvalid(
+  page: Pick<ResolvedPage, "target"> | Pick<ExperimentSelectionCandidate, "pageId" | "route">,
+  reason: string,
+): ReportExperimentSelectionInvalid {
+  const target = "target" in page
+    ? { pageId: page.target.pageId, route: page.target.route }
+    : page;
+  return Object.freeze({
+    code: "report-experiment-selection-invalid" as const,
+    pageId: target.pageId,
+    route: target.route,
+    reason: reason.slice(0, 512),
+  });
+}
+
 function addSitePage(
   pages: ClosedSitePage[],
   routeOwners: Map<string, string>,
@@ -724,6 +852,7 @@ export function reportDefinitionIdentity(report: ReportDefinition): string {
       title: page.title,
       navigation: page.navigation,
       presentation: page.presentation,
+      role: "role" in page ? page.role ?? null : null,
       parameterized: page.params !== undefined,
       load: page.load?.toString() ?? null,
       render: page.render.toString(),

--- a/packages/niceeval/src/report/host/static.ts
+++ b/packages/niceeval/src/report/host/static.ts
@@ -40,7 +40,11 @@ import {
   themeStylesheet,
   type ThemeDefinition,
 } from "../theme.ts";
-import type { ClosedReportSite, ClosedSitePage } from "./execute.ts";
+import type {
+  ClosedExperimentSelection,
+  ClosedReportSite,
+  ClosedSitePage,
+} from "./execute.ts";
 import {
   REPORT_STYLESHEET_PATH,
 } from "./site-assets.ts";
@@ -295,7 +299,8 @@ function buildSiteFiles(site: ClosedReportSite, theme: ThemeDefinition): readonl
   add(projections, hostStaticPath(projections.path));
 
   assertAssetBudgets(files, site.pages);
-  const landing = landingPage(pages);
+  const experimentSelection = validateExperimentSelection(site.experimentSelection, pages);
+  const defaultRoute = experimentSelection?.options[0]?.route ?? landingPage(pages).page.target.route;
   const manifestValue = Object.freeze({
     format: "niceeval.report-static/v2",
     sampleIdentity: site.sampleIdentity,
@@ -304,7 +309,8 @@ function buildSiteFiles(site: ClosedReportSite, theme: ThemeDefinition): readonl
       en: resolveLocalizedText(site.title, "en"),
       "zh-CN": resolveLocalizedText(site.title, "zh-CN"),
     },
-    defaultRoute: landing.page.target.route,
+    defaultRoute,
+    ...(experimentSelection === undefined ? {} : { experimentSelection }),
     pages: pages.map((entry) => Object.freeze({
       pageId: entry.page.target.pageId,
       route: entry.page.target.route,
@@ -374,6 +380,37 @@ function landingPage(pages: readonly ClosedSitePage[]): ClosedSitePage {
   const landing = pages.find((entry) => entry.presentation === "page");
   if (landing === undefined) throw siteFailure("render", "a report site requires at least one page presentation");
   return landing;
+}
+
+function validateExperimentSelection(
+  selection: ClosedExperimentSelection | undefined,
+  pages: readonly ClosedSitePage[],
+): ClosedExperimentSelection | undefined {
+  if (selection === undefined) return undefined;
+  if (!Array.isArray(selection.options) || selection.options.length === 0) {
+    throw siteFailure("identity", "closed experiment selection must contain at least one option");
+  }
+  const pageByRoute = new Map(pages.map((entry) => [entry.page.target.route, entry]));
+  const labels = new Set<string>();
+  let priorRoute: string | undefined;
+  for (const option of selection.options) {
+    if (typeof option.route !== "string" || typeof option.label !== "string" || option.label.length === 0) {
+      throw siteFailure("identity", "closed experiment selection contains an invalid option");
+    }
+    if (priorRoute !== undefined && compareUtf8(priorRoute, option.route) >= 0) {
+      throw siteFailure("identity", "closed experiment selection routes are not in canonical order");
+    }
+    priorRoute = option.route;
+    const page = pageByRoute.get(option.route);
+    if (page === undefined || page.presentation !== "page") {
+      throw siteFailure("identity", `closed experiment route ${option.route} is not a page presentation`);
+    }
+    if (labels.has(option.label)) {
+      throw siteFailure("identity", `closed experiment label ${option.label} is ambiguous`);
+    }
+    labels.add(option.label);
+  }
+  return selection;
 }
 
 function renderProblems(problems: readonly ReportProblem[], locale: string): string {


### PR DESCRIPTION
<!-- niceeval:pr-body
base: e8b4f34d9436453f088c39b3489da52174a5a2e9
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: e6393b5caf6b0bbe1a4d3505167ccff8b1a146a5
-->

## Problem

- User goal: 每个 NiceEval PR 都有一个能直接查看完整 Report 能力、并能从 Header 切换实验范围的 deploy preview。
- Current limitation: 现有 preview 固定读取 MemoryBench 2.0；SPA 合并后又把实验选择器退化成正文链接索引，根 URL 没有默认选中任何实验范围。
- Required capability: 使用独立、确定性、无付费模型调用的 showcase repo，并由同一次 Report revision 交付稳定排序的实验 route、标签与默认范围。
- User outcome: reviewer 打开 PR 的 Netlify preview 会直接进入 `gallery`，在语言选择左侧切换 5 个实验范围，同时浏览 15 个 eval、6 个 experiment、全部 matcher、正反断言、状态、group、reuse、sandbox、skill 与事件时间线。

## Observable behavior and data contracts

### Changed

#### Case: Netlify deploy preview 展示确定性全功能 fixture

##### Before

```sh
CONTEXT=deploy-preview bash netlify-preview/build-report-preview.sh
```

```text
Cloning into '.../MemoryBench'...
```

##### After

```sh
CONTEXT=deploy-preview bash netlify-preview/build-report-preview.sh
```

```text
NiceEval preview fixture: 587f07590bb8f1883b30feade86c5af6220b58f2
0.4.6
Exported static report site: .../netlify-report-preview
```

##### User impact

PR preview 不再依赖 MemoryBench 的 agent 凭证或单一 benchmark 形态。相同构建入口会从公开的 [NiceEval-Preview](https://github.com/NiceEval/NiceEval-Preview) 拉取封存 Record，用当前 PR 候选包生成可复查的全功能 Report，并在日志中打印精确 fixture SHA。

#### Case: 根 URL 默认进入第一实验组并从 Header 切换

##### Before

```sh
pnpm exec niceeval view --out .preview
```

```text
URL: /
Header comboboxes: Language
Body experiment links: gallery, judge-unavailable, sandbox-group, sandbox-reuse, states
```

##### After

```sh
pnpm exec niceeval view --out .preview
```

```text
URL: /#/group/named/gallery
Header comboboxes: Experiments=gallery, Language=EN
Experiment options: gallery, judge-unavailable, sandbox-group, sandbox-reuse, states
```

##### User impact

读者打开报告就看到稳定排序的第一个具体实验范围，而不是未选择状态的链接索引。两个及以上范围时，实验选择器固定在语言选择左侧；单个范围直接进入且不浪费 Header 空间。切换、Back/Forward、详情 overlay 与语言变化都保持同一个基础实验范围。

## Environment variables

### Added

#### Case: `NICEEVAL_PREVIEW_REPOSITORY`

##### Before

```sh
CONTEXT=deploy-preview \
NICEEVAL_PREVIEW_REPOSITORY=/tmp/NiceEval-Preview \
bash netlify-preview/build-report-preview.sh
```

```text
Cloning into '.../MemoryBench'...
```

##### After

```sh
CONTEXT=deploy-preview \
NICEEVAL_PREVIEW_REPOSITORY=/tmp/NiceEval-Preview \
bash netlify-preview/build-report-preview.sh
```

```text
NiceEval preview fixture: <commit from /tmp/NiceEval-Preview>
Exported static report site: .../netlify-report-preview
```

##### Environment boundary

只由 Netlify preview 构建脚本消费；未设置时默认使用公开只读地址 `https://github.com/NiceEval/NiceEval-Preview.git`。它不向子进程传递凭证、不覆盖 fixture 自身配置，也不改变 production 或 release 构建。

##### Necessity

Netlify 与本地验收共用同一个无参数构建入口；环境变量允许隔离测试替换 clone 边界，同时保持部署命令和默认来源固定。

##### User and security impact

云端使用默认公开仓库，无需 secret。维护者可在本地指向临时 clone 验证候选；只有主动设置该变量时才改变来源。

#### Case: `NICEEVAL_PREVIEW_REF`

##### Before

```sh
CONTEXT=deploy-preview \
NICEEVAL_PREVIEW_REF=fixture-candidate \
bash netlify-preview/build-report-preview.sh
```

```text
Cloning into '.../MemoryBench'...
```

##### After

```sh
CONTEXT=deploy-preview \
NICEEVAL_PREVIEW_REF=fixture-candidate \
bash netlify-preview/build-report-preview.sh
```

```text
NiceEval preview fixture: <commit at fixture-candidate>
Exported static report site: .../netlify-report-preview
```

##### Environment boundary

只由 preview clone 步骤消费；未设置时使用 `main`。该值作为 `git clone --single-branch --branch` 的 ref，不作为 shell 代码执行，也不传播到 NiceEval runtime。

##### Necessity

fixture repo 与 NiceEval PR 分开发布；ref override 让维护者在合并 fixture 更新前验收对应 preview，同时不改 Netlify build command。

##### User and security impact

默认行为保持追踪 fixture 的 `main`。维护者可以显式测试分支或 tag；不存在新增 secret，也不会影响其它 CI job。

## Tests

### `e2e/report/test/report.browser.spec.ts`

- Purpose: `feature + bug regression`
- Protects: Report 根入口默认进入稳定的第一实验组；多组 Header 在语言左侧显示有当前值的实验选择器，并在组切换、历史导航、语言切换与详情 overlay 后保持一致。
- Runs: 安装候选后通过真实 `niceeval exp` 生成命名组与同名 singleton，启动 `niceeval view`，再由 Chromium 执行根导航、原生 select、Back/Forward、语言、overlay 与静态站动作。
- Asserts: 单组隐藏 selector，多组 option 无歧义且顺序稳定，根 route 和 Overview alias 指向当前组，控件 DOM 顺序为 Experiments 后 Language，切换后的 URL、内容、历史和深链恢复正确；自定义 Report 不伪造实验选择。

```ts
// owner: docs/engineering/testing/e2e/report.md#report-browser-journey
// regression: memory/report-header-experiment-selector-regression.md
// rerun: pnpm e2e test --repo report -- --run test/report.browser.spec.ts
//
// This Journey observes only the installed candidate, exported files, HTTP,
// hash navigation, and browser-visible content. It never reads Record files.

import { pollUntil, waitForOutput } from "@niceeval/testkit";
import { createServer, type Server } from "node:http";
import { readFile, readdir, stat, writeFile } from "node:fs/promises";
import { join, relative, resolve } from "node:path";
import { pathToFileURL } from "node:url";
import { expect, test } from "@playwright/test";
import { reportCaseArtifacts, reportE2E } from "./support.ts";

test("静态站与 view 只交付 SPA shell；普通页面使用 hash 和 fragment，缺少 JavaScript 时明确报错", async ({ browser }) => {
  test.setTimeout(120_000);
  await reportE2E.case(
    "browser-static-spa-site",
    { artifacts: reportCaseArtifacts(["site-export"]) },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      for (const id of ["main", "source"] as const) {
        const run = await niceeval.run(["exp", id, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const exported = await niceeval.run(["view", "--report", "./reports/site.tsx", "--out", "site-export", "--no-open"]);
      expect(exported.exitCode, exported.diagnostic()).toBe(0);

      const exportRoot = join(projectRoot, "site-export");
      await expect(readFile(join(exportRoot, "index.html"), "utf8")).resolves.toContain('src="_niceeval/app.js"');
      expect(await htmlFiles(exportRoot)).toEqual(["index.html"]);

      const live = niceeval.start(
        ["view", "--report", "./reports/site.tsx", "--host", "127.0.0.1", "--port", "0", "--no-open"],
        { timeoutMs: 60_000 },
      );
      const startup = await waitForOutput(live, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000, label: "SPA view URL",
      });
      const liveOrigin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(liveOrigin, startup).toBeDefined();
      await waitForHttp(liveOrigin!, "SPA view readiness");
      await expectSameBody(new URL(liveOrigin!), pathToFileURL(join(exportRoot, "index.html")));

      // Exact-file-only HTTP: no /source rewrite exists or is needed for a hash route.
      const staticServer = await serveStaticDirectory(exportRoot);
      try {
        const page = await browser.newPage();
        try {
          await page.goto(new URL("index.html", staticServer.origin).href);
          await expect(page.getByRole("heading", { name: "Fixture overview" })).toBeVisible();
          await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);
          const fragment = page.waitForRequest((request) =>
            request.url() === new URL("_niceeval/fragments/source.json", staticServer.origin).href,
          );
          await page.getByRole("link", { name: "Source detail" }).click();
          await expect(page).toHaveURL(/#\/source$/);
          await fragment;
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();

          const copiedUrl = page.url();
          await page.reload();
          expect(page.url()).toBe(copiedUrl);
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).toBeVisible();
        } finally {
          await page.close();
        }
        const offline = await browser.newContext({ javaScriptEnabled: false });
        try {
          const page = await offline.newPage();
          await page.goto(new URL("index.html#/source", staticServer.origin).href);
          await expect(page.getByRole("heading", { name: "JavaScript required" })).toBeVisible();
          await expect(page.getByRole("alert")).toContainText("Enable JavaScript to view this NiceEval report.");
          await expect(page.getByRole("heading", { name: "Source fixture detail" })).not.toBeVisible();
        } finally {
          await offline.close();
        }
      } finally {
        await staticServer.close();
      }
    },
  );
});

test("经典报告默认并切换实验组，Attempt 作为可分享、可关闭并保留历史的 overlay", async ({ browser }) => {
  test.setTimeout(180_000);
  await reportE2E.case(
    "browser-classic-attempt-overlay",
    { artifacts: reportCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      await writeFile(
        join(projectRoot, "experiments", "classic.ts"),
        `import { defineExperiment } from "niceeval";
import { deterministicAgent } from "../agents/deterministic.ts";

const agent = deterministicAgent("report-group-label-collision", 0.00002);

export default defineExperiment({
  description: "classic: root Experiment that shares a label with the classic/* named group",
  agent,
  model: "report-fixture-v1",
  evals: ["deliberate-fail"],
});
`,
        "utf8",
      );
      for (const id of [
        "classic/baseline",
        "classic/memory-a",
        "classic/incompatible",
      ] as const) {
        const run = await niceeval.run(["exp", id, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }
      const view = niceeval.start(["view", "--host", "127.0.0.1", "--port", "0", "--no-open"], { timeoutMs: 60_000 });
      const startup = await waitForOutput(view, "stdout", /http:\/\/127\.0\.0\.1:\d+\//, {
        timeoutMs: 30_000, label: "classic SPA view URL",
      });
      const origin = startup.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
      expect(origin, startup).toBeDefined();
      await waitForHttp(origin!, "classic SPA view readiness");

      const page = await browser.newPage();
      try {
        await page.goto(origin!);
        await expect(page).toHaveURL(/#\/group\/named\/classic$/);
        await expect(page.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();

        // A single group is still the default comparison, without wasting
        // Header space on a one-option selector.
        await expect(page.getByRole("combobox", { name: "Experiments" })).toHaveCount(0);

        // Adding a root Experiment creates a legal label collision with the
        // classic/* named group. The live revision exposes two unambiguous,
        // stable options and keeps the current group selected.
        const collisionRun = await niceeval.run(["exp", "classic", "--rerun", "all", "--json"]);
        expect(collisionRun.expReceipt(), collisionRun.diagnostic()).toMatchObject({ completion: "completed" });
        const experimentSelector = page.getByRole("combobox", { name: "Experiments" });
        await expect(experimentSelector).toBeVisible({ timeout: 15_000 });
        await expect(experimentSelector.getByRole("option")).toHaveText([
          "named/classic",
          "singleton/classic",
        ]);
        await expect(experimentSelector).toHaveValue("/group/named/classic");

        const comboboxes = page.getByRole("combobox");
        await expect(comboboxes).toHaveCount(2);
        await expect(comboboxes.nth(0)).toHaveAccessibleName("Experiments");
        await expect(comboboxes.nth(1)).toHaveAccessibleName("Language");

        const overview = page.getByRole("link", { name: "Overview" });
        await expect(overview).toHaveAttribute("href", "#/group/named/classic");
        await expect(overview).toHaveAttribute("aria-current", "page");

        await experimentSelector.selectOption("/group/singleton/classic");
        await expect(page).toHaveURL(/#\/group\/singleton\/classic$/);
        await expect(experimentSelector).toHaveValue("/group/singleton/classic");
        await expect(page.getByText("classic (1/1)", { exact: true })).toBeVisible();

        await page.goBack();
        await expect(page).toHaveURL(/#\/group\/named\/classic$/);
        await expect(experimentSelector).toHaveValue("/group/named/classic");
        await expect(page.getByText("classic/memory-a (9/9)", { exact: true })).toBeVisible();
        await page.goForward();
        await expect(page).toHaveURL(/#\/group\/singleton\/classic$/);
        await expect(experimentSelector).toHaveValue("/group/singleton/classic");

        await experimentSelector.selectOption("/group/named/classic");
        await expect(page).toHaveURL(/#\/group\/named\/classic$/);
        const englishRoute = page.url();
        const languageSelector = page.getByRole("combobox", { name: "Language" });
        await languageSelector.selectOption("zh-CN");
        expect(page.url()).toBe(englishRoute);
        await expect(page.locator("html")).toHaveAttribute("lang", "zh-CN");
        await expect(page.getByRole("combobox", { name: "实验" })).toHaveValue("/group/named/classic");
        await expect(page.getByRole("link", { name: "总览" })).toHaveAttribute("href", "#/group/named/classic");
        await languageSelector.selectOption("en");
        await expect(page.locator("html")).toHaveAttribute("lang", "en");

        const experiment = page.locator('a[href^="#/experiment/"]').filter({
          has: page.locator("title").filter({ hasText: "classic/memory-a" }),
        });
        const experimentSummary = page.locator("summary").filter({
          has: page.getByText("classic/memory-a (9/9)", { exact: true }),
        });
        await expect(experimentSummary).toHaveCount(1);
        await expect(experimentSummary).toContainText("classic/memory-a (9/9)");
        expect((await experimentSummary.textContent())?.match(/9\/9/g)).toHaveLength(1);
        const expandedExperiment = experimentSummary.locator("..");
        await experimentSummary.click();
        await expect(expandedExperiment).toHaveAttribute("open", "");
        const dialog = page.getByRole("dialog");
        const scoreExperimentSummary = page.locator("summary.niceeval-table-hierarchy-summary").filter({
          hasText: /^classic\/incompatible /,
        });
        await expect(scoreExperimentSummary).toHaveCount(1);
        await expect(scoreExperimentSummary).toContainText("classic/incompatible (1/1)");
        await expect(scoreExperimentSummary).toContainText("7");
        await expect(scoreExperimentSummary).not.toContainText("missed check");
        await expect(scoreExperimentSummary).not.toContainText("passed");

        await experiment.click();
        await expect(page).toHaveURL(/#\/experiment\//);
        await expect(dialog).toBeVisible();
        // regression: memory/react19-dangerously-set-inner-html-identity.md
        await expect(expandedExperiment).toHaveAttribute("open", "");

        const attempt = page.locator('a[href^="#/attempt/"]').filter({ visible: true }).first();
        await expect(attempt).toBeVisible();
        const href = await attempt.getAttribute("href");
        expect(href).toMatch(/^#\/attempt\/a1[0-9a-hjkmnp-tv-z]{12}$/);
        const route = href!.slice(1);
        const detail = new URL(`_niceeval/fragments${route}.json`, origin!);

        const overlayRequests: string[] = [];
        page.on("request", (request) => {
          if (new URL(request.url()).pathname.includes("/_niceeval/fragments/"))
            overlayRequests.push(request.url());
        });

        let detailRequested!: () => void;
        const requested = new Promise<void>((done) => { detailRequested = done; });
        let releaseDetail!: () => void;
        const released = new Promise<void>((done) => { releaseDetail = done; });
        let detailContinued!: () => void;
        const continued = new Promise<void>((done) => { detailContinued = done; });
        await page.route(detail.href, async (request) => {
          detailRequested();
          await released;
          await request.continue();
          detailContinued();
        });
        try {
          await attempt.click();
          await requested;
          await expect(page).toHaveURL(new RegExp(`#${route}$`));
          await expect(dialog).toBeVisible();
          await expect(dialog.getByRole("status")).toContainText("Loading details…");
          await expect(
            page.locator("h1", { hasText: "NiceEval overview" }),
          ).toBeVisible();
        } finally {
          releaseDetail();
          await continued;
          await page.unroute(detail.href);
        }
        await expect(dialog.getByText(/^@[0-9A-Z]+$/).first()).toBeVisible();

        const assertionLine = dialog.locator("summary").filter({ hasText: "t.check(t.reply" }).first();
        await assertionLine.click();
        const rootMatch = dialog.getByLabel(/^and\(includes.+: matched$/).first();
        await expect(rootMatch).toBeVisible();
        await rootMatch.click();
        const orMatch = dialog.getByLabel(/^or\(includes.+: matched$/).first();
        await expect(orMatch).toBeVisible();
        await orMatch.click();
        const orNode = orMatch.locator("xpath=..");
        await expect(orNode.getByLabel('includes("RECALL_OK"): matched')).toBeVisible();
        await expect(orNode.getByLabel('includes("NEVER_PRESENT"): mismatched')).toBeVisible();

        const copiedUrl = page.url();
        await page.getByRole("button", { name: "Close" }).click();
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("#/group/named/classic");
        expect(overlayRequests).toEqual([detail.href]);

        await page.goForward();
        await expect(dialog).toBeVisible();
        await page.goBack();
        await expect(dialog).not.toBeVisible();
        await page.goForward();
        await expect(dialog).toBeVisible();
        await page.reload();
        expect(page.url()).toBe(copiedUrl);
        await expect(dialog).toBeVisible();

        // Pasting the copied hash restores an overlay over the report, never a
        // separate Attempt document.
        const shared = await browser.newPage();
        try {
          await shared.goto(copiedUrl);
          await expect(shared.getByRole("dialog")).toBeVisible();
          await expect(shared.getByRole("heading", { name: "NiceEval overview" })).toBeVisible();
          await shared.getByRole("button", { name: "Close" }).click();
          await expect(shared.getByRole("dialog")).not.toBeVisible();
          await expect(shared).toHaveURL(/#\/group\/named\/classic$/);
          const directSelector = shared.getByRole("combobox", { name: "Experiments" });
          await expect(directSelector).toHaveValue("/group/named/classic");
          await directSelector.selectOption("/group/singleton/classic");
          await expect(shared).toHaveURL(/#\/group\/singleton\/classic$/);
          await expect(shared.getByRole("dialog")).not.toBeVisible();
        } finally {
          await shared.close();
        }

        await page.mouse.click(5, 5);
        await expect(dialog).not.toBeVisible();
        expect(new URL(page.url()).hash).toBe("#/group/named/classic");

        const baselineSummary = page.locator("summary").filter({ hasText: /^classic\/baseline \(9\/9\)/ }).first();
        if (await baselineSummary.locator("xpath=..").getAttribute("open") === null) await baselineSummary.click();
        const classicSummary = page.locator("summary").filter({ hasText: /^classic \(8 evals\)/ }).first();
        if (await classicSummary.locator("xpath=..").getAttribute("open") === null) await classicSummary.click();
        const toolEvalSummary = page.locator("summary").filter({ hasText: /^tool-note/ }).first();
        if (await toolEvalSummary.locator("xpath=..").getAttribute("open") === null) await toolEvalSummary.click();
        const toolAttemptHref = await toolEvalSummary.locator("xpath=..").locator('a[href^="#/attempt/"]').first().getAttribute("href");
        expect(toolAttemptHref).toMatch(/^#\/attempt\//);
        await page.goto(new URL(toolAttemptHref!, origin!).href);
        await expect(dialog).toBeVisible({ timeout: 10_000 });

        const toolAssertion = dialog.locator("summary").filter({ hasText: 'calledTool("write_note"' }).first();
        await expect(toolAssertion).toBeVisible({ timeout: 5_000 });
        if (await toolAssertion.locator("xpath=..").getAttribute("open") === null) await toolAssertion.click();
        const toolMatcher = dialog.getByLabel(/calledTool.+: mismatched$/).filter({ visible: true }).first();
        await expect(toolMatcher).toBeVisible({ timeout: 5_000 });
        await toolMatcher.click();
        await expect(dialog.getByRole("heading", { name: "Tool calls" })).toBeVisible({ timeout: 5_000 });
        await expect(dialog.getByText('exactly 1 × toolMatch("write_note")', { exact: true })).toBeVisible();
        await expect(dialog.getByText("0 definite matches", { exact: true })).toBeVisible();

        const commandAssertion = dialog.locator("summary").filter({ hasText: "t.check({" }).first();
        await expect(commandAssertion).toBeVisible({ timeout: 5_000 });
        if (await commandAssertion.locator("xpath=..").getAttribute("open") === null) await commandAssertion.click();
        const commandMatcher = dialog.getByLabel("commandSucceeded(): matched").filter({ visible: true });
        await expect(commandMatcher).toBeVisible({ timeout: 5_000 });
        await commandMatcher.click();
        await expect(dialog.getByRole("heading", { name: "Command result" })).toBeVisible();
        await expect(dialog.getByText("pnpm test", { exact: true })).toBeVisible();
        await expect(dialog.getByText("Exit code 0", { exact: true })).toBeVisible();
        await expect(dialog.getByText("PASS src/example.test.ts", { exact: true })).not.toBeVisible();

      } finally {
        await page.close();
      }
    },
  );
});

async function expectSameBody(liveUrl: URL, staticUrl: URL): Promise<void> {
  const expected = await readFile(staticUrl);
  const response = await fetch(liveUrl);
  expect(response.status, `${liveUrl} should serve the exported shell`).toBe(200);
  expect(Buffer.from(await response.arrayBuffer()), `${liveUrl} body`).toEqual(expected);
}

async function htmlFiles(root: string): Promise<readonly string[]> {
  const paths: string[] = [];
  async function visit(directory: string): Promise<void> {
    for (const entry of await readdir(directory, { withFileTypes: true })) {
      const file = join(directory, entry.name);
      if (entry.isDirectory()) await visit(file);
      else if (entry.isFile() && entry.name.endsWith(".html")) paths.push(relative(root, file));
    }
  }
  await visit(root);
  return paths.sort();
}

async function waitForHttp(origin: string, label: string): Promise<void> {
  await pollUntil(async () => {
    try {
      return (await fetch(origin)).status === 200 ? true : undefined;
    } catch {
      return undefined;
    }
  }, { timeoutMs: 15_000, intervalMs: 100, label });
}

async function serveStaticDirectory(root: string): Promise<{ readonly origin: string; readonly close: () => Promise<void> }> {
  const absoluteRoot = resolve(root);
  const server = createServer(async (request, response) => {
    const pathname = decodeURIComponent(new URL(request.url ?? "/", "http://static.invalid").pathname);
    const file = resolve(absoluteRoot, `.${pathname === "/" ? "/index.html" : pathname}`);
    if (file !== absoluteRoot && !file.startsWith(`${absoluteRoot}/`)) return void response.writeHead(403).end();
    try {
      if (!(await stat(file)).isFile()) throw new Error("not a file");
      const mediaType = file.endsWith(".html") ? "text/html; charset=utf-8"
        : file.endsWith(".js") ? "text/javascript; charset=utf-8"
        : file.endsWith(".css") ? "text/css; charset=utf-8"
        : file.endsWith(".json") ? "application/json; charset=utf-8"
        : "application/octet-stream";
      response.writeHead(200, { "content-type": mediaType }).end(await readFile(file));
    } catch {
      response.writeHead(404).end();
    }
  });
  await new Promise<void>((done, reject) => {
    server.once("error", reject);
    server.listen(0, "127.0.0.1", done);
  });
  const address = server.address();
  if (address === null || typeof address === "string") throw new Error("static server did not expose a TCP address");
  return { origin: `http://127.0.0.1:${address.port}/`, close: () => closeServer(server) };
}

async function closeServer(server: Server): Promise<void> {
  await new Promise<void>((done, reject) => server.close((error) => error === undefined ? done() : reject(error)));
}
```

### Verification receipt

- Candidate: `e6393b5caf6b0bbe1a4d3505167ccff8b1a146a5`; NiceEval tarball SHA-256 `4c26ab7f9a42890dfe2a3e37e1e353baab56e262f026a5c92967b07b8e5ec693`
- Red: fix-parent `dc3f89c243de2214555960dc9e48d7356a48157f` 的安装候选 `3465f8f1fa110c0303c3efd4f9478247f46438e83e51fe059a14670286aaf4f2` 运行同一浏览器 Journey，最早在根 URL 断言失败：收到 `/`，预期 `#/group/named/classic`
- Green: `pnpm e2e test --repo report -- --run test/report.browser.spec.ts` → Chromium `2 passed`；链接同一候选到 `NiceEval-Preview` 后，`niceeval view` 首屏为 `#/group/named/gallery`，控件顺序为 `Experiments=gallery`、`Language=EN`，并列出 5 个组
- Repeatability: `pnpm e2e takeover --candidate <4c26…ec693.tgz> --repo report ...` → 3 份独立安装、同副本重复、repo 默认并行 `6 files / 13 tests`、目标单副本全部通过，scratch 清理成功
- Fixed conditions: base `e8b4f34d9436453f088c39b3489da52174a5a2e9`; fixture `NiceEval/NiceEval-Preview@587f07590bb8f1883b30feade86c5af6220b58f2`; pnpm `11.18.0`; Docker evidence already sealed in the fixture Record
- Unit count: `not applicable — no Unit changed`; unit project `14 passed / 1` unrelated Judge virtual-time assertion failed reproducibly and is logged as Frog `20260824122121`; `pnpm lint` passed 12 files / 51 tests, docs validation, and broken-link checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790130502&installation_model_id=431746&pr_number=108&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F108&signature=11f33b7fecea131e7aa15c96e1d8c61274af5a8d947bf4934d6b19acb772a8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
