### PR TITLE
feat(sandbox): cache E2B setup prefixes as snapshots

### DIFF
--- a/docs/feature/sandbox/architecture.md
+++ b/docs/feature/sandbox/architecture.md
@@ -456,7 +456,7 @@ action 成功后 capture 失败时不得再执行该 action。当前容器仍完
 
 opaque callback、`defineSandboxCommand()`、runtime secret overlay、租约、外部会话与当前 Attempt locator 都是 barrier。barrier 之前的最长 verified prefix 仍可命中；barrier 之后的 action 真实执行，但不能发布共享前缀。
 
-E2B 只回收 NiceEval 自己登记的 SetupPrefix snapshots；用户声明的 image、template 与 snapshot 永不由 NiceEval 自动删除。自动回收先确认最短保护期已过、没有活跃私有 clone root，并在 provider 删除后才 tombstone 登记；无法验证的 legacy 或 provider-only artifact 永远保留。Docker task-build image 已有显式 GC；Docker SetupPrefix image 的同等回收入口仍须单独接入。作者可见的运行开关只有 `sandboxCache.setup: "use" | "bypass"` 和对应 CLI flag。
+每个 SetupPrefix artifact 还保存不含 action 内容的 replacement lineage。相同 lineage 的新 artifact 发布后，NiceEval 立即淘汰已被替代的 Docker image 或 E2B snapshot。仍被 private clone、lease 或未完成 capture 使用的旧 generation 不会删除；最后一个 root 释放后再次尝试淘汰。删除失败保留登记并重试，不按年龄、名称或“不在当前 Run”猜测垃圾。用户声明的 image、template 与 snapshot 永不由 NiceEval 自动删除。作者可见的运行开关只有 `sandboxCache.setup: "use" | "bypass"` 和对应 CLI flag。
 
 ## 运行事实的唯一归属
 

--- a/docs/feature/sandbox/architecture.md
+++ b/docs/feature/sandbox/architecture.md
@@ -426,23 +426,27 @@ SetupPrefixKey 不包含 cache lookup 结果、本地 image/container locator、
 
 `verified` 只有三项含义：
 
-1. 声明 identity、SetupPrefixKey、manifest、Docker labels 与 exact image ID 双向一致。
+1. 声明 identity、SetupPrefixKey、manifest 与 provider artifact identity 双向一致；Docker 使用 exact image ID，E2B 使用 NiceEval 登记的 raw snapshot ID。
 2. Provider artifact 包含 action 声明 state 的全部结果；普通 Docker 是 outer writable rootfs，Profile 可以是 quiescent Docker data。
 3. 每个消费者从 immutable artifact 创建独立 writable state，不共享 writable layer 或 Docker data slot。
 
 `verified` 不证明 action 业务语义正确，也不证明任意 shell、网络、时钟或随机读取具有确定性。`defineSandboxAction()` 是作者对确定性的承诺。普通 JSON 与文本由作者声明为非敏感；已知 `Secret`、credential handle 与 runtime binding 在 planning 拒绝。发布前对框架已知 secret bytes 的扫描只做纵深防御。
 
-## Docker 支持边界
+## Docker 与 E2B 支持边界
 
 普通本地单容器 `dockerSandbox()` 只在全部可变状态都位于 outer writable rootfs 时报告 `persistent`。每个成功 action 都 commit 一枚 exact image，inspect 其 ID、labels 与 manifest，再从该 image 启动下一个 staging 容器。最终命中也从 exact image 启动私有 writable 容器，然后才注入 runtime secret 并运行 Agent/test。
 
-bind mount、tmpfs、Docker Compose sidecar、host socket、E2B、Vercel 与 custom Provider 报告 `unsupported`。它们仍按同一 DAG 真实执行 action，不把部分状态或 Provider 原生 cache 伪装成 SetupPrefix hit。
+E2B 把作者声明的 template 当作 Base identity。每个 eligible `sandboxState.all` 前缀在 Sandbox ready 后创建持久 snapshot。
+
+E2B 创建 snapshot 时暂停 staging Sandbox。因此 NiceEval 总是从返回的 raw snapshot ID 新建私有 Sandbox，再交给下一前缀或 Agent。snapshot 不使用可移动的 name/tag，也不替换、修改或删除用户声明的 template。NiceEval 已知 secret 或 credential 值出现时拒绝 capture，当前私有 Sandbox 继续以 uncached 路径完成 Attempt。
+
+bind mount、tmpfs、Docker Compose sidecar、host socket、Vercel 与 custom Provider 报告 `unsupported`。它们仍按同一 DAG 真实执行 action，不把部分状态或 Provider 原生 cache 伪装成 SetupPrefix hit。
 
 raw privileged 与 managed rootless Docker Profile 把 private Docker data-root 放在 outer rootfs 之外。单独 commit outer image 会丢失 inner image 与 volume，因此不能完整保存默认 `sandboxState.all`。
 
 Profile 只在 published seed 与每个 slot 都是独立、fully allocated、fixed-size filesystem image 时声明支持 `sandboxState.dockerData`。该 state 仅包含 inner daemon quiesce 后的持久 `/var/lib/docker`；workspace、home、outer rootfs、tmpfs、socket、PID、运行中 container/BuildKit session 与 secret 都不在其中。shared loop-ext4/project-quota Profile 继续报告 `unsupported`。
 
-Runner 对排序后的 action 累积 state。第一个 `all`、opaque 或其它 Provider 不支持的 state 是 barrier；它与全部后缀都重新执行，后面的 `dockerData` action 也不能脱离祖先状态重新命中。Host 以 typed capability 与 receipt 核对 required state、SetupPrefixKey、manifest digest、filesystem identity 和 generation；每个命中从 immutable seed创建不同 writable slot。
+Runner 对排序后的 action 累积 state。第一个 opaque 或其它 Provider 不支持的 state 是 barrier；它与全部后缀都重新执行。Docker Profile 的 `dockerData` action 也不能脱离祖先状态重新命中。Host 以 typed capability 与 receipt 核对 required state、SetupPrefixKey、manifest digest、artifact identity 和 generation；每个命中从 immutable seed创建不同 writable slot。
 
 ## 前缀缓存是可失败的优化
 
@@ -452,7 +456,7 @@ action 成功后 capture 失败时不得再执行该 action。当前容器仍完
 
 opaque callback、`defineSandboxCommand()`、runtime secret overlay、租约、外部会话与当前 Attempt locator 都是 barrier。barrier 之前的最长 verified prefix 仍可命中；barrier 之后的 action 真实执行，但不能发布共享前缀。
 
-这个能力不公开 setup-prefix inventory、精确失效或 GC，也不把本地 image 保护建模成 host lease/index 协议。作者可见的运行开关只有 `sandboxCache.setup: "use" | "bypass"` 和对应 CLI flag。
+E2B 只回收 NiceEval 自己登记的 SetupPrefix snapshots；用户声明的 image、template 与 snapshot 永不由 NiceEval 自动删除。自动回收先确认最短保护期已过、没有活跃私有 clone root，并在 provider 删除后才 tombstone 登记；无法验证的 legacy 或 provider-only artifact 永远保留。Docker task-build image 已有显式 GC；Docker SetupPrefix image 的同等回收入口仍须单独接入。作者可见的运行开关只有 `sandboxCache.setup: "use" | "bypass"` 和对应 CLI flag。
 
 ## 运行事实的唯一归属
 

