### PR TITLE
fix(analysis): 区分 usage 与 conversation 缺口

### DIFF
--- a/docs/feature/analysis/library.md
+++ b/docs/feature/analysis/library.md
@@ -86,6 +86,11 @@ unknown family、known future schemaVersion 与不相容 Core 在 current `Recor
 input；它不同于 current catalog family 缺失的 `not-recorded`，也不同于已知 family predecessor 所需的
 `migration-required`。
 
+一个 fixed Attachment 同时承载多个子通道时，binding 按 limitation 的 retention target 投影自己所需的输入。
+例如 `niceeval.agent-turns` 的 `turn-item` 缺口只影响 conversation；已经完整持久化的 `usage-observation` 仍能形成 Tokens。
+整 Turn、payload 或 usage 自身的缺口才影响 usage input。DomainView 的 source dependency 继续保留整个 family 的
+`partial` 状态，各具名子视图则只显示属于自己的 collection limitation。
+
 `PopulationMembers` 同样由 NiceEval 或领域包发布。它固定一个总体的成员穷尽规则，且不含 Record reader、
 路径或原始 payload。
 

--- a/e2e/report/agents/classic.ts
+++ b/e2e/report/agents/classic.ts
@@ -81,6 +81,10 @@ export function classicMemoryAgent() {
         },
         events: [
           {
+            type: "thinking" as const,
+            text: "Private reasoning is intentionally not retained as a conversation item.",
+          },
+          {
             type: "operation.started" as const,
             operationId,
             operation: {

--- a/e2e/report/test/report-show.test.ts
+++ b/e2e/report/test/report-show.test.ts
@@ -235,19 +235,29 @@ test("show 对单组默认直达 comparison，对多组默认列索引并以实�
   );
 });
 
-test("show 保留 named identity，并按各实验实际运行的 Eval population 比较", async () => {
+// regression: memory/analysis-usage-projection-conflates-conversation-limitations.md
+test("show 保留 named identity、实际 Eval population 与独立完整的 usage", async () => {
   await reportE2E.case(
     "show-named-group-comparison",
     { artifacts: reportCaseArtifacts() },
     async ({ commands: { niceeval } }) => {
+      let baselineLocator: string | undefined;
       for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/incompatible"] as const) {
         const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
         expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
+        if (experimentId === "classic/baseline") {
+          baselineLocator = only(
+            run.expEvalEvents(),
+            (event) => event.evalId === "classic/recall-name",
+            run.diagnostic(),
+          ).locator;
+        }
       }
 
       const shown = await niceeval.run(["show", "--experiment", "classic", "--json"]);
       expect(shown.exitCode, shown.diagnostic()).toBe(0);
-      expect(shown.json<BuiltInShowDocument>()).toMatchObject({
+      const document = shown.json<BuiltInShowDocument>();
+      expect(document).toMatchObject({
         format: "niceeval.show",
         page: { route: "/group/named/classic", pageId: "group-named" },
         data: {
@@ -264,6 +274,74 @@ test("show 保留 named identity，并按各实验实际运行的 Eval populatio
           },
         },
       });
+      if (document.data.kind !== "experiment-group") throw new Error("expected experiment group");
+      const rows = document.data.comparison.rows as readonly {
+        readonly experiment: string;
+        readonly tokens: {
+          readonly value: number | null;
+          readonly state: string;
+          readonly samples: number;
+          readonly total: number;
+        };
+      }[];
+      const tokensByExperiment = new Map(rows.map((row) => [row.experiment, row.tokens]));
+      expect(tokensByExperiment.get("classic/baseline")).toEqual(expect.objectContaining({
+        value: expect.closeTo(800 / 9),
+        state: "available",
+        samples: 9,
+        total: 9,
+      }));
+      expect(tokensByExperiment.get("classic/incompatible")).toEqual(expect.objectContaining({
+        value: 0,
+        state: "available",
+        samples: 2,
+        total: 2,
+      }));
+      expect(tokensByExperiment.get("classic/memory-a")).toEqual(expect.objectContaining({
+        value: expect.closeTo(1_408 / 9),
+        state: "available",
+        samples: 9,
+        total: 9,
+      }));
+      expect(document.problems).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ summary: "usage collection is incomplete" }),
+      ]));
+
+      if (baselineLocator === undefined) throw new Error("baseline usage locator was not recorded");
+      const attempt = await niceeval.run(["show", baselineLocator, "--json"]);
+      expect(attempt.exitCode, attempt.diagnostic()).toBe(0);
+      const attemptDocument = attempt.json<BuiltInShowDocument>();
+      if (attemptDocument.data.kind !== "attempt") throw new Error("expected attempt");
+      const observability = attemptDocument.data.observability as {
+        readonly entries: readonly {
+          readonly detail: {
+            readonly sources: {
+              readonly agentTurns: {
+                readonly state: string;
+                readonly limitations: readonly { readonly code: string; readonly target: string }[];
+              };
+            };
+            readonly usage: {
+              readonly collection: { readonly state: string; readonly limitations: readonly unknown[] };
+              readonly observations: readonly {
+                readonly kind: string;
+                readonly bucket?: string;
+                readonly tokens?: number;
+              }[];
+            };
+          };
+        }[];
+      };
+      const detail = only(observability.entries, () => true, attempt.diagnostic()).detail;
+      expect(detail.sources.agentTurns).toMatchObject({
+        state: "partial",
+        limitations: [expect.objectContaining({ code: "unsupported-input", target: "turn-item" })],
+      });
+      expect(detail.usage.collection).toEqual({ state: "complete", limitations: [] });
+      expect(detail.usage.observations).toEqual(expect.arrayContaining([
+        expect.objectContaining({ kind: "token-bucket", bucket: "input", tokens: 80 }),
+        expect.objectContaining({ kind: "token-bucket", bucket: "output", tokens: 20 }),
+      ]));
     },
   );
 });

--- a/feedback/feedback-preview-usage-collection-incomplete/README.md
+++ b/feedback/feedback-preview-usage-collection-incomplete/README.md
@@ -1,0 +1,31 @@
+---
+format: niceeval.feedback/v1
+id: feedback-preview-usage-collection-incomplete
+title: Preview 把完整 usage 报成 collection incomplete
+state: closed
+reportedAt: 2026-08-24T14:07:42+08:00
+source:
+  kind: dogfood
+  repository: NiceEval/NiceEval-Preview
+  originId: preview-pr-110-usage-collection-incomplete
+  commit: 705d90329848825b25b1fbde389905b513ccb93a
+subject: product
+claim: defect
+observation: 在 https://deploy-preview-110--niceeval-report-preview.netlify.app/#/group/named/pass-gallery 的数据说明中，重复出现十条 `analysis-missing — usage collection is incomplete`；该 preview 使用刚重新生成并提交的示例 Record。
+impact: Report 把样本已经记录的 input/output token usage 显示为无数据，并用十条重复告警暗示新跑 Record 的 usage 采集不完整，读者无法比较实验 Tokens，也无法判断问题来自样本还是 NiceEval。
+adoptedContract:
+  path: docs/feature/analysis/library.md
+  anchor: 已发布的输入与成员集
+memoryRelations:
+  - kind: root-cause
+    memory: analysis-usage-projection-conflates-conversation-limitations
+closure:
+  kind: fixed
+  memory: analysis-usage-projection-conflates-conversation-limitations
+  proof:
+    - Installed-candidate E2E red/green and the complete reliability takeover passed for e2e/report/test/report-show.test.ts with fixed candidate SHA-256 3c52d917283e7f72b3be8539d1dd999cb72c89eee2ea89681a1426c1b2d4eacc.
+    - The unchanged NiceEval-Preview commit 705d90329848825b25b1fbde389905b513ccb93a and sealed Records produced zero usage collection is incomplete problems for /group/named/pass-gallery; pass-gallery/candidate remained 4/4 available at 208 tokens.
+---
+# Preview 把完整 usage 报成 collection incomplete
+
+用户在 PR 110 的公开 Report preview 中观察到十条重复的 `analysis-missing — usage collection is incomplete`，并要求确认是新跑样本、运行过程还是 NiceEval 的问题。公开 `niceeval show` 可读到对应 Attempt 的 input/output token buckets 与 provider cost。

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -309,6 +309,7 @@ memory 的召回全靠这份索引:漏索引的条目等于不存在。维护规
 
 ### 台账
 
+- 已修 [analysis-usage-projection-conflates-conversation-limitations](analysis-usage-projection-conflates-conversation-limitations.md) — Preview 的完整 token buckets 因同一 agent-turns source 含 conversation-only `turn-item` limitation 被误报 usage incomplete；Analysis 改为按 retention target 投影各子通道状态
 - 已修 [report-header-experiment-selector-regression](report-header-experiment-selector-regression.md) — Report SPA 合并时丢掉实验组导航投影，根页退化成未选范围的链接索引且 Header 只剩语言；修法是 closure 交付闭合 route/label、根入口默认第一组并恢复语言左侧原生 selector
 - 已修 [record-only-assertions-labeled-soft](record-only-assertions-labeled-soft.md) — Attempt 展开把未计分 Assertion 标成 `soft`，正常 `notCalledTool` 看不出这是已记录的零命中结果；改为 `recorded passed/failed/unavailable`，并由浏览器 E2E 守住零命中与决定性见证
 - 已修 [commandsucceeded-received-excerpt-not-tail](commandsucceeded-received-excerpt-not-tail.md) — commandSucceeded 失败摘录曾落在输出中段:合并顺序(stdout 前置让 stderr 装包噪声占末尾)+ 摘录窗口宽过终端行预算被从头收口,双因叠加;修为 stderr 在前合并 + 76 字符窗口(src/context/context.ts),合并顺序钉进 display.md;同批裁决 commands.json 落盘不截

--- a/memory/analysis-usage-projection-conflates-conversation-limitations.md
+++ b/memory/analysis-usage-projection-conflates-conversation-limitations.md
@@ -1,0 +1,39 @@
+---
+format: niceeval.memory/v1
+id: analysis-usage-projection-conflates-conversation-limitations
+title: Analysis usage 投影混入 conversation limitation
+createdAt: 2026-08-24T14:07:42+08:00
+kind:
+  type: problem
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - "Installed-candidate E2E red: candidate SHA-256 82b7507542e1febf2c65d94db16e8db179df2c12058fd7b43f2f771d140ec1f5 failed e2e/report/test/report-show.test.ts because classic/baseline Tokens was partial with 1/9 samples and eight analysis-missing usage collection is incomplete problems while agentTurns carried only unsupported-input(target=turn-item)."
+      - "Installed-candidate E2E green: candidate SHA-256 3c52d917283e7f72b3be8539d1dd999cb72c89eee2ea89681a1426c1b2d4eacc passed the targeted regression, all six Report files / 13 Vitest tests, and both Chromium browser journeys."
+      - "E2E reliability takeover: artifacts/e2e/takeover-report-usage/takeover-summary.json reports all three isolated copies, the same-installed-copy repeat, repo-default-parallel, and target-single as clean pass with matrixValidation ok and complete."
+      - "Public downstream check: NiceEval/NiceEval-Preview commit 705d90329848825b25b1fbde389905b513ccb93a with its existing sealed Records and candidate 3c52d917283e7f72b3be8539d1dd999cb72c89eee2ea89681a1426c1b2d4eacc returned zero usage collection is incomplete problems for /group/named/pass-gallery; pass-gallery/candidate was available with 4/4 samples and 208 tokens."
+promotions:
+  - kind: feature
+    current:
+      path: docs/feature/analysis/library.md
+      anchor: 已发布的输入与成员集
+    history: []
+---
+# Analysis usage 投影混入 conversation limitation
+
+## 问题
+
+完整记录 input/output token buckets 的 Attempt 在 Analysis `tokens` Measure 中形成 `analysis-missing — usage collection is incomplete`。Report 因而把 Tokens 显示为无数据，并在 Data notes 中逐 Attempt 重复暴露错误缺口。
+
+## 根因
+
+`niceeval.agent-turns` 同时承载 conversation items 与 usage observations，collection limitation 以 `target` 区分子通道。Preview 的确定性 Direct Agent 发出 `thinking`、`compaction` 等不持久化 conversation 事件，因此 source 合法带有 `unsupported-input(target=turn-item)` 并处于 `partial`；它的 usage observations 仍完整包含 input/output token buckets。
+
+Analysis 的 `attemptTokens` projector 和 Attempt Observability usage view 直接复用了整个 source 的 `partial` 状态，没有按 `usage-observation` target 投影。前者拒绝已有 token buckets 后又找不到 usage-specific limitation，错误回退为 `usage collection is incomplete`；后者也把完整 usage 显示为 partial。
+
+## 修复边界
+
+从一个多通道 source 派生输入或 DomainView 时，只让属于该子通道 target 的 limitation 决定其 collection 状态；其它 target 的 limitation 仍保留在 source dependency 和对应 conversation/command view 中。Record bytes、source family schema 与采集策略不变。
+
+回归由安装后 Report E2E 的静态站公开结果拥有，先证明含 unsupported conversation item 且完整 usage 的 Attempt 不再产生 usage 缺失，并继续保留 conversation partial limitation。

--- a/packages/niceeval/src/analysis/bindings.ts
+++ b/packages/niceeval/src/analysis/bindings.ts
@@ -20,6 +20,10 @@ import type { AttemptRunnerActivitiesAttachment } from "../record/family/runner-
 import type { AttemptRunnerDiagnosticsAttachment } from "../record/family/runner-diagnostics/definition.ts";
 import type { SandboxCommandsAttachment } from "../record/family/sandbox-commands/definition.ts";
 import type { SourcesAttachment } from "../record/family/sources.ts";
+import type {
+  SourceReceiptCollection,
+  SourceReceiptLimitation,
+} from "../record/family/source-receipt.ts";
 import type { TurnContextsAttachment } from "../record/family/turn-contexts/definition.ts";
 import type {
   FixedFamilyRead,
@@ -424,8 +428,9 @@ export const publishedAnalysisInputBindings = Object.freeze({
       readonly core: ClosedAttemptCore;
       readonly payload: RecordAttachmentPayloadSnapshot<AgentTurnsAttachment>;
     }): InputProjection<number> => {
-      if (payload.collection.state !== "complete") {
-        return collectionProjection(payload.collection, "usage-observation", "usage collection is incomplete");
+      const usageCollection = agentTurnUsageCollection(payload);
+      if (usageCollection.state !== "complete") {
+        return collectionProjection(usageCollection, "usage-observation", "usage collection is incomplete");
       }
       const observations = payload.segments.flatMap((segment) => segment.usage);
       let input = 0;
@@ -921,7 +926,11 @@ function closeUsage(
     : [];
   return Object.freeze({
     dependencies: Object.freeze(["niceeval.agent-turns"] as const),
-    collection: closeTraceCollection(value),
+    collection: closeTraceCollection(
+      value.state === "complete" || value.state === "partial"
+        ? agentTurnUsageCollection(value.value)
+        : value,
+    ),
     observations: Object.freeze(observations.map((observation) => {
       switch (observation.kind) {
         case "token-bucket":
@@ -947,6 +956,31 @@ function closeUsage(
       }
     })),
   });
+}
+
+const usageCollectionTargets = new Set<SourceReceiptLimitation["target"]>([
+  "turn",
+  "usage-observation",
+  "payload-byte",
+]);
+
+/** @internal Projects the shared Agent Turns receipt onto its Usage subchannel. */
+export function agentTurnUsageCollection(
+  payload: RecordAttachmentPayloadSnapshot<AgentTurnsAttachment>,
+): SourceReceiptCollection {
+  const limitations = payload.collection.limitations.filter((limitation) =>
+    usageCollectionTargets.has(limitation.target)
+  );
+  const [first, ...rest] = limitations;
+  return first === undefined
+    ? Object.freeze({ state: "complete" as const, limitations: Object.freeze([]) as readonly [] })
+    : Object.freeze({
+        state: "partial" as const,
+        limitations: Object.freeze([first, ...rest]) as readonly [
+          SourceReceiptLimitation,
+          ...SourceReceiptLimitation[],
+        ],
+      });
 }
 
 function closeTiming(

--- a/packages/niceeval/src/sample/capability.ts
+++ b/packages/niceeval/src/sample/capability.ts
@@ -7,7 +7,7 @@ import type {
   PublishedAnalysisInputBinding,
   RecordReadBinding,
 } from "../analysis/bindings.ts";
-import { agentTurnsSource } from "../analysis/bindings.ts";
+import { agentTurnsSource, agentTurnUsageCollection } from "../analysis/bindings.ts";
 import type {
   BuiltinDomainView,
   ClosedRunDiagnosticsEntry,
@@ -907,7 +907,7 @@ function readCostSlot(
           member: included,
           core: resolved.core,
           usage: Object.freeze({
-            collection: cached.read.value.collection,
+            collection: agentTurnUsageCollection(cached.read.value),
             observations: Object.freeze(cached.read.value.segments.flatMap((segment) => segment.usage)),
           }),
           profile,


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 794c67a6296322b71ea50800ce0ad9d85b34675c
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: 2c032479607fdcb53b79c2d43a5df02a0ef99811
-->

## Problem

- User goal: 在 Report 中比较已经由 Agent 完整返回的 token usage，并能区分 usage 缺口与对话事件缺口。
- Current limitation: `niceeval.agent-turns` 同时承载 conversation 与 usage；只要未持久化 `thinking` 等 conversation item，Analysis 就把完整 token buckets 误判为 `usage collection is incomplete`。
- Required capability: Analysis 必须按 source limitation 的 retention target 投影各子通道，让 `turn-item` 只影响 conversation，让 `usage-observation` 自己的 limitation 决定 Tokens、Attempt usage 与 Cost。
- User outcome: 现有 Record 无需重跑即可恢复 token 比较与价格估算，同时继续如实显示 conversation partial。

## Use cases

### Case: 查看含未持久化思考事件的实验组

#### Starting state

```text
Agent 的每轮 usage 都包含 inputTokens、outputTokens 与 requests；同一轮还有未作为 conversation item 持久化的 thinking 事件。
```

#### Action

```sh
pnpm exec niceeval show --experiment pass-gallery --json
```

#### Result

```json
{
  "usageProblems": [],
  "candidate": {
    "tokens": { "state": "available", "samples": 4, "total": 4, "value": 208 }
  }
}
```

同一批封存 Record 无需重跑即可得到完整 Tokens。Attempt 的 `agentTurns` source 仍为 `partial`，并保留 `unsupported-input(target=turn-item)`，因此 conversation 缺口没有被隐藏。

## Observable behavior and data contracts

### Changed

#### Case: 多通道 source 的 usage 状态按 retention target 闭合

##### Before

```sh
pnpm exec niceeval show --experiment classic --json
```

```text
classic/baseline Tokens: partial, 1/9 samples, value 0
analysis-missing — usage collection is incomplete ×8
```

##### After

```sh
pnpm exec niceeval show --experiment classic --json
```

```text
classic/baseline Tokens: available, 9/9 samples, value 88.88888888888889
usage collection is incomplete ×0
Attempt source: partial — unsupported-input(target=turn-item)
Attempt usage: complete — input 80, output 20
```

##### User impact

完整持久化的 usage 不再被同一 Attachment 中无关的 conversation limitation 污染。Tokens、Attempt usage 详情与 token 定价成本使用同一投影；真正指向 `turn`、`payload-byte` 或 `usage-observation` 的 limitation 仍会让 usage 降级。Record family、schemaVersion 与既有字节均不变。

## Tests

### `e2e/report/agents/classic.ts`

- Purpose: `bug regression`
- Protects: 确定性 Direct Agent 同时形成完整 usage 与 conversation-only turn-item limitation，让 Report owner 能区分两个子通道。
- Runs: 安装候选后由 niceeval exp 调用 Direct Agent，返回固定 usage、thinking、tool events 与 assistant message，不调用 provider。
- Asserts: fixture 对每个 Eval 稳定返回 input/output tokens 与 requests，同时让 thinking 不作为 conversation item 持久化。

```ts
import { completeEvidenceCoverage, defineAgent } from "niceeval/adapter";

