### PR TITLE
fix(cli): 完整展示分组实验结果

### DIFF
--- a/docs/engineering/testing/e2e/report.md
+++ b/docs/engineering/testing/e2e/report.md
@@ -39,9 +39,10 @@ Contract: [Inspection CLI · `niceeval show`](../../../feature/inspection/cli.md
 `show-cli.test.ts` 是人读终端 Inspection Journey owner。它从安装后 candidate 经真实 CLI 读取已封口
 Record，验证默认 Overview、重复 exact `--run`、重复 exact `--experiment`、Attempt 概览与全部五个证据切面。
 
-overview 必须保留 operation 已选的 totals、Experiment summary 与 locator。层级固定为
-Experiment → Eval → Attempt。renderer 不得从行数或标量重算 denominator、pass rate、score、
-coverage 或 Evidence。
+overview 必须保留 operation 已选的 totals、Experiment summary 与完整 locator。层级固定为
+Experiment 路径首段显示分组 → 完整 Experiment → Eval → Attempt；默认 Attempt 表不以 membership action
+或 relation 挤占 identity。健康 metric 隐藏 `available`，其它 state 继续可见。renderer 不得从行数或标量重算
+denominator、pass rate、score、coverage 或 Evidence。
 
 Attempt 概览要给出可执行的 source、execution、timing、usage 和 diff 后续命令。Journey 分别运行
 `--source`、`--execution [--expand <stable-id>]`、`--timing`、`--usage` 与 `--diff`。它核对以下人读结果：

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -231,7 +231,10 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
 ### 固定投影
 
 - 无 selector 时调用 `overview.get`，格式化 totals、Experiment summaries 以及
-  Experiment → Eval → Attempt table。每个可下钻 Attempt 显示稳定 locator。
+  Experiment → Eval → Attempt table。Experiment ID 含 `/` 时，首段形成显示分组，组内 Experiment 与同前缀
+  Eval 使用相对标签；每个 Experiment 小节仍显示一次完整 ID，每个可下钻 Attempt 显示完整稳定 locator。
+  Attempt 表只保留 `Eval`、`Attempt` 与 `Score`，不显示 membership action 或 origin/reference relation。这些 provenance
+  仍由具名 operation 保留并可在 Run/Attempt 下钻中查看。
 - 一个或多个 `--experiment` 逐个调用 exact `experiment.get`，格式化指定 Experiment 的 aggregate、Eval cells 和 Attempt locators。
   CLI 不得调用 `overview.get` 后按 `experimentId` 过滤。
 - 一个或多个 `--run` 逐个调用 exact `run.overview`，并且只消费这一份闭合 result。
@@ -256,6 +259,60 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
 
 `--source`、`--execution`、`--timing`、`--usage` 与 `--diff` 都要求一个 Attempt locator，且五者互斥。
 `--expand` 只能与 `--execution` 同用。`--record` 与上述所有 selector 正交，它只选 source。
+
+### 默认 Overview 示例
+
+human renderer 将 pass rate 显示为百分比。`available` 是健康 metric 的默认状态，不附加在数值后；
+`partial`、`unavailable`、`empty`、`unsupported` 与 `failed` 仍须明确显示。Experiment summary 按路径首段分组，
+Attempt 明细再按完整 Experiment 分表，使 80 列终端可以在同一行保留完整 locator：
+
+```text
+$ niceeval show
+NiceEval results
+  Totals
+
+  Observed   5/5
+  Verdicts   5 passed
+  Pass rate  100%
+  Score      74
+
+Experiments
+  harness
+  Experiment  Observed  Pass rate  Score
+  ----------  --------  ---------  -----
+  canary      3/3       100%       32
+  v0.12.0     2/2       100%       32
+
+  install
+  Experiment  Observed  Pass rate  Score
+  ----------  --------  ---------  -----
+  canary      2/2       100%       10
+
+Attempts · harness
+  Experiment harness/canary
+  Eval              Attempt         Score
+  ----------------  --------------  -----
+  terminal-install  @1M9Y03P6DXYQ   16
+  terminal-init     @1MYD6J9PK5GA   14
+  terminal-run      @19YRYDKT4JMB   2
+
+  Experiment harness/v0.12.0
+  Eval              Attempt         Score
+  ----------------  --------------  -----
+  terminal-install  @19VNWKYFC0FC   16
+  terminal-init     @1VNQTXJ03XJD   14
+
+Attempts · install
+  Experiment install/canary
+  Eval          Attempt         Score
+  ------------  --------------  -----
+  db-gateway    @1SY1PRPXSBFN   5
+  gpt-provider  @1QD6PEMZY39P   5
+```
+
+没有 `/` 的 Experiment 仍以完整 ID 显示在未分组 summary 与 `Attempts` 小节。Eval 相对标签只有在其首段与
+Experiment 显示分组相同时才去掉该段；否则保留完整 Eval ID。宽度仍不足时只折行，不截断 Experiment、Eval
+或 Attempt identity。
 
 ### Attempt 概览示例
 

--- a/e2e/eval/test/inspection.ts
+++ b/e2e/eval/test/inspection.ts
@@ -47,8 +47,10 @@ export async function inspectAssertion<T extends InspectionDocument>(
   return { receipt, document: receipt.json<T>() };
 }
 
-// Each detail read starts the installed CLI; keep the per-file bound low because Vitest also runs files in parallel.
-const ASSERTION_DETAIL_QUERY_CONCURRENCY = 2;
+// Each detail read starts the installed CLI while Vitest also runs files in
+// parallel. Keep one reader per Record so the suite cannot multiply process
+// and SQLite validation pressure inside a single case.
+const ASSERTION_DETAIL_QUERY_CONCURRENCY = 1;
 
 /** Read every Assertion detail in declaration order with an explicit process bound. */
 export async function inspectAssertionEntries<T extends InspectionDocument>(

--- a/e2e/report/experiments/harness/canary.ts
+++ b/e2e/report/experiments/harness/canary.ts
@@ -1,0 +1,10 @@
+import { defineExperiment } from "niceeval";
+import { deterministicAgent, deterministicSandbox } from "../../agents/deterministic.ts";
+
+export default defineExperiment({
+  description: "harness/canary: exercise grouped terminal inspection output",
+  agent: deterministicAgent(),
+  sandbox: deterministicSandbox,
+  model: "inspection-fixture-v1",
+  evals: ["inspection"],
+});

--- a/e2e/report/experiments/install/canary.ts
+++ b/e2e/report/experiments/install/canary.ts
@@ -1,0 +1,10 @@
+import { defineExperiment } from "niceeval";
+import { deterministicAgent, deterministicSandbox } from "../../agents/deterministic.ts";
+
+export default defineExperiment({
+  description: "install/canary: exercise a second terminal inspection group",
+  agent: deterministicAgent(),
+  sandbox: deterministicSandbox,
+  model: "inspection-fixture-v1",
+  evals: ["inspection"],
+});

--- a/e2e/report/test/show-cli.test.ts
+++ b/e2e/report/test/show-cli.test.ts
@@ -55,7 +55,9 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
     "show-terminal-review",
     { artifacts: reportCaseArtifacts() },
     async ({ commands: { niceeval } }) => {
-      const mainProduced = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
+      const mainExperimentId = "harness/canary";
+      const alternateExperimentId = "install/canary";
+      const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
       expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
       expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
       const mainRunId = only(mainProduced.expReceipt().runIds, () => true, mainProduced.diagnostic());
@@ -67,7 +69,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(attempt).toMatchObject({ verdict: "passed" });
       const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;
 
-      const alternateProduced = await niceeval.run(["exp", "alternate", "--rerun", "all", "--json"]);
+      const alternateProduced = await niceeval.run(["exp", alternateExperimentId, "--rerun", "all", "--json"]);
       expect(alternateProduced.exitCode, alternateProduced.diagnostic()).toBe(0);
       expect(alternateProduced.expReceipt(), alternateProduced.diagnostic()).toMatchObject({ completion: "completed" });
       const alternateRunId = only(
@@ -89,17 +91,23 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(overview.exitCode, overview.diagnostic()).toBe(0);
       expectHumanText(overview.stdout);
       expectInOrder(overview.stdout, ["Totals", "Experiments"]);
-      expect(overview.stdout).toMatch(/Experiment\s+Eval\s+Attempt\s+Action\s+Relation\s+Score/u);
-      expect(overview.stdout).toContain("main");
-      expect(overview.stdout).toContain("alternate");
+      expectInOrder(overview.stdout, ["harness", "Experiment", "Observed", "Pass rate", "Score", "canary"]);
+      expectInOrder(overview.stdout, ["install", "Experiment", "Observed", "Pass rate", "Score", "canary"]);
+      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
+      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
+      expect(overview.stdout).toMatch(/Eval\s+Attempt\s+Score/u);
+      expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
       expect(overview.stdout).toContain(locator);
       expect(overview.stdout).toContain(alternateLocator);
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${locator}\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toContain("100%");
 
       const run = await niceeval.run(["show", "--run", mainRunId]);
       expect(run.exitCode, run.diagnostic()).toBe(0);
       expectHumanText(run.stdout);
       expect(run.stdout).toContain(mainRunId);
-      expectInOrder(run.stdout, ["main", "inspection", locator]);
+      expectInOrder(run.stdout, [mainExperimentId, "inspection", locator]);
 
       const runs = await niceeval.run([
         "show",
@@ -125,31 +133,31 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       ]);
       expectShowFailure(atomicRunsFailure, ["missing-run"]);
 
-      const mainExperiment = await niceeval.run(["show", "--experiment", "main"]);
+      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId]);
       expect(mainExperiment.exitCode, mainExperiment.diagnostic()).toBe(0);
       expectHumanText(mainExperiment.stdout);
-      expect(mainExperiment.stdout).toContain("main");
+      expect(mainExperiment.stdout).toContain(mainExperimentId);
       expect(mainExperiment.stdout).toContain(locator);
       expect(mainExperiment.stdout).not.toContain(alternateLocator);
 
       const experiments = await niceeval.run([
         "show",
         "--experiment",
-        "alternate",
+        alternateExperimentId,
         "--experiment",
-        "main",
+        mainExperimentId,
       ]);
       expect(experiments.exitCode, experiments.diagnostic()).toBe(0);
       expectHumanText(experiments.stdout);
-      expect(experiments.stdout).toContain("main");
-      expect(experiments.stdout).toContain("alternate");
+      expect(experiments.stdout).toContain(mainExperimentId);
+      expect(experiments.stdout).toContain(alternateExperimentId);
       expect(experiments.stdout).toContain(locator);
       expect(experiments.stdout).toContain(alternateLocator);
 
       const missingExperiment = await niceeval.run([
         "show",
         "--experiment",
-        "main",
+        mainExperimentId,
         "--experiment",
         "does-not-exist",
       ]);
@@ -159,7 +167,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(attemptOverview.exitCode, attemptOverview.diagnostic()).toBe(0);
       expectHumanText(attemptOverview.stdout);
       expect(attemptOverview.stdout).toContain(locator);
-      expectInOrder(attemptOverview.stdout, ["main", "inspection", "Outcome", "Score", "Evidence"]);
+      expectInOrder(attemptOverview.stdout, [mainExperimentId, "inspection", "Outcome", "Score", "Evidence"]);
       expect(attemptOverview.stdout).toContain("passed");
       expect(attemptOverview.stdout).toContain("Inspection tool occurrence");
       expect(attemptOverview.stdout).toContain("Compact score contribution");
@@ -280,7 +288,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
         { argv: ["show", locator, "--source", "--execution"], stderr: ["--source", "--execution"] },
         { argv: ["show", locator, "--expand", itemIdentity], stderr: ["--expand", "--execution"] },
         { argv: ["show", locator, "--run", mainRunId], stderr: ["--run"] },
-        { argv: ["show", locator, "--experiment", "main"], stderr: ["--experiment"] },
+        { argv: ["show", locator, "--experiment", mainExperimentId], stderr: ["--experiment"] },
         { argv: ["show", locator, "--timing", "--usage"], stderr: ["--timing", "--usage"] },
         { argv: ["show", locator, "--source", "--diff"], stderr: ["--source", "--diff"] },
         { argv: ["show", locator, "--execution", "--expand", "item_missing"], stderr: ["item_missing"] },

--- a/packages/niceeval/src/context/assert-first.ts
+++ b/packages/niceeval/src/context/assert-first.ts
@@ -406,6 +406,22 @@ interface ToolScopeSnapshot {
   readonly snapshot: unknown;
 }
 
+interface ToolScopeProjectionCache {
+  readonly cutKey: string;
+  readonly value: ToolScopeSnapshot;
+}
+
+function toolScopeCutKey(
+  sourceSnapshot: MatcherSourceSnapshot,
+  snapshot: unknown,
+): string {
+  const encoded = JSON.stringify([sourceSnapshot, snapshot]);
+  if (encoded === undefined) {
+    throw new Error("Tool scope cut must be JSON-serializable");
+  }
+  return encoded;
+}
+
 function unavailableSourceSnapshot(
   snapshot: MatcherSourceSnapshot,
 ): MatcherSourceSnapshot {
@@ -1561,9 +1577,11 @@ export function createAssertFirstEvalContext(
     started: boolean;
     inFlight: number;
     failed: boolean;
+    toolScopeCache?: ToolScopeProjectionCache;
   }
 
   const sessions: SessionScopeState[] = [];
+  let attemptToolScopeCache: ToolScopeProjectionCache | undefined;
   const matcherSource = Object.freeze({
     family: "niceeval.agent-turns" as const,
     schemaVersion: 2,
@@ -1694,40 +1712,55 @@ export function createAssertFirstEvalContext(
 
   const sessionToolScope = (scope: SessionScopeState): ToolScopeSnapshot => {
     const coverage = sessionCoverage(scope);
-    return projectToolScope({
-      turns: Object.freeze([...scope.turns]),
-      sourceSnapshot: sessionSourceSnapshot(scope, coverage.actions, true),
+    const turns = Object.freeze([...scope.turns]);
+    const sourceSnapshot = sessionSourceSnapshot(scope, coverage.actions, true);
+    const snapshot = Object.freeze({
+      sessionIndex: scope.session.index,
+      turnCount: scope.turns.length,
+      status: sessionStatus(scope),
       coverage,
-      snapshot: Object.freeze({
-        sessionIndex: scope.session.index,
-        turnCount: scope.turns.length,
-        status: sessionStatus(scope),
-        coverage,
-      }),
+    });
+    const cutKey = toolScopeCutKey(sourceSnapshot, snapshot);
+    const cached = scope.toolScopeCache;
+    if (cached !== undefined && cached.cutKey === cutKey) return cached.value;
+    const value = projectToolScope({
+      turns,
+      sourceSnapshot,
+      coverage,
+      snapshot,
       resolveEvaluation: resolveObservedEvaluation,
     });
+    scope.toolScopeCache = Object.freeze({ cutKey, value });
+    return value;
   };
 
   const attemptToolScope = (): ToolScopeSnapshot => {
     const active = sessions.filter((scope) => scope.started);
     const coverage = attemptCoverage();
     const turns = Object.freeze(active.flatMap((scope) => scope.turns));
-    return projectToolScope({
-      turns,
-      sourceSnapshot: attemptSourceSnapshot(turns, coverage.actions, true),
+    const sourceSnapshot = attemptSourceSnapshot(turns, coverage.actions, true);
+    const snapshot = Object.freeze({
+      sessions: Object.freeze(active.map((scope) => ({
+        sessionIndex: scope.session.index,
+        turnCount: scope.turns.length,
+        status: sessionStatus(scope),
+        coverage: sessionCoverage(scope),
+      }))),
+      status: attemptStatus(),
       coverage,
-      snapshot: Object.freeze({
-        sessions: Object.freeze(active.map((scope) => ({
-          sessionIndex: scope.session.index,
-          turnCount: scope.turns.length,
-          status: sessionStatus(scope),
-          coverage: sessionCoverage(scope),
-        }))),
-        status: attemptStatus(),
-        coverage,
-      }),
+    });
+    const cutKey = toolScopeCutKey(sourceSnapshot, snapshot);
+    const cached = attemptToolScopeCache;
+    if (cached !== undefined && cached.cutKey === cutKey) return cached.value;
+    const value = projectToolScope({
+      turns,
+      sourceSnapshot,
+      coverage,
+      snapshot,
       resolveEvaluation: resolveObservedEvaluation,
     });
+    attemptToolScopeCache = Object.freeze({ cutKey, value });
+    return value;
   };
 
   const sessionScopedEvents = (scope: SessionScopeState): readonly StreamEvent[] =>

--- a/packages/niceeval/src/show/render.ts
+++ b/packages/niceeval/src/show/render.ts
@@ -30,10 +30,19 @@ const fmt = (value: number): string =>
     ? String(value)
     : value.toFixed(2).replace(/0+$/u, "").replace(/\.$/u, "");
 
-const metric = (value: Metric): string =>
-  value.value === null
-    ? value.state
-    : `${fmt(value.value)} (${value.state})`;
+const metric = (
+  value: Metric,
+  formatValue: (value: number) => string = fmt,
+): string => {
+  if (value.value === null) return value.state;
+  const rendered = formatValue(value.value);
+  return value.state === "available"
+    ? rendered
+    : `${rendered} (${value.state})`;
+};
+
+const passRate = (value: Metric): string =>
+  metric(value, (rate) => `${fmt(rate * 100)}%`);
 
 const score = (value: ScoredValue): string =>
   value.state === "not-scored"
@@ -52,11 +61,65 @@ const aggregateEntries = (
     { key: "Observed", value: `${value.observed}/${value.expected}` },
     {
       key: "Verdicts",
-      value: `${value.passed} passed; ${value.failed} failed; ${value.errored} errored; ${value.skipped} skipped`,
+      value: value.failed === 0 && value.errored === 0 && value.skipped === 0
+        ? `${value.passed} passed`
+        : `${value.passed} passed; ${value.failed} failed; ${value.errored} errored; ${value.skipped} skipped`,
     },
-    { key: "Pass rate", value: metric(value.passRate) },
+    { key: "Pass rate", value: passRate(value.passRate) },
     { key: "Score", value: metric(value.score) },
   ],
+});
+
+interface ExperimentGroup {
+  readonly name: string | null;
+  readonly experiments: OverviewView["experiments"];
+}
+
+function experimentGroup(experimentId: string): string | null {
+  const separator = experimentId.indexOf("/");
+  return separator <= 0 ? null : experimentId.slice(0, separator);
+}
+
+function relativeToGroup(id: string, group: string | null): string {
+  const prefix = group === null ? "" : `${group}/`;
+  return prefix !== "" && id.startsWith(prefix) ? id.slice(prefix.length) : id;
+}
+
+function groupExperiments(value: OverviewView): readonly ExperimentGroup[] {
+  const groups = new Map<string | null, OverviewView["experiments"][number][]>();
+  for (const experiment of value.experiments) {
+    const group = experimentGroup(experiment.experimentId);
+    const members = groups.get(group) ?? [];
+    members.push(experiment);
+    groups.set(group, members);
+  }
+  return [...groups].map(([name, experiments]) => ({ name, experiments }));
+}
+
+const attemptTable = (
+  cells: OverviewView["cells"],
+  group: string | null,
+): TerminalPanelContentBlock & { readonly kind: "table" } => ({
+  kind: "table",
+  columns: [
+    { header: "Eval", maxWidth: 55 },
+    { header: "Attempt", maxWidth: 14 },
+    { header: "Score" },
+  ],
+  overflow: "wrap",
+  rows: cells.flatMap((cell) =>
+    cell.members.length === 0
+      ? [[
+        relativeToGroup(cell.evalId, group),
+        "not-recorded",
+        metric(cell.aggregate.score),
+      ]]
+      : cell.members.map((member) => [
+        relativeToGroup(cell.evalId, group),
+        member.locator ?? "not-recorded",
+        metric(member.score),
+      ]),
+  ),
 });
 
 const stateCount = (state: string, count: number, noun: string): string =>
@@ -77,10 +140,14 @@ export function renderOverview(value: OverviewView): string {
     },
   ];
   if (value.experiments.length > 0) {
+    const groups = groupExperiments(value);
     blocks.push({
       kind: "panel",
       title: "Experiments",
-      blocks: [
+      blocks: groups.flatMap((group) => [
+        ...(group.name === null
+          ? []
+          : [{ kind: "divider" as const, title: group.name }]),
         {
           kind: "table",
           columns: [
@@ -89,53 +156,34 @@ export function renderOverview(value: OverviewView): string {
             { header: "Pass rate" },
             { header: "Score" },
           ],
-          rows: value.experiments.map((experiment) => [
-            experiment.experimentId,
+          rows: group.experiments.map((experiment) => [
+            relativeToGroup(experiment.experimentId, group.name),
             `${experiment.aggregate.observed}/${experiment.aggregate.expected}`,
-            metric(experiment.aggregate.passRate),
+            passRate(experiment.aggregate.passRate),
             metric(experiment.aggregate.score),
           ]),
         },
-      ],
+      ]),
     });
   }
   if (value.cells.length > 0) {
-    blocks.push({
-      kind: "panel",
-      title: "Attempts",
-      blocks: [
-        {
-          kind: "table",
-          columns: [
-            { header: "Experiment" },
-            { header: "Eval" },
-            { header: "Attempt" },
-            { header: "Action" },
-            { header: "Relation" },
-            { header: "Score" },
-          ],
-          rows: value.cells.flatMap((cell) =>
-            cell.members.length === 0
-              ? [[
-                cell.experimentId,
-                cell.evalId,
-                "not-recorded",
-                "missing",
-                "not-recorded",
-                metric(cell.aggregate.score),
-              ]]
-              : cell.members.map((member) => [
-                cell.experimentId,
-                cell.evalId,
-                member.locator ?? "not-recorded",
-                member.action,
-                member.relation ?? "not-recorded",
-                metric(member.score),
-              ]),
-          ),
-        },
-      ],
-    });
+    for (const group of groupExperiments(value)) {
+      const experimentIds = new Set(group.experiments.map(({ experimentId }) => experimentId));
+      const cells = value.cells.filter(({ experimentId }) => experimentIds.has(experimentId));
+      blocks.push({
+        kind: "panel",
+        title: group.name === null ? "Attempts" : `Attempts · ${group.name}`,
+        blocks: group.experiments.flatMap((experiment) => {
+          const experimentCells = cells.filter(({ experimentId }) =>
+            experimentId === experiment.experimentId
+          );
+          return [
+            { kind: "divider" as const, title: `Experiment ${experiment.experimentId}` },
+            attemptTable(experimentCells, group.name),
+          ];
+        }),
+      });
+    }
   }
   return terminal(blocks);
 }
@@ -152,26 +200,21 @@ export function renderExperiment(value: ExperimentView): string {
         {
           kind: "table",
           columns: [
-            { header: "Eval" },
-            { header: "Attempt" },
-            { header: "Action" },
-            { header: "Relation" },
+            { header: "Eval", maxWidth: 55 },
+            { header: "Attempt", maxWidth: 14 },
             { header: "Score" },
           ],
+          overflow: "wrap",
           rows: value.cells.flatMap((cell) =>
             cell.members.length === 0
               ? [[
                 cell.evalId,
-                "not-recorded",
-                "missing",
                 "not-recorded",
                 metric(cell.aggregate.score),
               ]]
               : cell.members.map((member) => [
                 cell.evalId,
                 member.locator ?? "not-recorded",
-                member.action,
-                member.relation ?? "not-recorded",
                 metric(member.score),
               ]),
           ),


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 4231603e353d71a7a3680d0609e83c73c660ac2e
templateSha256: 0b13a59152cd3a8d61875b2cbdd6a622f2a8a56978a3f4fa8772356f5607c9af
head: 492d7a19e8e5d6b02517e520ceed749fd9454e0f
-->

## Problem

- User goal: 在终端中快速比较多个 namespaced Experiment，并复制完整 Attempt locator 继续下钻。
- Current limitation: 默认 show 把所有 Attempt 塞进六列表格，重复 Experiment 前缀与 provenance 列会在 80 列终端截断 Eval、locator 和 Score，健康 metric 还重复显示 available。
- Required capability: human renderer 需要按 Experiment 路径首段分组、按完整 Experiment 分表，并为 selector 与结果值保留稳定列宽。
- User outcome: niceeval show 在 80 列终端完整显示 Eval、Attempt locator 与 Score，同时保留异常 metric state 和下钻能力。

## CLI

### Changed

#### Case: 按 Experiment 分组审阅默认 show

##### Before

```sh
pnpm exec niceeval show
```

```text
Attempts
  Experiment      Eval        Attempt         Action    Relation  Score
  harness/canary  inspection  @179BBNW39A1NY  executed  origin    37.11 (availa…)
```

##### After

```sh
pnpm exec niceeval show
```

```text
Experiments
  harness
  Experiment  Observed  Pass rate  Score
  canary      1/1       100%       37.11

Attempts · harness
  Experiment harness/canary
  Eval        Attempt         Score
  inspection  @179BBNW39A1NY  37.11
```

##### User impact

Experiment summary 保持可横向比较；Attempt 明细按完整 Experiment 分表，隐藏健康 available 与 membership provenance，完整 locator 可直接复制给 niceeval show @<locator>。partial、unavailable、empty、unsupported 和 failed 仍明确显示。

## Tests

### `e2e/report/test/show-cli.test.ts`

- Purpose: `feature`
- Protects: 默认 show 按 namespaced Experiment 分组，并在同一行完整显示 Eval、Attempt locator 与 Score；Run、Experiment、Attempt 与证据下钻保持可用。
- Runs: pnpm e2e test --repo report -- --run test/show-cli.test.ts
- Asserts: 安装后 CLI 输出首段分组、相对标签、百分比 pass rate、无健康 available/Action/Relation，并完整包含两个动态 locator；随后验证所有既有 show 下钻。

```ts
// owner: docs/engineering/testing/e2e/report.md#show-terminal-review
// rerun: pnpm e2e test --repo report -- --run test/show-cli.test.ts

import { only } from "@niceeval/testkit";
import { expect, test } from "vitest";
import { reportCaseArtifacts, reportE2E } from "./support.ts";

function expectHumanText(stdout: string): void {
  expect(stdout.trim()).not.toBe("");
  expect(() => JSON.parse(stdout)).toThrow();
}

function expectInOrder(stdout: string, values: readonly string[]): void {
  let cursor = 0;
  for (const value of values) {
    const position = stdout.indexOf(value, cursor);
    expect(
      position,
      `expected ${JSON.stringify(value)} after byte ${cursor} in:\n${stdout}`,
    ).toBeGreaterThanOrEqual(cursor);
    cursor = position + value.length;
  }
}

interface FailedShowResult {
  readonly exitCode: number;
  readonly stdout: string;
  readonly stderr: string;
  diagnostic(): string;
}

function expectShowFailure(
  result: FailedShowResult,
  stderrValues: readonly string[],
): void {
  expect(result.exitCode, result.diagnostic()).not.toBe(0);
  expect(result.stdout, result.diagnostic()).toBe("");
  expect(result.stderr.trim(), result.diagnostic()).not.toBe("");
  for (const value of stderrValues) {
    expect(result.stderr, result.diagnostic()).toContain(value);
  }
}

function stableIdentity(stdout: string, label: string): string {
  const escaped = label.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
  const identity = stdout.match(new RegExp(`^\\s*${escaped}\\s+(\\S+)\\s*$`, "mu"))?.[1];
  expect(identity, `expected ${label} in stable identity index:\n${stdout}`).toBeDefined();
  if (identity === undefined) throw new Error(`expected ${label} stable identity`);
  expect(identity).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
  return identity;
}

test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面", async () => {
  await reportE2E.case(
    "show-terminal-review",
    { artifacts: reportCaseArtifacts() },
    async ({ commands: { niceeval } }) => {
      const mainExperimentId = "harness/canary";
      const alternateExperimentId = "install/canary";
      const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
      expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
      expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const mainRunId = only(mainProduced.expReceipt().runIds, () => true, mainProduced.diagnostic());
      const attempt = only(
        mainProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        mainProduced.diagnostic(),
      );
      expect(attempt).toMatchObject({ verdict: "passed" });
      const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;

      const alternateProduced = await niceeval.run(["exp", alternateExperimentId, "--rerun", "all", "--json"]);
      expect(alternateProduced.exitCode, alternateProduced.diagnostic()).toBe(0);
      expect(alternateProduced.expReceipt(), alternateProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const alternateRunId = only(
        alternateProduced.expReceipt().runIds,
        () => true,
        alternateProduced.diagnostic(),
      );
      const alternateAttempt = only(
        alternateProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        alternateProduced.diagnostic(),
      );
      expect(alternateAttempt).toMatchObject({ verdict: "passed" });
      const alternateLocator = alternateAttempt.locator.startsWith("@")
        ? alternateAttempt.locator
        : `@${alternateAttempt.locator}`;

      const overview = await niceeval.run(["show"]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      expectHumanText(overview.stdout);
      expectInOrder(overview.stdout, ["Totals", "Experiments"]);
      expectInOrder(overview.stdout, ["harness", "Experiment", "Observed", "Pass rate", "Score", "canary"]);
      expectInOrder(overview.stdout, ["install", "Experiment", "Observed", "Pass rate", "Score", "canary"]);
      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(overview.stdout).toMatch(/Eval\s+Attempt\s+Score/u);
      expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
      expect(overview.stdout).toContain(locator);
      expect(overview.stdout).toContain(alternateLocator);
      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${locator}\\s+37\\.11\\s*$`, "mu"));
      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+37\\.11\\s*$`, "mu"));
      expect(overview.stdout).toContain("100%");

      const run = await niceeval.run(["show", "--run", mainRunId]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      expectHumanText(run.stdout);
      expect(run.stdout).toContain(mainRunId);
      expectInOrder(run.stdout, [mainExperimentId, "inspection", locator]);

      const runs = await niceeval.run([
        "show",
        "--run",
        alternateRunId,
        "--run",
        mainRunId,
      ]);
      expect(runs.exitCode, runs.diagnostic()).toBe(0);
      expectHumanText(runs.stdout);
      expect(runs.stdout).toContain(`Run ${mainRunId}`);
      expect(runs.stdout).toContain(`Run ${alternateRunId}`);
      expect(runs.stdout).toContain(locator);
      expect(runs.stdout).toContain(alternateLocator);
      expect(runs.stdout.match(/^Run /gmu)).toHaveLength(2);

      const atomicRunsFailure = await niceeval.run([
        "show",
        "--run",
        mainRunId,
        "--run",
        "missing-run",
      ]);
      expectShowFailure(atomicRunsFailure, ["missing-run"]);

      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId]);
      expect(mainExperiment.exitCode, mainExperiment.diagnostic()).toBe(0);
      expectHumanText(mainExperiment.stdout);
      expect(mainExperiment.stdout).toContain(mainExperimentId);
      expect(mainExperiment.stdout).toContain(locator);
      expect(mainExperiment.stdout).not.toContain(alternateLocator);

      const experiments = await niceeval.run([
        "show",
        "--experiment",
        alternateExperimentId,
        "--experiment",
        mainExperimentId,
      ]);
      expect(experiments.exitCode, experiments.diagnostic()).toBe(0);
      expectHumanText(experiments.stdout);
      expect(experiments.stdout).toContain(mainExperimentId);
      expect(experiments.stdout).toContain(alternateExperimentId);
      expect(experiments.stdout).toContain(locator);
      expect(experiments.stdout).toContain(alternateLocator);

      const missingExperiment = await niceeval.run([
        "show",
        "--experiment",
        mainExperimentId,
        "--experiment",
        "does-not-exist",
      ]);
      expectShowFailure(missingExperiment, ["does-not-exist"]);

      const attemptOverview = await niceeval.run(["show", locator]);
      expect(attemptOverview.exitCode, attemptOverview.diagnostic()).toBe(0);
      expectHumanText(attemptOverview.stdout);
      expect(attemptOverview.stdout).toContain(locator);
      expectInOrder(attemptOverview.stdout, [mainExperimentId, "inspection", "Outcome", "Score", "Evidence"]);
      expect(attemptOverview.stdout).toContain("passed");
      expect(attemptOverview.stdout).toContain("Inspection tool occurrence");
      expect(attemptOverview.stdout).toContain("Compact score contribution");
      expect(attemptOverview.stdout).toContain("Mismatched Boolean contributes zero");
      expect(attemptOverview.stdout).toContain("Measurement contributes three points");
      expect(attemptOverview.stdout).toContain("Collection evidence remains bounded");
      expect(attemptOverview.stdout).toMatch(/assertions\s+(?:available|partial)\s+·\s+5 entries/u);
      expect(attemptOverview.stdout).toMatch(/coverage\s+.+/u);
      expect(attemptOverview.stdout).toMatch(/limitations\s+.+/u);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --source`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --execution`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --timing`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --usage`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --diff`);

      const source = await niceeval.run(["show", locator, "--source"]);
      expect(source.exitCode, source.diagnostic()).toBe(0);
      expectHumanText(source.stdout);
      expect(source.stdout).toContain("Captured source");
      expect(source.stdout).toContain("inspection.eval.ts");
      expect(source.stdout).toContain("Inspection tool occurrence");
      const sourceIdentity = source.stdout.match(/inspection\.eval\.ts · (\S+) · \d+ bytes/u)?.[1];
      expect(sourceIdentity, source.diagnostic()).toBeDefined();
      if (sourceIdentity === undefined) throw new Error("expected captured source identity");
      expect(source.stdout.split(sourceIdentity).length - 1).toBeGreaterThan(1);
      expect(source.stdout).toMatch(
        new RegExp(`Assertion source facts[\\s\\S]+mapped · ${sourceIdentity} · [0-9a-f]{64}`, "u"),
      );

      const execution = await niceeval.run(["show", locator, "--execution"]);
      expect(execution.exitCode, execution.diagnostic()).toBe(0);
      expectHumanText(execution.stdout);
      expect(execution.stdout).toContain(locator);
      expect(execution.stdout).toContain("Conversation · partial");
      expect(execution.stdout).toContain("Commands ·");
      expect(execution.stdout).toContain("Stable identities");
      expect(execution.stdout).toContain("inspection_fixture");
      expect(execution.stdout).toContain("inspection-tool-input");
      expect(execution.stdout).toContain("inspection-tool-result");
      const itemIdentity = stableIdentity(execution.stdout, "item");
      const toolIdentity = stableIdentity(execution.stdout, "tool occurrence");
      const commandIdentity = stableIdentity(execution.stdout, "command");
      expect(execution.stdout.split(itemIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(toolIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(commandIdentity).length - 1).toBeGreaterThan(1);

      const itemDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        itemIdentity,
      ]);
      expect(itemDetail.exitCode, itemDetail.diagnostic()).toBe(0);
      expectHumanText(itemDetail.stdout);
      expect(itemDetail.stdout).toContain(locator);
      expect(itemDetail.stdout).toContain(itemIdentity);
      expect(itemDetail.stdout).toContain("item");

      const toolDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        toolIdentity,
      ]);
      expect(toolDetail.exitCode, toolDetail.diagnostic()).toBe(0);
      expectHumanText(toolDetail.stdout);
      expect(toolDetail.stdout).toContain(locator);
      expect(toolDetail.stdout).toContain(toolIdentity);
      expect(toolDetail.stdout).toContain("inspection_fixture");
      expect(toolDetail.stdout).toContain("inspection-tool-input");
      expect(toolDetail.stdout).toContain("inspection-tool-result");

      const commandDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        commandIdentity,
      ]);
      expect(commandDetail.exitCode, commandDetail.diagnostic()).toBe(0);
      expectHumanText(commandDetail.stdout);
      expect(commandDetail.stdout).toContain(locator);
      expect(commandDetail.stdout).toContain(commandIdentity);
      expect(commandDetail.stdout).toMatch(/invocation|command/iu);
      expect(commandDetail.stdout).toMatch(/outcome|exit/iu);

      const timing = await niceeval.run(["show", locator, "--timing"]);
      expect(timing.exitCode, timing.diagnostic()).toBe(0);
      expectHumanText(timing.stdout);
      expect(timing.stdout).toContain(locator);
      expect(timing.stdout).toMatch(/timing/iu);
      expect(timing.stdout).toContain("eval.run");

      const usage = await niceeval.run(["show", locator, "--usage"]);
      expect(usage.exitCode, usage.diagnostic()).toBe(0);
      expectHumanText(usage.stdout);
      expect(usage.stdout).toContain(locator);
      expect(usage.stdout).toMatch(/usage/iu);
      expect(usage.stdout).toMatch(/input(?: tokens)?\s+10/iu);
      expect(usage.stdout).toMatch(/output(?: tokens)?\s+5/iu);
      expect(usage.stdout).toMatch(/requests?\s+1/iu);

      const diff = await niceeval.run(["show", locator, "--diff"]);
      expect(diff.exitCode, diff.diagnostic()).toBe(0);
      expectHumanText(diff.stdout);
      expect(diff.stdout).toContain(locator);
      expect(diff.stdout).toMatch(/diff/iu);
      expect(diff.stdout).toContain("complete");
      expect(diff.stdout).toContain("inspection-agent-change.txt");
      expect(diff.stdout).toContain("created");

      const usageErrors: readonly {
        readonly argv: readonly string[];
        readonly stderr: readonly string[];
      }[] = [
        { argv: ["show", locator, "--source", "--execution"], stderr: ["--source", "--execution"] },
        { argv: ["show", locator, "--expand", itemIdentity], stderr: ["--expand", "--execution"] },
        { argv: ["show", locator, "--run", mainRunId], stderr: ["--run"] },
        { argv: ["show", locator, "--experiment", mainExperimentId], stderr: ["--experiment"] },
        { argv: ["show", locator, "--timing", "--usage"], stderr: ["--timing", "--usage"] },
        { argv: ["show", locator, "--source", "--diff"], stderr: ["--source", "--diff"] },
        { argv: ["show", locator, "--execution", "--expand", "item_missing"], stderr: ["item_missing"] },
        { argv: ["show", locator, "--execution", "--expand", "t1.c1"], stderr: ["stable", "itemId"] },
        { argv: ["show", locator, "--execution", "--expand", "cmd1"], stderr: ["stable", "commandId"] },
        { argv: ["show", locator, "--json"], stderr: ["--json"] },
        { argv: ["show", locator, "--report", "standard"], stderr: ["--report"] },
        { argv: ["show", "@does-not-exist"], stderr: ["does-not-exist"] },
      ];
      for (const usageError of usageErrors) {
        expectShowFailure(
          await niceeval.run([...usageError.argv]),
          usageError.stderr,
        );
      }
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790415200&installation_model_id=431746&pr_number=174&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F174&signature=fac9f19265fdaaecc6f1265c8872a24bc812da18e1a1fdc1042305229c3f15ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