--- a/docs/feature/sandbox/cli.md
+++ b/docs/feature/sandbox/cli.md
@@ -29,7 +29,7 @@ niceeval exp <experiment> [eval...] --sandbox-setup-cache=bypass
 
 `bypass` 禁止 SetupPrefix lookup 与 publication，并真实 replay 全部 eligible before。BuildKey 的 lookup/build 仍照常执行；该选择不改变 BuildKey、SetupPrefixKey、CaseKey、Attempt fingerprint 或 result identity。该 flag 只用于冷路径验收、排障与绕开本机 cache，不是强制重跑历史结果的入口。
 
-`--dry` 无论取值都只计算计划和 identity，固定显示 `cacheLookup: "not-probed"`。运行反馈在 bypass 时显示 `replay · bypass`。这个准备缓存不新增 inventory、精确失效或 GC 命令；根级也不存在 `niceeval cache`。
+`--dry` 无论取值都只计算计划和 identity，固定显示 `cacheLookup: "not-probed"`。运行反馈在 bypass 时显示 `replay · bypass`。准备缓存只管理 NiceEval 创建并登记的 Docker image 与 E2B snapshot；它不接管用户声明的 image、template 或 snapshot。
 
 ## `--keep-sandbox`:跑完留下现场
 

--- a/docs/feature/sandbox/lifecycle.md
+++ b/docs/feature/sandbox/lifecycle.md
@@ -126,11 +126,11 @@ reuse: reset baseline -> before -> Agent/test -> after
 ```text
 BuildKey ready
   -> lookup longest verified SetupPrefix
-  -> create private staging from exact parent or Base
+  -> create private staging from exact parent image, E2B snapshot, or Base
   -> for each remaining eligible action:
        replay action
-       -> quiesce / commit / verify exact Docker image
-       -> create next staging from that exact image
+       -> quiesce / commit or snapshot / verify provider artifact
+       -> create next private staging from that exact artifact
   -> create final private writable clone
   -> runtime secret overlay
   -> agent.ensure / Adapter runtime / Agent / Eval test

--- a/docs/feature/sandbox/lifecycle.md
+++ b/docs/feature/sandbox/lifecycle.md
@@ -130,6 +130,7 @@ BuildKey ready
   -> for each remaining eligible action:
        replay action
        -> quiesce / commit or snapshot / verify provider artifact
+       -> new artifact supersedes the same lineage's inactive older generation
        -> create next private staging from that exact artifact
   -> create final private writable clone
   -> runtime secret overlay

--- a/packages/niceeval/src/runner/attempt.ts
+++ b/packages/niceeval/src/runner/attempt.ts
@@ -1768,6 +1768,7 @@ function plannedSetupPrefixActions(
   })}`;
   const planned: PlannedSetupPrefixAction[] = [];
   const actionManifest: JsonValue[] = [];
+  const replacementLineage: JsonValue[] = [];
   let cumulativeState: SandboxActionState | undefined;
   for (const entry of entries) {
     cumulativeState = mergeSandboxActionState(cumulativeState, entry.data.plan.state);
@@ -1800,6 +1801,15 @@ function plannedSetupPrefixActions(
         steps: entry.data.plan.steps,
       },
     }) as unknown as JsonValue);