/** Memory condition for the three classic experiments. */
export type ClassicMemory = "baseline" | "memory-a" | "memory-b";

export const CLASSIC_RECALL_EVAL_IDS = [
  "classic/recall-name",
  "classic/recall-date",
  "classic/recall-fact",
  "classic/recall-constraint",
  "classic/recall-procedure",
  "classic/recall-entity",
  "classic/recall-multi",
  "classic/tool-note",
] as const;

export type ClassicRecallEvalId = (typeof CLASSIC_RECALL_EVAL_IDS)[number];

const PASSES: Record<ClassicMemory, ReadonlySet<string>> = {
  baseline: new Set(["classic/recall-name", "classic/tool-note", "source-snapshot"]),
  "memory-a": new Set([
    "classic/recall-name",
    "classic/recall-date",
    "classic/recall-fact",
    "classic/recall-constraint",
    "classic/recall-procedure",
    "classic/tool-note",
    "source-snapshot",
  ]),
  "memory-b": new Set([
    "classic/recall-name",
    "classic/recall-date",
    "classic/recall-fact",
    "classic/recall-constraint",
    "classic/recall-procedure",
    "classic/recall-entity",
    "classic/recall-multi",
    "classic/tool-note",
    "source-snapshot",
  ]),
};

const USAGE: Record<ClassicMemory, { inputTokens: number; outputTokens: number }> = {
  baseline: { inputTokens: 80, outputTokens: 20 },
  "memory-a": { inputTokens: 140, outputTokens: 36 },
  "memory-b": { inputTokens: 190, outputTokens: 48 },
};

