### PR TITLE
refactor(sandbox): 用 sandboxLayer 声明 Nested Docker 要求

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -93,9 +93,9 @@ Roadmap 提出的候选原语单列在「候选术语」,链接 Roadmap 入口;�
 | `t.sandbox` | EvalSandbox (`t.sandbox`) | 沙箱型 eval 的文件 IO、宿主传输、命令执行、断言与 diff 接口 | [Sandbox operations](feature/sandbox/library/operations.md) |
 | 变更分类账 | Change ledger | runner 私有的 git 分类账;只把参照点之后的改动放进 agent 归因视图 | [Sandbox architecture](feature/sandbox/architecture.md) |
 | Sandbox template | SandboxTemplate | 同时选择 Provider 并由其启动完整 Sandbox 实例的唯一起点；可以是 Compose、Dockerfile、image、E2B template 或 snapshot | [Sandbox Layer](feature/sandbox/layers.md#template-bearing-factory) |
-| Sandbox 能力要求 | Sandbox capability requirement | Eval 对 Sandbox 必须兑现的 provider-neutral 约束；它不选择 Provider，也不创建第二个 Sandbox origin | [Nested Docker PLAN-5](design/nested-docker-execution/PLAN-5/README.md#能力绑定) |
-| Docker 执行要求 | DockerExecutionRequirement | `docker/v1` 对私有 daemon、Compose、专用 kernel 与最低 Docker data 容量的穷尽要求 | [Nested Docker PLAN-5](design/nested-docker-execution/PLAN-5/README.md#library-调用面) |
-| 专用 kernel 隔离 | dedicated-kernel isolation (`dedicated-kernel/v1`) | Agent 的 Docker 权限止于当前 guest kernel，不能到达宿主 daemon、kernel 或其它 Attempt | [Nested Docker Architecture](design/nested-docker-execution/PLAN-5/architecture.md#四个-owner) |
+| Sandbox 能力要求 | Sandbox capability requirement | Sandbox layer 对所选 Provider 必须兑现的 provider-neutral 约束；它不选择 Provider，也不创建第二个 Sandbox origin | [Nested Docker](feature/sandbox/nested-docker/architecture.md#requirement-与-capability) |
+| Nested Docker 要求 | Nested Docker requirement (`NestedDockerRequirement`) | Eval 对私有 Docker daemon、Compose、专用 kernel 与最低 Docker data 容量的要求 | [Nested Docker Library](feature/sandbox/nested-docker/library.md#sandboxlayer-requirements) |
+| 专用 kernel 隔离 | dedicated-kernel isolation (`dedicated-kernel/v1`) | Agent 的 Docker 权限止于当前 guest kernel，不能到达宿主 daemon、kernel 或其它 Attempt | [Nested Docker Architecture](feature/sandbox/nested-docker/architecture.md#安全边界) |
 | Sandbox 实例 | Sandbox instance | Provider 启动的主 Sandbox；存在 sidecar、网络或服务时，同时点名这些伴随资源 | [Sandbox 实例与伴随资源](feature/sandbox/case.md) |
 | 主 Sandbox | —(`workspaceService` 对应实例) | Provider 启动的唯一执行空间;Agent、Eval、文件 API、workdir 与 diff 都锚定它 | [Sandbox 实例与伴随资源](feature/sandbox/case.md#主-sandbox-不变量) |
 | BuildKey | BuildKey | 一次 Provider 构建的输入身份,用于复用 Docker image 或 E2B template 构建结果 | [Sandbox 实例与伴随资源](feature/sandbox/case.md#buildkey-与-casekey两个身份各管一件事) |

--- a/docs/design/nested-docker-execution/DECISION.md
+++ b/docs/design/nested-docker-execution/DECISION.md
@@ -50,7 +50,7 @@ dedicated kernel、private daemon 与 minimum data bytes 都能在 create 前穷
 | loop-ext4 image | 容易放进现有目录 | Incus 明确不建议生产 loop pool；重回 loop/attach/fsck 状态空间 | 禁止 |
 
 storage driver 只影响 Provider artifact format、capacity receipt 与 deployment identity，不进入 Eval 的
-`DockerExecutionRequirement`。改变 executionDomainId 后，旧 artifact 是 foreign，不自动 adoption。
+Nested Docker requirement。改变 executionDomainId 后，旧 artifact 是 foreign，不自动 adoption。
 
 ## 缓存裁决
 
@@ -117,4 +117,4 @@ NiceEval 之外的显式运维流程。
 - Runloop 是否能证明 dedicated kernel、4 GiB hard limit、metadata inventory 与 detached destroy 尚待 PoC。
 - Provider artifact capture 的 guest quiesce protocol需要故障注入，尤其是 BuildKit session 与 daemon stop。
 - capability API 与现有 environment-model 的一次 template owner 规则需要在实现前同步到 Feature 契约；
-  `sandboxRequirements()` 保持 command-only，不创建第二个 origin。
+  `sandboxLayer({ requirements })` 保持 command-only，不创建第二个 origin。

--- a/docs/design/nested-docker-execution/PLAN-5/README.md
+++ b/docs/design/nested-docker-execution/PLAN-5/README.md
@@ -15,17 +15,17 @@ Eval 的声明是 command-only Sandbox layer，不选择 Provider 或 Sandbox or
 
 ```ts
 import { defineEval } from "niceeval";
-import { sandboxRequirements } from "niceeval/sandbox";
+import { sandboxLayer } from "niceeval/sandbox";
 
 const GiB = 1024 ** 3;
 
 export default defineEval({
-  environment: sandboxRequirements({
-    docker: {
-      api: "docker/v1",
-      compose: "v2",
-      isolation: "dedicated-kernel/v1",
-      minimumDataBytes: 4 * GiB,
+  sandbox: sandboxLayer({
+    requirements: {
+      nestedDocker: {
+        compose: "v2",
+        minimumDataBytes: 4 * GiB,
+      },
     },
   }),
   // ...
@@ -35,20 +35,23 @@ export default defineEval({
 公开形状完整定义为：
 
 ```ts
-interface SandboxRequirementsOptions {
-  readonly docker?: DockerExecutionRequirement;
+interface SandboxLayerOptions {
+  readonly requirements?: SandboxLayerRequirements;
 }
 
-interface DockerExecutionRequirement {
-  readonly api: "docker/v1";
-  readonly compose: "v2" | "not-required";
-  readonly isolation: "dedicated-kernel/v1";
+interface SandboxLayerRequirements {
+  readonly nestedDocker?: NestedDockerRequirement;
+}
+
+interface NestedDockerRequirement {
+  readonly compose?: "v2";
   readonly minimumDataBytes: number;
 }
 ```
 
 `minimumDataBytes` 是正整数 byte 数。4 GiB 是本题的最低要求，不是所有 Eval 的全局默认。
-没有 `docker` 字段的 Sandbox 不因此启动 daemon。
+`nestedDocker` 固定表示 `docker/v1`、sandbox-private daemon 与专用 kernel；`compose` 省略时不要求 Compose。
+没有 `nestedDocker` 字段的 Sandbox 不因此启动 daemon。
 
 Experiment 选择具体 Provider 与完整 Sandbox origin。自托管写法是：
 

--- a/docs/design/nested-docker-execution/PLAN-5/architecture.md
+++ b/docs/design/nested-docker-execution/PLAN-5/architecture.md
@@ -3,7 +3,7 @@
 ## 边界
 
 ```text
-Eval DockerExecutionRequirement
+Eval NestedDockerRequirement
   + Experiment SandboxTemplate / Provider planner
   -> capability check and capacity reservation
   -> durable SandboxAllocation intent + generation
@@ -13,7 +13,7 @@ Eval DockerExecutionRequirement
 ```
 
 `SandboxTemplate` 仍是选择 Provider 与完整 origin 的声明。
-`DockerExecutionRequirement` 只是配对时必须满足的约束，不是第二个 template。
+`NestedDockerRequirement` 只是配对时必须满足的约束，不是第二个 template。
 
 ## 四个 owner
 

--- a/docs/design/nested-docker-execution/PLAN-5/lifecycle.md
+++ b/docs/design/nested-docker-execution/PLAN-5/lifecycle.md
@@ -5,7 +5,7 @@
 ```text
 discover Eval and Experiment
   -> select the single SandboxTemplate
-  -> collect DockerExecutionRequirement
+  -> collect normalized Nested Docker requirement
   -> Provider plans SandboxCase and returns capability receipt
   -> compare requirement / capability
   -> compute BuildKey, CaseKey and SetupPrefixKey

--- a/docs/feature/sandbox/README.md
+++ b/docs/feature/sandbox/README.md
@@ -21,7 +21,7 @@ relations: {}
 
 这些约束由容器 / 微 VM provider 兑现。`defineSandbox` 接入的自定义 provider 也必须由作者负责提供与其用途相符的隔离边界；NiceEval 不会替自定义实现补上文件系统、进程、网络或凭据隔离。
 
-普通 `dockerSandbox({ source })` 继续提供单容器执行；Agent 需要在 Sandbox 内运行 Docker / Compose，或需要专用 kernel、资源配额与可复用准备缓存时，推荐 [Nested Docker](nested-docker/README.md)。Eval 用 `sandboxRequirements()` 声明能力，Experiment 用 `incusSandbox()` 选择 Host 的 Incus project 中的一次性 VM。guest 运行普通 Docker daemon；用户不在 privileged outer Docker container 里再启动 inner daemon，也不复制或捕获其 data root。
+普通 `dockerSandbox({ source })` 继续提供单容器执行；Agent 需要在 Sandbox 内运行 Docker / Compose，或需要专用 kernel、资源配额与可复用准备缓存时，推荐 [Nested Docker](nested-docker/README.md)。Eval 用 `sandboxLayer({ requirements })` 声明能力，Experiment 用 `incusSandbox()` 选择 Host 的 Incus project 中的一次性 VM。guest 运行普通 Docker daemon；用户不在 privileged outer Docker container 里再启动 inner daemon，也不复制或捕获其 data root。
 
 ## 已封口事实的归属
 
@@ -112,7 +112,7 @@ niceeval 的调用方是写 eval 的人,大多数调用(`runCommand("npm", ["tes
 - [Library](library.md) —— 路径与 workdir、执行身份、Provider 选择、before action、自定义 Provider。
 - [Case](case.md) —— 一份 Sandbox 声明的完整运行单位:五类 case、BuildKey / CaseKey、构建协调、Compose、能力矩阵。
 - [预制实例](library/prebuilt-environments.md) —— 把稳定依赖做成 image / template / snapshot,attempt 直接从中启动。
-- [Nested Docker](nested-docker/README.md) —— `sandboxRequirements()`、`incusSandbox()`、资源配额、prepared artifact 与 DestroyOnly 生命周期。
+- [Nested Docker](nested-docker/README.md) —— `sandboxLayer({ requirements })`、`incusSandbox()`、资源配额、prepared artifact 与 DestroyOnly 生命周期。
 - [原 Docker Profile 迁移](docker-profiles/README.md) —— 普通 Docker container 与原 raw / managed DinD 路径的边界，以及迁移到 Incus 的方式。
 - [CLI](cli.md) —— `--keep-sandbox` 留存失败现场与 `niceeval sandbox list` / `stop` 的完整生命周期。
 - [Sandbox 复用](reuse.md) —— Experiment 用 `sandboxReuse: true` 声明多条 Attempt 可以共用 Sandbox；Provider 用 `lifetimeMs` 单独声明 Sandbox 存活时间。

--- a/docs/feature/sandbox/case.md
+++ b/docs/feature/sandbox/case.md
@@ -116,7 +116,7 @@ Provider 无法承诺的选项不进公共类型:Docker 的 build args 与 targe
 | 预制单 Sandbox | provider 起点构建结果(image / template / snapshot) | 该实例 | 无 | 对应 provider |
 | 按需构建单 Sandbox | Dockerfile / OCI context | 构建结果实例 | 无 | 声明支持构建的 provider |
 | Docker Compose | Compose + overlay | `workspaceService` 容器 | 同项目 services / network | Docker provider |
-| Nested Docker | Eval `sandboxRequirements` + Experiment `incusSandbox` | guest 工作空间 | 私有 Docker data disk | Incus Provider |
+| Nested Docker | Eval `sandboxLayer({ requirements })` + Experiment `incusSandbox` | guest 工作空间 | 私有 Docker data disk | Incus Provider |
 | 云端 Compose | Compose + provider 配置 | main 容器 | Pod 或原生组网 | 声明支持的云 provider |
 | 自定义 case | 用户纯数据身份 + Sandbox creator callback | 用户返回的 Sandbox | 用户句柄 | 自定义 provider |
 

--- a/docs/feature/sandbox/docker-profiles/README.md
+++ b/docs/feature/sandbox/docker-profiles/README.md
@@ -10,8 +10,8 @@ relations: {}
 
 Eval 在 Sandbox 内使用 Docker 的唯一契约是
 [Nested Docker](../nested-docker/README.md)：
-`sandboxRequirements()` 声明 `docker/v1` 与 `dedicated-kernel/v1`，
-Experiment 用 `incusSandbox()` 选择一次性 Incus VM。
+Eval 用 `sandboxLayer({ requirements: { nestedDocker } })` 声明 Nested Docker 要求。
+该要求固定包含 `docker/v1` 与 `dedicated-kernel/v1`；Experiment 用 `incusSandbox()` 选择一次性 Incus VM。
 
 `dockerSandbox({ dockerAccess })` 的宿主 Docker socket、raw privileged DinD 与
 managed rootless DinD 不能满足这条能力。
@@ -23,7 +23,7 @@ planning 不能把它们降为 fallback。
 
 ```text
 adopted public path
-  Eval sandboxRequirements({ docker: docker/v1 + dedicated-kernel/v1 })
+  Eval sandboxLayer({ requirements: { nestedDocker } })
   + Experiment incusSandbox(...)
   -> disposable Incus VM + guest 普通 dockerd
 

--- a/docs/feature/sandbox/docker-profiles/library.md
+++ b/docs/feature/sandbox/docker-profiles/library.md
@@ -2,7 +2,7 @@
 
 `dockerSandbox()` 的 adopted 公开形状没有 `dockerAccess`。
 Agent 需要 Docker API 时，使用 [Nested Docker Library](../nested-docker/library.md) 的
-`sandboxRequirements()` 与 `incusSandbox()`。
+`sandboxLayer({ requirements: { nestedDocker } })` 与 `incusSandbox()`。
 
 ## 不是 public path 的 access
 
@@ -36,6 +36,6 @@ dockerSandbox({
 
 | 输入 | 结果 |
 |---|---|
-| Eval `sandboxRequirements({ docker })` 配 `dockerAccess` | `sandbox-capability-unsatisfied` |
+| Eval `sandboxLayer({ requirements: { nestedDocker } })` 配 `dockerAccess` | `sandbox-capability-unsatisfied` |
 | managed 失败后改 raw 或 socket | 禁止 fallback |
 | 把 `sandboxState.dockerData` 当作 nested Docker cache | 不是 public state surface |

--- a/docs/feature/sandbox/docker-profiles/use-case/niceeval-eval.md
+++ b/docs/feature/sandbox/docker-profiles/use-case/niceeval-eval.md
@@ -10,7 +10,7 @@ relations: {}
 
 NiceEval-Eval 需要 Agent 在 Sandbox 内运行 `docker` 与 `docker compose` 时，走
 [声明 Docker 能力](../../nested-docker/use-case/声明Docker能力.md)。
-Eval 写 `sandboxRequirements()`，Experiment 写 `incusSandbox()`。
+Eval 写 `sandboxLayer({ requirements: { nestedDocker } })`，Experiment 写 `incusSandbox()`。
 
 单容器 raw / managed DinD、官方 `docker:<version>-dind` 派生镜像与
 `niceeval docker profile doctor default` 不能满足 `dedicated-kernel/v1`。

--- a/docs/feature/sandbox/layers.md
+++ b/docs/feature/sandbox/layers.md
@@ -6,7 +6,7 @@ Eval 与 Experiment 使用完全相同的公开 `sandbox` 字段和 `SandboxLaye
 对每个实际选中的 `Eval × Experiment` 配对:
 
 - 恰好一方的 layer 是 template-bearing,由具体 Provider factory 构造,携带完整起点并同时选定 Provider;
-- 另一方是 command-only layer,只能在已经启动的主 Sandbox 中执行命令;
+- 另一方是 command-only layer,可以携带 Provider 能力要求和在已经启动的主 Sandbox 中执行的命令，但不提供起点;
 - Agent layer 始终是 command-only,并与其它 owner 进入同一个 ready set；数值更小的 Agent action 可以先于 Experiment、Eval Group 或 Eval action;
 - 每个 occurrence 内跨 owner 建立依赖 DAG；依赖满足后，从 ready set 选择最小 `changeFrequency`；after 按实际登记栈逆序退出。
 
@@ -40,7 +40,7 @@ template 的唯一性是配对局部约束,一个 Run 可以同时存在多个 t
 
 ## 作者只学四个规则
 
-1. `dockerComposeSandbox()` / `e2bSandbox()` / `incusSandbox()` 等具体 factory 声明 template;`sandboxLayer()` 与 `sandboxRequirements()` 只声明命令。
+1. `dockerComposeSandbox()` / `e2bSandbox()` / `incusSandbox()` 等具体 factory 声明 template；`sandboxLayer()` 创建 command-only layer，可用 `requirements` 声明 Provider 能力要求。
 2. 一个配对只能有一方带 template。两边都有是 `sandbox.template-conflict`,两边都没有是 `sandbox.template-missing`。
 3. Experiment、Eval Group、Eval、Agent 使用同一种 `before()` / `after()`；owner 只保留声明出处与归因。
 4. before 按依赖与数值排队。成功取得资源后用 `context.onCleanup()` 登记释放；无条件 after 在入口登记，所有收尾按实际登记栈逆序退出。
@@ -67,7 +67,6 @@ import {
   incusSandbox,
   sandboxContent,
   sandboxLayer,
-  sandboxRequirements,
   sandboxStep,
   shell,
   uploadDirectory,
@@ -191,14 +190,16 @@ interface IncusSandboxOptions {
   readonly acceptDevelopmentDomain?: boolean;
 }
 
-interface SandboxRequirementsOptions {
-  readonly docker?: DockerExecutionRequirement;
+interface SandboxLayerOptions {
+  readonly requirements?: SandboxLayerRequirements;
 }
 
-interface DockerExecutionRequirement {
-  readonly api: "docker/v1";
-  readonly compose: "v2" | "not-required";
-  readonly isolation: "dedicated-kernel/v1";
+interface SandboxLayerRequirements {
+  readonly nestedDocker?: NestedDockerRequirement;
+}
+
+interface NestedDockerRequirement {
+  readonly compose?: "v2";
   readonly minimumDataBytes: number;
 }
 
@@ -218,19 +219,18 @@ declare function incusSandbox(
   options: IncusSandboxOptions,
 ): SandboxLayer<"template-bearing">;
 
-declare function sandboxLayer(): SandboxLayer<"command-only">;
-declare function sandboxRequirements(
-  options: SandboxRequirementsOptions,
+declare function sandboxLayer(
+  options?: SandboxLayerOptions,
 ): SandboxLayer<"command-only">;
 ```
 
-`sandboxRequirements()` 与 `incusSandbox()` 的字段语义、capability receipt 与 identity 单源在
+`sandboxLayer({ requirements })` 与 `incusSandbox()` 的字段语义、capability receipt 与 identity 单源在
 [Nested Docker Library](nested-docker/library.md)。
 
 `user` 替换整个 Sandbox 的默认执行身份,省略时沿用起点声明的身份;语义与各 provider 的支持面见 [Library · 执行身份](library.md#执行身份),值进入 fingerprint。
 
 Docker image/Dockerfile 还可声明结构化 `resources`。
-Agent 要在 Sandbox 内使用 Docker API 时，Eval 写 `sandboxRequirements()`，Experiment 写 `incusSandbox()`；
+Agent 要在 Sandbox 内使用 Docker API 时，Eval 写 `sandboxLayer({ requirements: { nestedDocker } })`，Experiment 写 `incusSandbox()`；
 完整契约见 [Nested Docker](nested-docker/README.md)。
 `dockerAccess` 的 socket / raw / managed DinD 不是 adopted nested-Docker public path，也不能降为 fallback。
 
@@ -247,8 +247,8 @@ dockerSandbox({ source: { type: "dockerfile", context, ... } }) -> Dockerfile te
 dockerSandbox({ source: { type: "image", image } })              -> image template + Docker Provider
 e2bSandbox({ template })                         -> E2B template + E2B Provider
 vercelSandbox({ snapshotId })                    -> snapshot template + Vercel Provider
-incusSandbox({ image, project, storagePool })    -> Incus VM template + Incus Provider
-sandboxRequirements({ docker })                  -> command-only nested Docker requirement
+incusSandbox({ image, project, storagePool })                 -> Incus VM template + Incus Provider
+sandboxLayer({ requirements: { nestedDocker } })              -> command-only layer + nested Docker requirement
 ```
 
 原生起点字段必填：`dockerSandbox` 必须给出带 `type` 的 `source`，`e2bSandbox` 必须给 `template`。
@@ -820,7 +820,7 @@ Adapter 不能提供 template 或 Provider;Agent 需要特殊系统起点时,Eva
 
 - [三方准备时序](lifecycle.md) —— action schedule、fresh / reuse 次数、身份与错误归属。
 - [Case](case.md) —— template 之下的完整运行单位:BuildKey / CaseKey、构建协调、Compose。
-- [Nested Docker](nested-docker/README.md) —— `sandboxRequirements()` 与 `incusSandbox()`。
+- [Nested Docker](nested-docker/README.md) —— `sandboxLayer({ requirements })` 与 `incusSandbox()`。
 - [Library](library.md) —— 运行中 Sandbox 的路径、执行身份、超时与自定义 Provider。
 - [Sandbox 复用](reuse.md) —— `sandboxReuse` 下的重新执行、reset 与寿命确认。
 - [Agent Ensure](../adapters/architecture/agent-ensure.md) —— Agent layer 的安装协议与事实。

--- a/docs/feature/sandbox/library.md
+++ b/docs/feature/sandbox/library.md
@@ -220,7 +220,7 @@ import {
   dockerSandbox,
   e2bSandbox,
   incusSandbox,
-  sandboxRequirements,
+  sandboxLayer,
   vercelSandbox,
 } from "niceeval/sandbox";
 
@@ -237,12 +237,12 @@ incusSandbox({                                           // Experiment:一次性
   project: "niceeval-eval",
   storagePool: "niceeval-evals",
 })
-sandboxRequirements({                                    // Eval:nested Docker requirement
-  docker: {
-    api: "docker/v1",
-    compose: "v2",
-    isolation: "dedicated-kernel/v1",
-    minimumDataBytes: 4 * 1024 ** 3,
+sandboxLayer({                                           // Eval:nested Docker requirement
+  requirements: {
+    nestedDocker: {
+      compose: "v2",
+      minimumDataBytes: 4 * 1024 ** 3,
+    },
   },
 })
 ```
@@ -270,7 +270,12 @@ e2bSandbox({
 
 普通 `dockerSandbox({ source })` 继续提供 Docker image / Dockerfile 单容器执行；它适合 Agent 不需要控制另一层 Docker daemon 的任务。
 
-Agent 要在 Sandbox 内运行 Docker 或 Compose 时，Eval 用 `sandboxRequirements()` 声明 provider-neutral 的 `docker/v1`、Compose、专用 kernel 与最低 data capacity。Experiment 用 `incusSandbox()` 选择 Host 管理的 Incus project、storage pool 与 digest-pinned trusted image。完整公开形状、资源字段、capability receipt 与错误码见 [Nested Docker Library](nested-docker/library.md)。
+Agent 要在 Sandbox 内运行 Docker 或 Compose 时，Eval 用
+`sandboxLayer({ requirements: { nestedDocker } })` 声明 provider-neutral 的 Nested Docker、Compose 与最低 data capacity。
+`docker/v1`、sandbox-private daemon 与专用 kernel 是这项要求的固定语义。
+
+Experiment 用 `incusSandbox()` 选择 Host 管理的 Incus project、storage pool 与 digest-pinned trusted image。
+完整公开形状、资源字段、capability receipt 与错误码见 [Nested Docker Library](nested-docker/library.md)。
 
 Incus 为每条 Attempt 创建一次性 VM。guest 内运行普通 dockerd，Docker data 使用与 root / workspace 分开的私有 virtual disk；`resources.cpus`、`memoryBytes` 与 `dockerDataBytes` 进入 identity 和容量检查。SetupPrefix 复用完整、可验证的 immutable Provider artifact，每个 consumer clone 私有 writable root / data disk。
 
@@ -471,7 +476,7 @@ Scope release 统一执行 stop 或已经提交的 keep disposition。
 
 - [README](README.md) ——为什么需要沙箱、provider 统一接口。
 - [Sandbox Layer](layers.md) —— `sandbox` 声明:template 配对、准备命令与顺序。
-- [Nested Docker](nested-docker/README.md) —— `sandboxRequirements()` 与 `incusSandbox()`。
+- [Nested Docker](nested-docker/README.md) —— `sandboxLayer({ requirements })` 与 `incusSandbox()`。
 - [三方准备时序](lifecycle.md) —— link 规划、action schedule 与 fresh / reuse 次数。
 - [预制实例](library/prebuilt-environments.md) ——各 provider 的构建工作流、官方 agent 起点与运行时 checkpoint。
 - [CLI](cli.md) —— `--keep-sandbox` 留存现场与 `niceeval sandbox` 销毁命令。

--- a/docs/feature/sandbox/lifecycle.md
+++ b/docs/feature/sandbox/lifecycle.md
@@ -47,7 +47,7 @@ linked pair
   -> 读取本地 Compose / Dockerfile 输入
   -> 确定目标平台与 provider locator
   -> 校验 Agent capability requirement
-  -> 比较 Eval sandboxRequirements 与 Provider capability receipt
+  -> 比较 Eval layer requirements 与 Provider capability receipt
   -> SandboxProviderPlan
   -> fingerprint
 ```

--- a/docs/feature/sandbox/nested-docker/README.md
+++ b/docs/feature/sandbox/nested-docker/README.md
@@ -9,7 +9,8 @@ relations: {}
 Coding Agent 经常要在评估现场里执行 `docker build`、`docker run` 与 `docker compose`。
 这件事是 Eval 对 Sandbox 必须兑现的能力要求，不是 Docker Profile、宿主 socket 或 Provider 产品名。
 
-Eval 用 `sandboxRequirements()` 声明 `docker/v1`、Compose、专用 kernel 与最低 data capacity。
+Eval 用 `sandboxLayer({ requirements })` 声明 Nested Docker、Compose 与最低 data capacity；
+`docker/v1`、sandbox-private daemon 与专用 kernel 是这项要求的固定语义，不是作者选项。
 Experiment 用 `incusSandbox()` 选择一台一次性 Incus VM，兑现这些要求。
 配对规则仍是现有 Sandbox Layer：Eval 这一侧是 command-only，Experiment 这一侧带 template。
 
@@ -20,7 +21,7 @@ V1 只承诺具名能力 `docker/v1`。
 
 ```text
 Eval
-  sandboxRequirements({ docker: docker/v1 + dedicated-kernel/v1 + Compose + minimumDataBytes })
+  sandboxLayer({ requirements: { nestedDocker: { compose?, minimumDataBytes } } })
   -> command-only layer，不选择 Provider
 
 Experiment
@@ -46,12 +47,12 @@ Docker data 使用与 root、workspace 分开的私有 virtual disk。
 nested Docker 的 adopted public path 只有这一组 factory：
 
 ```ts
-sandboxRequirements({
-  docker: {
-    api: "docker/v1",
-    compose: "v2" | "not-required",
-    isolation: "dedicated-kernel/v1",
-    minimumDataBytes,
+sandboxLayer({
+  requirements: {
+    nestedDocker: {
+      compose?: "v2",
+      minimumDataBytes,
+    },
   },
 })
 
@@ -75,7 +76,7 @@ incusSandbox({
 
 本主题包含：
 
-- Eval 的 provider-neutral `sandboxRequirements()`；
+- Eval layer 的 provider-neutral `requirements.nestedDocker`；
 - Experiment 的 `incusSandbox()` 与 DestroyOnly 生命周期；
 - reference 与 development 两个 execution domain；
 - `niceeval sandbox provider doctor incus [--development]` 的只读 fail-closed 诊断；
@@ -96,7 +97,7 @@ base；但在它之上，NiceEval 可以创建 Provider-native 的派生 prepara
 
 ## 入口
 
-- [Library](library.md) —— `sandboxRequirements()` 与 `incusSandbox()` 的公开形状。
+- [Library](library.md) —— `sandboxLayer({ requirements })` 与 `incusSandbox()` 的公开形状。
 - [CLI](cli.md) —— doctor、`--development`、`--dry` identity。
 - [Architecture](architecture.md) —— requirement / capability、domain、信任与安全边界。
 - [Lifecycle](lifecycle.md) —— planning、DestroyOnly、doctor 与 fail-closed。

--- a/docs/feature/sandbox/nested-docker/architecture.md
+++ b/docs/feature/sandbox/nested-docker/architecture.md
@@ -3,7 +3,7 @@
 ## 边界
 
 ```text
-Eval DockerExecutionRequirement
+Eval NestedDockerRequirement
   + Experiment incusSandbox template
   -> capability check and capacity reservation
   -> durable SandboxAllocation intent + generation
@@ -13,7 +13,8 @@ Eval DockerExecutionRequirement
 ```
 
 `incusSandbox()` 仍是选择 Provider 与完整 origin 的 template。
-`sandboxRequirements()` 只是配对时必须满足的约束，不是第二个 template。
+`sandboxLayer({ requirements })` 只是让 command-only layer 携带配对时必须满足的约束，
+不是第二个 template。
 
 ## 四个 owner
 
@@ -38,7 +39,7 @@ NiceEval control plane 才拥有 business cache 的意图、key、生命周期�
 
 ## requirement 与 capability
 
-Eval 的 `DockerExecutionRequirement` 是 provider-neutral 比较键。
+Eval 的 `NestedDockerRequirement` 经规范化后形成 provider-neutral 比较键。
 它不编码 Incus、ZFS 或某个 pathname。
 
 Incus planner 返回 `DockerExecutionCapability`。

--- a/docs/feature/sandbox/nested-docker/library.md
+++ b/docs/feature/sandbox/nested-docker/library.md
@@ -3,47 +3,52 @@
 Eval 声明能力，Experiment 选择 Incus VM。
 两者都放进现有 `sandbox` 字段，不新增第二套 origin 字段。
 
-## `sandboxRequirements()`
+## `sandboxLayer({ requirements })`
 
 ```ts
-import { sandboxRequirements } from "niceeval/sandbox";
+import { sandboxLayer } from "niceeval/sandbox";
 
-interface SandboxRequirementsOptions {
-  readonly docker?: DockerExecutionRequirement;
+interface SandboxLayerOptions {
+  readonly requirements?: SandboxLayerRequirements;
 }
 
-interface DockerExecutionRequirement {
-  readonly api: "docker/v1";
-  readonly compose: "v2" | "not-required";
-  readonly isolation: "dedicated-kernel/v1";
+interface SandboxLayerRequirements {
+  readonly nestedDocker?: NestedDockerRequirement;
+}
+
+interface NestedDockerRequirement {
+  readonly compose?: "v2";
   readonly minimumDataBytes: number;
 }
 
-declare function sandboxRequirements(
-  options: SandboxRequirementsOptions,
+declare function sandboxLayer(
+  options?: SandboxLayerOptions,
 ): SandboxLayer<"command-only">;
 ```
 
 `minimumDataBytes` 是正整数 byte 数。
 4 GiB 是 NiceEval-Eval 这类题目的最低要求，不是所有 Eval 的全局默认。
-没有 `docker` 字段时，该 layer 不要求启动 daemon。
+`compose` 省略时不要求 Compose；写出 `"v2"` 时 Provider 必须证明 Compose V2 可用。
+没有 `nestedDocker` 字段时，该 layer 不要求启动 daemon。
 
-Eval 侧只能用这份 command-only layer 声明 nested Docker。
+`nestedDocker` 固定表示 `docker/v1`、sandbox-private daemon 与 `dedicated-kernel/v1`；
+这些是能力本身的语义，不是作者重复填写的选项。
+Eval 侧用这份 command-only layer 配置声明 Nested Docker。
 它不选择 image、project、storage pool 或 Provider。
 
 ```ts
 import { defineEval } from "niceeval";
-import { sandboxRequirements } from "niceeval/sandbox";
+import { sandboxLayer } from "niceeval/sandbox";
 
 const GiB = 1024 ** 3;
 
 export default defineEval({
-  sandbox: sandboxRequirements({
-    docker: {
-      api: "docker/v1",
-      compose: "v2",
-      isolation: "dedicated-kernel/v1",
-      minimumDataBytes: 4 * GiB,
+  sandbox: sandboxLayer({
+    requirements: {
+      nestedDocker: {
+        compose: "v2",
+        minimumDataBytes: 4 * GiB,
+      },
     },
   }),
   async test(t) {
@@ -162,7 +167,7 @@ planning 比较 requirement 与 receipt。
 | `executionDomain` | `"reference"` | `"development"` |
 | `capacity` | `{ _tag: "Attested", bytes }` | `{ _tag: "Unattested", acceptedByExperiment: true, reason }` |
 
-Eval 写 `compose: "not-required"` 时，receipt 仍可以是 `"v2"`。
+Eval 省略 `compose` 时，receipt 仍可以是 `"v2"`。
 Eval 写 `compose: "v2"` 而 receipt 是 `"unavailable"` 时失败。
 
 ## Guest 与公开句柄
@@ -184,7 +189,7 @@ Provider 负责把 Docker CLI、Compose 与 daemon 带进 trusted origin。
 
 会改变执行语义的字段进入 identity 与 `--dry`：
 
-- requirement 的 `api`、`compose`、`isolation`、`minimumDataBytes`；
+- Nested Docker requirement 的 `compose` 与 `minimumDataBytes`；
 - `incusSandbox()` 的 `image`、`project`、`storagePool`、`resources`、`acceptDevelopmentDomain`；
 - Provider 的 execution domain 与 capability receipt。
 
@@ -195,7 +200,7 @@ development domain 不是 reference，也不能参加 reference 对照。
 
 | 输入 | 结果 |
 |---|---|
-| Eval 声明 `docker` requirement，Experiment 不是 `incusSandbox()` | `sandbox-capability-unsatisfied`；不回退 |
+| Eval 声明 `requirements.nestedDocker`，Experiment 不是 `incusSandbox()` | `sandbox-capability-unsatisfied`；不回退 |
 | `incusSandbox()` 配 `--keep-sandbox` | 创建资源前失败 |
 | `incusSandbox()` 配 `sandboxReuse: true` | 创建资源前失败 |
 | 省略 `acceptDevelopmentDomain` 却选择 development project / pool | fail-closed，不改走 reference 伪装 |

--- a/docs/feature/sandbox/nested-docker/lifecycle.md
+++ b/docs/feature/sandbox/nested-docker/lifecycle.md
@@ -9,7 +9,7 @@ V1 是 DestroyOnly。
 ```text
 discover Eval and Experiment
   -> select the single SandboxTemplate
-  -> collect DockerExecutionRequirement
+  -> collect normalized Nested Docker requirement
   -> Incus planner returns capability receipt
   -> compare requirement / capability
   -> compute BuildKey, CaseKey and SetupPrefixKey

--- a/docs/feature/sandbox/nested-docker/use-case/声明Docker能力.md
+++ b/docs/feature/sandbox/nested-docker/use-case/声明Docker能力.md
@@ -15,17 +15,17 @@ Eval 保持 command-only：
 
 ```ts
 import { defineEval } from "niceeval";
-import { sandboxRequirements } from "niceeval/sandbox";
+import { sandboxLayer } from "niceeval/sandbox";
 
 const GiB = 1024 ** 3;
 
 export default defineEval({
-  sandbox: sandboxRequirements({
-    docker: {
-      api: "docker/v1",
-      compose: "v2",
-      isolation: "dedicated-kernel/v1",
-      minimumDataBytes: 4 * GiB,
+  sandbox: sandboxLayer({
+    requirements: {
+      nestedDocker: {
+        compose: "v2",
+        minimumDataBytes: 4 * GiB,
+      },
     },
   }),
   async test(t) {
@@ -78,5 +78,5 @@ workdir 是 `/home/sandbox/workspace`，执行身份是 `node` uid 1000。
 
 ## 替代
 
-题目不需要 Docker API 时，不要写 `docker` requirement。
+题目不需要 Docker API 时，不要写 `requirements.nestedDocker`。
 普通 `dockerSandbox({ source })` 仍可做无 nested Docker 的单容器起点。

--- a/packages/niceeval/src/sandbox/index.ts
+++ b/packages/niceeval/src/sandbox/index.ts
@@ -6,7 +6,6 @@ export { defineSandbox } from "../define.ts";
 export {
   CustomSandboxMaterializationError,
   sandboxLayer,
-  sandboxRequirements,
   dockerSandbox,
   dockerComposeSandbox,
   e2bSandbox,
@@ -78,9 +77,9 @@ export {
 export type {
   SandboxLayer,
   SandboxLayerKind,
-  SandboxRequirementsOptions,
-  SandboxRequirement,
-  DockerExecutionRequirement,
+  SandboxLayerOptions,
+  SandboxLayerRequirements,
+  NestedDockerRequirement,
   DockerImageSource,
   DockerfileSource,
   DockerSandboxSource,

--- a/packages/niceeval/src/sandbox/layer.ts
+++ b/packages/niceeval/src/sandbox/layer.ts
@@ -82,20 +82,29 @@ export interface SandboxLayer<Kind extends SandboxLayerKind = SandboxLayerKind> 
   after(action: SandboxAfterAction | SandboxCleanupCommand): SandboxLayer<Kind>;
 }
 
-/** Docker execution is an Eval requirement, not a request for a particular Provider. */
-export interface DockerExecutionRequirement {
+export interface NestedDockerRequirement {
+  readonly compose?: "v2";
+  readonly minimumDataBytes: number;
+}
+
+export interface SandboxLayerRequirements {
+  readonly nestedDocker?: NestedDockerRequirement;
+}
+
+export interface SandboxLayerOptions {
+  readonly requirements?: SandboxLayerRequirements;
+}
+
+/** Normalized provider-neutral requirement used by physical planning and identity. */
+export interface NormalizedNestedDockerRequirement {
   readonly api: "docker/v1";
   readonly compose: "v2" | "not-required";
   readonly isolation: "dedicated-kernel/v1";
   readonly minimumDataBytes: number;
 }
 
-export interface SandboxRequirementsOptions {
-  readonly docker?: DockerExecutionRequirement;
-}
-
 export type SandboxRequirement =
-  | { readonly _tag: "DockerExecution"; readonly docker: DockerExecutionRequirement };
+  | { readonly _tag: "DockerExecution"; readonly docker: NormalizedNestedDockerRequirement };
 
 export interface DockerComposeSandboxOptions {
   readonly file: string | URL;
@@ -1589,10 +1598,55 @@ function createLayer(state: SandboxLayerState): SandboxLayer {
   return Object.freeze(layer);
 }
 
-export function sandboxLayer(): SandboxLayer<"command-only"> {
+function requirementsFromSandboxLayerOptions(
+  options: SandboxLayerOptions | undefined,
+): readonly SandboxRequirement[] {
+  if (options === undefined) return [];
+  assertRecord(options, "sandboxLayer options");
+  assertOnlyKeys(options, ["requirements"], "sandboxLayer options");
+  if (options.requirements === undefined) return [];
+
+  const requirements: unknown = options.requirements;
+  assertRecord(requirements, "sandboxLayer options.requirements");
+  assertOnlyKeys(requirements, ["nestedDocker"], "sandboxLayer options.requirements");
+  if (requirements.nestedDocker === undefined) return [];
+
+  const nestedDocker: unknown = requirements.nestedDocker;
+  assertRecord(nestedDocker, "sandboxLayer options.requirements.nestedDocker");
+  assertOnlyKeys(
+    nestedDocker,
+    ["compose", "minimumDataBytes"],
+    "sandboxLayer options.requirements.nestedDocker",
+  );
+  if (nestedDocker.compose !== undefined && nestedDocker.compose !== "v2") {
+    throw new TypeError(
+      "sandboxLayer options.requirements.nestedDocker.compose must be v2 or omitted",
+    );
+  }
+  if (
+    typeof nestedDocker.minimumDataBytes !== "number" ||
+    !Number.isSafeInteger(nestedDocker.minimumDataBytes) ||
+    nestedDocker.minimumDataBytes <= 0
+  ) {
+    throw new TypeError(
+      "sandboxLayer options.requirements.nestedDocker.minimumDataBytes must be a positive safe integer",
+    );
+  }
+  return [Object.freeze({
+    _tag: "DockerExecution" as const,
+    docker: Object.freeze({
+      api: "docker/v1" as const,
+      compose: nestedDocker.compose ?? "not-required",
+      isolation: "dedicated-kernel/v1" as const,
+      minimumDataBytes: nestedDocker.minimumDataBytes,
+    }),
+  })];
+}
+
+export function sandboxLayer(options?: SandboxLayerOptions): SandboxLayer<"command-only"> {
   return createLayer({
     kind: "command-only",
-    requirements: [],
+    requirements: requirementsFromSandboxLayerOptions(options),
     commands: [],
     before: [],
     after: [],
@@ -1668,58 +1722,6 @@ export function defineSandboxTemplate(
     kind: "template-bearing",
     template: declaration,
     requirements: [],
-    commands: [],
-    before: [],
-    after: [],
-    setupHooks: [],
-    teardownHooks: [],
-  });
-}
-
-/** Declare physical capabilities that the selected Sandbox Provider must prove before creation. */
-export function sandboxRequirements(
-  options: SandboxRequirementsOptions,
-): SandboxLayer<"command-only"> {
-  assertRecord(options, "sandboxRequirements options");
-  assertOnlyKeys(options, ["docker"], "sandboxRequirements options");
-  const requirements: SandboxRequirement[] = [];
-  if (options.docker !== undefined) {
-    const docker: unknown = options.docker;
-    assertRecord(docker, "sandboxRequirements docker");
-    assertOnlyKeys(
-      docker,
-      ["api", "compose", "isolation", "minimumDataBytes"],
-      "sandboxRequirements docker",
-    );
-    if (docker.api !== "docker/v1") {
-      throw new TypeError("sandboxRequirements docker.api must be docker/v1");
-    }
-    if (docker.compose !== "v2" && docker.compose !== "not-required") {
-      throw new TypeError("sandboxRequirements docker.compose must be v2 or not-required");
-    }
-    if (docker.isolation !== "dedicated-kernel/v1") {
-      throw new TypeError("sandboxRequirements docker.isolation must be dedicated-kernel/v1");
-    }
-    if (
-      typeof docker.minimumDataBytes !== "number" ||
-      !Number.isSafeInteger(docker.minimumDataBytes) ||
-      docker.minimumDataBytes <= 0
-    ) {
-      throw new TypeError("sandboxRequirements docker.minimumDataBytes must be a positive safe integer");
-    }
-    requirements.push(Object.freeze({
-      _tag: "DockerExecution" as const,
-      docker: Object.freeze({
-        api: docker.api,
-        compose: docker.compose,
-        isolation: docker.isolation,
-        minimumDataBytes: docker.minimumDataBytes,
-      }),
-    }));
-  }
-  return createLayer({
-    kind: "command-only",
-    requirements,
     commands: [],
     before: [],
     after: [],

--- a/packages/niceeval/src/sandbox/plan.ts
+++ b/packages/niceeval/src/sandbox/plan.ts
@@ -9,7 +9,7 @@ import {
   sandboxTemplateIdentity,
   type SandboxProviderPlan,
   type SandboxProviderPlanningError,
-  type DockerExecutionRequirement,
+  type NormalizedNestedDockerRequirement,
   type SandboxTemplateDeclaration,
   type SandboxTemplatePlanningInput,
 } from "./layer.ts";
@@ -54,7 +54,7 @@ export type SandboxPhysicalCapabilityRequirement =
   | { readonly _tag: "Reuse" }
   | { readonly _tag: "Retention" }
   | { readonly _tag: "SessionDuration"; readonly milliseconds: number }
-  | { readonly _tag: "DockerExecution"; readonly docker: DockerExecutionRequirement };
+  | { readonly _tag: "DockerExecution"; readonly docker: NormalizedNestedDockerRequirement };
 
 /**
  * 通用 planner 调用边界。默认实现只调用 template 私绑 planner；测试可注入拦截器，


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 080d230d18ec09e3ccb100654597459899960b46
templateSha256: 2a855926ca633a0d3f93cdd0559a0bbbae80a53779a52341ef7a42faaf6ad449
head: b3e18de9fdebf13fc4e776b72cae96711ea6e25e
-->

## Problem

- User goal: Eval 作者需要声明题目会在评估现场运行 Docker 与 Compose，同时让 Experiment 继续负责选择实际 Sandbox Provider。
- Current limitation: 现有写法需要额外叠加 `sandboxRequirements()`，并重复填写用户不能选择的 `docker/v1` 与 `dedicated-kernel/v1` 固定值，让 requirement 看起来像第二种 Layer。
- Required capability: command-only `sandboxLayer()` 需要直接接收 Nested Docker 要求，并把固定的 API 与隔离语义留给 NiceEval 归一化。
- User outcome: 作者只需在一个 Sandbox Layer 中声明 Compose 版本与最低 Docker data 容量，仍可继续使用 `.before()` / `.after()` 并与 Experiment 的 `incusSandbox()` 配对。

## Use cases

### Case: 为 Eval 声明 Nested Docker 能力

#### Starting state

```text
Experiment 已通过 incusSandbox() 选择具备专用 kernel 与足够 Docker data 容量的起点。
```

#### Action

```ts
import { defineEval } from "niceeval";
import { sandboxLayer } from "niceeval/sandbox";

const GiB = 1024 ** 3;

export default defineEval({
  sandbox: sandboxLayer({
    requirements: {
      nestedDocker: {
        compose: "v2",
        minimumDataBytes: 4 * GiB,
      },
    },
  }),
  async test(t) {
    await t.send("用 docker compose 安装并验证服务。");
  },
});
```

#### Result

```text
pnpm exec tsc --noEmit
exit 0
```

Eval 的声明仍是 command-only Sandbox Layer；物理规划继续由 Experiment 选择的 Provider 满足要求。完整的 Eval、Experiment、失败与开发环境边界见[声明 Docker 能力](docs/feature/sandbox/nested-docker/use-case/声明Docker能力.md)。

## Public API

### Removed

#### Case: `sandboxRequirements()` 与旧 requirement 类型

##### Before

```ts
import { defineEval } from "niceeval";
import {
  sandboxRequirements,
  type DockerExecutionRequirement,
} from "niceeval/sandbox";

const docker: DockerExecutionRequirement = {
  api: "docker/v1",
  compose: "v2",
  isolation: "dedicated-kernel/v1",
  minimumDataBytes: 4 * 1024 ** 3,
};

export default defineEval({
  sandbox: sandboxRequirements({ docker }),
  async test(t) {
    await t.send("验证服务。");
  },
});
```

```text
SandboxLayer<"command-only">
```

##### After

```text
removed
```

##### User impact

`sandboxRequirements`、`SandboxRequirementsOptions`、`SandboxRequirement` 与 `DockerExecutionRequirement` 不再从 `niceeval/sandbox` 导出。调用方改为把 `requirements.nestedDocker` 传给 `sandboxLayer()`；无需再填写固定的 API 与隔离版本。

### Added

#### Case: `SandboxLayerOptions`、`SandboxLayerRequirements` 与 `NestedDockerRequirement`

##### Before

```ts
import { defineEval } from "niceeval";
import { sandboxLayer, type SandboxLayerOptions } from "niceeval/sandbox";

const options: SandboxLayerOptions = {
  requirements: {
    nestedDocker: { compose: "v2", minimumDataBytes: 4 * 1024 ** 3 },
  },
};

export default defineEval({ sandbox: sandboxLayer(options), async test() {} });
```

```text
TS2305: Module 'niceeval/sandbox' has no exported member 'SandboxLayerOptions'.
```

##### After

```ts
import { defineEval } from "niceeval";
import {
  sandboxLayer,
  type NestedDockerRequirement,
  type SandboxLayerOptions,
  type SandboxLayerRequirements,
} from "niceeval/sandbox";

const nestedDocker: NestedDockerRequirement = {
  compose: "v2",
  minimumDataBytes: 4 * 1024 ** 3,
};
const requirements: SandboxLayerRequirements = { nestedDocker };
const options: SandboxLayerOptions = { requirements };

export default defineEval({ sandbox: sandboxLayer(options), async test() {} });
```

```text
pnpm exec tsc --noEmit
exit 0
```

##### User impact

封装 Eval 配置的库可以直接复用并导出新的 Sandbox Layer 选项类型，而不必暴露物理规划所使用的归一化 requirement。

### Changed

#### Case: `sandboxLayer(options?)`

##### Before

```ts
import { defineEval } from "niceeval";
import { sandboxLayer } from "niceeval/sandbox";

export default defineEval({ sandbox: sandboxLayer(), async test() {} });
```

```text
SandboxLayer<"command-only">，不携带能力要求。
```

##### After

```ts
import { defineEval } from "niceeval";
import { sandboxLayer } from "niceeval/sandbox";

export default defineEval({
  sandbox: sandboxLayer({
    requirements: {
      nestedDocker: { compose: "v2", minimumDataBytes: 4 * 1024 ** 3 },
    },
  }),
  async test() {},
});
```

```text
SandboxLayer<"command-only">，携带一项 Nested Docker 要求，并可继续调用 .before() / .after()。
```

##### User impact

原有 `sandboxLayer()` 调用保持有效。需要 Nested Docker 的调用方把要求放进同一个 Layer；`compose` 只接受 `"v2"` 或省略，`minimumDataBytes` 必须是正的安全整数。

## Terminology

### Added terms

#### Case: Nested Docker 要求

##### Before

```md
Eval 通过 Docker 执行要求声明私有 daemon、Compose、专用 kernel 与最低容量。
```

```text
首选术语：Docker 执行要求
```

##### After

```md
Eval 通过 Nested Docker 要求声明私有 daemon、Compose、专用 kernel 与最低容量。
```

```text
首选术语：Nested Docker 要求
```

##### User impact

Nested Docker 要求专指 Agent 在 Sandbox 内使用私有 Docker daemon 的完整能力要求，并与普通 Docker Sandbox 起点区分；定义见[核心概念：Sandbox](docs/concepts.md#sandbox)。

### Removed terms

#### Case: Docker 执行要求

##### Before

```md
Docker 执行要求由 sandboxRequirements() 单独生成一个 command-only Layer。
```

```text
首选术语：Docker 执行要求
```

##### After

```md
Nested Docker 要求由 sandboxLayer({ requirements }) 直接承载。
```

```text
首选术语：Nested Docker 要求
```

##### User impact

旧词随独立工厂与公开类型一起移除，避免把 requirement 误解为另一种 Layer；调用方迁移到[核心概念：Sandbox](docs/concepts.md#sandbox)中的 Nested Docker 要求。

## Tests

### Verification receipt

- Candidate: Git `b3e18de9f`; `niceeval-0.4.6.tgz` SHA-256 `2623c801c46cfa7e32237a4963f97caca29b1095bcb8d3a3757ba51193e6174f`
- Green: 在隔离项目执行 `pnpm add <niceeval-0.4.6.tgz> && pnpm exec tsc --noEmit && node smoke.mjs`；安装后类型检查通过，公开入口输出 `installed sandboxLayer requirements API passed`，旧导出缺失、`.before()` 链式调用和非法 `compose: "v1"` 拒绝均通过检查
- Repeatability: 同一 candidate 完成一次隔离安装与公开 Library 入口验收，临时项目与 tarball 已清理；本 PR 未新增长期测试 owner
- Fixed conditions: Git `b3e18de9f`、仓库当前 lockfile、Node `v24.19.0`、pnpm `11.18.0`；未连接 Incus Provider
- Unit count: `pnpm test` 共 7 个文件、15 个测试通过；未修改 Unit

### Deliberately not automated

- Case: 真实 Incus Provider 满足 Nested Docker 要求并完成资源生命周期
- Public action: 安装后的 `niceeval exp <experiment> --dry` 与正式 Experiment 运行
- Observation: 已验证安装后声明 API、类型导出、链式组合、运行时校验与内部归一化；本地验收没有创建 Incus allocation
- Remaining risk: 真实 Incus capability 匹配、Docker data 容量与创建/销毁生命周期仍缺少长期 E2E owner，需由具备 Provider 的环境验证

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790299943&installation_model_id=431746&pr_number=164&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F164&signature=5e64be4420bcfdb8e2bf9de1d24992eef2b70aadd573c57d5c4c10a41a0db215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->