+    replacementLineage.push(Object.freeze({
+      owner: { kind: entry.owner.kind, id: entry.owner.id, ordinal: entry.ordinal },
+      order: entry.executionOrder.topologicalOrdinal,
+      action: {
+        id: entry.data.plan.id,
+        family: entry.data.plan.family,
+        declaredState: entry.data.plan.state,
+      },
+    }) as unknown as JsonValue);
     const declarationMetadata = Object.freeze({
       protocol: "niceeval.setup-prefix-manifest/v1",
       parentKey,
@@ -1821,6 +1831,27 @@ function plannedSetupPrefixActions(
         },
       },
       actionManifest: [...actionManifest],
+      // This deliberately excludes action input/fingerprint/steps. A later
+      // publication with the same lineage scope replaces this prefix's old
+      // artifact once no private clone still owns it.
+      replacementScope: Object.freeze({
+        protocol: "niceeval.setup-prefix-replacement/v1",
+        baseImageId,
+        provider: {
+          id: provider.provider,
+          plannerRevision: provider.plannerRevision,
+          caseKind: provider.caseKind,
+          caseKey: provider.build.caseKey,
+          identity: provider.identity,
+        },
+        occurrence: {
+          experimentId: attempt.plan.pair.experimentId,
+          evalId: attempt.plan.pair.evalId,
+          agentName: attempt.plan.pair.agentName,
+        },
+        target: targetIdentity,
+        lineage: [...replacementLineage],
+      }),
       requiredState: cumulativeState,
       target: targetIdentity,
       revisions: {

--- a/packages/niceeval/src/sandbox/docker-setup-prefix-cache.ts
+++ b/packages/niceeval/src/sandbox/docker-setup-prefix-cache.ts
@@ -86,6 +86,16 @@ interface ValidatedManifest {
   readonly declarationDigest: string;
 }
 
+function replacementScope(manifest: ValidatedManifest): string {
+  const metadata = manifest.value.declarationMetadata;
+  if (typeof metadata !== "object" || metadata === null || Array.isArray(metadata)) {
+    throw new TypeError("setup-prefix declaration metadata must be a record");
+  }
+  const scope = (metadata as { readonly replacementScope?: unknown }).replacementScope;
+  if (scope === undefined) throw new TypeError("setup-prefix declaration metadata has no replacement scope");
+  return canonicalJson(scope);
+}
+
 interface HolderIdentity {
   readonly hostId: string;
   readonly bootId: string;
@@ -322,6 +332,16 @@ function setupPrefixSchema(db: DatabaseSync): void {
       CREATE TABLE IF NOT EXISTS setup_prefix_generation_fences (
       setup_prefix_key TEXT PRIMARY KEY,
       next_generation INTEGER NOT NULL
+    );
+      CREATE TABLE IF NOT EXISTS setup_prefix_replacement_scopes (
+      entry_id TEXT PRIMARY KEY REFERENCES setup_prefix_entries(entry_id),
+      replacement_scope TEXT NOT NULL
+    );
+      CREATE INDEX IF NOT EXISTS setup_prefix_replacement_scope
+        ON setup_prefix_replacement_scopes(replacement_scope);
+      CREATE TABLE IF NOT EXISTS setup_prefix_replacement_heads (
+      replacement_scope TEXT PRIMARY KEY,
+      entry_id TEXT NOT NULL REFERENCES setup_prefix_entries(entry_id)
     );
       CREATE TABLE IF NOT EXISTS setup_prefix_leases (
       lease_id TEXT PRIMARY KEY,
@@ -816,6 +836,7 @@ async function releaseDurableRoot(input: {
   } finally {
     domain.db.close();
   }
+  await reclaimSupersededDockerImages();
 }
 
 async function restoreLeaseIntoTarget(
@@ -1091,6 +1112,8 @@ async function reserveEntry(
       now.toISOString(),
       new Date(now.getTime() + MINIMUM_AGE_MS).toISOString(),
     );
+    domain.db.prepare("INSERT INTO setup_prefix_replacement_scopes(entry_id, replacement_scope) VALUES (?, ?)")
+      .run(entryId, replacementScope(manifest));
     domain.db.prepare("UPDATE setup_prefix_entries SET state = 'building' WHERE entry_id = ? AND state = 'reserved'").run(entryId);
     domain.db.prepare(`
       INSERT INTO setup_prefix_leases(
@@ -1166,6 +1189,11 @@ async function publishEntry(row: SetupPrefixEntryRow, imageId: string, signal: A
       .run(row.setup_prefix_key, row.entry_id);
     domain.db.prepare("UPDATE setup_prefix_entries SET state = 'indexed' WHERE entry_id = ? AND state = 'published'")
       .run(row.entry_id);
+    domain.db.prepare(`
+      INSERT INTO setup_prefix_replacement_heads(replacement_scope, entry_id)
+      SELECT replacement_scope, entry_id FROM setup_prefix_replacement_scopes WHERE entry_id = ?
+      ON CONFLICT(replacement_scope) DO UPDATE SET entry_id = excluded.entry_id
+    `).run(row.entry_id);
     domain.db.prepare("UPDATE metadata SET value = CAST(value AS INTEGER) + 1 WHERE key = 'setupPrefixSafetyRevision'").run();
     domain.db.exec("COMMIT");
   } catch (cause) {
@@ -1190,6 +1218,71 @@ async function failedCaptureImageCanBeRemoved(imageId: string, entryId: string):
       !siblingSetupPrefixClaimsImage(domain.db, entryId, imageId);
   } finally {
     domain.db.close();
+  }
+}
+
+/** Retire an artifact only after a replacement with the identical logical lineage is indexed. */
+async function reclaimSupersededDockerImages(scope?: string, exceptEntryId?: string): Promise<void> {
+  const domain = await openSetupPrefixDomain();
+  const candidates: SetupPrefixEntryRow[] = [];
+  try {
+    domain.db.exec("BEGIN IMMEDIATE");
+    const rows = domain.db.prepare(`
+      SELECT entry.* FROM setup_prefix_entries AS entry
+      JOIN setup_prefix_replacement_scopes AS scope ON scope.entry_id = entry.entry_id
+      JOIN setup_prefix_replacement_heads AS head ON head.replacement_scope = scope.replacement_scope
+      WHERE entry.state = 'indexed'
+        AND (? IS NULL OR scope.replacement_scope = ?)
+        AND (? IS NULL OR entry.entry_id != ?)
+        AND entry.entry_id != head.entry_id
+        AND NOT EXISTS (
+          SELECT 1 FROM setup_prefix_roots AS root
+          WHERE root.entry_id = entry.entry_id AND root.state IN ('prepared','active','releasing')
+        )
+    `).all(scope ?? null, scope ?? null, exceptEntryId ?? null, exceptEntryId ?? null) as unknown as SetupPrefixEntryRow[];
+    for (const row of rows) {
+      if (reconcileLeaseCount(domain.db, row.entry_id) > 0 || row.image_id === null) continue;
+      const marked = domain.db.prepare("UPDATE setup_prefix_entries SET state = 'deleting' WHERE entry_id = ? AND state = 'indexed'")
+        .run(row.entry_id);
+      if (marked.changes !== 1) continue;
+      domain.db.prepare("DELETE FROM setup_prefix_index WHERE entry_id = ?").run(row.entry_id);
+      candidates.push(row);
+    }
+    domain.db.exec("COMMIT");
+  } catch (cause) {
+    try { domain.db.exec("ROLLBACK"); } catch { /* no active transaction */ }
+    throw cause;
+  } finally {
+    domain.db.close();
+  }
+
+  for (const candidate of candidates) {
+    const imageId = candidate.image_id!;
+    let state: "indexed" | "tombstoned" = "indexed";
+    try {
+      const signal = AbortSignal.timeout(PROVIDER_CLEANUP_TIMEOUT_MS);
+      if (
+        !await hasContainerReference(imageId, signal) &&
+        await failedCaptureImageCanBeRemoved(imageId, candidate.entry_id)
+      ) {
+        await new Docker().getImage(imageId).remove({ abortSignal: signal });
+        state = "tombstoned";
+      }
+    } catch {
+      // A replacement is already live. Keep the old generation indexed if its
+      // provider deletion cannot be proven; a later publish/root release retries.
+    }
+    const settled = await openSetupPrefixDomain();
+    try {
+      settled.db.prepare("UPDATE setup_prefix_entries SET state = ? WHERE entry_id = ? AND generation = ? AND state = 'deleting'")
+        .run(state, candidate.entry_id, candidate.generation);
+      if (state === "indexed") {
+        settled.db.prepare("INSERT OR IGNORE INTO setup_prefix_index(setup_prefix_key, entry_id) VALUES (?, ?)")
+          .run(candidate.setup_prefix_key, candidate.entry_id);
+      }
+    } finally {
+      settled.db.close();
+    }
   }
 }
 
@@ -1233,6 +1326,7 @@ async function captureAndRebase(
     const inspection = await inspectExactImage(imageId, signal);
     validateImageLabels(inspection, imageId, labels);
     await publishEntry(reservedRow, imageId, signal);
+    await reclaimSupersededDockerImages(replacementScope(manifest), reservedRow.entry_id);
     signal.throwIfAborted();
     const lease = await acquireIndexedLease(input, manifest, reservedRow.entry_id);
     if (lease === undefined) throw new Error("captured setup-prefix generation was not indexed");

--- a/packages/niceeval/src/sandbox/e2b-setup-prefix-cache.ts
+++ b/packages/niceeval/src/sandbox/e2b-setup-prefix-cache.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { Effect } from "effect";
+import { sandboxActionStateCovers } from "./action.ts";
+import {
+  SandboxSetupPrefixCacheCaptureError,
+  SandboxSetupPrefixCacheLookupError,
+  SandboxSetupPrefixCacheRestoreError,
+  SandboxSetupPrefixCacheValidationError,
+  type SandboxSetupPrefixCacheCapability,
+  type SandboxSetupPrefixCacheCaptureResult,
+  type SandboxSetupPrefixCacheEligibility,
+  type SandboxSetupPrefixCacheLookupResult,
+  type SandboxSetupPrefixCacheOperation,
+} from "./backend.ts";
+
+const MINIMUM_AGE_MS = 24 * 60 * 60 * 1000;
+
+export interface E2BSetupPrefixRootOwnership {
+  readonly release: () => Promise<void>;
+}
+
+export interface E2BSetupPrefixCacheTarget {
+  readonly eligibility: () => SandboxSetupPrefixCacheEligibility;
+  readonly captureSnapshot: () => Promise<string>;
+  readonly deleteSnapshot: (snapshotId: string) => Promise<boolean>;
+  readonly rebaseToSnapshot: (snapshotId: string, signal: AbortSignal) => Promise<{ readonly sandboxId: string }>;
+  readonly recoverCleanBase: (signal: AbortSignal) => Promise<{ readonly sandboxId: string }>;
+  readonly adoptSetupPrefixRoot: (root: E2BSetupPrefixRootOwnership) => void;
+}
+
+interface Entry {
+  readonly setup_prefix_key: string;
+  readonly base_identity: string;
+  readonly snapshot_id: string | null;
+  readonly declaration_digest: string;
+  readonly generation: number;
+  readonly created_at: string;
+  readonly last_successful_use_at: string | null;
+  readonly protected_until: string;
+  readonly state: "building" | "indexed" | "unverified" | "deleting" | "tombstoned";
+}
+
+function statePath(): string {
+  return join(process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state"), "niceeval", "cache", "v2", "e2b-setup-prefix.sqlite");
+}
+
+async function open(): Promise<DatabaseSync> {
+  const path = statePath();
+  await mkdir(dirname(path), { recursive: true });
+  const db = new DatabaseSync(path);
+  db.exec("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS entries (
+      setup_prefix_key TEXT PRIMARY KEY,
+      base_identity TEXT NOT NULL,
+      snapshot_id TEXT UNIQUE,
+      declaration_digest TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      created_at TEXT NOT NULL,
+      last_successful_use_at TEXT,
+      protected_until TEXT NOT NULL,
+      state TEXT NOT NULL CHECK(state IN ('building','indexed','unverified','deleting','tombstoned'))
+    );
+    CREATE TABLE IF NOT EXISTS roots (
+      root_id TEXT PRIMARY KEY,
+      setup_prefix_key TEXT NOT NULL REFERENCES entries(setup_prefix_key),
+      sandbox_id TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function declarationDigest(input: SandboxSetupPrefixCacheOperation): string {
+  const value = input.manifest.declarationMetadata;
+  const json = JSON.stringify(value);
+  // The runner's key is content-addressed from this exact value. Requiring the
+  // same digest-shaped relationship avoids accepting a registry key supplied by
+  // an arbitrary caller without duplicating the runner's canonicalizer.
+  if (input.manifest.setupPrefixKey.length === 0 || input.manifest.setupManifestDigest !== `sha256:${input.manifest.setupPrefixKey.slice(7)}`) {
+    throw new Error("E2B setup-prefix key and manifest digest do not agree");
+  }
+  return json;
+}
+
+function validate(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPrefixCacheOperation): Extract<SandboxSetupPrefixCacheEligibility, { readonly _tag: "Eligible" }> {
+  const eligibility = target.eligibility();
+  if (eligibility._tag === "Unsupported") throw new Error(eligibility.reason);
+  if (input.manifest.baseImageId !== eligibility.baseImageId) throw new Error("E2B setup-prefix Base identity changed");
+  if (!sandboxActionStateCovers(eligibility.coverage, input.manifest.requiredState)) throw new Error("E2B snapshot does not cover the requested state");
+  declarationDigest(input);
+  return eligibility;
+}
+
+function failure<T extends Error>(ErrorType: new (fields: ConstructorParameters<typeof SandboxSetupPrefixCacheLookupError>[0]) => T, operation: string, input: SandboxSetupPrefixCacheOperation, cause: unknown): T {
+  return new ErrorType({ operation, reason: cause instanceof Error ? cause.message : String(cause), setupPrefixKey: input.manifest.setupPrefixKey, cause });
+}
+
+async function releaseRoot(rootId: string): Promise<void> {
+  const db = await open();
+  try { db.prepare("DELETE FROM roots WHERE root_id = ?").run(rootId); } finally { db.close(); }
+}
+
+/** Best-effort automatic GC only touches snapshots that have a complete NiceEval registry proof. */
+async function reclaimColdSnapshots(target: E2BSetupPrefixCacheTarget): Promise<void> {
+  const db = await open();
+  const candidates: Entry[] = [];
+  try {
+    db.exec("BEGIN IMMEDIATE");
+    const now = Date.now();
+    const rows = db.prepare(`
+      SELECT entry.* FROM entries AS entry
+      WHERE entry.state = 'indexed'
+        AND entry.snapshot_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM roots WHERE roots.setup_prefix_key = entry.setup_prefix_key)
+    `).all() as unknown as Entry[];
+    for (const row of rows) {
+      const lastUse = Date.parse(row.last_successful_use_at ?? row.created_at);
+      if (Date.parse(row.protected_until) > now || now - lastUse < MINIMUM_AGE_MS) continue;
+      const marked = db.prepare("UPDATE entries SET state = 'deleting' WHERE setup_prefix_key = ? AND state = 'indexed'")
+        .run(row.setup_prefix_key);
+      if (marked.changes === 1) candidates.push(row);
+    }
+    db.exec("COMMIT");
+  } catch (cause) {
+    try { db.exec("ROLLBACK"); } catch { /* no active transaction */ }
+    throw cause;
+  } finally { db.close(); }
+  for (const candidate of candidates) {
+    const settled = await open();
+    try {
+      let state: "indexed" | "tombstoned" = "indexed";
+      try {
+        if (candidate.snapshot_id === null) throw new Error("E2B GC entry has no snapshot identity");
+        await target.deleteSnapshot(candidate.snapshot_id);
+        state = "tombstoned";
+      } catch { /* retain an artifact when provider deletion cannot be proven */ }
+      settled.prepare("UPDATE entries SET state = ? WHERE setup_prefix_key = ? AND generation = ? AND state = 'deleting'")
+        .run(state, candidate.setup_prefix_key, candidate.generation);
+    } finally { settled.close(); }
+  }
+}
+
+async function restore(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPrefixCacheOperation, signal: AbortSignal): Promise<SandboxSetupPrefixCacheLookupResult> {
+  try {
+    validate(target, input);
+    const db = await open();
+    let row: Entry | undefined;
+    let rootId: string | undefined;
+    try {
+      row = db.prepare("SELECT * FROM entries WHERE setup_prefix_key = ? AND state = 'indexed'").get(input.manifest.setupPrefixKey) as Entry | undefined;
+      if (row === undefined || row.base_identity !== input.manifest.baseImageId) return { _tag: "Miss", setupPrefixKey: input.manifest.setupPrefixKey };
+      if (row.snapshot_id === null) throw new Error("indexed E2B setup-prefix entry has no snapshot identity");
+      const snapshotId = row.snapshot_id;
+      const allocatedRootId = randomUUID();
+      rootId = allocatedRootId;
+      db.prepare("INSERT INTO roots(root_id, setup_prefix_key, sandbox_id, created_at) VALUES (?, ?, ?, ?)")
+        .run(allocatedRootId, row.setup_prefix_key, `pending:${allocatedRootId}`, new Date().toISOString());
+      const rebound = await target.rebaseToSnapshot(snapshotId, signal);
+      db.prepare("UPDATE roots SET sandbox_id = ? WHERE root_id = ? AND sandbox_id = ?")
+        .run(rebound.sandboxId, allocatedRootId, `pending:${allocatedRootId}`);
+      db.prepare("UPDATE entries SET last_successful_use_at = ? WHERE setup_prefix_key = ? AND snapshot_id = ? AND state = 'indexed'")
+        .run(new Date().toISOString(), row.setup_prefix_key, snapshotId);
+      target.adoptSetupPrefixRoot({ release: () => releaseRoot(allocatedRootId) });
+      return { _tag: "Restored", setupPrefixKey: row.setup_prefix_key, entryId: row.setup_prefix_key, generation: row.generation, artifactId: snapshotId, sandboxId: rebound.sandboxId };
+    } catch (cause) {
+      if (rootId !== undefined) db.prepare("DELETE FROM roots WHERE root_id = ?").run(rootId);
+      throw cause;
+    } finally { db.close(); }
+  } catch (cause) {
+    if (cause instanceof SandboxSetupPrefixCacheValidationError) throw cause;
+    throw failure(SandboxSetupPrefixCacheLookupError, "restore E2B setup-prefix snapshot", input, cause);
+  }
+}
+
+async function capture(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPrefixCacheOperation, signal: AbortSignal): Promise<SandboxSetupPrefixCacheCaptureResult> {
+  try {
+    validate(target, input);
+    if ((input.knownSensitiveValues ?? []).some((value) => value.length > 0)) {
+      return { _tag: "ContinuedUncached", setupPrefixKey: input.manifest.setupPrefixKey, reason: "capture-failed", sandboxId: "e2b-sensitive-state" };
+    }
+    const db = await open();
+    let generation: number;
+    try {
+      db.exec("BEGIN IMMEDIATE");
+      const existing = db.prepare("SELECT * FROM entries WHERE setup_prefix_key = ?").get(input.manifest.setupPrefixKey) as Entry | undefined;
+      if (existing !== undefined) {
+        db.exec("COMMIT");
+        return { _tag: "Contended", setupPrefixKey: input.manifest.setupPrefixKey, reason: existing.state === "indexed" ? "indexed-generation" : "active-writer" };
+      }
+      generation = (db.prepare("SELECT COALESCE(MAX(generation), 0) AS n FROM entries").get() as { n: number }).n + 1;
+      db.prepare("INSERT INTO entries(setup_prefix_key, base_identity, snapshot_id, declaration_digest, generation, created_at, protected_until, state) VALUES (?, ?, NULL, ?, ?, ?, ?, 'building')")
+        .run(input.manifest.setupPrefixKey, input.manifest.baseImageId, declarationDigest(input), generation, new Date().toISOString(), new Date(Date.now() + MINIMUM_AGE_MS).toISOString());
+      db.exec("COMMIT");
+    } catch (cause) {
+      try { db.exec("ROLLBACK"); } catch { /* no active transaction */ }
+      throw cause;
+    } finally { db.close(); }
+
+    let snapshotId: string | undefined;
+    try {
+      snapshotId = await target.captureSnapshot();
+      signal.throwIfAborted();
+      const publishing = await open();
+      try {
+        const published = publishing.prepare("UPDATE entries SET snapshot_id = ?, state = 'indexed' WHERE setup_prefix_key = ? AND generation = ? AND state = 'building'")
+          .run(snapshotId, input.manifest.setupPrefixKey, generation);
+        if (published.changes !== 1) throw new Error("E2B setup-prefix publication lost its generation fence");
+      } finally { publishing.close(); }
+      const rebound = await target.rebaseToSnapshot(snapshotId, signal);
+      const active = await open();
+      const rootId = randomUUID();
+      active.prepare("INSERT INTO roots(root_id, setup_prefix_key, sandbox_id, created_at) VALUES (?, ?, ?, ?)")
+        .run(rootId, input.manifest.setupPrefixKey, rebound.sandboxId, new Date().toISOString());
+      active.close();
+      target.adoptSetupPrefixRoot({ release: () => releaseRoot(rootId) });
+      return { _tag: "Captured", setupPrefixKey: input.manifest.setupPrefixKey, entryId: input.manifest.setupPrefixKey, generation, artifactId: snapshotId, sandboxId: rebound.sandboxId };
+    } catch (cause) {
+      if (snapshotId !== undefined) await target.deleteSnapshot(snapshotId).catch(() => undefined);
+      const failed = await open();
+      try { failed.prepare("UPDATE entries SET state = 'unverified' WHERE setup_prefix_key = ? AND generation = ? AND state = 'building'").run(input.manifest.setupPrefixKey, generation); } finally { failed.close(); }
+      throw cause;
+    }
+  } catch (cause) {
+    throw failure(SandboxSetupPrefixCacheCaptureError, "capture E2B setup-prefix snapshot", input, cause);
+  }
+}
+
+export function makeE2BSetupPrefixCacheCapability(target: E2BSetupPrefixCacheTarget): SandboxSetupPrefixCacheCapability {
+  return {
+    eligibility: target.eligibility,
+    lookupAndRebase: (input) => Effect.tryPromise({
+      try: async (signal) => { await reclaimColdSnapshots(target); return restore(target, input, signal); },
+      catch: (cause) => cause as never,
+    }),
+    captureAndRebase: (input) => Effect.tryPromise({
+      try: async (signal) => { await reclaimColdSnapshots(target); return capture(target, input, signal); },
+      catch: (cause) => cause as never,
+    }),
+    recoverCleanBase: () => Effect.tryPromise({
+      try: async (signal) => {
+        const eligibility = target.eligibility();
+        if (eligibility._tag === "Unsupported") throw new Error(eligibility.reason);
+        return {
+          _tag: "RecoveredCleanBase" as const,
+          baseImageId: eligibility.baseImageId,
+          sandboxId: (await target.recoverCleanBase(signal)).sandboxId,
+        };
+      },
+      catch: (cause) => new SandboxSetupPrefixCacheRestoreError({ operation: "recover E2B setup-prefix Base", reason: cause instanceof Error ? cause.message : String(cause), cause }),
+    }),
+  };
+}

--- a/packages/niceeval/src/sandbox/e2b-setup-prefix-cache.ts
+++ b/packages/niceeval/src/sandbox/e2b-setup-prefix-cache.ts
@@ -17,8 +17,6 @@ import {
   type SandboxSetupPrefixCacheOperation,
 } from "./backend.ts";
 
-const MINIMUM_AGE_MS = 24 * 60 * 60 * 1000;
-
 export interface E2BSetupPrefixRootOwnership {
   readonly release: () => Promise<void>;
 }
@@ -63,6 +61,7 @@ async function open(): Promise<DatabaseSync> {
       created_at TEXT NOT NULL,
       last_successful_use_at TEXT,
       protected_until TEXT NOT NULL,
+      replacement_scope TEXT NOT NULL DEFAULT '',
       state TEXT NOT NULL CHECK(state IN ('building','indexed','unverified','deleting','tombstoned'))
     );
     CREATE TABLE IF NOT EXISTS roots (
@@ -71,7 +70,17 @@ async function open(): Promise<DatabaseSync> {
       sandbox_id TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS replacement_heads (
+      replacement_scope TEXT PRIMARY KEY,
+      setup_prefix_key TEXT NOT NULL REFERENCES entries(setup_prefix_key)
+    );
   `);
+  const columns = new Set((db.prepare("PRAGMA table_info(entries)").all() as Array<{ readonly name: string }>).map((row) => row.name));
+  if (!columns.has("replacement_scope")) {
+    // Existing entries cannot prove replacement lineage, so an empty sentinel
+    // keeps them reusable but prevents an automatic replacement deletion.
+    db.exec("ALTER TABLE entries ADD COLUMN replacement_scope TEXT NOT NULL DEFAULT ''");
+  }
   return db;
 }
 
@@ -87,6 +96,16 @@ function declarationDigest(input: SandboxSetupPrefixCacheOperation): string {
   return json;
 }
 
+function replacementScope(input: SandboxSetupPrefixCacheOperation): string {
+  const metadata = input.manifest.declarationMetadata;
+  if (typeof metadata !== "object" || metadata === null || Array.isArray(metadata)) {
+    throw new Error("E2B setup-prefix declaration metadata is not a record");
+  }
+  const scope = (metadata as { readonly replacementScope?: unknown }).replacementScope;
+  if (scope === undefined) throw new Error("E2B setup-prefix declaration has no replacement scope");
+  return JSON.stringify(scope);
+}
+
 function validate(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPrefixCacheOperation): Extract<SandboxSetupPrefixCacheEligibility, { readonly _tag: "Eligible" }> {
   const eligibility = target.eligibility();
   if (eligibility._tag === "Unsupported") throw new Error(eligibility.reason);
@@ -100,27 +119,30 @@ function failure<T extends Error>(ErrorType: new (fields: ConstructorParameters<
   return new ErrorType({ operation, reason: cause instanceof Error ? cause.message : String(cause), setupPrefixKey: input.manifest.setupPrefixKey, cause });
 }
 
-async function releaseRoot(rootId: string): Promise<void> {
+async function releaseRoot(rootId: string, target: E2BSetupPrefixCacheTarget): Promise<void> {
   const db = await open();
   try { db.prepare("DELETE FROM roots WHERE root_id = ?").run(rootId); } finally { db.close(); }
+  await reclaimSupersededSnapshots(target);
 }
 
-/** Best-effort automatic GC only touches snapshots that have a complete NiceEval registry proof. */
-async function reclaimColdSnapshots(target: E2BSetupPrefixCacheTarget): Promise<void> {
+/** A replacement is scoped to the same logical action lineage, never a loose template name. */
+async function reclaimSupersededSnapshots(target: E2BSetupPrefixCacheTarget, scope?: string, exceptKey?: string): Promise<void> {
   const db = await open();
   const candidates: Entry[] = [];
   try {
     db.exec("BEGIN IMMEDIATE");
-    const now = Date.now();
     const rows = db.prepare(`
       SELECT entry.* FROM entries AS entry
+      JOIN replacement_heads AS head ON head.replacement_scope = entry.replacement_scope
       WHERE entry.state = 'indexed'
         AND entry.snapshot_id IS NOT NULL
+        AND entry.replacement_scope != ''
+        AND (? IS NULL OR entry.replacement_scope = ?)
+        AND (? IS NULL OR entry.setup_prefix_key != ?)
+        AND entry.setup_prefix_key != head.setup_prefix_key
         AND NOT EXISTS (SELECT 1 FROM roots WHERE roots.setup_prefix_key = entry.setup_prefix_key)
-    `).all() as unknown as Entry[];
+    `).all(scope ?? null, scope ?? null, exceptKey ?? null, exceptKey ?? null) as unknown as Entry[];
     for (const row of rows) {
-      const lastUse = Date.parse(row.last_successful_use_at ?? row.created_at);
-      if (Date.parse(row.protected_until) > now || now - lastUse < MINIMUM_AGE_MS) continue;
       const marked = db.prepare("UPDATE entries SET state = 'deleting' WHERE setup_prefix_key = ? AND state = 'indexed'")
         .run(row.setup_prefix_key);
       if (marked.changes === 1) candidates.push(row);
@@ -135,10 +157,10 @@ async function reclaimColdSnapshots(target: E2BSetupPrefixCacheTarget): Promise<
     try {
       let state: "indexed" | "tombstoned" = "indexed";
       try {
-        if (candidate.snapshot_id === null) throw new Error("E2B GC entry has no snapshot identity");
+        if (candidate.snapshot_id === null) throw new Error("E2B replacement entry has no snapshot identity");
         await target.deleteSnapshot(candidate.snapshot_id);
         state = "tombstoned";
-      } catch { /* retain an artifact when provider deletion cannot be proven */ }
+      } catch { /* retain it when provider deletion cannot be proven */ }
       settled.prepare("UPDATE entries SET state = ? WHERE setup_prefix_key = ? AND generation = ? AND state = 'deleting'")
         .run(state, candidate.setup_prefix_key, candidate.generation);
     } finally { settled.close(); }
@@ -165,7 +187,7 @@ async function restore(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPre
         .run(rebound.sandboxId, allocatedRootId, `pending:${allocatedRootId}`);
       db.prepare("UPDATE entries SET last_successful_use_at = ? WHERE setup_prefix_key = ? AND snapshot_id = ? AND state = 'indexed'")
         .run(new Date().toISOString(), row.setup_prefix_key, snapshotId);
-      target.adoptSetupPrefixRoot({ release: () => releaseRoot(allocatedRootId) });
+      target.adoptSetupPrefixRoot({ release: () => releaseRoot(allocatedRootId, target) });
       return { _tag: "Restored", setupPrefixKey: row.setup_prefix_key, entryId: row.setup_prefix_key, generation: row.generation, artifactId: snapshotId, sandboxId: rebound.sandboxId };
     } catch (cause) {
       if (rootId !== undefined) db.prepare("DELETE FROM roots WHERE root_id = ?").run(rootId);
@@ -193,8 +215,8 @@ async function capture(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPre
         return { _tag: "Contended", setupPrefixKey: input.manifest.setupPrefixKey, reason: existing.state === "indexed" ? "indexed-generation" : "active-writer" };
       }
       generation = (db.prepare("SELECT COALESCE(MAX(generation), 0) AS n FROM entries").get() as { n: number }).n + 1;
-      db.prepare("INSERT INTO entries(setup_prefix_key, base_identity, snapshot_id, declaration_digest, generation, created_at, protected_until, state) VALUES (?, ?, NULL, ?, ?, ?, ?, 'building')")
-        .run(input.manifest.setupPrefixKey, input.manifest.baseImageId, declarationDigest(input), generation, new Date().toISOString(), new Date(Date.now() + MINIMUM_AGE_MS).toISOString());
+      db.prepare("INSERT INTO entries(setup_prefix_key, base_identity, snapshot_id, declaration_digest, generation, created_at, protected_until, replacement_scope, state) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, 'building')")
+        .run(input.manifest.setupPrefixKey, input.manifest.baseImageId, declarationDigest(input), generation, new Date().toISOString(), new Date().toISOString(), replacementScope(input));
       db.exec("COMMIT");
     } catch (cause) {
       try { db.exec("ROLLBACK"); } catch { /* no active transaction */ }
@@ -210,14 +232,19 @@ async function capture(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPre
         const published = publishing.prepare("UPDATE entries SET snapshot_id = ?, state = 'indexed' WHERE setup_prefix_key = ? AND generation = ? AND state = 'building'")
           .run(snapshotId, input.manifest.setupPrefixKey, generation);
         if (published.changes !== 1) throw new Error("E2B setup-prefix publication lost its generation fence");
+        publishing.prepare(`
+          INSERT INTO replacement_heads(replacement_scope, setup_prefix_key) VALUES (?, ?)
+          ON CONFLICT(replacement_scope) DO UPDATE SET setup_prefix_key = excluded.setup_prefix_key
+        `).run(replacementScope(input), input.manifest.setupPrefixKey);
       } finally { publishing.close(); }
+      await reclaimSupersededSnapshots(target, replacementScope(input), input.manifest.setupPrefixKey);
       const rebound = await target.rebaseToSnapshot(snapshotId, signal);
       const active = await open();
       const rootId = randomUUID();
       active.prepare("INSERT INTO roots(root_id, setup_prefix_key, sandbox_id, created_at) VALUES (?, ?, ?, ?)")
         .run(rootId, input.manifest.setupPrefixKey, rebound.sandboxId, new Date().toISOString());
       active.close();
-      target.adoptSetupPrefixRoot({ release: () => releaseRoot(rootId) });
+      target.adoptSetupPrefixRoot({ release: () => releaseRoot(rootId, target) });
       return { _tag: "Captured", setupPrefixKey: input.manifest.setupPrefixKey, entryId: input.manifest.setupPrefixKey, generation, artifactId: snapshotId, sandboxId: rebound.sandboxId };
     } catch (cause) {
       if (snapshotId !== undefined) await target.deleteSnapshot(snapshotId).catch(() => undefined);
@@ -233,14 +260,8 @@ async function capture(target: E2BSetupPrefixCacheTarget, input: SandboxSetupPre
 export function makeE2BSetupPrefixCacheCapability(target: E2BSetupPrefixCacheTarget): SandboxSetupPrefixCacheCapability {
   return {
     eligibility: target.eligibility,
-    lookupAndRebase: (input) => Effect.tryPromise({
-      try: async (signal) => { await reclaimColdSnapshots(target); return restore(target, input, signal); },
-      catch: (cause) => cause as never,
-    }),
-    captureAndRebase: (input) => Effect.tryPromise({
-      try: async (signal) => { await reclaimColdSnapshots(target); return capture(target, input, signal); },
-      catch: (cause) => cause as never,
-    }),
+    lookupAndRebase: (input) => Effect.tryPromise({ try: (signal) => restore(target, input, signal), catch: (cause) => cause as never }),
+    captureAndRebase: (input) => Effect.tryPromise({ try: (signal) => capture(target, input, signal), catch: (cause) => cause as never }),
     recoverCleanBase: () => Effect.tryPromise({
       try: async (signal) => {
         const eligibility = target.eligibility();

--- a/packages/niceeval/src/sandbox/e2b.ts
+++ b/packages/niceeval/src/sandbox/e2b.ts
@@ -34,6 +34,10 @@ import { commandLimit, SandboxCommandTimeoutError } from "./deadline.ts";
 import { successfulCommandResult } from "./operations.ts";
 import { ManagedProcessOutput } from "./managed-process.ts";
 import { supportedBackendCapability, unsupportedBackendCapability, unsupportedBackendCapabilityBecause, type SandboxProviderBackend } from "./backend.ts";
+import {
+  makeE2BSetupPrefixCacheCapability,
+  type E2BSetupPrefixRootOwnership,
+} from "./e2b-setup-prefix-cache.ts";
 
 // e2b 默认用户 "user",home 在 /home/user;工作区放其下。
 const E2B_WORKDIR = "/home/user/workspace";
@@ -395,7 +399,10 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
   private readonly userOverride?: string;
   /** factory `pathPrepend`;按声明顺序前置到受管 PATH,省略 = 空数组。 */
   private readonly pathPrepend: readonly string[];
-  readonly sandboxId: string;
+  sandboxId: string;
+  /** The author-declared template, retained when a cache snapshot temporarily becomes the start point. */
+  private readonly baseTemplate?: string;
+  private setupPrefixRoot?: E2BSetupPrefixRootOwnership;
 
   private deadlineAt?: number;
   readonly capabilities = {
@@ -407,6 +414,32 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
     managedProcess: unsupportedBackendCapabilityBecause(
       "E2B managed processes are not enabled until the provider boundary has a public installed-candidate E2E owner",
     ),
+    setupPrefixCache: supportedBackendCapability(makeE2BSetupPrefixCacheCapability({
+      eligibility: () => ({
+        _tag: "Eligible" as const,
+        persistence: "persistent" as const,
+        dependency: "parent-backed" as const,
+        coverage: "all" as const,
+        // E2B does not expose a digest for a template ref. The declared ref is
+        // still part of the complete Case identity, and snapshots never float.
+        baseImageId: `e2b-template:${this.baseTemplate ?? "base"}`,
+        keyScope: {
+          protocol: "niceeval-e2b-snapshot-setup-prefix/v1",
+          storageSchemaRevision: "niceeval.e2b-setup-prefix-storage/v1",
+          artifactFormatRevision: "niceeval.e2b-snapshot/v1",
+          semanticIdentity: { capture: "e2b-snapshot", baseTemplate: this.baseTemplate ?? "base" },
+        },
+      }),
+      captureSnapshot: async () => {
+        const snapshot = await this.sbx.createSnapshot({ apiKey: process.env.E2B_API_KEY });
+        if (snapshot.snapshotId.length === 0) throw new Error("E2B returned an empty snapshot identity");
+        return snapshot.snapshotId;
+      },
+      deleteSnapshot: (snapshotId) => E2BSdkSandbox.deleteSnapshot(snapshotId, { apiKey: process.env.E2B_API_KEY }),
+      rebaseToSnapshot: (snapshotId, signal) => this.rebaseTo(snapshotId, signal),
+      recoverCleanBase: (signal) => this.rebaseTo(this.baseTemplate, signal),
+      adoptSetupPrefixRoot: (root) => this.adoptSetupPrefixRoot(root),
+    })),
   };
 
   private async startManagedProcess(input: ManagedProcessStart): Promise<ManagedProcess> {
@@ -460,6 +493,7 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
     userOverride: string | undefined,
     pathPrepend: readonly string[] = [],
     deadlineAt?: number,
+    baseTemplate?: string,
   ) {
     this.sbx = sbx;
     this.sandboxId = id;
@@ -468,6 +502,7 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
     this.userOverride = userOverride;
     this.pathPrepend = pathPrepend;
     this.deadlineAt = deadlineAt;
+    this.baseTemplate = baseTemplate;
   }
 
   /** 复用下由池在每次借出时换成承接者自己的 deadline(见 sandbox/deadline.ts)。 */
@@ -560,7 +595,16 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
     try {
       // 备好工作区目录(模板默认 cwd 是 home,workspace 子目录可能不存在)。
       await sbx.commands.run(`mkdir -p ${E2B_WORKDIR}`);
-      return new E2BSandbox(sbx, sbx.sandboxId, commandTimeoutMs, opts.lifetime, opts.user, opts.pathPrepend ?? [], opts.deadlineAt);
+      return new E2BSandbox(
+        sbx,
+        sbx.sandboxId,
+        commandTimeoutMs,
+        opts.lifetime,
+        opts.user,
+        opts.pathPrepend ?? [],
+        opts.deadlineAt,
+        opts.template ?? "base",
+      );
     } catch (e) {
       await sbx.kill().catch(() => {});
       throw e;
@@ -814,6 +858,38 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
     await this.retire();
   }
 
+  private adoptSetupPrefixRoot(root: E2BSetupPrefixRootOwnership): void {
+    if (this.setupPrefixRoot !== undefined) throw new Error("the previous E2B setup-prefix root has not been released");
+    this.setupPrefixRoot = root;
+  }
+
+  private async rebaseTo(template: string | undefined, signal: AbortSignal): Promise<{ readonly sandboxId: string }> {
+    signal.throwIfAborted();
+    if (template === undefined) throw new Error("E2B cache recovery has no Base template");
+    const previous = this.sbx;
+    const apiKey = process.env.E2B_API_KEY;
+    const next = await E2BSdkSandbox.create(template, {
+      apiKey,
+      ...(this.lifetime._tag === "Requested" ? { timeoutMs: this.lifetime.milliseconds } : {}),
+    });
+    try {
+      await next.commands.run(`mkdir -p ${E2B_WORKDIR}`);
+      signal.throwIfAborted();
+      await previous.kill().catch(() => undefined);
+      const root = this.setupPrefixRoot;
+      this.setupPrefixRoot = undefined;
+      await root?.release();
+      this.sbx = next;
+      this.sandboxId = next.sandboxId;
+      this.retired = false;
+      this.retirement = undefined;
+      return { sandboxId: next.sandboxId };
+    } catch (cause) {
+      await next.kill().catch(() => undefined);
+      throw cause;
+    }
+  }
+
   private retire(): Promise<void> {
     if (this.retired) return Promise.resolve();
     if (this.retirement !== undefined) return this.retirement;
@@ -821,7 +897,11 @@ export class E2BSandbox implements SandboxProviderBackend, SandboxReuseCapabilit
     attempt = this.sbx.kill().then(
       () => {
         this.retired = true;
-        if (this.retirement === attempt) this.retirement = undefined;
+        const root = this.setupPrefixRoot;
+        this.setupPrefixRoot = undefined;
+        return root?.release().then(() => {
+          if (this.retirement === attempt) this.retirement = undefined;
+        });
       },
       (error: unknown) => {
         if (this.retirement === attempt) this.retirement = undefined;

--- a/packages/niceeval/src/sandbox/layer.ts
+++ b/packages/niceeval/src/sandbox/layer.ts
@@ -1777,10 +1777,7 @@ const e2bProviderModule = Object.freeze({
   capabilities: Object.freeze({
     retention: Object.freeze({ _tag: "Suspendable" }),
     reuse: Object.freeze({ _tag: "Supported" }),
-    setupPrefix: Object.freeze({
-      _tag: "Unsupported",
-      reason: "E2B does not expose a NiceEval setup-prefix capture contract.",
-    }),
+    setupPrefix: Object.freeze({ _tag: "Persistent", coverage: sandboxState.all }),
     sessionLimit: Object.freeze({
       _tag: "ProviderValidated",
       reason: "E2B validates lifetimeMs against the active account tier when the sandbox is created or renewed.",


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 250d50b5cf81af4333f06cd87749711c5f20b4d8
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: 6ab11e835a27eab6acfd37f1e2cbd670032d10a1
-->

## Problem

- User goal: reuse deterministic E2B `before()` preparation across Attempts.
- Current limitation: E2B replays every eligible setup action because it reports no SetupPrefix capture capability.
- Required capability: persist a verified E2B snapshot for each eligible prefix and restore it into an isolated Sandbox.
- User outcome: repeated E2B evaluations avoid reinstalling the same prepared dependencies while retaining fresh writable state per Attempt.
- Replacement outcome: when changed preparation publishes a new artifact, reclaim its unused previous Docker image or E2B snapshot immediately instead of retaining generations by age.

## Use cases

### Case: reuse an E2B setup prefix

#### Starting state

```ts
const sandbox = e2bSandbox({ template: "acme/evals:1" });
const setup = sandboxLayer().before(shell({ script: "pnpm install --frozen-lockfile" }));
```

#### Action

```ts
defineExperiment({ sandbox, /* linked with setup */ });
```

#### Result

```text
first eligible prefix: replay → E2B snapshot published
later identical prefix: hit → private Sandbox starts from that snapshot
```

Each Attempt gets a new writable Sandbox, so an Agent cannot change the snapshot used by another Attempt. A known secret blocks capture and continues on the uncached path.

## Observable behavior and data contracts

### Changed

#### Case: E2B setup-prefix lifecycle

##### Before

```ts
e2bSandbox({ template: "acme/evals:1" });
```

```text
SetupPrefix cache=unsupported; eligible before actions replay for every Attempt
```

##### After

```ts
e2bSandbox({ template: "acme/evals:1" });
```

```text
SetupPrefix cache=hit when a matching NiceEval-managed snapshot exists
```

##### User impact

No public API changes. Existing E2B declarations gain automatic reuse of eligible `sandboxState.all` prefixes. User-declared templates and snapshots remain outside NiceEval deletion authority.

#### Case: changed preparation replaces the inactive prior generation

##### Before

```text
Docker SetupPrefix artifacts remain after a changed prefix publishes.
```

```text
E2B SetupPrefix snapshots remain after a changed prefix publishes.
```

##### After

```text
Docker: new artifact published → same-lineage inactive old image deleted
```

```text
E2B: new artifact published → same-lineage inactive old snapshot deleted
active private clone / lease → deletion deferred until root release
```

##### User impact

Docker and E2B retain the current generation for each logical action lineage. NiceEval never deletes a user-declared image, template, or snapshot; a provider deletion failure keeps the old registered artifact for a later retry.

## Record schema and stored-data upgrade

### Private persisted data

### Case: E2B snapshot registry

#### Before

```text
NiceEval has no E2B SetupPrefix registry or provider-owned cleanup path.
```

#### After

```text
$XDG_STATE_HOME/niceeval/cache/v2/e2b-setup-prefix.sqlite records only NiceEval-created snapshot IDs, prefix keys, replacement lineage heads, and active clone roots. The Docker SetupPrefix registry stores the equivalent lineage head beside its managed image entries.
```

#### User impact

Publishing a new artifact makes it the replacement head for its stable action lineage. Automatic cleanup deletes only a registered, superseded artifact with no active private clone root, lease, or capture; a failed deletion retains its registry entry and is retried on later publication or root release. Existing user templates and snapshots are not imported, modified, or removed.

## Tests

- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm test` — blocked by two existing virtual-time failures in `assertions/judge.test.ts` and `runner/lock.test.ts`, outside this change.
- `pnpm e2e test --repo lifecycle -- --run test/sandbox-setup-prefix-cache.test.ts` — configuration-blocked: the host lacks `linux-loop-project-quota`.
- Live E2B validation is pending because `E2B_API_KEY` is absent in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790249607&installation_model_id=431746&pr_number=161&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F161&signature=2bf22706b0a771c3bae712af5233398a6e6daf8fdd9c03c2b39d1ff942860f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
