### PR TITLE
ci(test): 将全量 Unit 纳入合入检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,26 @@ jobs:
       - name: Lint docs
         run: pnpm run lint:docs
 
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up pnpm and Node
+        uses: pnpm/setup@v2
+        with:
+          runtime: node@24
+          cache: true
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Test
+        run: pnpm test
+
   docs-site:
     name: docs-site
     runs-on: ubuntu-latest

--- a/packages/niceeval/src/assertions/judge.test.ts
+++ b/packages/niceeval/src/assertions/judge.test.ts
@@ -120,8 +120,10 @@ describe("Judge virtual-time lifecycle", () => {
       expect(result).toMatchObject({
         state: "unavailable",
         reason: "source-unavailable",
-        detail: "judge-call-failed",
-        evidence: expect.stringContaining("timed out after 5s"),
+        detail: {
+          failureDetail: "judge-call-failed",
+          failureEvidence: expect.stringContaining("timed out after 5s"),
+        },
       });
       expect(providerAborted).toBe(true);
     }));

--- a/packages/niceeval/src/runner/lock.test.ts
+++ b/packages/niceeval/src/runner/lock.test.ts
@@ -27,6 +27,17 @@ function runTest<A>(effect: Effect.Effect<A, unknown, never>): Promise<A> {
   return Effect.runPromise(effect.pipe(Effect.provide(TestContext.TestContext)));
 }
 
