### PR TITLE
docs(effect): 接入官方 v4 agent 指南

### DIFF
--- a/.agents/skills/effect-ts/SKILL.md
+++ b/.agents/skills/effect-ts/SKILL.md
@@ -1,80 +1,32 @@
 ---
 name: effect-ts
-description: Use when implementing, debugging, or reviewing NiceEval code whose correctness depends on Effect v4 APIs or semantics, including typed failures, Schema decoding, Scope and resource lifecycles, concurrency, retries, services, layers, or Effect-backed tests. Do not use for domain modeling, data ownership, ordinary control-flow analysis, or generic observability questions that can be answered without reasoning about Effect behavior.
+description: Use when implementing, debugging, or reviewing NiceEval code whose correctness depends on Effect APIs or semantics, including typed failures, Schema, Scope, concurrency, services, layers, or Effect-backed tests. Do not use for domain questions that can be answered without Effect-specific reasoning.
 ---
 
-# Effect v4 workflow
+# Effect workflow
 
-Treat this repository as an Effect v4 codebase. Keep every Effect package on the exact version declared by the repository; while v4 is an RC, do not float tags or mix RC revisions.
+Follow the [official Effect skill](https://github.com/Effect-TS/skills/tree/main/skills/effect-ts): learn Effect from the guidance shipped with the exact installed package, not from a copied API summary in this skill.
 
-## Applicability gate
+## Load the official guidance first
 
-Use this workflow only when the task requires changing Effect code or making a claim that depends on exact Effect v4 behavior.
+Before writing or changing Effect code:
 
-Do not activate it merely because:
+1. Identify the owning workspace package and inspect its `package.json` together with the root lockfile.
+2. Resolve that workspace's installed `effect/package.json`, for example with `pnpm --filter <workspace> exec node -p "require.resolve('effect/package.json')"`.
+3. Require Effect major version 4 and keep every retained `effect` / `@effect/*` package on the exact repository-pinned RC revision.
+4. Read the resolved package's sibling `AGENTS.md` **completely**. Follow its relative links into `ai-docs/` and `src/` when the current topic requires them; read large linked guides such as `SCHEMA.md` in relevant chunks.
+5. Use the installed package source as the authority for exact signatures and behavior. Escalate to the canonical `Effect-TS/effect` repository only when needed, preferring the exact installed-version tag over `main`.
 
-- the inspected file imports Effect;
-- the relevant implementation happens to be Effect-based;
-- the task mentions Schema or observability in a product-domain sense;
-- a domain or data-ownership question can be answered from payloads and write paths alone.
+If dependencies are absent, install the locked workspace dependencies first. Do not float `beta` / RC tags, mix RC revisions, or infer current behavior from v3, an older beta, or `effect-smol`.
 
-If removing Effect from the implementation would leave the question unchanged, handle the task without this skill.
+## NiceEval boundaries
 
-## Establish the version and source
+Read `docs/architecture.md` before changing a runtime boundary. Keep pure planning and result folding outside Effect when they do not read the outside world; keep I/O, concurrency, cancellation, and resource lifetime inside Effect. Run Effect only at the owning public Promise or process boundary, preserve typed failures until their domain result boundary, and scope acquired resources so failure and interruption release them.
 
-1. Read `package.json` and the lockfile before changing Effect code.
-2. Read the installed `effect/package.json` through the workspace's package-manager resolution and require major version 4.
-3. Use the installed `effect/dist/*.d.ts` and JavaScript as the first source for exact signatures and behavior. They match the installed package exactly.
-4. Use the canonical `Effect-TS/effect` repository only when package source is insufficient. Prefer the exact `effect@<installed-version>` tag; use `main` only when investigating an unreleased v4 change and label that distinction.
-5. Never infer RC behavior from an older beta, v3, or the archived `Effect-TS/effect-smol` repository.
+`effect` remains an exact peer of the published NiceEval package because public Host and Record APIs exchange Effect and Schema values with consumers. Modules under `effect/unstable/*` may support private tooling, but must not leak through published declarations.
 
-If the installed declaration and JavaScript files are missing, install the locked dependencies with the repository package manager before making source-level claims. Do not create a second Effect checkout merely for routine API research.
-
-## Preserve the repository boundary
-
-Read `docs/architecture.md` before changing a runtime boundary, then preserve these rules:
-
-- Keep identity, selection, planning, fingerprints, and result folding pure when they do not read the outside world.
-- Put file, network, process, dynamic-import, concurrency, cancellation, and resource-lifecycle work in `Effect`.
-- Adapt public callbacks and Provider SDK Promises once with `Effect.tryPromise` or `Effect.promise` at their boundary.
-- Run Effect only at the outer public Promise facade or result-closing boundary. Do not introduce nested `Effect.runPromise`, `runPromiseExit`, or `runSync` calls in internal modules.
-- Hold acquired resources in `Effect.Scope`; use `Effect.acquireRelease`, `Effect.addFinalizer`, or an equivalent scoped primitive so failure and interruption release them.
-- Preserve typed failure, defect, and interruption as separate channels until the owning result boundary closes them.
-
-## Research in this order
-
-1. Inspect nearby NiceEval Effect patterns and the feature contract owning the behavior.
-2. Search the installed `effect/dist/` declarations and implementation for the exact v4 API and its types.
-3. Inspect the exact-version upstream tag when tests, history, or implementation context are required.
-4. Prefer the simplest v4 primitive that satisfies the contract; do not introduce an abstraction only because Effect provides one.
-
-Always research source details for resource lifecycles, interruption, concurrency, retry timing, complex typed-error hierarchies, services/layers, and unfamiliar Schema transformations.
-
-## Implementation rules
-
-- Use `Effect.tryPromise` when a Promise can reject and map the rejection to a domain error.
-- Use `Effect.promise` only when rejection is impossible or the boundary intentionally treats rejection as a defect.
-- Model expected failures in the typed error channel; reserve defects for broken invariants and truly unexpected failures.
-- Decode `unknown` at JavaScript, JSON, dynamic-import, SDK, and file-format boundaries with Schema or a complete domain guard.
-- Use `Effect.gen` for readable sequential workflows. Use `Effect.fn` for reusable Effect-returning business operations when its tracing/function boundary is useful.
-- Introduce `Context.Service`, services, and `Layer` only when dependency provisioning or resource lifetime benefits from them; do not wrap trivial parameter passing.
-- Provide services at an outer composition edge instead of repeatedly providing them inside business logic.
-- Treat v4 `Result<A, E>` as the official successor to v3 `Either<A, E>` without changing success/failure direction or domain error values.
-- Schema decoding and encoding may return `Exit`; close it at the owning boundary and never leak `Cause` through an existing domain result. Use `Schema.toType` when the old code validated only the type side of a transformation.
-- Audit `forkChild` startup, explicit `Deferred.await` / `Fiber.join` / `Ref.get`, flattened `Cause`, and shared Layer memoization instead of applying v3 renames mechanically.
-- Avoid `any`, unsafe assertions, and casts that bypass boundary decoding.
-
-## Effect v4 ecosystem packages
-
-Keep `effect` and every retained Effect ecosystem package on the exact validated v4 version declared by this repository. `effect` is a peer of the published NiceEval package because its public Host and Record APIs exchange Effect and Schema values with consumers.
-
-Do not restore packages merged into v4 core. Import platform services from `effect/*` and internal CLI/process tools from their documented `effect/unstable/*` modules. Unstable modules may be used by private repository tooling, but they must not leak from the published package's public declarations.
-
-Install only packages required by the concrete runtime or feature. Do not add `@effect/platform-node`, `@effect/vitest`, or `@effect/opentelemetry` merely to make the dependency list look more Effect-native.
+For an actual v3-to-v4 migration, also read `../effect-v3-to-v4/SKILL.md`; do not keep migration-only symbol mappings in this ongoing Effect skill.
 
 ## Validation
 
-- Run `pnpm typecheck` after Effect dependency or source changes.
-- Follow `docs/engineering/testing/README.md` and the repository test-reset rules before changing tests.
-- Do not add `@effect/vitest` automatically. Use it only when an authorized Effect test owner needs its clock, layer, or scoped-test facilities and its exact v4 peer version is compatible.
-- Run the smallest real runtime path that exercises changed interruption, finalizer, or Promise-adaptation behavior when implementation changes go beyond a dependency-only upgrade.
+Run `pnpm typecheck` after Effect dependency or source changes, then run the smallest real runtime path covering any changed interruption, finalizer, concurrency, or Promise-adaptation behavior. Follow the repository testing skill before changing test owners.

--- a/.agents/skills/effect-v3-to-v4/SKILL.md
+++ b/.agents/skills/effect-v3-to-v4/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: effect-v3-to-v4
+description: Use when migrating a codebase from Effect v3 to Effect v4, upgrading effect or any @effect/* package across the v3/v4 boundary.
+---
+
+# Effect v3 to v4 migration
+
+This is NiceEval's repository-local adaptation of the [official Effect migration skill](https://github.com/Effect-TS/skills/tree/main/skills/effect-v3-to-v4). Drive every rename, removal, and signature change from upstream migration data; do not guess replacements.
+
+## Workflow
+
+1. Set up and validate the canonical v4 and v3 reference checkouts described below.
+2. Read `.repos/effect/MIGRATION.md` once and list `.repos/effect/migration/` for the guide index.
+3. Migrate package manifests first: remove consolidated packages and align every retained Effect package on one exact v4 version.
+4. Run the repository typecheck to obtain the initial error inventory.
+5. For each error, search `migration/v3-to-v4.md` for the exact symbol, then escalate through the topic guide and exact source as needed. Never silence an error instead of resolving it.
+6. Finish only after typecheck is clean; run the relevant tests and report their outcome honestly.
+
+## Canonical reference checkouts
+
+Use two shallow, single-branch clones of the canonical Effect repository:
+
+```sh
+git clone --depth 1 --single-branch https://github.com/Effect-TS/effect .repos/effect
+git clone --depth 1 --single-branch --branch v3 https://github.com/Effect-TS/effect .repos/effect-v3
+```
+
+- `.repos/effect` is v4 `main` and owns `MIGRATION.md`, `migration/`, and v4 source.
+- `.repos/effect-v3` is the v3 escalation-only reference.
+
+Validate any existing checkout before trusting it:
+
+```sh
+git -C .repos/effect remote get-url origin
+node -p "require('./.repos/effect/packages/effect/package.json').version"
+```
+
+The origin must be `Effect-TS/effect` and the version must be 4.x. A stale `effect-smol` checkout is not a valid migration source. These reference clones are not NiceEval development worktrees; do not create or switch NiceEval branches or worktrees for the migration.
+
+## Lookup order
+
+1. Read `.repos/effect/MIGRATION.md` once.
+2. Search `.repos/effect/migration/v3-to-v4.md` for each changed import or API. Never read this roughly 16,000-line generated reference whole.
+3. Read a relevant `.repos/effect/migration/*.md` topic guide when the mapping implies a structural rewrite.
+4. Read v4 source under `.repos/effect/packages/*/src/` to confirm the replacement's exact signature.
+5. Read `.repos/effect-v3` only when old semantics remain unclear.
+
+Useful searches:
+
+```sh
+rg -n 'AnthropicTokenizer\.layer' .repos/effect/migration/v3-to-v4.md
+rg -n -A 40 '^### `@effect/platform/FileSystem`' .repos/effect/migration/v3-to-v4.md
+rg -n '^@effect/platform/FileSystem ' .repos/effect/migration/v3-to-v4.md
+rg -n '^### `@effect/cluster/' .repos/effect/migration/v3-to-v4.md
+```
+
+A miss in the import map is not final: also inspect the removed-modules and no-counterpart-imports sections.
+
+## Repository-level changes
+
+- Remove packages merged into v4 core, including `@effect/platform`, `@effect/rpc`, and `@effect/cluster`, and rewrite imports according to the upstream map.
+- Keep packages that remain separate, such as `@effect/platform-*`, `@effect/sql-*`, `@effect/ai-*`, `@effect/opentelemetry`, and `@effect/vitest`.
+- Align `effect` and every retained `@effect/*` dependency on the same exact v4 version.
+- Use mapped `effect/unstable/*` imports where v4 requires them; treat their APIs as unstable.
+
+## NiceEval worker rules
+
+For large, independent migration slices, use only the Herdr worker workflow authorized by the root `AGENTS.md`. Never use built-in or custom subagents, never give two workers overlapping write sets, and never let a worker replace the parent agent's error inventory, diff review, or validation. Small migrations stay with the primary agent.
+
+## Hard prohibitions
+
+- Do not introduce a v3-shaped compatibility layer.
+- Do not use `any` or `as` casts to hide migration errors.
+- Do not invent replacement APIs; every replacement must trace to the generated reference, a topic guide, or v4 source.
+
+## Done condition
+
+The repository typechecks against v4. Run relevant tests without weakening them, and report typecheck, test results, constructed replacements, and any unresolved gaps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 不要从本文件学习整个项目。先按任务进入对应目录，读取该目录最近的 `README.md`、`AGENTS.md` 或索引，再沿链接只加载相关正文：
 
 - 产品、架构或内部设计：[`docs/README.md`](docs/README.md)
+- 实现、调试或评审依赖 Effect API / 语义的代码：先读 [`.agents/skills/effect-ts/SKILL.md`](.agents/skills/effect-ts/SKILL.md)，并按它的入口完整读取当前 workspace 安装的 `effect/AGENTS.md`；跨 v3 / v4 迁移再同时读取 [`.agents/skills/effect-v3-to-v4/SKILL.md`](.agents/skills/effect-v3-to-v4/SKILL.md)
 - 新建、查询或修改 Feature / Use Case：先读 [`.agents/skills/feature/SKILL.md`](.agents/skills/feature/SKILL.md)，再用 `pnpm run repo docs feature --help` 进入当前可运行命令
 - 设计、修改或采用 Roadmap：先读 [`.agents/skills/roadmap/SKILL.md`](.agents/skills/roadmap/SKILL.md)，再进入 Roadmap 与 Trace 正式契约；缺失的结构写命令不得用手抄模板代替
 - 查询、编写、修正或评审测试：先读 [`.agents/skills/testing/SKILL.md`](.agents/skills/testing/SKILL.md)，再按测试入口选择对应 E2E 或 Unit 例外路径

--- a/docs/design/report-authoring/PLAN-5/README.md
+++ b/docs/design/report-authoring/PLAN-5/README.md
@@ -18,14 +18,14 @@
 ```
 
 ```ts
-import { Either } from "effect";
+import { Result } from "effect";
 
 const inputs = reportInputs({
   verdicts: attemptSlotProjection(verdictProjector),
 });
 
 const quality = defineCalculation({
-  id: Either.getOrThrow(reportComponentId("quality")),
+  id: Result.getOrThrow(reportComponentId("quality")),
   inputs,
   completeness: "allow-partial",
   calculate: ({ sample, inputs }) =>
@@ -33,14 +33,14 @@ const quality = defineCalculation({
 });
 
 const overview = definePage({
-  id: Either.getOrThrow(reportComponentId("overview")),
-  route: Either.getOrThrow(reportRoute("/")),
+  id: Result.getOrThrow(reportComponentId("overview")),
+  route: Result.getOrThrow(reportRoute("/")),
   calculations: { quality },
   render: ({ calculations }) => renderQuality(calculations.quality),
 });
 
 export default defineReport({
-  id: Either.getOrThrow(reportId("quality")),
+  id: Result.getOrThrow(reportId("quality")),
   calculations: { quality },
   pages: [overview],
 });

--- a/docs/design/report-authoring/README.md
+++ b/docs/design/report-authoring/README.md
@@ -85,18 +85,18 @@ PLAN-4，默认写法同 PLAN-2，官方数据源答不了时才落到 SQL：
 PLAN-5，用静态 input、普通 Calculation 与 Page 组合：
 
 ```ts
-import { Either } from "effect";
+import { Result } from "effect";
 
 const performance = defineCalculation({
-  id: Either.getOrThrow(reportComponentId("performance")),
+  id: Result.getOrThrow(reportComponentId("performance")),
   inputs: reportInputs({ verdicts, usage }),
   completeness: "allow-partial",
   calculate: ({ sample, inputs }) => derivePerformance(sample, inputs),
 });
 
 const overview = definePage({
-  id: Either.getOrThrow(reportComponentId("overview")),
-  route: Either.getOrThrow(reportRoute("/")),
+  id: Result.getOrThrow(reportComponentId("overview")),
+  route: Result.getOrThrow(reportRoute("/")),
   calculations: { performance },
   render: ({ calculations }) => renderPerformance(calculations.performance),
 });

--- a/docs/engineering/docs-traceability/README.md
+++ b/docs/engineering/docs-traceability/README.md
@@ -373,7 +373,7 @@ compiler 连续枚举并读取两次全部 Trace 输入；集合和 bytes 相同
 `packages/repo-tools/src/docs/trace/**` 是 RepoRef、关系 target validation、pure compiler、Snapshot、投影、presentation、lock/generation 与 findings 的唯一 owner。
 Feedback 与 Memory codec/state 仍归各自领域；它们复用 Trace RepoRef/target checker，不复制 path/anchor parser。
 
-`packages/repo-tools/src/cli.ts` 只把 `feature`、`test` 与维护命令接进同一个 `@effect/cli` 根和 Node runtime。
+`packages/repo-tools/src/cli.ts` 只把 `feature`、`test` 与维护命令接进同一个 `effect/unstable/cli` 根和 Node runtime。
 Effect 层拥有文件系统、lock、journal、recovery 与 receipt。
 
 `lint/docs/**` 只是直接调用 pure checker 的薄 adapter，不复制 parser，也不通过子进程调用 CLI。

--- a/docs/roadmap/experiment-authoring/display-names/library.md
+++ b/docs/roadmap/experiment-authoring/display-names/library.md
@@ -41,7 +41,7 @@ type ExperimentPresentationError = {
 
 declare const experimentDisplayName: (
   input: string,
-) => Either.Either<ExperimentDisplayName, ExperimentPresentationError>;
+) => Result.Result<ExperimentDisplayName, ExperimentPresentationError>;
 ```
 
 作者显式给出的 `displayName` 必须是单行 Unicode scalar text，长度为 1 至 160 UTF-8 bytes。

--- a/packages/niceeval/src/runner/attempt.ts
+++ b/packages/niceeval/src/runner/attempt.ts
@@ -3192,7 +3192,7 @@ function isAttemptAborted(signal: AbortSignal | undefined): boolean {
 
 /**
  * The legacy body treated rejected author and SDK promises as defects. Keep
- * that result channel while giving every Promise a named Effect v3 boundary
+ * that result channel while giving every Promise a named Effect boundary
  * and its cancellation signal.
  */
 function tryPromiseAsDefect<Value>(

--- a/packages/niceeval/src/runner/cleanup-timeout.ts
+++ b/packages/niceeval/src/runner/cleanup-timeout.ts
@@ -40,7 +40,7 @@ export function cleanupCallback<T>(
 ): Effect.Effect<T, unknown | CleanupTimeoutError> {
   return withCleanupTimeout(
     Effect.tryPromise({
-      // Keep this wrapper arity at one: Effect v3 only creates and aborts the
+      // Keep this wrapper arity at one: Effect only creates and aborts the
       // signal for a `tryPromise` callback that declares it.
       try: (signal) => Promise.resolve(fn(signal)),
       // Preserve the callback's original error identity for legacy diagnostics.


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 520c4a65e21c027d8334a92575b87a99c038b283
templateSha256: 0b13a59152cd3a8d61875b2cbdd6a622f2a8a56978a3f4fa8772356f5607c9af
head: efbd5fa6469db3b767d3e0a18a1ffa6537efbc21
-->

## Problem

- User goal: 让后续 coding agent 使用 Effect 官方随安装版本更新的 v4 指南，并避免仓库示例继续传播 v3 写法。
- Current limitation: 现有 effect-ts skill 维护了一份本地 API 摘要，容易随 RC 漂移；仓库入口没有要求读取安装包自带的官方 AGENTS.md，少数当前文档和源码注释仍保留 v3 名称。
- Required capability: 接入 Effect-TS/skills 的官方分层：日常工作读取当前 workspace 安装包的完整 AGENTS.md，跨版本迁移使用独立的上游查表流程，并让当前目标文档统一采用 v4 Result 与 CLI 写法。
- User outcome: Agent 会按仓库锁定的 Effect 版本获得准确指导，迁移查证可追溯到官方资料，后续实现和设计不会被遗留 v3 示例误导。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790390793&installation_model_id=431746&pr_number=171&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F171&signature=2adfbcacd825b7281c1eddca47ba402b9709aeca54545d625d63ec23f9cb1302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->