### PR TITLE
fix(e2e): 避免 Report 完整套件因运行波动误报失败

### DIFF
--- a/e2e/report/project.json
+++ b/e2e/report/project.json
@@ -43,7 +43,7 @@
             "node",
             "scripts/run-native.mjs"
           ],
-          "timeoutMinutes": 3,
+          "timeoutMinutes": 5,
           "harness": {
             "testkit": true
           },


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 52f0e41c11aaffdc09d672f9463ae8e1eab63611
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: 8b5ac8ed433d92c448894836ea1fcec4814555da
-->

## Problem

- User goal: 维护者运行完整 Report E2E 时，只因真实回归收到红灯，不因 GitHub runner 的正常耗时波动收到误报。
- Current limitation: Report Repo 的单次测试预算只有 3 分钟；同一套件一轮在 180 秒被 `SIGTERM`，另一轮则以约 168 秒擦线通过。
- Required capability: 让 Report Repo 自己拥有足以覆盖现有 13 个 Vitest 断言与 2 个 Playwright Journey 的明确预算，同时不修改其它 matrix cell、测试断言或失败分类。
- User outcome: 完整 Report E2E 在正常运行波动下稳定完成，真实失败仍由原有 runner、owner 和无重试门禁报告。

## Package scripts

### Changed

#### Case: `pnpm e2e test --repo report`

##### Before

```sh
pnpm e2e test --repo report
```

```json
{
  "repoId": "report",
  "exitCode": null,
  "category": "regression",
  "test": {
    "timedOut": true,
    "signal": "SIGTERM"
  }
}
```

##### After

```sh
pnpm e2e test --repo report
```

```json
{
  "results": [
    {
      "id": "report",
      "exitCode": 0,
      "category": "pass",
      "detail": "clean pass"
    }
  ],
  "category": "pass",
  "detail": "clean pass"
}
```

##### User impact

Report 的测试调用预算从 3 分钟调整为 5 分钟。测试集合、公开候选安装、浏览器动作、失败判定和清理要求均保持不变；CI 只是不再在现有完整套件尚未结束时提前终止进程组。

## Tests

### Verification receipt

- Candidate: `8b5ac8ed433d92c448894836ea1fcec4814555da`; NiceEval tarball SHA-256 `4c26ab7f9a42890dfe2a3e37e1e353baab56e262f026a5c92967b07b8e5ec693`
- Red: GitHub E2E run `32690233320`，selection head `f6f308b044e710d389aebb4069771227ece6f9c8`，candidate SHA-256 `6e6993bd2de6b781c2d5664b986c86002436721b7327d89ca489bfff6a407a75`；Report 测试调用在 180 秒预算处得到 `timedOut: true`、`signal: SIGTERM`，此前 13 个 Vitest 断言与第一条 Playwright Journey 已通过
- Green: `pnpm e2e test --repo report`；exit 0，13 个 Vitest 断言与 2 个 Playwright Journey 全部通过，Report receipt 为 `clean pass`
- Repeatability: 不适用 owner takeover——本次未修改测试 owner、fixture 或产品行为；完整安装候选的 Report Repo 已经由默认并行入口运行，runner 确认 scratch tree 删除成功
- Fixed conditions: checkout `8b5ac8ed433d92c448894836ea1fcec4814555da`，当前 lockfile，签入的 Report fixture，Playwright `1.61.1` Chromium，无外部 provider；Testkit digest `6eb438b9585090f663e53f9a61bee011db5676e3713ce39060625a9a3a844917`
- Unit count: `not applicable — no Unit changed`