export function classicExpectedVerdict(memory: ClassicMemory, evalId: string): "passed" | "failed" {
  return PASSES[memory].has(evalId) ? "passed" : "failed";
}

export function classicMemoryOf(flags: Readonly<Record<string, unknown>> | undefined): ClassicMemory {
  const value = flags?.memory;
  if (value === "baseline" || value === "memory-a" || value === "memory-b") return value;
  return "baseline";
}

/**
 * Public Direct Agent fixture: deterministic completed events, usage, and one tool
 * call. Outcome depends only on experiment flags.memory × eval id.
 */
export function classicMemoryAgent() {
  return defineAgent({
    name: "classic-memory",
    evidenceCoverage: completeEvidenceCoverage,
    async send(_input, ctx) {
      if (ctx.signal.aborted) throw new Error("classic fixture aborted");
      const memory = classicMemoryOf(ctx.flags);
      const evalId = ctx.evalId ?? "unknown";
      ctx.session.capture(`classic:${memory}:${evalId}`);
      const recalled = PASSES[memory].has(evalId);
      const usage = USAGE[memory];
      const operationId = "classic-note-1";
      return {
        status: "completed" as const,
        usage: {
          inputTokens: usage.inputTokens,
          outputTokens: usage.outputTokens,
          requests: 1,
        },
        events: [
          {
            type: "thinking" as const,
            text: "Private reasoning is intentionally not retained as a conversation item.",
          },
          {
            type: "operation.started" as const,
            operationId,
            operation: {
              kind: "tool" as const,
              name: "command_execution",
              input: {
                command: `printf '${evalId}: recalled=${recalled}\\n' > memory-note.txt`,
                cwd: ".",
              },
            },
          },
          {
            type: "operation.finished" as const,
            operationId,
            kind: "tool" as const,
            output: {
              output: `wrote memory-note.txt\n${evalId}: recalled=${recalled}\n`,
              exit_code: 0,
              written: true,
              recalled,
            },
            status: "completed" as const,
          },
          {
            type: "message" as const,
            role: "assistant" as const,
            text: recalled
              ? `I remember this. RECALL_OK for ${evalId}.`
              : `I do not remember this. RECALL_MISS for ${evalId}.`,
          },
        ],
      };
    },
  });
}
```

### `e2e/report/test/report-show.test.ts`

- Purpose: `bug regression`
- Protects: Report group Tokens、Attempt Observability usage 与成本消费者不再把 turn-item limitation 当成 usage limitation，同时 source dependency 继续显示 conversation partial。
- Runs: 从安装候选运行三个 classic 实验，通过真实 niceeval show 读取实验组和单个 Attempt 的 JSON，并由完整 Report suite 执行价格估算与浏览器闭包。
- Asserts: baseline 和 memory 实验 Tokens 为 available 且 samples 等于 total，usage incomplete problem 不存在；单 Attempt 的 agentTurns 为 partial、usage 为 complete，并保留 input 80 与 output 20。

```ts
// owner: docs/engineering/testing/e2e/report.md#report-show-json
// rerun: pnpm e2e test --repo report -- --run test/report-show.test.ts

