### PR TITLE
fix(repo-tools): 让状态命令直接接收具名参数

### DIFF
--- a/.agents/skills/feedback/SKILL.md
+++ b/.agents/skills/feedback/SKILL.md
@@ -10,10 +10,10 @@ metadata:
 
 Read the [legacy Feedback and Memory design](../../../docs/engineering/feedback-memory/README.md#legacy-feedback) before changing an existing Feedback state or relationship. Run `pnpm feedback --help` for the current syntax.
 
-Feedback is a retained Git owner for records that already exist. Use this skill to list, show, export, check, migrate, or repair those records and their current relationships. Do not run `add` or `import` to create a new Observation owner. Prepare a public sanitized Issue through the Issue skill instead; suspected vulnerabilities still go to Private Vulnerability Reporting.
+Feedback is a retained Git owner for records that already exist. Use this skill to list, show, export, check, migrate, or repair those records and their current relationships. The public CLI has no `add` command. Use `import` only to recover an already-produced historical downstream envelope, never to create a new Observation owner. Prepare a public sanitized Issue through the Issue skill instead; suspected vulnerabilities still go to Private Vulnerability Reporting.
 
 Preserve the stored observation and provenance. Do not rewrite it into an inferred root cause or physically merge duplicate history. For an existing record, use `adopt` only when the observation is represented by an exact current Roadmap, Feature, Use Case, or Engineering contract. Use `retire` when that exact ref stops being current; never edit adoption history by hand.
 
-Create or link a Memory when legacy investigation produces a Problem, Decision, or reusable Insight. Close an existing Feedback only with the evidence required by the legacy design. A local Feedback mutation never authorizes or synchronizes a remote Issue mutation.
+Create or link a Memory when legacy investigation produces a Problem, Decision, or reusable Insight. Close an existing Feedback with `pnpm feedback close <id> --kind <kind>` and the kind-specific native fields: `--memory`, `--target`, repeatable `--proof`, `--canonical`, repeatable `--evidence`, `--dependency`, or `--version`. Do not assemble closure JSON; the command rejects missing fields and fields that belong to another kind. A local Feedback mutation never authorizes or synchronizes a remote Issue mutation.
 
 Use `check` after mutations and include the changed Feedback directory in explicit Git paths. If a read reports `TraceRecoveryRequired`, do not inspect the owner directly; run `pnpm run repo docs trace recover` and retry the public command.

--- a/.agents/skills/memory/SKILL.md
+++ b/.agents/skills/memory/SKILL.md
@@ -12,6 +12,8 @@ Read the [Memory design](../../../docs/engineering/feedback-memory/README.md#mem
 
 Use Problem for a reproducible problem and its root cause, Decision for an adopted choice, and Insight for know-how that remains useful without a problem lifecycle. Search existing Memory first. Do not create Feedback merely to justify a Memory.
 
+Use native CLI fields instead of assembling metadata or resolution JSON. Create with `pnpm memory add <id> --title <title> --kind <problem|decision|insight> --body <markdown>`; `--created-at` is optional. Resolve with `pnpm memory resolve <id> --kind <kind> --proof <receipt>`, repeating `--proof` for each independent receipt.
+
 Resolve a product Problem as fixed only after the public-entry E2E regression gate passes. Promote a conclusion by linking to the exact current Roadmap, Feature, Use Case, or Engineering target; Memory remains historical evidence and never replaces the target contract. Use `retire` when an exact promotion stops being current, and never edit promotion history by hand.
 
 Legacy unstructured Memory is searchable and referenceable but read-only. Run `check` after mutations and include only the changed Memory files in explicit Git paths. If a read reports `TraceRecoveryRequired`, do not inspect the owner directly; run `pnpm run repo docs trace recover` and retry the public command.

--- a/docs/engineering/feedback-memory/README.md
+++ b/docs/engineering/feedback-memory/README.md
@@ -108,7 +108,7 @@ interface FeedbackEnvelopeV1 {
 ```
 
 `feedback import` 以 `origin.repository + origin.originId` 作为幂等键。同一 digest 重复导入返回既有 ID；不同 digest 使用同一幂等键时失败并显示冲突，不替换历史。
-Envelope 只承载下游 dogfood；Issue 与本仓库开发观察由 `feedback add` 写入各自的 `source`，导入器不会把 `source.kind` 静默改写成 dogfood。
+Envelope 只承载下游 dogfood，导入器不会把 `source.kind` 静默改写成 dogfood。Issue 与本仓库开发观察不进入 Feedback。
 
 导入只接受 manifest 中声明的普通文件。绝对路径、`..`、symlink、超出大小上限、摘要不匹配或未登记文件都在写入前失败。导入器只复制字节，不执行、不按语法读取，也不渲染附件中的主动内容。
 
@@ -180,21 +180,21 @@ E2E owner 只引用 Problem Memory，并沿用测试头的既有格式：
 正式入口属于同一个 `@niceeval/repo-tools` runtime：
 
 ```text
-pnpm feedback add|import|export|list|show|link|adopt|retire|close|reopen|check
+pnpm feedback import|export|list|show|link|adopt|retire|close|reopen|check
 pnpm memory   add|list|show|search|resolve|reopen|supersede|promote|retire|check
 pnpm run repo docs trace recover
 ```
 
 普通读取与 dry-run 持有 Trace shared lease，且不执行恢复。首次读取可以初始化 Git-private 的持久 lock inode，但不修改 owner、journal 或 generation。
 
-所有条目写命令持有 exclusive lease，先恢复旧 journal，再完成两次 Snapshot/preimage 校验与单 owner publication。所有新 Feedback 无论有无附件，都先写 `feedback/.stage-<token>`，再以整个目录的 manifest、journal 与同文件系统 atomic rename 发布。
+所有条目写命令持有 exclusive lease，先恢复旧 journal，再完成两次 Snapshot/preimage 校验与单 owner publication。历史 envelope 导入为 Feedback 时，无论有无附件都先写 `feedback/.stage-<token>`，再以整个目录的 manifest、journal 与同文件系统 atomic rename 发布。
 
 既有 Feedback 与 Memory 使用 file publication，Memory add 使用 absent-preimage file publication。generation durable replace 是唯一 commit point。
 
 崩溃恢复只有在 worktree identity、HEAD、Git index、mode、digest 与 manifest 全部匹配时才回滚。其它状态保留 owner、stage 与 journal，并具名失败。
 
 所有会改变 Trace 可见 Feedback/Memory metadata 的发布步骤都经过同一结构锁，并在成功后递增 generation。
-`feedback add` 只接受空 adoptions。输入携带的 `memoryRelations` 必须去重、逐项命中真实 Memory，并把这些 owner 纳入 publication preimage。
+Feedback 没有普通创建命令；`import` 只恢复既有的历史 envelope，并把引用 owner 纳入 publication preimage。
 `memory add` 只接受空 promotions。新条目只能从 `problem/open`、`decision/adopted` 或 `insight/current` 初态创建；terminal state 必须走具名 transition，不能借创建入口绕过 fixed E2E 门、supersession 或 history。
 
 `check` 聚合报告 Schema、引用、状态、环、promotion、关闭凭据、E2E 门、unknown stage 与 recovery 问题，不遇到第一项就停止。正常命令失败只留下原始文件或完整新文件；进程崩溃后的 journal/stage 是显式恢复证据，不冒充已发布 Feedback。

--- a/docs/engineering/feedback-memory/README.md
+++ b/docs/engineering/feedback-memory/README.md
@@ -70,7 +70,11 @@ Feedback 的人读状态只显示“未处理”与“已处理”。关闭原�
 | `invalid` | 观察的事实前提无法成立 | 保存可重新执行的反证；界面不得显示为“已修复” |
 | `external-fixed` | dependency 行为已由上游版本修复 | 保存依赖名、版本和原观察步骤的再次执行结果 |
 
-`feedback close --closure <json>` 在写入前验证整张表。`memoryRelations` 只接受表中列出的关系，不能重复。
+`feedback close --kind <kind>` 直接接收该关闭原因所需的具名参数：`fixed`、`delivered` 与
+`external-fixed` 的 `--proof`，以及 `invalid` 的 `--evidence` 都可重复传入。命令不要求调用者先组装临时
+JSON，并在写入前验证整张关闭表。不属于所选 kind 的参数同样会被拒绝。
+
+`memoryRelations` 只接受表中列出的关系，不能重复。
 `duplicate` 的 canonical 只存在 closure 中，不再另存 `duplicateOf`。被引用的 Problem Memory 后续重新打开时，
 `pnpm feedback check` 报关闭凭据失效，不静默修改 Feedback，也不隐藏既有 adoption/promotion。
 
@@ -162,7 +166,12 @@ E2E owner 只引用 Problem Memory，并沿用测试头的既有格式：
 3. 证明失败出现在最早公开边界，修复后同一 candidate、fixture 与原生 runner 转绿。
 4. 通过该 owner 的可靠性与接管检查；测试文件中的 canonical `regression:` 是门的机器凭据，Problem resolution 的 `proof` 只保存红绿收据与解释。
 
-`pnpm memory resolve --kind fixed` 与 `feedback close --kind fixed` 都从同一 Trace Snapshot 反查真实 E2E owner；没有 canonical regression 时零写入失败。`pnpm memory check` 也反向扫描并报告既存的无 owner `resolved(fixed)` Problem。Memory 不保存另一份 E2E 反向列表，`proof` 中出现 “e2e” 或路径文本都不算通过。
+`pnpm memory resolve --kind fixed --proof <receipt>` 与
+`feedback close --kind fixed --memory <memory-id> --proof <receipt>` 都从同一 Trace Snapshot 反查真实 E2E owner。
+`--proof` 可重复传入；没有 canonical regression 时，命令零写入失败。
+
+`pnpm memory check` 也反向扫描并报告既存的无 owner `resolved(fixed)` Problem。Memory 不保存另一份 E2E
+反向列表，`proof` 中出现 “e2e” 或路径文本都不算通过。
 
 无法固定的外部条件、安全限制或 Provider 可以暂停自动化，但在专门的结构化例外凭据落地前不能冒充 `fixed`；保持 Problem open，并在 `proof`/正文保存公开入口人工验收和复查条件。dependency 已由上游修复时使用 `external-fixed`。仓库 DX 问题仍使用真实仓库命令或 lint 的红绿凭据，不伪造产品 E2E。
 

--- a/packages/repo-tools/src/cli.ts
+++ b/packages/repo-tools/src/cli.ts
@@ -131,15 +131,6 @@ function renderUnhandledError(error: unknown): string {
   return String(error);
 }
 
-const feedbackAdd = Command.make("add", {
-  input: inputOption,
-  dryRun: dryRunOption,
-  json: jsonOption,
-}, ({ dryRun, input, json }) => readJson(input).pipe(
-  Effect.flatMap((document) => runFeedbackCommand({ operation: "add", document, dryRun })),
-  Effect.flatMap((outcome) => emit(outcome, json)),
-)).pipe(Command.withDescription("Add one decoded Feedback document."));
-
 const feedbackImport = Command.make("import", {
   envelope: Options.string("envelope").pipe(Options.withDescription("Feedback envelope JSON path.")),
   artifacts: Options.string("artifacts").pipe(Options.withDescription("Envelope artifact directory.")),
@@ -275,9 +266,8 @@ const feedbackCheck = Command.make("check", { json: jsonOption }, ({ json }) =>
   )).pipe(Command.withDescription("Validate Feedback, relations, closures, and migration provenance."));
 
 const feedback = Command.make("feedback").pipe(
-  Command.withDescription("Record, relate, close, and validate repository feedback."),
+  Command.withDescription("Audit, relate, close, and validate legacy repository Feedback."),
   Command.withSubcommands([
-    feedbackAdd,
     feedbackImport,
     feedbackExport,
     feedbackList,

--- a/packages/repo-tools/src/cli.ts
+++ b/packages/repo-tools/src/cli.ts
@@ -1,6 +1,6 @@
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Argument as Args, Command, Flag as Options } from "effect/unstable/cli";
-import { Data, Effect, FileSystem, Layer, Option } from "effect";
+import { Clock, Data, Effect, FileSystem, Layer, Option } from "effect";
 
 import { linkDownstreamCandidate } from "./downstream/index.js";
 import {
@@ -224,13 +224,42 @@ const feedbackRetire = Command.make("retire", {
 
 const feedbackClose = Command.make("close", {
   id: Args.string("feedback-id"),
-  closure: Options.string("closure").pipe(Options.withDescription("Closure JSON path.")),
+  kind: Options.choice("kind", ["fixed", "delivered", "duplicate", "declined", "invalid", "external-fixed"] as const),
+  memory: Options.string("memory").pipe(Options.withDescription("Related Memory ID."), Options.optional),
+  target: Options.string("target").pipe(Options.withDescription("Delivered repository ref."), Options.optional),
+  proof: Options.string("proof").pipe(
+    Options.atLeast(0),
+    Options.withDescription("Closure evidence; repeat for each proof item."),
+  ),
+  canonical: Options.string("canonical").pipe(Options.withDescription("Canonical Feedback ID."), Options.optional),
+  evidence: Options.string("evidence").pipe(
+    Options.atLeast(0),
+    Options.withDescription("Invalid-observation evidence; repeat for each item."),
+  ),
+  dependency: Options.string("dependency").pipe(Options.withDescription("Fixed external dependency."), Options.optional),
+  version: Options.string("version").pipe(Options.withDescription("External fixed version."), Options.optional),
   dryRun: dryRunOption,
   json: jsonOption,
-}, ({ closure, dryRun, id, json }) => readJson(closure).pipe(
-  Effect.flatMap((value) => runFeedbackCommand({ operation: "close", id, closure: value, dryRun })),
+}, ({ canonical, dependency, dryRun, evidence, id, json, kind, memory, proof, target, version }) => {
+  const memoryValue = Option.getOrUndefined(memory);
+  const targetValue = Option.getOrUndefined(target);
+  const canonicalValue = Option.getOrUndefined(canonical);
+  const dependencyValue = Option.getOrUndefined(dependency);
+  const versionValue = Option.getOrUndefined(version);
+  const closure = {
+    kind,
+    ...(memoryValue === undefined ? {} : { memory: memoryValue }),
+    ...(targetValue === undefined ? {} : { target: targetValue }),
+    ...(proof.length === 0 ? {} : { proof }),
+    ...(canonicalValue === undefined ? {} : { canonical: canonicalValue }),
+    ...(evidence.length === 0 ? {} : { evidence }),
+    ...(dependencyValue === undefined ? {} : { dependency: dependencyValue }),
+    ...(versionValue === undefined ? {} : { version: versionValue }),
+  };
+  return runFeedbackCommand({ operation: "close", id, closure, dryRun }).pipe(
   Effect.flatMap((outcome) => emit(outcome, json)),
-)).pipe(Command.withDescription("Close Feedback with validated evidence."));
+  );
+}).pipe(Command.withDescription("Close Feedback with validated evidence."));
 
 const feedbackReopen = Command.make("reopen", {
   id: Args.string("feedback-id"),
@@ -263,14 +292,37 @@ const feedback = Command.make("feedback").pipe(
 );
 
 const memoryAdd = Command.make("add", {
-  input: inputOption,
+  id: Args.string("memory-id"),
+  title: Options.string("title"),
+  kind: Options.choice("kind", ["problem", "decision", "insight"] as const),
+  createdAt: Options.string("created-at").pipe(
+    Options.withDescription("Creation date (YYYY-MM-DD); defaults to today."),
+    Options.optional,
+  ),
   body: Options.string("body").pipe(Options.withDescription("Markdown body path.")),
   dryRun: dryRunOption,
   json: jsonOption,
-}, ({ body, dryRun, input, json }) => Effect.all({ metadata: readJson(input), body: readText(body) }).pipe(
-  Effect.flatMap(({ body: source, metadata }) => runMemoryCommand({
+}, ({ body, createdAt, dryRun, id, json, kind, title }) => Effect.all({
+  body: readText(body),
+  createdAt: Option.match(createdAt, {
+    onNone: () => Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString().slice(0, 10))),
+    onSome: Effect.succeed,
+  }),
+}).pipe(
+  Effect.flatMap(({ body: source, createdAt }) => runMemoryCommand({
     operation: "add",
-    metadata,
+    metadata: {
+      format: "niceeval.memory/v1",
+      id,
+      title,
+      createdAt,
+      kind: kind === "problem"
+        ? { type: kind, state: "open" }
+        : kind === "decision"
+          ? { type: kind, state: "adopted" }
+          : { type: kind, state: "current" },
+      promotions: [],
+    },
     body: source,
     dryRun,
   })),
@@ -296,11 +348,19 @@ const memorySearch = Command.make("search", {
 
 const memoryResolve = Command.make("resolve", {
   id: Args.string("memory-id"),
-  resolution: Options.string("resolution").pipe(Options.withDescription("Problem resolution JSON path.")),
+  kind: Options.choice("kind", ["fixed", "not-a-bug", "wont-fix", "external-fixed"] as const),
+  proof: Options.string("proof").pipe(
+    Options.atLeast(1),
+    Options.withDescription("Resolution evidence; repeat for each proof item."),
+  ),
   dryRun: dryRunOption,
   json: jsonOption,
-}, ({ dryRun, id, json, resolution }) => readJson(resolution).pipe(
-  Effect.flatMap((value) => runMemoryCommand({ operation: "resolve", id, resolution: value, dryRun })),
+}, ({ dryRun, id, json, kind, proof }) => runMemoryCommand({
+  operation: "resolve",
+  id,
+  resolution: { kind, proof },
+  dryRun,
+}).pipe(
   Effect.flatMap((outcome) => emit(outcome, json)),
 )).pipe(Command.withDescription("Resolve one structured Problem Memory."));
 


### PR DESCRIPTION
<!-- niceeval:pr-body
base: f2d39309ae12225524b06086cf149a7065a6731c
templateSha256: 0b13a59152cd3a8d61875b2cbdd6a622f2a8a56978a3f4fa8772356f5607c9af
head: dee880cdfb45ec843d1b67c9da5753030d0879fc
-->

## Problem

- User goal: 直接通过仓库 CLI 创建、解决 Memory，并安全维护存量 Feedback。
- Current limitation: Memory 状态转换和 Feedback 关闭要求手工组装临时 JSON，同时已停用的新 Feedback 创建入口仍公开可见。
- Required capability: CLI 需要提供具名状态参数、组合校验，并只暴露仍受支持的 Feedback 维护入口。
- User outcome: 维护者无需临时 JSON 即可完成状态变更；新 Observation 会进入 Issue，不会误建 Feedback。

## CLI

### Removed

#### Case: 创建新 Feedback

##### Before

```sh
pnpm feedback add --help
```

```text
DESCRIPTION
  Add one decoded Feedback document.

FLAGS
  --input string    Path to a JSON input document.
  --dry-run
  --json
```

##### After

```text
removed
```

##### User impact

新 Observation 改走脱敏 GitHub Issue；feedback import 只恢复已经产生的历史下游 envelope，存量 Feedback 的读取与关系维护命令保持可用。

### Changed

#### Case: 关闭存量 Feedback

##### Before

```sh
pnpm feedback close --help
```

```text
FLAGS
  --closure string    Closure JSON path.
```

##### After

```sh
pnpm feedback close --help
```

```text
FLAGS
  --kind choice          (choices: fixed, delivered, duplicate, declined, invalid, external-fixed)
  --memory string
  --target string
  --proof string
  --canonical string
  --evidence string
  --dependency string
  --version string
```

##### User impact

每种关闭原因只接受自身需要的具名参数；缺失必填值或混入其它 kind 的参数会在零写入时失败。

#### Case: 创建结构化 Memory

##### Before

```sh
pnpm memory add --help
```

```text
FLAGS
  --input string    Path to a JSON input document.
  --body string     Markdown body path.
```

##### After

```sh
pnpm memory add --help
```

```text
USAGE
  niceeval-repo memory add [flags] <memory-id>

FLAGS
  --title string
  --kind choice          (choices: problem, decision, insight)
  --created-at string    Creation date (YYYY-MM-DD); defaults to today.
  --body string          Markdown body path.
```

##### User impact

维护者直接声明 ID、标题和种类；工具生成固定 format、初始 state 与空 promotions，并在省略日期时使用当天日期。

#### Case: 解决 Problem Memory

##### Before

```sh
pnpm memory resolve --help
```

```text
FLAGS
  --resolution string    Problem resolution JSON path.
```

##### After

```sh
pnpm memory resolve --help
```

```text
FLAGS
  --kind choice     (choices: fixed, not-a-bug, wont-fix, external-fixed)
  --proof string    Resolution evidence; repeat for each proof item.
```

##### User impact

维护者可以重复传入 --proof，不再创建 resolution JSON；既有 Schema 与 E2E regression gate 继续验证最终状态。