+function waitForHeartbeat(root: string, expected: string): Effect.Effect<void, unknown> {
+  return Effect.gen(function*() {
+    for (let turn = 0; turn < 200; turn++) {
+      const record = yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID);
+      if (record?.heartbeatAt === expected) return;
+      yield* Effect.yieldNow();
+    }
+    return yield* Effect.dieMessage(`timed out waiting for heartbeat ${expected}`);
+  });
+}
+
 afterEach(async () => {
   await Effect.runPromise(drainHeldCaseLocksEffect());
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
@@ -92,6 +103,7 @@ describe("case lock virtual time", () => {
       expect((yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID))?.heartbeatAt).toBe(initial?.heartbeatAt);
 
       yield* TestClock.adjust(1);
+      yield* waitForHeartbeat(root, new Date(1_001_000).toISOString());
       expect((yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID))?.heartbeatAt)
         .toBe(new Date(1_001_000).toISOString());
 


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 250d50b5cf81af4333f06cd87749711c5f20b4d8
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: dd99edd8cb0b5dd3df03f560efc05a74d78a992a
-->

## Problem

- User goal: 让全量 Unit 成为稳定、持续执行的合入门，而不是只在本地偶尔运行。
- Current limitation: 两个 Effect TestClock owner 分别断言了旧的 Judge 结果形状、在心跳异步写入完成前读取文件；同时 CI 没有调用根 `pnpm test`。
- Required capability: Unit owner 必须同步到当前公开结果，并在虚拟时间唤醒后等待可观察的异步文件写入；CI 必须独立执行完整 Unit project。
- User outcome: 本地与 PR/main CI 都会稳定运行同一套 15 条 Unit，并阻止这些确定性语义回归进入主线。

## Tests

### `packages/niceeval/src/assertions/judge.test.ts`

- Purpose: `bug regression`
- Protects: Judge 调用在超时边界前保持 pending，到点中断 provider，并按当前 Assertion detail 形状记录失败原因和超时证据。
- Runs: 通过 Effect TestClock 从 4,999ms 推进到 5,000ms，并从公开的 evaluateJudgeMeasurement 入口读取结果。
- Asserts: 边界前 fiber 未完成且 provider 未中断；边界到达后结果为 source-unavailable，failureDetail 为 judge-call-failed，failureEvidence 包含 5s 超时，provider 已中断。

```ts
// owner: docs/engineering/testing/unit/assertions.md#证明范围规范
// cases: docs/engineering/testing/unit/assertions.md

import { Cause, Effect, Exit, Fiber, Option, TestClock, TestContext } from "effect";
import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";

import { evaluateJudgeMeasurement } from "./judge.ts";
import type { JudgeRecipeExecution } from "./judge.ts";

const TEST_KEY_ENV = "NICEEVAL_JUDGE_TEST_KEY";

function judgeInput(timeoutMs: number, signal?: AbortSignal): JudgeRecipeExecution {
  return {
    judge: {
      model: "judge-model",
      baseUrl: "https://judge.example/v1",
      apiKeyEnv: TEST_KEY_ENV,
      timeoutMs,
    },
    recipe: "closedQA",
    reference: "The answer is correct",
    material: { input: "question", output: "answer" },
    ...(signal === undefined ? {} : { signal }),
  };
}

function acceptedResponse(): Response {
  return new Response(JSON.stringify({
    id: "completion-1",
    object: "chat.completion",
    created: 0,
    model: "judge-model",
    choices: [{
      index: 0,
      finish_reason: "tool_calls",
      message: {
        role: "assistant",
        content: null,
        tool_calls: [{
          id: "call-1",
          type: "function",
          function: {
            name: "select_choice",
            arguments: JSON.stringify({ choice: "Y", reasons: "correct" }),
          },
        }],
      },
    }],
  }), { status: 200, headers: { "Content-Type": "application/json" } });
}

function transientResponse(retryAfter?: string): Response {
  return new Response(JSON.stringify({ error: { message: "busy", type: "server_error" } }), {
    status: 503,
    headers: {
      "Content-Type": "application/json",
      ...(retryAfter === undefined ? {} : { "Retry-After": retryAfter }),
    },
  });
}

function waitUntil(predicate: () => boolean, description: string): Effect.Effect<void> {
  return Effect.gen(function* () {
    for (let turn = 0; turn < 200; turn++) {
      if (predicate()) return;
      yield* Effect.yieldNow();
    }
    return yield* Effect.dieMessage(`timed out waiting for ${description}`);
  });
}

function waitForSleep(instant: number): Effect.Effect<void> {
  return Effect.gen(function* () {
    for (let turn = 0; turn < 200; turn++) {
      const sleeps = yield* TestClock.sleeps();
      if (Array.from(sleeps).includes(instant)) return;
      yield* Effect.yieldNow();
    }
    return yield* Effect.dieMessage(`timed out waiting for clock sleep at ${instant}`);
  });
}

function runTestClock<A>(effect: Effect.Effect<A, never, never>): Promise<A> {
  return Effect.runPromise(effect.pipe(Effect.provide(TestContext.TestContext)));
}

describe("Judge virtual-time lifecycle", () => {
  beforeEach(() => {
    process.env[TEST_KEY_ENV] = "test-key";
  });

  afterEach(() => {
    delete process.env[TEST_KEY_ENV];
    vi.unstubAllGlobals();
  });

  test("timeout stays pending before its boundary, then interrupts the provider request", async () => {
    let providerAborted = false;
    const fetchMock = vi.fn((_input: string | URL | Request, init?: RequestInit) =>
      new Promise<Response>((_resolve, reject) => {
        const signal = init?.signal;
        if (signal == null) throw new Error("Judge fetch did not receive an AbortSignal");
        signal.addEventListener("abort", () => {
          providerAborted = true;
          reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
        }, { once: true });
      }));
    vi.stubGlobal("fetch", fetchMock);

    await runTestClock(Effect.gen(function* () {
      const fiber = yield* Effect.fork(evaluateJudgeMeasurement(judgeInput(5_000)));
      yield* waitUntil(() => fetchMock.mock.calls.length === 1, "the provider request");

      yield* TestClock.adjust(4_999);
      expect(Option.isNone(yield* Fiber.poll(fiber))).toBe(true);
      expect(providerAborted).toBe(false);

      yield* TestClock.adjust(1);
      const result = yield* Fiber.join(fiber);
      expect(result).toMatchObject({
        state: "unavailable",
        reason: "source-unavailable",
        detail: {
          failureDetail: "judge-call-failed",
          failureEvidence: expect.stringContaining("timed out after 5s"),
        },
      });
      expect(providerAborted).toBe(true);
    }));
  });

  test("randomized retry starts only when its backoff boundary arrives", async () => {
    const fetchMock = vi.fn()
      .mockResolvedValueOnce(transientResponse())
      .mockResolvedValueOnce(acceptedResponse());
    vi.stubGlobal("fetch", fetchMock);

    await runTestClock(Effect.gen(function* () {
      const fiber = yield* Effect.fork(
        evaluateJudgeMeasurement(judgeInput(5_000)).pipe(Effect.withRandomFixed([0.5])),
      );
      yield* waitForSleep(500);

      yield* TestClock.adjust(499);
      expect(fetchMock).toHaveBeenCalledTimes(1);
      expect(Option.isNone(yield* Fiber.poll(fiber))).toBe(true);

      yield* TestClock.adjust(1);
      yield* waitUntil(() => fetchMock.mock.calls.length === 2, "the retry request");
      expect(yield* Fiber.join(fiber)).toMatchObject({ state: "measured", value: 1 });
    }));
  });

  test("HTTP-date Retry-After is measured from the Effect clock and gates the retry", async () => {
    const fetchMock = vi.fn()
      .mockResolvedValueOnce(transientResponse("Thu, 01 Jan 1970 00:00:02 GMT"))
      .mockResolvedValueOnce(acceptedResponse());
    vi.stubGlobal("fetch", fetchMock);

    await runTestClock(Effect.gen(function* () {
      const fiber = yield* Effect.fork(evaluateJudgeMeasurement(judgeInput(5_000)));
      yield* waitForSleep(2_000);

      yield* TestClock.adjust(1_999);
      expect(fetchMock).toHaveBeenCalledTimes(1);

      yield* TestClock.adjust(1);
      yield* waitUntil(() => fetchMock.mock.calls.length === 2, "the Retry-After request");
      expect(yield* Fiber.join(fiber)).toMatchObject({ state: "measured", value: 1 });
    }));
  });

  test("caller cancellation interrupts the provider instead of becoming a Judge result", async () => {
    const controller = new AbortController();
    let providerAborted = false;
    const fetchMock = vi.fn((_input: string | URL | Request, init?: RequestInit) =>
      new Promise<Response>((_resolve, reject) => {
        const signal = init?.signal;
        if (signal == null) throw new Error("Judge fetch did not receive an AbortSignal");
        signal.addEventListener("abort", () => {
          providerAborted = true;
          reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
        }, { once: true });
      }));
    vi.stubGlobal("fetch", fetchMock);

    await runTestClock(Effect.gen(function* () {
      const fiber = yield* Effect.fork(evaluateJudgeMeasurement(judgeInput(5_000, controller.signal)));
      yield* waitUntil(() => fetchMock.mock.calls.length === 1, "the cancellable provider request");
      controller.abort();

      const exit = yield* Fiber.await(fiber);
      expect(Exit.isFailure(exit)).toBe(true);
      if (Exit.isFailure(exit)) expect(Cause.isInterruptedOnly(exit.cause)).toBe(true);
      expect(providerAborted).toBe(true);
    }));
  });
});
```

### `packages/niceeval/src/runner/lock.test.ts`

- Purpose: `bug regression`
- Protects: case lock 按心跳周期续租，并在 release 后停止写入和删除锁记录，且测试不会把 TestClock 唤醒误当成异步文件写入完成。
- Runs: 通过 Effect TestClock 推进心跳边界，从公开 case-lock Effect 读取锁记录，再释放 claim 并继续推进时钟。
- Asserts: 999ms 前心跳不变；1,000ms 时最终可观察到新心跳；release 后即使再推进 10 秒也没有锁记录。

```ts
// owner: docs/engineering/testing/unit/experiments-runner.md#证明范围规范
// cases: docs/engineering/testing/unit/experiments-runner.md

import { mkdtemp, rm } from "node:fs/promises";
import { tmpdir } from "node:os";
import { join } from "node:path";
import { afterEach, describe, expect, it } from "vitest";
import { Deferred, Effect, Fiber, Option, TestClock, TestContext } from "effect";
import {
  acquireCaseLockEffect,
  drainHeldCaseLocksEffect,
  readCaseLockEffect,
} from "./lock.ts";

const EXPERIMENT_ID = "compare/test-clock";
const EVAL_ID = "case/lock";

const roots: string[] = [];

async function makeRoot(): Promise<string> {
  const dir = await mkdtemp(join(tmpdir(), "niceeval-case-lock-clock-"));
  roots.push(dir);
  return join(dir, ".niceeval");
}

function runTest<A>(effect: Effect.Effect<A, unknown, never>): Promise<A> {
  return Effect.runPromise(effect.pipe(Effect.provide(TestContext.TestContext)));
}

function waitForHeartbeat(root: string, expected: string): Effect.Effect<void, unknown> {
  return Effect.gen(function*() {
    for (let turn = 0; turn < 200; turn++) {
      const record = yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID);
      if (record?.heartbeatAt === expected) return;
      yield* Effect.yieldNow();
    }
    return yield* Effect.dieMessage(`timed out waiting for heartbeat ${expected}`);
  });
}

afterEach(async () => {
  await Effect.runPromise(drainHeldCaseLocksEffect());
  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
});

describe("case lock virtual time", () => {
  it("polls only when the configured boundary is reached", async () => {
    const root = await makeRoot();
    let waitStarts = 0;

    await runTest(Effect.gen(function*() {
      const first = yield* acquireCaseLockEffect(
        root,
        EXPERIMENT_ID,
        EVAL_ID,
        { pid: 1, host: "first" },
        { heartbeatIntervalMs: 60_000 },
      );
      const waiting = yield* Deferred.make<void>();
      const secondFiber = yield* acquireCaseLockEffect(
        root,
        EXPERIMENT_ID,
        EVAL_ID,
        { pid: 2, host: "second" },
        {
          pollIntervalMs: 1_000,
          heartbeatIntervalMs: 60_000,
          onWaitStart: () => {
            waitStarts += 1;
            Effect.runFork(Deferred.succeed(waiting, undefined));
          },
        },
      ).pipe(Effect.fork);

      yield* Deferred.await(waiting);
      yield* TestClock.adjust(999);
      expect(Option.isNone(yield* Fiber.poll(secondFiber))).toBe(true);

      yield* first.claim.release;
      yield* TestClock.adjust(1);
      const second = yield* Fiber.join(secondFiber);
      expect(second.takenOver).toBe(false);
      expect(waitStarts).toBe(1);
      yield* second.claim.release;
    }));
  });

  it("renews once per heartbeat period and never writes after release", async () => {
    const root = await makeRoot();

    await runTest(Effect.gen(function*() {
      yield* TestClock.setTime(1_000_000);
      const acquired = yield* acquireCaseLockEffect(
        root,
        EXPERIMENT_ID,
        EVAL_ID,
        { pid: 3, host: "heartbeat" },
        { heartbeatIntervalMs: 1_000 },
      );
      const initial = yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID);

      yield* TestClock.adjust(999);
      expect((yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID))?.heartbeatAt).toBe(initial?.heartbeatAt);

      yield* TestClock.adjust(1);
      yield* waitForHeartbeat(root, new Date(1_001_000).toISOString());
      expect((yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID))?.heartbeatAt)
        .toBe(new Date(1_001_000).toISOString());

      yield* acquired.claim.release;
      yield* TestClock.adjust(10_000);
      expect(yield* readCaseLockEffect(root, EXPERIMENT_ID, EVAL_ID)).toBeUndefined();
    }));
  });
});
```

### Verification receipt

- Candidate: 当前工作树（提交后由 PR 工具校验 pushed HEAD）；没有 package 字节变化，因此不生成 NiceEval tarball。
- Red: `pnpm exec vitest run --project unit packages/niceeval/src/assertions/judge.test.ts packages/niceeval/src/sandbox/retry.test.ts packages/niceeval/src/sandbox/io-retry.test.ts packages/niceeval/src/runner/lock.test.ts packages/niceeval/src/runner/cleanup-timeout.test.ts packages/niceeval/src/context/send-retry.test.ts --reporter=verbose`，2 failed / 12 passed；最早失败分别是 Judge 旧扁平 detail 断言和 heartbeatAt 仍为 `1970-01-01T00:16:40.000Z`。
- Green: `pnpm test`，7 files passed、15 tests passed。
- Repeatability: 两个修改 owner 连续运行 5 次，每次 2 files passed、6 tests passed；全量默认并行随后通过；临时锁目录由 `afterEach` 清理。
- Fixed conditions: Node v24.19.0、pnpm 11.18.0、锁定依赖、Effect 3.22.1、Vitest 4.1.11、Effect TestContext/TestClock；无真实 provider、网络或容器。
- Unit count: `pnpm test` Tests = 15（不超过 200）。

补充验证：`pnpm typecheck` 通过；`pnpm lint` 通过（12 files / 51 tests，Mint validate 与 links 均通过）；`git diff --check` 通过。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790250702&installation_model_id=431746&pr_number=162&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F162&signature=a746c7d17716867656ba3b0514ee0e6deb5dd984c36d7618677e7364b08c36b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->