import { only } from "@niceeval/testkit";
import { stripVTControlCharacters } from "node:util";
import { expect, test } from "vitest";
import {
  reportCaseArtifacts,
  reportE2E,
  runReportPty,
} from "./support.ts";

interface ReportProblem {
  readonly code: string;
  readonly path: readonly string[];
  readonly refs: readonly string[];
  readonly summary?: string;
}

interface ReportProjections {
  readonly format: "niceeval.report-projections/v1";
  readonly pricingProfile: Record<string, unknown> | null;
  readonly costs: readonly {
    readonly page: { readonly pageId: string; readonly route: string };
    readonly measureId: string;
    readonly row: { readonly key: string; readonly dimensions: Record<string, unknown> };
    readonly profileIdentity: string;
    readonly projection: Record<string, unknown>;
  }[];
}

/** The documented built-in machine document (docs/feature/reports/cli.md). */
interface BuiltInShowDocument {
  readonly format: "niceeval.show";
  readonly locale: "en";
  readonly selection:
    | {
        readonly kind: "project-current";
        readonly sampleIdentity: string;
        readonly experimentIds: readonly string[];
      }
    | {
        readonly kind: "explicit-runs";
        readonly sampleIdentity: string;
        readonly runIds: readonly string[];
      }
    | {
        readonly kind: "attempt-locator";
        readonly sampleIdentity: string;
        readonly locator: string;
      };
  readonly report: { readonly token: string; readonly identity: string };
  readonly page: { readonly route: string; readonly pageId: string; readonly title: string | Record<string, string> };
  readonly data:
    | {
        readonly kind: "groups";
        readonly groups: readonly {
          readonly group:
            | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
            | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
          readonly members: readonly string[];
          readonly href: string;
        }[];
      }
    | {
        readonly kind: "experiment-group";
        readonly group:
          | { readonly kind: "named"; readonly groupId: string; readonly key: `named/${string}` }
          | { readonly kind: "singleton"; readonly experimentId: string; readonly key: `singleton/${string}` };
        readonly comparison: {
          readonly members: readonly string[];
          readonly coverage: readonly {
            readonly member: string;
            readonly coveredEvalCount: number;
            readonly groupEvalCount: number;
          }[];
          readonly rows: readonly unknown[];
        };
      }
    | {
        readonly kind: "run-membership";
        readonly summary: unknown;
        readonly members: readonly {
          readonly experiment: string;
          readonly selectedRun: string;
          readonly locator: string | null;
          readonly verdict: string | null;
        }[];
        readonly errors: readonly unknown[];
        readonly evidence: unknown;
      }
    | {
        readonly kind: "attempt";
        readonly evidence: unknown;
        readonly observability: unknown;
      readonly fileChanges: unknown;
    };
  readonly projections: ReportProjections;
  readonly problems: readonly ReportProblem[];
}

/** The documented custom single-target manifest (docs/feature/reports/cli.md). */
interface CustomTargetExecutionManifest {
  readonly format: "niceeval.report-target-execution/v1";
  readonly locale: "en";
  readonly selection: { readonly kind: "project-current"; readonly sampleIdentity: string; readonly experimentIds: readonly string[] };
  readonly report: { readonly identity: string; readonly title: string | Record<string, string> };
  readonly page: {
    readonly route: string;
    readonly pageId: string;
    readonly title: string | Record<string, string>;
    readonly renderedText: string;
  };
  readonly downloads: readonly { readonly path: string; readonly mediaType: string; readonly bytes: number }[];
  readonly projections: ReportProjections;
  readonly problems: readonly ReportProblem[];
}

function expectCanonicalProblemTable(problems: readonly ReportProblem[], pageId: string): void {
  for (const problem of problems) {
    expect(problem).toMatchObject({
      code: expect.any(String),
      path: ["page", pageId],
      refs: expect.any(Array),
    });
    expect(problem.refs).toEqual([...new Set(problem.refs)].sort());
    if (problem.summary !== undefined) expect(problem.summary).toEqual(expect.any(String));
  }
  const keys = problems.map((problem) => JSON.stringify([
    problem.code,
    problem.path,
    problem.refs,
    problem.summary ?? "",
  ]));
  expect(keys).toEqual([...keys].sort());
}

function expectBuiltInPricingProfile(projections: ReportProjections): void {
  expect(projections).toMatchObject({
    format: "niceeval.report-projections/v1",
    pricingProfile: {
      contentIdentity: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
      currency: "USD",
      provenance: { kind: "declared-rate-card" },
    },
  });
}

test("show 对单组默认直达 comparison，对多组默认列索引并以实验选择精确读取", async () => {
  await reportE2E.case(
    "show-overview",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.exitCode, run.diagnostic()).not.toBe(0);
      expect(run.expReceipt()).toMatchObject({ completion: "completed" });
      const evals = run.expEvalEvents();
      expect(evals.map((event) => [event.evalId, event.verdict]).sort()).toEqual([
        ["deliberate-error", "errored"],
        ["deliberate-fail", "failed"],
        ["tool-call", "passed"],
      ]);

      const text = await niceeval.run(["show", "--experiment", "main"]);
      expect(text.exitCode, text.diagnostic()).toBe(0);
      expect(text.stdout).toContain("Experiment comparison");
      expect(text.stdout).toContain("main");
      expect(text.stdout).not.toMatch(/\d+ \/ \d+ slot/);

      const singleJson = await niceeval.run(["show", "--experiment", "main", "--json"]);
      expect(singleJson.exitCode, singleJson.diagnostic()).toBe(0);
      const singleDocument = singleJson.json<BuiltInShowDocument>();
      expect(singleDocument).toMatchObject({
        format: "niceeval.show",
        locale: "en",
        selection: {
          kind: "project-current",
          experimentIds: ["main"],
        },
        page: { route: "/group/singleton/main", pageId: "group-singleton" },
        data: {
          kind: "experiment-group",
          group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
          comparison: { members: ["main"] },
        },
      });
      expectCanonicalProblemTable(singleDocument.problems, "group-singleton");
      expectBuiltInPricingProfile(singleDocument.projections);

      const sourceRun = await niceeval.run(["exp", "source", "--rerun", "all", "--json"]);
      expect(sourceRun.exitCode, sourceRun.diagnostic()).toBe(0);

      const indexText = await niceeval.run(["show"]);
      expect(indexText.exitCode, indexText.diagnostic()).toBe(0);
      expect(indexText.stdout).toContain("niceeval show --experiment 'main'");
      expect(indexText.stdout).toContain("niceeval show --experiment 'source'");
      expect(indexText.stdout).not.toContain("Experiment comparison");

      const indexJson = await niceeval.run(["show", "--json"]);
      expect(indexJson.exitCode, indexJson.diagnostic()).toBe(0);
      const indexDocument = indexJson.json<BuiltInShowDocument>();
      expect(indexDocument).toMatchObject({
        format: "niceeval.show",
        page: { route: "/", pageId: "overview" },
        data: {
          kind: "groups",
          groups: [
            {
              group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
              members: ["main"],
              href: "/group/singleton/main",
            },
            {
              group: { kind: "singleton", experimentId: "source", key: "singleton/source" },
              members: ["source"],
              href: "/group/singleton/source",
            },
          ],
        },
      });

      const selected = await niceeval.run(["show", "--experiment", "main", "--json"]);
      expect(selected.exitCode, selected.diagnostic()).toBe(0);
      expect(selected.json<BuiltInShowDocument>()).toMatchObject({
        format: "niceeval.show",
        page: { route: "/group/singleton/main", pageId: "group-singleton" },
        data: {
          kind: "experiment-group",
          group: { kind: "singleton", experimentId: "main", key: "singleton/main" },
          comparison: { members: ["main"] },
        },
      });

    },
  );
});

// regression: memory/analysis-usage-projection-conflates-conversation-limitations.md
test("show 保留 named identity、实际 Eval population 与独立完整的 usage", async () => {
  await reportE2E.case(
    "show-named-group-comparison",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      let baselineLocator: string | undefined;
      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/incompatible"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
        if (experimentId === "classic/baseline") {
          baselineLocator = only(
            run.expEvalEvents(),
            (event) => event.evalId === "classic/recall-name",
            run.diagnostic(),
          ).locator;
        }
      }

      const shown = await niceeval.run(["show", "--experiment", "classic", "--json"]);
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      const document = shown.json<BuiltInShowDocument>();
      expect(document).toMatchObject({
        format: "niceeval.show",
        page: { route: "/group/named/classic", pageId: "group-named" },
        data: {
          kind: "experiment-group",
          group: { kind: "named", groupId: "classic", key: "named/classic" },
          comparison: {
            members: ["classic/baseline", "classic/incompatible", "classic/memory-a"],
            coverage: [
              { member: "classic/baseline", coveredEvalCount: 9, groupEvalCount: 10 },
              { member: "classic/incompatible", coveredEvalCount: 1, groupEvalCount: 10 },
              { member: "classic/memory-a", coveredEvalCount: 9, groupEvalCount: 10 },
            ],
            rows: expect.any(Array),
          },
        },
      });
      if (document.data.kind !== "experiment-group") throw new Error("expected experiment group");
      const rows = document.data.comparison.rows as readonly {
        readonly experiment: string;
        readonly tokens: {
          readonly value: number | null;
          readonly state: string;
          readonly samples: number;
          readonly total: number;
        };
      }[];
      const tokensByExperiment = new Map(rows.map((row) => [row.experiment, row.tokens]));
      expect(tokensByExperiment.get("classic/baseline")).toEqual(expect.objectContaining({
        value: expect.closeTo(800 / 9),
        state: "available",
        samples: 9,
        total: 9,
      }));
      expect(tokensByExperiment.get("classic/incompatible")).toEqual(expect.objectContaining({
        value: 0,
        state: "available",
        samples: 2,
        total: 2,
      }));
      expect(tokensByExperiment.get("classic/memory-a")).toEqual(expect.objectContaining({
        value: expect.closeTo(1_408 / 9),
        state: "available",
        samples: 9,
        total: 9,
      }));
      expect(document.problems).not.toEqual(expect.arrayContaining([
        expect.objectContaining({ summary: "usage collection is incomplete" }),
      ]));

      if (baselineLocator === undefined) throw new Error("baseline usage locator was not recorded");
      const attempt = await niceeval.run(["show", baselineLocator, "--json"]);
      expect(attempt.exitCode, attempt.diagnostic()).toBe(0);
      const attemptDocument = attempt.json<BuiltInShowDocument>();
      if (attemptDocument.data.kind !== "attempt") throw new Error("expected attempt");
      const observability = attemptDocument.data.observability as {
        readonly entries: readonly {
          readonly detail: {
            readonly sources: {
              readonly agentTurns: {
                readonly state: string;
                readonly limitations: readonly { readonly code: string; readonly target: string }[];
              };
            };
            readonly usage: {
              readonly collection: { readonly state: string; readonly limitations: readonly unknown[] };
              readonly observations: readonly {
                readonly kind: string;
                readonly bucket?: string;
                readonly tokens?: number;
              }[];
            };
          };
        }[];
      };
      const detail = only(observability.entries, () => true, attempt.diagnostic()).detail;
      expect(detail.sources.agentTurns).toMatchObject({
        state: "partial",
        limitations: [expect.objectContaining({ code: "unsupported-input", target: "turn-item" })],
      });
      expect(detail.usage.collection).toEqual({ state: "complete", limitations: [] });
      expect(detail.usage.observations).toEqual(expect.arrayContaining([
        expect.objectContaining({ kind: "token-bucket", bucket: "input", tokens: 80 }),
        expect.objectContaining({ kind: "token-bucket", bucket: "output", tokens: 20 }),
      ]));
    },
  );
});

test("show 对 immutable Attempt 交付精确 evidence JSON", async () => {
  await reportE2E.case(
    "show-attempt-json",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.exitCode, run.diagnostic()).not.toBe(0);
      const failed = only(
        run.expEvalEvents(),
        (event) => event.evalId === "deliberate-fail",
        run.diagnostic(),
      );

      const attempt = await niceeval.run(["show", failed.locator, "--json"]);
      expect(attempt.exitCode, attempt.diagnostic()).toBe(0);
      const document = attempt.json<BuiltInShowDocument>();
      expect(document).toMatchObject({
        format: "niceeval.show",
        locale: "en",
        selection: { kind: "attempt-locator", locator: failed.locator },
        page: { route: "/", pageId: "attempt-overview", title: "Attempt overview" },
      });
      expectCanonicalProblemTable(document.problems, "attempt-overview");
      expect(document.data.kind).toBe("attempt");
      expectBuiltInPricingProfile(document.projections);
      expect(document.projections.costs).toEqual([]);

      const payload = JSON.stringify(document.data);
      expect(payload).toContain(failed.locator);
      expect(payload).toContain("mismatched");
    },
  );
});

test("show --run 保留 deterministic classic World 的历史 Run 与 Attempt 身份", async () => {
  await reportE2E.case(
    "show-classic-world",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const historyRunIds: string[] = [];
      for (const experimentId of ["classic/baseline", "classic/memory-a", "classic/memory-b", "classic/baseline"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
        const runId = only(run.expReceipt().runIds, () => true, run.diagnostic());
        historyRunIds.push(runId);
      }

      const historical = await niceeval.run([
        "show",
        ...historyRunIds.flatMap((runId) => ["--run", runId]),
        "--json",
      ]);
      expect(historical.exitCode, historical.diagnostic()).toBe(0);
      const document = historical.json<BuiltInShowDocument>();
      expect(document).toMatchObject({
        format: "niceeval.show",
        locale: "en",
        selection: {
          kind: "explicit-runs",
          runIds: [...historyRunIds].sort(),
        },
        page: { route: "/", pageId: "run-membership" },
        data: {
          kind: "run-membership",
          errors: [],
        },
      });
      if (document.data.kind !== "run-membership") throw new Error("expected run membership");
      expect(document.data.members.map((member) => member.selectedRun)).toEqual(
        expect.arrayContaining(historyRunIds),
      );
      expect(document.data.members.map((member) => member.experiment)).toEqual(
        expect.arrayContaining(["classic/baseline", "classic/memory-a", "classic/memory-b"]),
      );
      const includedMembers = document.data.members.filter((member) => member.locator !== null);
      expect(includedMembers.map((member) => member.selectedRun)).toEqual(
        expect.arrayContaining(historyRunIds),
      );
      expect(includedMembers.every((member) => member.verdict !== null)).toBe(true);
      expectCanonicalProblemTable(document.problems, "run-membership");
      expectBuiltInPricingProfile(document.projections);
      expect(document.projections.costs).toEqual([]);
    },
  );
});

test("show 在 pipe 与真实 PTY 中保留独立、可读的公开文本", async () => {
  await reportE2E.case(
    "show-pty",
    { artifacts: reportCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });

      const piped = await niceeval.run(["show"]);
      expect(piped.exitCode, piped.diagnostic()).toBe(0);
      expect(piped.stdout).toContain("Experiment comparison");
      expect(piped.stdout).toContain("main");
      expect(piped.stdout).not.toMatch(/[╭╮╰╯├┤]/u);

      const terminal = await runReportPty(
        ["show"],
        {
          columns: 120,
          rows: 40,
          cwd: projectRoot,
          env: { TERM: "dumb", NO_COLOR: "1", FORCE_COLOR: undefined },
          timeoutMs: 60_000,
        },
      );
      expect(terminal.exitCode, terminal.diagnostic()).toBe(0);
      const visible = stripVTControlCharacters(terminal.stdout);
      expect(visible).toContain("Experiment comparison");
      expect(visible).toContain("main");
      expect(visible).not.toMatch(/\d+ \/ \d+ slot/);
      expect(visible).not.toMatch(/deliberate-fail[^\n]*0%/);
      expect(visible).not.toMatch(/tool-call[^\n]*100%/);
      expect(visible).toContain("├─ deliberate-error");
      expect(visible).toContain("│  └─ !");
      expect(visible).toMatch(/^╭.*╮$/mu);
      expect(visible).toMatch(/^╰.*╯$/mu);
    },
  );
});

test("自定义 Report 的 show 是单目标阅读面，JSON 只含 target-execution manifest", async () => {
  await reportE2E.case(
    "show-custom-fixture",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      for (const experimentId of ["main", "source"] as const) {
        const run = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      }

      // This makes the unrelated parameter Page's enumerate() fail. A target
      // show must still succeed because only view/static build the whole site.
      const targetOnlyEnv = { NICEEVAL_E2E_FAIL_UNRELATED_ENUMERATE: "1" };

      const shown = await niceeval.run(
        ["show", "--report", "./reports/site.tsx"],
        { env: targetOnlyEnv },
      );
      expect(shown.exitCode, shown.diagnostic()).toBe(0);
      expect(shown.stdout).toContain("Report fixture static");
      expect(shown.stdout).toMatch(/Fixture pass rate is\s+available \(4\/4\)/);
      expect(shown.stdout).toContain("Source detail");
      expect(shown.stdout).toContain("Diff detail");
      const json = await niceeval.run(
        ["show", "--report", "./reports/site.tsx", "--json"],
        { env: targetOnlyEnv },
      );
      expect(json.exitCode, json.diagnostic()).toBe(0);
      const manifest = json.json<CustomTargetExecutionManifest>();
      expect(manifest).toMatchObject({
        format: "niceeval.report-target-execution/v1",
        locale: "en",
        selection: {
          kind: "project-current",
          experimentIds: [
            "classic/baseline",
            "classic/incompatible",
            "classic/memory-a",
            "classic/memory-b",
            "main",
            "source",
          ],
        },
        report: { title: "Report fixture" },
        page: {
          route: "/",
          pageId: "overview",
          title: "Report fixture",
          renderedText: expect.stringContaining("Report fixture static"),
        },
        downloads: [],
      });
      expectCanonicalProblemTable(manifest.problems, "overview");
      expect(manifest.report.identity).toEqual(expect.any(String));
      expect(manifest.selection.sampleIdentity).toEqual(expect.any(String));
      expectBuiltInPricingProfile(manifest.projections);
      expect(manifest.projections.costs).toHaveLength(1);
      expect(manifest.projections.costs.map((entry) => entry.page)).toEqual([
        { pageId: "overview", route: "/" },
      ]);
    },
  );
});

test("参数化 show 按规范 key 读取详情页，并对非成员 key 返回单目标错误", async () => {
  await reportE2E.case(
    "show-parameterized",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });

      const json = await niceeval.run(["show", "--report", "./reports/site.tsx", "--json"]);
      expect(json.exitCode, json.diagnostic()).toBe(0);
      const manifest = json.json<CustomTargetExecutionManifest>();
      const slotId = /Slot detail (slot-[a-zA-Z0-9_-]+)/.exec(manifest.page.renderedText);
      expect(slotId, "the overview must expose at least one slot detail target").not.toBeNull();
      const slotKey = slotId![1];

      const detail = await niceeval.run([
        "show",
        "--report",
        "./reports/site.tsx",
        "--page",
        `/slot/${slotKey}`,
        "--json",
      ]);
      expect(detail.exitCode, detail.diagnostic()).toBe(0);
      const detailManifest = detail.json<CustomTargetExecutionManifest>();
      expect(detailManifest).toMatchObject({
        format: "niceeval.report-target-execution/v1",
        page: {
          route: `/slot/${slotKey}`,
          pageId: "slot",
          renderedText: expect.stringContaining(`Slot fixture detail ${slotKey}`),
        },
        problems: [],
      });
      expect(detailManifest.downloads, "a single target carries only its own downloads").toEqual([]);
      expect(detailManifest.projections.costs, "show carries only the selected Page capture").toEqual([]);

      const missing = await niceeval.run([
        "show",
        "--report",
        "./reports/site.tsx",
        "--page",
        "/slot/not-a-member-slot",
      ]);
      expect(missing.exitCode, missing.diagnostic()).not.toBe(0);
      expect(missing.stdout, missing.diagnostic()).not.toContain("Slot fixture detail");
    },
  );
});
```

### Verification receipt

- Candidate: Git `2c032479607fdcb53b79c2d43a5df02a0ef99811`；NiceEval tarball SHA-256 `3c52d917283e7f72b3be8539d1dd999cb72c89eee2ea89681a1426c1b2d4eacc`
- Red: 安装候选 `82b7507542e1febf2c65d94db16e8db179df2c12058fd7b43f2f771d140ec1f5` 运行目标 owner，最早在 `classic/baseline` Tokens 断言失败：收到 `partial`、`1/9`、`value 0`，并产生 8 条 `usage collection is incomplete`
- Green: `pnpm e2e test --repo report` → 6 个 Vitest 文件 / 13 tests 与 Chromium 2 tests 全部通过；最终候选链接到 `NiceEval/NiceEval-Preview@705d90329848825b25b1fbde389905b513ccb93a` 后，原封存 Record 的 `/group/named/pass-gallery` 为 0 条 usage incomplete，candidate Tokens 为 available 4/4、208
- Repeatability: `pnpm e2e takeover --candidate artifacts/niceeval-candidate.tgz --repo report --artifact-root artifacts/e2e/takeover-report-usage -- --run test/report-show.test.ts -t "show 保留 named identity、实际 Eval population 与独立完整的 usage"` → 三份独立安装、同副本重复、repo 默认并行与目标单项全部 clean pass，matrix complete，scratch 清理成功
- Fixed conditions: base `794c67a6296322b71ea50800ce0ad9d85b34675c`、签入 lockfile、deterministic Report fixture、无 provider 调用、Playwright Chromium 1.61.1、Preview commit 与 Record 不变
- Unit count: `not applicable — no Unit changed`
