### PR TITLE
refactor(domain): 让有限值由所属领域统一管理

### DIFF
--- a/.agents/friction-log/20260827222835-lifecycle-单测被无关-loop/friction.md
+++ b/.agents/friction-log/20260827222835-lifecycle-单测被无关-loop/friction.md
@@ -1,0 +1,37 @@
+---
+title: 'lifecycle 单测被无关 loop quota preflight 整仓阻断'
+severity: 'major'
+---
+
+## Actual observation
+
+`pnpm e2e test --repo lifecycle -- --run test/incus-user-database-ledger.test.ts` 在运行测试前要求 `linux-loop-project-quota`，目标 fake-Incus 测试 0 次执行。
+
+## Expected behavior
+
+按测试文件选择 capability；fake-Incus 测试不继承其它场景的 loop quota preflight。
+
+## Impact
+
+正式 installed-candidate E2E 入口无法单独验证 Incus ledger。
+
+## Public entry-point reproduction
+
+`pnpm e2e test --repo lifecycle -- --run test/incus-user-database-ledger.test.ts --keep-workdir`
+
+## NiceEval identity
+
+main candidate 0.4.6
+
+## Environment
+
+Linux, Node v24.19.0, pnpm 11.12.0；Docker 可用，loop quota capability 不可用。
+
+## Source provenance
+
+NiceEval main 的根目录正式 e2e runner；receipt 显示 `testInvocations: 0`。
+
+## Public data confirmation
+
+- [x] I removed secrets, credentials, private customer data, private repository content, and other sensitive material from this issue.
+- [x] This issue does not disclose or describe a suspected security vulnerability.

--- a/docs/feature/sandbox/nested-docker/README.md
+++ b/docs/feature/sandbox/nested-docker/README.md
@@ -79,6 +79,7 @@ incusSandbox({
 - Experiment 的 `incusSandbox()` 与 DestroyOnly 生命周期；
 - reference 与 development 两个 execution domain；
 - `niceeval sandbox provider doctor incus [--development]` 的只读 fail-closed 诊断；
+- prepared artifact 满容量时的安全自动淘汰生命周期；
 - image trust、capability 绑定与安全边界。
 
 本主题不包含：

--- a/docs/feature/sandbox/nested-docker/architecture.md
+++ b/docs/feature/sandbox/nested-docker/architecture.md
@@ -113,6 +113,13 @@ consumer 从 artifact project 跨 project copy template root；Docker data 必�
 按 intent 和 metadata 查询，不能盲目重发。无 committed intent 的对象是 orphan；已提交但不再能验证的对象
 进入 quarantine，均不得被 warm lookup 采用。
 
+Incus repository 在用户级 UserDatabase 中独立持久化 replacement head、consumer lease
+与 destroy receipt。replacement scope 来自 provider-neutral SetupPrefix manifest；head 只
+指向已 committed generation。consumer handoff 在 clone 前重新核对 generation 并取得
+lease，clone settlement 释放 lease。旧 head 只有在 lease 归零后才能进入 destroy；VM 与
+dependent custom block volume 的 absent 证据分别落库，二者齐全才提交 `released`。这与
+Docker/E2B 的 replacement 生命周期同义，但 Incus 的删除单位是 VM+volume tuple。
+
 clean publication failure 可以回到最深的已提交 ancestor 或 exact base，重新执行后续 prefix。
 unknown acceptance、identity 漂移、metadata 不一致或无法删除 orphan 时一律 fail closed。
 

--- a/docs/feature/sandbox/nested-docker/cli.md
+++ b/docs/feature/sandbox/nested-docker/cli.md
@@ -17,6 +17,14 @@ niceeval sandbox provider doctor incus
 niceeval sandbox provider doctor incus --development
 ```
 
+Doctor 同时报告 runtime allocation 与 prepared artifact 两种容量；artifact `0 free`
+必须使整体结果为 `FAIL`，即使已有 warm artifact 仍可命中。
+
+容量回收是 provider 的内部职责，不增加日常运维命令。NiceEval 只自动回收已被同一
+replacement lineage 的新 generation 取代、consumer lease 已归零且 VM/volume 双向
+metadata 仍精确匹配的 artifact。若满容量时全部 artifact 都是当前 head 或仍被引用，
+doctor 与 reservation 明确报告有效 working set 容量不足，绝不按年龄删除仍有效缓存。
+
 默认只读检查 reference：execution domain、dedicated block-backed attested capacity、trusted image 与 inventory。
 它不执行 cleanup，也不操作 Eval allocation。
 

--- a/docs/feature/sandbox/nested-docker/lifecycle.md
+++ b/docs/feature/sandbox/nested-docker/lifecycle.md
@@ -96,6 +96,15 @@ Provider 只对完整、可验证的 prepared Sandbox artifact 声明缓存资�
 ## doctor 与 fail-closed
 
 `niceeval sandbox provider doctor incus [--development]` 只读。
+
+prepared artifact 是有界资源。`committed` artifact 持续占用 descriptor 的
+`artifactMaxInstances`。每个 artifact 持久化 replacement scope；repository 以 scope head
+证明同 lineage 的旧 generation 已被替代。consumer handoff 在 clone 前重新验证 committed
+generation 并取得 lease，clone 无论成功或失败都释放 lease。新 generation committed 并成为 head 后，旧 head 只有在
+lease 归零且 VM 与 custom block volume 双向 metadata 精确匹配时才进入持久 destroy
+流程；VM/volume 的 absent receipt 分别落库，两者都确认 absent 后才写 `released`。
+中断恢复只继续同一个已登记 tuple。若满容量时没有 superseded 且无 lease 的候选，说明
+有效 working set 确实超出容量，NiceEval 保留全部缓存并报告容量不足，不做 LRU 猜测。
 默认检查 reference；`--development` 分开检查 development domain。
 两条结果互相不替代。
 doctor 不 create、不 destroy allocation。

--- a/e2e/lifecycle/test/incus-user-database-ledger.test.ts
+++ b/e2e/lifecycle/test/incus-user-database-ledger.test.ts
@@ -92,6 +92,11 @@ function artifactConsumers(records: readonly JournalRecord[]): readonly JournalR
     record.detail.body?.source?.type === "copy" && record.detail.body.source.project === artifactProject);
 }
 
+function artifactDeletes(records: readonly JournalRecord[]): readonly JournalRecord[] {
+  return records.filter((record) => record.event === "query" && record.detail.method === "DELETE" &&
+    record.detail.project === artifactProject);
+}
+
 test("Incus repository fences admission, recovers crashes, and reuses only committed artifacts", async () => {
   await withProjectCopy(projectCopy, async ({ root: projectRoot }) => {
     await withTempDir("niceeval-e2e-incus-userdb-runtime-", async (runtimeRoot) => {
@@ -117,7 +122,7 @@ test("Incus repository fences admission, recovers crashes, and reuses only commi
           quota: "unattested",
           maxInstances: 4,
           artifactProject,
-          artifactMaxInstances: 4,
+          artifactMaxInstances: 1,
           dockerDataBytes: 1024 ** 3,
           workdir: "/home/sandbox/workspace",
           user: "node",
@@ -202,9 +207,27 @@ export default defineExperiment({
       expect(artifactConsumers(recoveryRecords)).toHaveLength(1);
 
       const doctor = await niceeval.run(["sandbox", "provider", "doctor", "incus", "--development"], { cwd: projectRoot, env: baseEnv });
-      expect(doctor.exitCode, doctor.diagnostic()).toBe(0);
-      expect(doctor.stdout).toContain("status: PASS (fail closed)");
+      expect(doctor.exitCode, doctor.diagnostic()).toBe(1);
+      expect(doctor.stdout).toContain("status: FAIL (fail closed)");
       expect(doctor.stdout).toContain("4 free of 4");
+      expect(doctor.stdout).toContain("artifact-capacity: FAIL");
+
+      await writeFile(join(projectRoot, "experiments/incus-ledger.ts"), `
+import { defineExperiment } from "niceeval";
+import { incusSandbox, shell } from "niceeval/sandbox";
+import { quickAgent } from "../agents/deterministic.ts";
+const sandbox = incusSandbox({ image: "niceeval/docker-execution-v1@sha256:${digest}", project: "${runtimeProject}", storagePool: "niceeval-sandbox-dev", acceptDevelopmentDomain: true, resources: { dockerDataBytes: ${1024 ** 3} } })
+  .before(shell({ id: "incus-ledger-prefix-v2", command: "true", changeFrequency: 10 }));
+export default defineExperiment({ agent: quickAgent, sandbox, evals: ["probe"], attempts: 1, maxConcurrency: 1 });
+`, "utf8");
+      const evictionStart = (await journal(journalPath)).length;
+      const eviction = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], { cwd: projectRoot, env: baseEnv });
+      expect(eviction.exitCode).not.toBe(0);
+      expect(`${eviction.stdout}\n${eviction.stderr}`).toContain("still-current replacement lineage");
+      const evictionRecords = (await journal(journalPath)).slice(evictionStart);
+      expect(artifactDeletes(evictionRecords)).toHaveLength(0);
+      expect(artifactPublishes(evictionRecords)).toHaveLength(0);
+      expect(artifactConsumers(evictionRecords)).toHaveLength(0);
     });
   });
 });

--- a/packages/e2e-runner/src/cli.ts
+++ b/packages/e2e-runner/src/cli.ts
@@ -13,7 +13,7 @@ import { Cause, Console, Data, Effect, Result, Exit, Fiber, Layer, Option, Queue
 
 const decodeNativeArgs = Schema.decodeUnknownSync(Schema.Array(Schema.String));
 
-import { decodePlanDocument, type SelectionReceipt } from "./contracts.ts";
+import { decodePlanDocument, LANES, type SelectionReceipt } from "./contracts.ts";
 import { runDiagnostic, type DiagnosticMode } from "./diagnose.ts";
 import { repoRootDir } from "./discovery.ts";
 import { forceKillOwnedProcesses, OwnedProcessLive, stopOwnedProcesses } from "./owned-process.ts";
@@ -31,7 +31,7 @@ const errorDetail = (cause: unknown): string =>
     ? cause.detail
     : cause instanceof Error ? cause.message : String(cause);
 const optionalText = (name: string) => Options.string(name).pipe(Options.optional, Options.map(Option.getOrUndefined));
-const lane = Options.choice("lane", ["pr", "main", "nightly", "release"] as const).pipe(Options.withDefault("pr"), Options.withDescription("Manifest lane to plan (default: pr)."));
+const lane = Options.choice("lane", LANES).pipe(Options.withDefault("pr"), Options.withDescription("Manifest lane to plan (default: pr)."));
 const repos = Options.string("repo").pipe(Options.atLeast(0), Options.withDescription("Scenario repository id; may be repeated."));
 const diffPaths = Options.string("diff-path").pipe(Options.atLeast(0), Options.withDescription("Changed path for affected planning; may be repeated."));
 const noDiff = Options.boolean("no-diff").pipe(Options.withDefault(false), Options.withDescription("Plan the full lane instead of affected repositories."));

--- a/packages/e2e-runner/src/contracts.ts
+++ b/packages/e2e-runner/src/contracts.ts
@@ -45,8 +45,8 @@ const isCanonicalPath = (value: string): boolean =>
   !value.startsWith("../") &&
   !value.split("/").some((segment) => segment.length === 0 || segment === "." || segment === "..");
 
-export const LaneSchema = Schema.Literals(["pr", "main", "nightly", "release"]);
-export const AreaSchema = Schema.Literals([
+export const LANES = ["pr", "main", "nightly", "release"] as const;
+export const AREAS = [
   "eval",
   "cli",
   "report",
@@ -56,11 +56,20 @@ export const AreaSchema = Schema.Literals([
   "adapter",
   "sandbox",
   "lifecycle",
-]);
-export const PlatformSchema = Schema.Literals(["linux", "darwin"]);
-export const BrowserSchema = Schema.Literals(["chromium", "firefox", "webkit"]);
-export const HostCapabilitySchema = Schema.Literals(["linux-loop-project-quota"]);
-export const HarnessAssetSchema = Schema.Literals(["docker-profile-host-scripts"]);
+] as const;
+export const PLATFORMS = ["linux", "darwin"] as const;
+export const BROWSERS = ["chromium", "firefox", "webkit"] as const;
+export const HOST_CAPABILITIES = ["linux-loop-project-quota"] as const;
+export const HARNESS_ASSETS = ["docker-profile-host-scripts"] as const;
+export const MANIFEST_SCHEMA_VERSION = 3 as const;
+export const MANIFEST_SCHEMA_VERSIONS = [MANIFEST_SCHEMA_VERSION] as const;
+
+export const LaneSchema = Schema.Literals(LANES);
+export const AreaSchema = Schema.Literals(AREAS);
+export const PlatformSchema = Schema.Literals(PLATFORMS);
+export const BrowserSchema = Schema.Literals(BROWSERS);
+export const HostCapabilitySchema = Schema.Literals(HOST_CAPABILITIES);
+export const HarnessAssetSchema = Schema.Literals(HARNESS_ASSETS);
 export const PlanModeSchema = Schema.Literals(["invalid", "affected", "full", "fail-open-full"]);
 export const CategorySchema = Schema.Literals(["pass", "regression", "infra", "configuration", "cancelled"]);
 export const StageNameSchema = Schema.Literals([
@@ -128,7 +137,7 @@ export const RepoHarnessSchema = Schema.Struct({
 
 /** The target metadata itself: repo identity is deliberately derived by discovery. */
 export const ManifestMetadataSchema = Schema.Struct({
-  schemaVersion: Schema.Literals([3]),
+  schemaVersion: Schema.Literals(MANIFEST_SCHEMA_VERSIONS),
   batch: BatchIdSchema,
   areas: UniqueAreaListSchema,
   lanes: UniqueLaneListSchema,
@@ -141,7 +150,7 @@ export const ManifestMetadataSchema = Schema.Struct({
   artifacts: Schema.Array(ArtifactPatternSchema),
 });
 export const ManifestSchema = Schema.Struct({
-  schemaVersion: Schema.Literals([3]), batch: BatchIdSchema, areas: UniqueAreaListSchema,
+  schemaVersion: Schema.Literals(MANIFEST_SCHEMA_VERSIONS), batch: BatchIdSchema, areas: UniqueAreaListSchema,
   lanes: UniqueLaneListSchema, executor: ExecutorSchema, command: Schema.NonEmptyArray(NonEmptyStringSchema),
   timeoutMinutes: PositiveFiniteNumberSchema, secrets: UniqueStringListSchema,
   requires: Schema.optional(RepoRequiresSchema), harness: Schema.optional(RepoHarnessSchema),

--- a/packages/e2e-runner/src/manifest.ts
+++ b/packages/e2e-runner/src/manifest.ts
@@ -7,7 +7,14 @@ import { Result, Schema, SchemaIssue } from "effect";
 
 import {
   ArtifactPatternSchema,
+  AREAS,
   BatchIdSchema,
+  BROWSERS,
+  HARNESS_ASSETS,
+  HOST_CAPABILITIES,
+  LANES,
+  MANIFEST_SCHEMA_VERSION,
+  PLATFORMS,
   RepoIdSchema,
   decodeManifestMetadata,
   type Area,
@@ -21,13 +28,8 @@ import {
   type Platform,
 } from "./contracts.ts";
 
-export const SCHEMA_VERSION = 3 as const;
-export const AREAS = ["eval", "cli", "report", "record", "package", "runner", "adapter", "sandbox", "lifecycle"] as const;
-export const LANES = ["pr", "main", "nightly", "release"] as const;
-export const PLATFORMS = ["linux", "darwin"] as const;
-export const BROWSERS = ["chromium", "firefox", "webkit"] as const;
-export const HOST_CAPABILITIES = ["linux-loop-project-quota"] as const;
-export const HARNESS_ASSETS = ["docker-profile-host-scripts"] as const;
+export const SCHEMA_VERSION = MANIFEST_SCHEMA_VERSION;
+export { AREAS, BROWSERS, HARNESS_ASSETS, HOST_CAPABILITIES, LANES, PLATFORMS };
 
 export type { Area, BatchId, Browser, HarnessAsset, HostCapability, Lane, Platform } from "./contracts.ts";
 export type Executor = ManifestMetadata["executor"];

--- a/packages/niceeval/src/agents/types.ts
+++ b/packages/niceeval/src/agents/types.ts
@@ -120,7 +120,8 @@ export interface AgentSetupManifest {
 // ───────────────────────── 证据覆盖声明 ─────────────────────────
 
 /** 证据通道的覆盖状态；不存在隐含的 unknown 第四态。 */
-export type EvidenceCoverageStatus = "complete" | "partial" | "unavailable";
+export const EVIDENCE_COVERAGE_STATUSES = ["complete", "partial", "unavailable"] as const;
+export type EvidenceCoverageStatus = (typeof EVIDENCE_COVERAGE_STATUSES)[number];
 
 /** 非完整通道必须解释缺口；完整通道不能携带一个自相矛盾的 reason。 */
 export type EvidenceCoverageEntry =

--- a/packages/niceeval/src/assertions/api.ts
+++ b/packages/niceeval/src/assertions/api.ts
@@ -14,9 +14,10 @@ import type {
   ToolMatch,
 } from "./match.ts";
 import type { AgentWorkspaceDiff } from "./workspace-diff.ts";
+import type { EvaluationKind } from "../shared/evaluation.ts";
 
 /** The two Evaluation kinds deliberately share one Assertion entry model. */
-export type AssertionEvaluationKind = "pass" | "score";
+export type AssertionEvaluationKind = EvaluationKind;
 
 /**
  * A bounded JSON-shaped value owned by the authoring runtime.  It is a
@@ -735,7 +736,7 @@ export interface SealedAssertionsRuntime {
 
 /** The runtime Verdict is independent of the durable Verdict attachment codec. */
 export interface AssertionVerdict {
-  readonly state: "passed" | "failed" | "errored" | "skipped";
+  readonly state: import("../shared/types.ts").Verdict;
 }
 
 export type AssertionScoreIncompleteReason =

--- a/packages/niceeval/src/assertions/match.ts
+++ b/packages/niceeval/src/assertions/match.ts
@@ -100,7 +100,8 @@ const thresholdedScoreMatches = new WeakMap<object, {
 }>();
 const numericComparisons = new WeakMap<object, NumericComparison>();
 
-export type NumericComparator = "less-than" | "at-most" | "greater-than" | "at-least";
+export const NUMERIC_COMPARATORS = ["less-than", "at-most", "greater-than", "at-least"] as const;
+export type NumericComparator = (typeof NUMERIC_COMPARATORS)[number];
 
 export interface NumericComparison {
   readonly comparator: NumericComparator;

--- a/packages/niceeval/src/assertions/record/codec.ts
+++ b/packages/niceeval/src/assertions/record/codec.ts
@@ -1,6 +1,7 @@
 import { Result, Schema } from "effect";
 import { isRecordContentHandle } from "../../record/attachment/content.ts";
 import { assertionRuntimeLimits } from "../limits.ts";
+import { NUMERIC_COMPARATORS } from "../match.ts";
 import {
   ASSERTION_ENTRY_ID_BRAND,
   type AssertionCoverage,
@@ -395,7 +396,7 @@ const NumericComparisonCriterionSchema = Schema.Struct({
   kind: Schema.Literal("builtin"),
   id: Schema.Literal("numeric-comparison/v1"),
   data: Schema.Struct({
-    comparator: Schema.Literals(["less-than", "at-most", "greater-than", "at-least"]),
+    comparator: Schema.Literals(NUMERIC_COMPARATORS),
     threshold: Schema.Finite,
     subject: Schema.Union([
       Schema.Struct({ kind: Schema.Literal("explicit-value") }),

--- a/packages/niceeval/src/assertions/record/model.ts
+++ b/packages/niceeval/src/assertions/record/model.ts
@@ -292,28 +292,8 @@ export interface AssertionCollectionReceipt {
   readonly decisive: boolean;
 }
 
-export type MatcherRelationStatus =
-  | { readonly state: "exact" }
-  | {
-      readonly state: "unavailable";
-      readonly reason:
-        | "historical-not-recorded"
-        | "source-unavailable"
-        | "ambiguous";
-    };
-
-export type MatcherSourceLocator =
-  | {
-      readonly kind: "tool-occurrence";
-      readonly toolOccurrenceId: string;
-      readonly relation: MatcherRelationStatus;
-    }
-  | {
-      readonly kind: "event";
-      readonly eventId: string;
-      readonly toolOccurrenceId?: string;
-      readonly relation: MatcherRelationStatus;
-    };
+export type { MatcherRelationStatus, MatcherSourceLocator } from "../api.ts";
+import type { MatcherSourceLocator } from "../api.ts";
 
 export type MatcherOverlayResult =
   | "matched"

--- a/packages/niceeval/src/eval/record/evaluation.ts
+++ b/packages/niceeval/src/eval/record/evaluation.ts
@@ -1,6 +1,7 @@
 import { Result, Schema } from "effect";
 import { SlotIdSchema } from "../../record/codec/identifiers.ts";
 import { compareCanonicalIdentity, type SlotId } from "../../record/model/identifiers.ts";
+import { EVALUATION_KINDS } from "../../shared/evaluation.ts";
 import {
   EvaluationRecordIdentitySchema,
   ExactEvaluationParseOptions,
@@ -10,7 +11,7 @@ import {
  * Eval-to-slot planning is transient. Core carries the immutable Slot identity
  * once a Run is created; no evaluations Attachment exists in Record v1.
  */
-export const EvaluationKindSchema = Schema.Literals(["pass", "score"]);
+export const EvaluationKindSchema = Schema.Literals(EVALUATION_KINDS);
 export type EvaluationKind = Schema.toType<typeof EvaluationKindSchema>["Type"];
 export type EvaluationId = Schema.toType<typeof EvaluationRecordIdentitySchema>["Type"];
 export type ExperimentId = Schema.toType<typeof EvaluationRecordIdentitySchema>["Type"];

--- a/packages/niceeval/src/eval/record/membership-provenance.ts
+++ b/packages/niceeval/src/eval/record/membership-provenance.ts
@@ -25,22 +25,26 @@ export type MembershipSourceBarrier = Schema.toType<typeof MembershipSourceBarri
 export const MembershipAttemptOriginSchema = Schema.Struct({ runId: RunIdSchema, slotId: SlotIdSchema });
 export type MembershipAttemptOrigin = Schema.toType<typeof MembershipAttemptOriginSchema>["Type"];
 
-export const ComparisonAttachmentSchema = Schema.Literals([
+export const COMPARISON_ATTACHMENTS = [
   "core",
   "niceeval.assertions",
   "niceeval.runner-activities",
-]);
+] as const;
+export const ComparisonAttachmentSchema = Schema.Literals(COMPARISON_ATTACHMENTS);
 export type ComparisonAttachment = Schema.toType<typeof ComparisonAttachmentSchema>["Type"];
-export const RecordedAttemptClaimSchema = Schema.Literals([
+export const RECORDED_ATTEMPT_CLAIMS = [
   "execution-identity",
   "attempt-outcome",
   "assertion-verdict",
   "execution-duration",
-]);
+] as const;
+export const RecordedAttemptClaimSchema = Schema.Literals(RECORDED_ATTEMPT_CLAIMS);
 export type RecordedAttemptClaim = Schema.toType<typeof RecordedAttemptClaimSchema>["Type"];
-export const ComparisonSourceStateSchema = Schema.Literals(["available", "unavailable", "unsupported", "invalid"]);
+export const COMPARISON_SOURCE_STATES = ["available", "unavailable", "unsupported", "invalid"] as const;
+export const ComparisonSourceStateSchema = Schema.Literals(COMPARISON_SOURCE_STATES);
 export type ComparisonSourceState = Schema.toType<typeof ComparisonSourceStateSchema>["Type"];
-export const ComparisonResultSchema = Schema.Literals(["match", "mismatch", "ineligible", "not-comparable"]);
+export const COMPARISON_RESULTS = ["match", "mismatch", "ineligible", "not-comparable"] as const;
+export const ComparisonResultSchema = Schema.Literals(COMPARISON_RESULTS);
 export type ComparisonResult = Schema.toType<typeof ComparisonResultSchema>["Type"];
 export const ComparisonProvenanceSchema = Schema.Struct({
   attachment: ComparisonAttachmentSchema,

--- a/packages/niceeval/src/eval/record/verdict.ts
+++ b/packages/niceeval/src/eval/record/verdict.ts
@@ -2,7 +2,7 @@ import { Schema } from "effect";
 import type { AssertionsAttachment } from "../../record/family/assertions/definition.ts";
 import { sealedAssertionResult } from "../../assertions/record/model.ts";
 import type { AttemptOutcome } from "../../record/model/core.ts";
-import type { Verdict } from "../../shared/types.ts";
+import { VERDICTS, type Verdict } from "../../shared/types.ts";
 import {
   EvaluationAttemptFactsSchema,
   isGateFailed,
@@ -14,12 +14,7 @@ import {
  * A transient fold result. Verdict is derived from sealed Assertion facts and
  * Attempt outcome; it is deliberately not a Record Attachment family.
  */
-export const VerdictStateSchema = Schema.Literals([
-  "passed",
-  "failed",
-  "errored",
-  "skipped",
-]);
+export const VerdictStateSchema = Schema.Literals(VERDICTS);
 
 export type VerdictState = Schema.toType<typeof VerdictStateSchema>["Type"];
 

--- a/packages/niceeval/src/i18n/core.ts
+++ b/packages/niceeval/src/i18n/core.ts
@@ -2,7 +2,8 @@
 // 必须保持环境无关(不 import node/browser API),vite 前端和 node CLI 都直接打包它。
 // view 在此之外注入 navigator+localStorage 与默认值。
 
-export type Locale = "zh-CN" | "en";
+export const LOCALES = ["en", "zh-CN"] as const;
+export type Locale = (typeof LOCALES)[number];
 
 export type Vars = globalThis.Record<string, string | number | boolean | undefined>;
 

--- a/packages/niceeval/src/inspection/results.ts
+++ b/packages/niceeval/src/inspection/results.ts
@@ -21,6 +21,13 @@ import {
 } from "../record/family/file-changes/schema.ts";
 import { SourceReceiptLimitationSchema } from "../record/family/source-receipt/index.ts";
 import {
+  ACTIVITY_OUTCOMES,
+  AGENT_TURN_OUTCOMES,
+  COMMAND_NOT_STARTED_REASONS,
+  COMMAND_TERMINATION_REASONS,
+  SANDBOX_COMMAND_PHASES,
+} from "../record/family/protocol-values.ts";
+import {
   SessionScopeIdSchema,
   TurnIdSchema,
 } from "../record/family/source-receipt/codec.ts";
@@ -348,7 +355,7 @@ const TraceProjectionLimitationSchema = Schema.Union([
     ])),
   }),
 ]);
-const TurnOutcomeSchema = Schema.Literals(["completed", "failed", "cancelled", "interrupted"]);
+const TurnOutcomeSchema = Schema.Literals(AGENT_TURN_OUTCOMES);
 const TraceTurnContextSchema = Schema.Union([
   Schema.Struct({ state: Schema.Literal("not-recorded") }),
   Schema.Struct({
@@ -463,8 +470,8 @@ export const InspectionTraceItemSchema = Schema.Union([
 ]);
 const CommandOutcomeSchema = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("exited"), exitCode: Schema.Number }),
-  Schema.Struct({ kind: Schema.Literal("terminated"), reason: Schema.Literals(["timeout", "cancelled", "transport-lost"]) }),
-  Schema.Struct({ kind: Schema.Literal("not-started"), reason: Schema.Literals(["spawn-failed", "cancelled-before-start"]) }),
+  Schema.Struct({ kind: Schema.Literal("terminated"), reason: Schema.Literals(COMMAND_TERMINATION_REASONS) }),
+  Schema.Struct({ kind: Schema.Literal("not-started"), reason: Schema.Literals(COMMAND_NOT_STARTED_REASONS) }),
 ]);
 export const InspectionTraceResultSchema = Schema.Struct({
   format: Schema.Literal("niceeval.inspection.trace/v1"),
@@ -494,7 +501,7 @@ export const InspectionTraceResultSchema = Schema.Struct({
     omittedLimitationCount: Schema.Number,
     items: Schema.Array(Schema.Struct({
       commandId: CommandIdSchema,
-      phase: Schema.Literals(["attempt.setup", "sandbox.prepare", "agent.ensure", "eval.run", "sandbox.command", "attempt.teardown"]),
+      phase: Schema.Literals(SANDBOX_COMMAND_PHASES),
       outcome: CommandOutcomeSchema,
     })),
     hasMore: Schema.Boolean,
@@ -720,7 +727,7 @@ export const InspectionAttemptTimingResultSchema = Schema.Struct({
     label: Schema.String,
     startOffsetMs: Schema.Number,
     durationMs: Schema.Number,
-    outcome: Schema.Literals(["completed", "failed", "cancelled", "interrupted", "unknown"]),
+    outcome: Schema.Literals(ACTIVITY_OUTCOMES),
   })),
   hasMore: Schema.Boolean,
   omittedActivityCount: Schema.Number,

--- a/packages/niceeval/src/inspection/trace.ts
+++ b/packages/niceeval/src/inspection/trace.ts
@@ -16,6 +16,8 @@ import {
 } from "../record/attachment/protocol.ts";
 import { NiceEvalCurrentRecordAttachments } from "../record/family/current.ts";
 import type { AgentTurnsAttachment } from "../record/family/agent-turns/schema.ts";
+import type { AgentTurnOutcome } from "../record/family/protocol-values.ts";
+import type { RecordAttachmentOwner } from "../record/model/core.ts";
 import type { SourceReceiptLimitation } from "../record/family/source-receipt/index.ts";
 import type {
   PersistedContentMetadata,
@@ -465,7 +467,7 @@ function projectToolOccurrenceDetail(
   if (agentTurns.state !== "available" || agentTurns.value.state === "legacy") return undefined;
   let call: InspectionTraceDetailItem | undefined;
   let result: InspectionTraceDetailItem | undefined;
-  let callTurn: { readonly turnId: string; readonly sequence: number; readonly outcome: "completed" | "failed" | "cancelled" | "interrupted" } | undefined;
+  let callTurn: { readonly turnId: string; readonly sequence: number; readonly outcome: AgentTurnOutcome } | undefined;
   let resultTurn: typeof callTurn;
   for (const turn of agentTurns.value.segments) {
     for (const item of turn.items) {
@@ -530,7 +532,7 @@ function projectTraceCommandDetail(
   });
 }
 
-function traceTurnIdentity(turn: { readonly turnId: string; readonly sequence: number; readonly outcome: "completed" | "failed" | "cancelled" | "interrupted" }) {
+function traceTurnIdentity(turn: { readonly turnId: string; readonly sequence: number; readonly outcome: AgentTurnOutcome }) {
   return Object.freeze({ turnId: turn.turnId, sequence: turn.sequence, outcome: turn.outcome });
 }
 
@@ -558,7 +560,7 @@ function projectFullConversationItem(
   turn: {
     readonly turnId: string;
     readonly sequence: number;
-    readonly outcome: "completed" | "failed" | "cancelled" | "interrupted";
+    readonly outcome: AgentTurnOutcome;
     readonly sessionId?: string;
   },
 ): Extract<InspectionTraceDetailResult, { readonly kind: "item" }>["item"] {
@@ -597,7 +599,7 @@ function projectFullConversationItem(
 }
 
 function readCurrentAttachment<
-  Owner extends "run" | "attempt",
+  Owner extends RecordAttachmentOwner,
   Family extends string,
   ValueSchema extends Schema.Top,
   Revision extends number,

--- a/packages/niceeval/src/project/host.ts
+++ b/packages/niceeval/src/project/host.ts
@@ -5,6 +5,7 @@ import {
   ProjectManifestFacts,
   ProjectProcessFacts,
   type ProjectPlatformError,
+  type ProjectPathKind,
 } from "./services.ts";
 import {
   AGENT_RULE_BEGIN,
@@ -34,8 +35,8 @@ export interface ProjectHostSDK {
 }
 
 function instructionTarget(input: {
-  readonly agentsKind: "missing" | "file" | "directory" | "other";
-  readonly claudeKind: "missing" | "file" | "directory" | "other";
+  readonly agentsKind: ProjectPathKind;
+  readonly claudeKind: ProjectPathKind;
 }): "AGENTS.md" | "CLAUDE.md" {
   return input.agentsKind === "file"
     ? "AGENTS.md"

--- a/packages/niceeval/src/project/services.ts
+++ b/packages/niceeval/src/project/services.ts
@@ -6,7 +6,8 @@ export type ProjectManagedPath =
   | "AGENTS.md"
   | "CLAUDE.md";
 
-export type ProjectPathKind = "missing" | "file" | "directory" | "other";
+export const PROJECT_PATH_KINDS = ["missing", "file", "directory", "other"] as const;
+export type ProjectPathKind = (typeof PROJECT_PATH_KINDS)[number];
 
 export class ProjectPlatformError extends Data.TaggedError("ProjectPlatformError")<{
   readonly operation:

--- a/packages/niceeval/src/record/codec/attachment.ts
+++ b/packages/niceeval/src/record/codec/attachment.ts
@@ -7,6 +7,7 @@ import {
   RECORD_ATTACHMENT_FORMAT,
   type DurableRecordAttachmentEnvelope,
 } from "../model/attachment.ts";
+import { RECORD_ATTACHMENT_OWNERS } from "../model/core.ts";
 
 const NonNegativeSafeInteger = Schema.Number.pipe(
   Schema.check(Schema.makeFilter((value) => Number.isSafeInteger(value) && value >= 0)),
@@ -24,7 +25,7 @@ const ContentPointer = Schema.Struct({
   byteLength: NonNegativeSafeInteger,
 });
 const Reference = Schema.Struct({
-  owner: Schema.Literals(["run", "attempt"]),
+  owner: Schema.Literals(RECORD_ATTACHMENT_OWNERS),
   family: Schema.String.pipe(Schema.check(Schema.makeFilter(isRecordAttachmentName))),
 });
 
@@ -56,7 +57,7 @@ function canonicalCollections(value: DurableRecordAttachmentEnvelope): boolean {
 
 export const DurableRecordAttachmentEnvelopeSchema = Schema.Struct({
   format: Schema.Literals([RECORD_ATTACHMENT_FORMAT]),
-  ownerKind: Schema.Literals(["run", "attempt"]),
+  ownerKind: Schema.Literals(RECORD_ATTACHMENT_OWNERS),
   family: Schema.String.pipe(Schema.check(Schema.makeFilter(isRecordAttachmentName))),
   revision: PositiveSafeInteger,
   payload: Pointer,

--- a/packages/niceeval/src/record/codec/core.ts
+++ b/packages/niceeval/src/record/codec/core.ts
@@ -19,6 +19,7 @@ import {
 } from "../errors/record-errors.ts";
 import {
   AttemptDocumentDefinition,
+  AttemptOutcomeSchema as CurrentAttemptOutcomeSchema,
   AttemptDocumentSchema as CurrentAttemptDocumentSchema,
   MemberDocumentDefinition,
   MemberDocumentSchema as CurrentMemberDocumentSchema,
@@ -34,7 +35,6 @@ import {
 } from "../model/definition.ts";
 import type {
   AttemptDocument,
-  AttemptOutcome,
   MemberDocument,
   MembershipAction,
   RecordAttachmentEnvelope,
@@ -45,7 +45,11 @@ import type {
   RunCore,
   RunDocument,
 } from "../model/core.ts";
-import { RECORD_ATTACHMENT_ENVELOPE_FORMAT } from "../model/core.ts";
+import {
+  MEMBERSHIP_ACTIONS,
+  RECORD_ATTACHMENT_ENVELOPE_FORMAT,
+  RECORD_ATTACHMENT_OWNERS,
+} from "../model/core.ts";
 import { RunContextSchema } from "../model/run-context.ts";
 import { isRecordAttachmentName } from "../model/identifiers.ts";
 import {
@@ -67,7 +71,7 @@ export type RecordCoreEncoded = RecordJsonObject;
 
 export interface RecordAttachmentEnvelopeEncoded {
   readonly format: typeof RECORD_ATTACHMENT_ENVELOPE_FORMAT;
-  readonly ownerKind: "run" | "attempt";
+  readonly ownerKind: RecordAttachmentEnvelope["ownerKind"];
   readonly family: string;
   readonly schemaVersion: number;
   readonly payload: { readonly sha256: string; readonly byteLength: number };
@@ -76,7 +80,7 @@ export interface RecordAttachmentEnvelopeEncoded {
     readonly sha256: string;
     readonly byteLength: number;
   }[];
-  readonly references: readonly { readonly owner: "run" | "attempt"; readonly family: string }[];
+  readonly references: readonly { readonly owner: RecordAttachmentEnvelope["ownerKind"]; readonly family: string }[];
 }
 
 /** Keep each source Schema's exact encoded side (notably branded IDs -> string). */
@@ -91,19 +95,8 @@ export const RecordCoreSchema = CurrentRecordCoreSchema;
 export const RunContextCurrentSchema = RunContextSchema;
 
 /** These small domain literals are composition helpers, not durable codec truth sources. */
-export const AttemptOutcomeSchema: Schema.Schema<AttemptOutcome> = Schema.Literals([
-  "completed",
-  "errored",
-  "cancelled",
-  "interrupted",
-]);
-export const MembershipActionSchema: Schema.Schema<MembershipAction> = Schema.Literals([
-  "executed",
-  "carried",
-  "accepted",
-  "not-dispatched",
-  "interrupted",
-]);
+export const AttemptOutcomeSchema = CurrentAttemptOutcomeSchema;
+export const MembershipActionSchema: Schema.Schema<MembershipAction> = Schema.Literals(MEMBERSHIP_ACTIONS);
 
 const NonNegativeSafeIntegerSchema = Schema.Number.pipe(
   Schema.check(Schema.makeFilter((value) => Number.isSafeInteger(value) && value >= 0)),
@@ -125,7 +118,7 @@ const RecordAttachmentContentPointerSchema = Schema.Struct({
 });
 
 const RecordAttachmentReferenceSchema = Schema.Struct({
-  owner: Schema.Literals(["run", "attempt"]),
+  owner: Schema.Literals(RECORD_ATTACHMENT_OWNERS),
   family: Schema.String.pipe(Schema.check(Schema.makeFilter(isRecordAttachmentName))),
 });
 
@@ -149,7 +142,7 @@ export const RecordAttachmentEnvelopeSchema: Schema.Codec<
   RecordAttachmentEnvelopeEncoded
 > = Schema.Struct({
   format: Schema.Literals([RECORD_ATTACHMENT_ENVELOPE_FORMAT]),
-  ownerKind: Schema.Literals(["run", "attempt"]),
+  ownerKind: Schema.Literals(RECORD_ATTACHMENT_OWNERS),
   family: Schema.String.pipe(Schema.check(Schema.makeFilter(isRecordAttachmentName))),
   schemaVersion: PositiveSafeIntegerSchema,
   payload: RecordAttachmentBytePointerSchema,

--- a/packages/niceeval/src/record/family/agent-turns/schema.ts
+++ b/packages/niceeval/src/record/family/agent-turns/schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { AGENT_TURN_OUTCOMES } from "../protocol-values.ts";
 
 import { projectObservedSourceEvents } from "../../../o11y/derive.ts";
 import {
@@ -136,7 +137,7 @@ const AgentTurnReceiptBase = {
   segmentId: SourceSegmentIdSchema,
   turnId: TurnIdSchema,
   sequence: PositiveSafeIntegerSchema,
-  outcome: Schema.Literals(["completed", "failed", "cancelled", "interrupted"]),
+  outcome: Schema.Literals(AGENT_TURN_OUTCOMES),
   usage: Schema.Array(AgentTurnUsageObservationSchema),
 } as const;
 

--- a/packages/niceeval/src/record/family/common.ts
+++ b/packages/niceeval/src/record/family/common.ts
@@ -12,7 +12,7 @@ export const FixedAttachmentValueLimits = Object.freeze({
   maximumStringUtf8Bytes: 1024 * 1024,
 });
 
-export type FixedRecordAttachmentOwner = "run" | "attempt";
+export type FixedRecordAttachmentOwner = import("../model/core.ts").RecordAttachmentOwner;
 
 export const NonNegativeSafeIntegerSchema = Schema.Number.pipe(
   Schema.check(Schema.makeFilter(

--- a/packages/niceeval/src/record/family/protocol-values.ts
+++ b/packages/niceeval/src/record/family/protocol-values.ts
@@ -1,0 +1,89 @@
+/** Canonical finite protocol vocabularies shared by current receipt owners and projections. */
+export const AGENT_TURN_OUTCOME = Object.freeze({
+  completed: "completed" as const,
+  failed: "failed" as const,
+  cancelled: "cancelled" as const,
+  interrupted: "interrupted" as const,
+});
+export const AGENT_TURN_OUTCOMES = [
+  AGENT_TURN_OUTCOME.completed,
+  AGENT_TURN_OUTCOME.failed,
+  AGENT_TURN_OUTCOME.cancelled,
+  AGENT_TURN_OUTCOME.interrupted,
+] as const;
+export type AgentTurnOutcome = (typeof AGENT_TURN_OUTCOMES)[number];
+
+export const RUNNER_PHASE = Object.freeze({
+  attemptSetup: "attempt.setup" as const,
+  sandboxPrepare: "sandbox.prepare" as const,
+  agentEnsure: "agent.ensure" as const,
+  evalRun: "eval.run" as const,
+  agentSend: "agent.send" as const,
+  sandboxCommand: "sandbox.command" as const,
+  assertionEvaluate: "assertion.evaluate" as const,
+  verdictFold: "verdict.fold" as const,
+  attemptTeardown: "attempt.teardown" as const,
+  runSetup: "run.setup" as const,
+  runDiscovery: "run.discovery" as const,
+  runPlan: "run.plan" as const,
+  runDispatch: "run.dispatch" as const,
+  runTeardown: "run.teardown" as const,
+  collection: "collection" as const,
+});
+export const ATTEMPT_ACTIVITY_PHASES = [
+  RUNNER_PHASE.attemptSetup, RUNNER_PHASE.sandboxPrepare, RUNNER_PHASE.agentEnsure,
+  RUNNER_PHASE.evalRun, RUNNER_PHASE.agentSend, RUNNER_PHASE.sandboxCommand,
+  RUNNER_PHASE.assertionEvaluate, RUNNER_PHASE.verdictFold, RUNNER_PHASE.attemptTeardown,
+] as const;
+export const ATTEMPT_NON_AGENT_ACTIVITY_PHASES = [
+  RUNNER_PHASE.attemptSetup, RUNNER_PHASE.sandboxPrepare, RUNNER_PHASE.agentEnsure,
+  RUNNER_PHASE.evalRun, RUNNER_PHASE.sandboxCommand, RUNNER_PHASE.assertionEvaluate,
+  RUNNER_PHASE.verdictFold, RUNNER_PHASE.attemptTeardown,
+] as const;
+export const RUN_ACTIVITY_PHASES = [
+  RUNNER_PHASE.runSetup, RUNNER_PHASE.runDiscovery, RUNNER_PHASE.runPlan,
+  RUNNER_PHASE.runDispatch, RUNNER_PHASE.runTeardown,
+] as const;
+export const DIAGNOSTIC_PROJECTION_PHASES = [RUNNER_PHASE.collection] as const;
+export const ATTEMPT_DIAGNOSTIC_PHASES = [
+  ...ATTEMPT_ACTIVITY_PHASES,
+  ...DIAGNOSTIC_PROJECTION_PHASES,
+] as const;
+export const RUN_DIAGNOSTIC_PHASES = [
+  ...RUN_ACTIVITY_PHASES,
+  ...DIAGNOSTIC_PROJECTION_PHASES,
+] as const;
+export const SANDBOX_COMMAND_PHASES = [
+  RUNNER_PHASE.attemptSetup, RUNNER_PHASE.sandboxPrepare, RUNNER_PHASE.agentEnsure,
+  RUNNER_PHASE.evalRun, RUNNER_PHASE.sandboxCommand, RUNNER_PHASE.attemptTeardown,
+] as const;
+
+export const ACTIVITY_OUTCOME = Object.freeze({
+  ...AGENT_TURN_OUTCOME,
+  unknown: "unknown" as const,
+});
+export const ACTIVITY_OUTCOMES = [
+  ACTIVITY_OUTCOME.completed,
+  ACTIVITY_OUTCOME.failed,
+  ACTIVITY_OUTCOME.cancelled,
+  ACTIVITY_OUTCOME.interrupted,
+  ACTIVITY_OUTCOME.unknown,
+] as const;
+export const COMMAND_TERMINATION_REASON = Object.freeze({
+  timeout: "timeout" as const,
+  cancelled: "cancelled" as const,
+  transportLost: "transport-lost" as const,
+});
+export const COMMAND_TERMINATION_REASONS = [
+  COMMAND_TERMINATION_REASON.timeout,
+  COMMAND_TERMINATION_REASON.cancelled,
+  COMMAND_TERMINATION_REASON.transportLost,
+] as const;
+export const COMMAND_NOT_STARTED_REASON = Object.freeze({
+  spawnFailed: "spawn-failed" as const,
+  cancelledBeforeStart: "cancelled-before-start" as const,
+});
+export const COMMAND_NOT_STARTED_REASONS = [
+  COMMAND_NOT_STARTED_REASON.spawnFailed,
+  COMMAND_NOT_STARTED_REASON.cancelledBeforeStart,
+] as const;

--- a/packages/niceeval/src/record/family/runner-activities/schema.ts
+++ b/packages/niceeval/src/record/family/runner-activities/schema.ts
@@ -16,14 +16,9 @@ import {
   SourceSegmentIdSchema,
   hasCanonicalSourceSegments,
 } from "../source-receipt/index.ts";
+import { ACTIVITY_OUTCOMES, ATTEMPT_NON_AGENT_ACTIVITY_PHASES, RUN_ACTIVITY_PHASES } from "../protocol-values.ts";
 
-const ActivityOutcomeSchema = Schema.Literals([
-  "completed",
-  "failed",
-  "cancelled",
-  "interrupted",
-  "unknown",
-]);
+const ActivityOutcomeSchema = Schema.Literals(ACTIVITY_OUTCOMES);
 
 const CanonicalTurnLabelSchema = Schema.String.pipe(
   Schema.check(Schema.makeFilter(isCanonicalTurnLabel)),
@@ -49,16 +44,7 @@ export const AttemptRunnerActivityReceiptSchema = Schema.Union([
   Schema.Struct({
     ...ActivityBase,
     turnId: Schema.Null,
-    phase: Schema.Literals([
-      "attempt.setup",
-      "sandbox.prepare",
-      "agent.ensure",
-      "eval.run",
-      "sandbox.command",
-      "assertion.evaluate",
-      "verdict.fold",
-      "attempt.teardown",
-    ]),
+    phase: Schema.Literals(ATTEMPT_NON_AGENT_ACTIVITY_PHASES),
     label: SafeIdentifierSchema,
   }),
 ]);
@@ -66,13 +52,7 @@ export const AttemptRunnerActivityReceiptSchema = Schema.Union([
 export const RunRunnerActivityReceiptSchema = Schema.Struct({
   ...ActivityBase,
   turnId: Schema.Null,
-  phase: Schema.Literals([
-    "run.setup",
-    "run.discovery",
-    "run.plan",
-    "run.dispatch",
-    "run.teardown",
-  ]),
+  phase: Schema.Literals(RUN_ACTIVITY_PHASES),
   label: SafeIdentifierSchema,
 });
 

--- a/packages/niceeval/src/record/family/runner-diagnostics/schema.ts
+++ b/packages/niceeval/src/record/family/runner-diagnostics/schema.ts
@@ -21,6 +21,10 @@ import {
   SourceSegmentIdSchema,
   hasCanonicalSourceSegments,
 } from "../source-receipt/index.ts";
+import {
+  ATTEMPT_ACTIVITY_PHASES,
+  RUN_ACTIVITY_PHASES,
+} from "../protocol-values.ts";
 
 const SourcePositionSchema = Schema.Struct({
   line: PositiveSafeIntegerSchema,
@@ -63,28 +67,12 @@ const DiagnosticBase = {
 
 export const AttemptRunnerDiagnosticReceiptSchema = Schema.Struct({
   ...DiagnosticBase,
-  phase: Schema.Literals([
-    "attempt.setup",
-    "sandbox.prepare",
-    "agent.ensure",
-    "eval.run",
-    "agent.send",
-    "sandbox.command",
-    "assertion.evaluate",
-    "verdict.fold",
-    "attempt.teardown",
-  ]),
+  phase: Schema.Literals(ATTEMPT_ACTIVITY_PHASES),
 });
 
 export const RunRunnerDiagnosticReceiptSchema = Schema.Struct({
   ...DiagnosticBase,
-  phase: Schema.Literals([
-    "run.setup",
-    "run.discovery",
-    "run.plan",
-    "run.dispatch",
-    "run.teardown",
-  ]),
+  phase: Schema.Literals(RUN_ACTIVITY_PHASES),
 });
 
 function validateRunnerDiagnostics(input: {

--- a/packages/niceeval/src/record/family/sandbox-commands/schema.ts
+++ b/packages/niceeval/src/record/family/sandbox-commands/schema.ts
@@ -23,6 +23,11 @@ import {
   SourceSegmentIdSchema,
   hasCanonicalSourceSegments,
 } from "../source-receipt/index.ts";
+import {
+  COMMAND_NOT_STARTED_REASONS,
+  COMMAND_TERMINATION_REASONS,
+  SANDBOX_COMMAND_PHASES,
+} from "../protocol-values.ts";
 
 /**
  * Command text is a logical handle; inline/object placement belongs to Record
@@ -42,7 +47,7 @@ export const SandboxCommandReceiptSchema = Schema.Struct({
   commandId: SafeIdentifierSchema,
   sequence: PositiveSafeIntegerSchema,
   turnId: Schema.NullOr(TurnIdSchema),
-  phase: Schema.Literals(["attempt.setup", "sandbox.prepare", "agent.ensure", "eval.run", "sandbox.command", "attempt.teardown"]),
+  phase: Schema.Literals(SANDBOX_COMMAND_PHASES),
   invocation: Schema.Union([
     Schema.Struct({ kind: Schema.Literal("argv"), executable: SafeTextSchema, arguments: Schema.Array(SafeTextSchema) }),
     Schema.Struct({ kind: Schema.Literal("shell"), command: SafeTextSchema }),
@@ -54,8 +59,8 @@ export const SandboxCommandReceiptSchema = Schema.Struct({
   ]),
   outcome: Schema.Union([
     Schema.Struct({ kind: Schema.Literal("exited"), exitCode: Schema.Number.pipe(Schema.check(Schema.makeFilter((value) => Number.isSafeInteger(value) && value >= -2_147_483_648 && value <= 2_147_483_647))) }),
-    Schema.Struct({ kind: Schema.Literal("terminated"), reason: Schema.Literals(["timeout", "cancelled", "transport-lost"]) }),
-    Schema.Struct({ kind: Schema.Literal("not-started"), reason: Schema.Literals(["spawn-failed", "cancelled-before-start"]) }),
+    Schema.Struct({ kind: Schema.Literal("terminated"), reason: Schema.Literals(COMMAND_TERMINATION_REASONS) }),
+    Schema.Struct({ kind: Schema.Literal("not-started"), reason: Schema.Literals(COMMAND_NOT_STARTED_REASONS) }),
   ]),
   stdout: SandboxCommandStreamSchema,
   stderr: SandboxCommandStreamSchema,

--- a/packages/niceeval/src/record/model/core.ts
+++ b/packages/niceeval/src/record/model/core.ts
@@ -26,19 +26,14 @@ export interface RecordAttemptRef {
 }
 
 /** The terminal execution fact required to interpret an origin Attempt. */
-export type AttemptOutcome =
-  | "completed"
-  | "errored"
-  | "cancelled"
-  | "interrupted";
+export const ATTEMPT_OUTCOMES = ["completed", "errored", "cancelled", "interrupted"] as const;
+export type AttemptOutcome = (typeof ATTEMPT_OUTCOMES)[number];
 
 /** The immutable final action for one planned denominator Slot. */
-export type MembershipAction =
-  | "executed"
-  | "carried"
-  | "accepted"
-  | "not-dispatched"
-  | "interrupted";
+export const MEMBERSHIP_ACTIONS = ["executed", "carried", "accepted", "not-dispatched", "interrupted"] as const;
+export type MembershipAction = (typeof MEMBERSHIP_ACTIONS)[number];
+export const MEMBERSHIP_ACTIONS_WITH_ATTEMPT = ["executed", "carried", "accepted"] as const;
+export const MEMBERSHIP_ACTIONS_WITHOUT_ATTEMPT = ["not-dispatched", "interrupted"] as const;
 
 /** Exact planned identity; its existing digest remains the only execution identity. */
 export interface RecordSlotIdentity {
@@ -111,7 +106,8 @@ export interface RecordAttachmentEnvelope<Family extends string = string> {
   }[];
 }
 
-export type RecordAttachmentOwner = "run" | "attempt";
+export const RECORD_ATTACHMENT_OWNERS = ["run", "attempt"] as const;
+export type RecordAttachmentOwner = (typeof RECORD_ATTACHMENT_OWNERS)[number];
 
 /** In-memory aggregate for cross-document Core refine; never a second disk document. */
 export interface RunCore {

--- a/packages/niceeval/src/record/model/definition.ts
+++ b/packages/niceeval/src/record/model/definition.ts
@@ -14,10 +14,10 @@ import {
   SlotIdSchema,
   UtcMillisSchema,
 } from "../codec/identifiers.ts";
-import type {
-  AttemptOutcome,
-  MemberDocument,
-  MembershipAction,
+import {
+  ATTEMPT_OUTCOMES,
+  MEMBERSHIP_ACTIONS_WITH_ATTEMPT,
+  MEMBERSHIP_ACTIONS_WITHOUT_ATTEMPT,
 } from "./core.ts";
 import { RunContextSchema } from "./run-context.ts";
 import {
@@ -58,20 +58,7 @@ function schemaFilterIssues(
     }));
 }
 
-const AttemptOutcomeSchema = Schema.Literals([
-  "completed",
-  "errored",
-  "cancelled",
-  "interrupted",
-]);
-
-const MembershipActionSchema = Schema.Literals([
-  "executed",
-  "carried",
-  "accepted",
-  "not-dispatched",
-  "interrupted",
-]);
+export const AttemptOutcomeSchema = Schema.Literals(ATTEMPT_OUTCOMES);
 
 /** Durable Slot ordinals are zero-based JSON-safe integers, not array indexes. */
 const AttemptOrdinalSchema = Schema.Number.pipe(
@@ -151,12 +138,12 @@ export const RunDocumentSchema = RunDocumentDefinition.schema;
 const MemberDocumentCurrentSchema = Schema.Union([
   Schema.Struct({
     slotId: SlotIdSchema,
-    action: Schema.Literals(["executed", "carried", "accepted"]),
+    action: Schema.Literals(MEMBERSHIP_ACTIONS_WITH_ATTEMPT),
     attempt: RecordAttemptRefSchema,
   }),
   Schema.Struct({
     slotId: SlotIdSchema,
-    action: Schema.Literals(["not-dispatched", "interrupted"]),
+    action: Schema.Literals(MEMBERSHIP_ACTIONS_WITHOUT_ATTEMPT),
     attempt: Schema.Null,
   }),
 ]).pipe(

--- a/packages/niceeval/src/record/reader/errors.ts
+++ b/packages/niceeval/src/record/reader/errors.ts
@@ -3,6 +3,7 @@ import type { RecordCoordinationError } from "../../coordination/record-leases.t
 import type { RecordFileSystemError } from "../platform/errors.ts";
 import type { RecordWriteError } from "../writer/types.ts";
 import type { SqliteRecordError } from "../sqlite/errors.ts";
+import { RECORD_ATTACHMENT_OWNERS } from "../model/core.ts";
 
 /** `record.json` could not be safely recognized as a usable Record root. */
 export class RecordBootstrapInvalid extends Schema.TaggedError<RecordBootstrapInvalid>()("RecordBootstrapInvalid", {
@@ -48,7 +49,7 @@ export class RecordHandleInvalid extends Schema.TaggedError<RecordHandleInvalid>
 /** The session catalog did not contribute the exact definition needed now. */
 export class FamilyDefinitionRequired extends Schema.TaggedError<FamilyDefinitionRequired>()("FamilyDefinitionRequired", {
   code: Schema.Literal("family-definition-required"),
-  owner: Schema.Literals(["run", "attempt"]),
+  owner: Schema.Literals(RECORD_ATTACHMENT_OWNERS),
   family: Schema.String,
   revision: Schema.Number,
 }) {}

--- a/packages/niceeval/src/record/sqlite/seal.ts
+++ b/packages/niceeval/src/record/sqlite/seal.ts
@@ -106,7 +106,7 @@ export const memberSealEntry = (runId: string, member: Pick<PersistedMember, "sl
 
 export const attachmentSealEntry = (input: {
   readonly attachmentId: string;
-  readonly ownerKind: "run" | "attempt";
+  readonly ownerKind: import("../model/core.ts").RecordAttachmentOwner;
   readonly ownerRunId: string;
   readonly ownerAttemptId?: string;
   readonly family: string;

--- a/packages/niceeval/src/record/sqlite/storage.ts
+++ b/packages/niceeval/src/record/sqlite/storage.ts
@@ -152,7 +152,7 @@ function optionalInteger(row: Row, field: string): number | undefined {
   return integer(row, field);
 }
 
-function ownerKind(row: Row, field: string): "run" | "attempt" {
+function ownerKind(row: Row, field: string): import("../model/core.ts").RecordAttachmentOwner {
   const value = text(row, field);
   if (value !== "run" && value !== "attempt") throw sqliteError("record-database-invalid", "decode-row", `${field} is not an owner kind`);
   return value;

--- a/packages/niceeval/src/record/sqlite/types.ts
+++ b/packages/niceeval/src/record/sqlite/types.ts
@@ -12,7 +12,7 @@ export const RECORD_SQLITE_MAX_VALIDATION_ROWS = 2_000_000;
 export const RECORD_SQLITE_VALIDATION_DEADLINE_MS = 30_000;
 
 export type RunStatus = "open" | "sealing" | "sealed";
-export type RecordOwnerKind = "run" | "attempt";
+export type RecordOwnerKind = import("../model/core.ts").RecordAttachmentOwner;
 export type SealEntryKind =
   | "record"
   | "run"

--- a/packages/niceeval/src/runner/feedback/human.ts
+++ b/packages/niceeval/src/runner/feedback/human.ts
@@ -1470,7 +1470,7 @@ export interface HumanDryPlanRow {
   prior?: readonly {
     attempt?: number;
     locator: string;
-    verdict: "passed" | "failed" | "errored" | "skipped";
+    verdict: import("../../shared/types.ts").Verdict;
     acceptance: "available" | "legacy-locator";
     evidenceState?: "local" | "borrowed" | "dangling";
     comparison?: HumanFingerprintComparison;

--- a/packages/niceeval/src/runner/feedback/json.ts
+++ b/packages/niceeval/src/runner/feedback/json.ts
@@ -679,7 +679,7 @@ export interface JsonPlanRow {
   /** previous-result 历史结果。`acceptance: legacy-locator` 表示旧 locator 不符合当前命令语法，不能接受。 */
   prior?: readonly {
     locator: string;
-    verdict: "passed" | "failed" | "errored" | "skipped";
+    verdict: import("../../shared/types.ts").Verdict;
     acceptance: "available" | "legacy-locator";
     evidenceState: "local" | "borrowed" | "dangling";
   }[];

--- a/packages/niceeval/src/runner/reuse-plan.ts
+++ b/packages/niceeval/src/runner/reuse-plan.ts
@@ -10,6 +10,12 @@ import {
   type DurationLimit,
 } from "../eval/record/eligibility.ts";
 import {
+  COMPARISON_SOURCE_STATES,
+  type ComparisonAttachment,
+  type ComparisonResult,
+  type RecordedAttemptClaim,
+} from "../eval/record/membership-provenance.ts";
+import {
   foldRecordedAttemptVerdict,
   type VerdictState,
 } from "../eval/record/verdict.ts";
@@ -66,22 +72,17 @@ export interface ExecutionDurationLimit {
  * folds Core outcome with Assertions, and reads duration from Runner Activity
  * receipts. None of these facts is a separate eligibility/verdict family.
  */
-export type ExecutionComparisonAttachment =
-  | "core"
-  | "niceeval.assertions"
-  | "niceeval.runner-activities";
-export type ExecutionComparisonSourceState =
-  | "available"
-  | "unavailable"
-  | "migration-required"
-  | "unsupported"
-  | "invalid";
-export type ExecutionComparisonResult = "match" | "mismatch" | "ineligible" | "not-comparable";
-export type ExecutionRecordedClaim =
-  | "execution-identity"
-  | "attempt-outcome"
-  | "assertion-verdict"
-  | "execution-duration";
+export const EXECUTION_COMPARISON_PROJECTION_STATE = Object.freeze({
+  migrationRequired: "migration-required" as const,
+});
+export const EXECUTION_COMPARISON_SOURCE_STATES = [
+  ...COMPARISON_SOURCE_STATES,
+  EXECUTION_COMPARISON_PROJECTION_STATE.migrationRequired,
+] as const;
+export type ExecutionComparisonAttachment = ComparisonAttachment;
+export type ExecutionComparisonSourceState = (typeof EXECUTION_COMPARISON_SOURCE_STATES)[number];
+export type ExecutionComparisonResult = ComparisonResult;
+export type ExecutionRecordedClaim = RecordedAttemptClaim;
 
 export interface ExecutionComparison {
   readonly attachment: ExecutionComparisonAttachment;
@@ -754,7 +755,7 @@ function attachmentProblem(input: {
     case "migration-required":
       return Object.freeze({
         reason: "source-attachment-migration-required" as const,
-        state: "migration-required" as const,
+        state: EXECUTION_COMPARISON_PROJECTION_STATE.migrationRequired,
         issues: Object.freeze([]),
       });
     case "unsupported":

--- a/packages/niceeval/src/runner/source-receipts/model/agent-turns.ts
+++ b/packages/niceeval/src/runner/source-receipts/model/agent-turns.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { AGENT_TURN_OUTCOMES } from "../../../record/family/protocol-values.ts";
 
 import {
   CallIdSchema,
@@ -41,7 +42,7 @@ const ConversationItemBaseFields = {
 export const ConversationTurnSchema = Schema.Struct({
   turnId: TurnIdSchema,
   sequence: PositiveSafeIntegerSchema,
-  outcome: Schema.Literals(["completed", "failed", "cancelled", "interrupted"]),
+  outcome: Schema.Literals(AGENT_TURN_OUTCOMES),
   refs: ConversationReferencesSchema,
 });
 

--- a/packages/niceeval/src/runner/source-receipts/model/runner-activities.ts
+++ b/packages/niceeval/src/runner/source-receipts/model/runner-activities.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { ACTIVITY_OUTCOMES, ATTEMPT_ACTIVITY_PHASES, RUN_ACTIVITY_PHASES } from "../../../record/family/protocol-values.ts";
 
 import { isCanonicalTurnLabel } from "../../../shared/turn-label.ts";
 import {
@@ -20,11 +21,11 @@ import {
   payloadFits,
 } from "./common.ts";
 
-export const AttemptTimingPhaseSchema = Schema.Literals(["attempt.setup", "sandbox.prepare", "agent.ensure", "eval.run", "agent.send", "sandbox.command", "assertion.evaluate", "verdict.fold", "attempt.teardown"]);
+export const AttemptTimingPhaseSchema = Schema.Literals(ATTEMPT_ACTIVITY_PHASES);
 
-export const RunTimingPhaseSchema = Schema.Literals(["run.setup", "run.discovery", "run.plan", "run.dispatch", "run.teardown"]);
+export const RunTimingPhaseSchema = Schema.Literals(RUN_ACTIVITY_PHASES);
 
-const TimingOutcomeSchema = Schema.Literals(["completed", "failed", "cancelled", "interrupted", "unknown"]);
+const TimingOutcomeSchema = Schema.Literals(ACTIVITY_OUTCOMES);
 
 const CanonicalTurnLabelSchema = Schema.String.pipe(
   Schema.check(Schema.makeFilter((value): value is string => isCanonicalTurnLabel(value), { identifier: "CanonicalTurnLabel" })),

--- a/packages/niceeval/src/runner/source-receipts/model/runner-diagnostics.ts
+++ b/packages/niceeval/src/runner/source-receipts/model/runner-diagnostics.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { ATTEMPT_DIAGNOSTIC_PHASES, RUN_DIAGNOSTIC_PHASES } from "../../../record/family/protocol-values.ts";
 
 import {
   Sha256DigestSchema,
@@ -34,9 +35,9 @@ import {
   payloadFits,
 } from "./common.ts";
 
-export const AttemptDiagnosticPhaseSchema = Schema.Literals(["attempt.setup", "sandbox.prepare", "agent.ensure", "eval.run", "agent.send", "sandbox.command", "assertion.evaluate", "verdict.fold", "attempt.teardown", "collection"]);
+export const AttemptDiagnosticPhaseSchema = Schema.Literals(ATTEMPT_DIAGNOSTIC_PHASES);
 
-export const RunDiagnosticPhaseSchema = Schema.Literals(["run.setup", "run.discovery", "run.plan", "run.dispatch", "run.teardown", "collection"]);
+export const RunDiagnosticPhaseSchema = Schema.Literals(RUN_DIAGNOSTIC_PHASES);
 
 export const SourcePositionSchema = Schema.Struct({
   line: PositiveSafeIntegerSchema,

--- a/packages/niceeval/src/runner/source-receipts/runtime/state.ts
+++ b/packages/niceeval/src/runner/source-receipts/runtime/state.ts
@@ -157,11 +157,11 @@ export interface CapturedCommandResult {
     | { readonly kind: "exited"; readonly exitCode: number }
     | {
         readonly kind: "terminated";
-        readonly reason: "timeout" | "cancelled" | "transport-lost";
+        readonly reason: (typeof import("../../../record/family/protocol-values.ts").COMMAND_TERMINATION_REASONS)[number];
       }
     | {
         readonly kind: "not-started";
-        readonly reason: "spawn-failed" | "cancelled-before-start";
+        readonly reason: (typeof import("../../../record/family/protocol-values.ts").COMMAND_NOT_STARTED_REASONS)[number];
       };
   readonly stdout: StagedCommandStream;
   readonly stderr: StagedCommandStream;

--- a/packages/niceeval/src/runner/types.ts
+++ b/packages/niceeval/src/runner/types.ts
@@ -644,7 +644,8 @@ export type ReporterEvent =
  * `"score"`(计分制,题内叠加挣分,读总分)。定义期事实,发现期从 `EvalDefinition.evaluationKind` 直接读取,
  * 不靠执行 `test()` 推断(见 docs/feature/experiments/score-points.md)。
  */
-export type EvaluationKind = "pass" | "score";
+import type { EvaluationKind } from "../shared/evaluation.ts";
+export type { EvaluationKind } from "../shared/evaluation.ts";
 
 /** The live Runner derives Pass and Score from one sealed Assert-first entry sequence. */
 export const EVALUATION_ALGORITHM = "assert-first/v2" as const;

--- a/packages/niceeval/src/sandbox/docker-cache-repository.ts
+++ b/packages/niceeval/src/sandbox/docker-cache-repository.ts
@@ -2,20 +2,71 @@ import { createHash } from "node:crypto";
 import { DatabaseSync } from "node:sqlite";
 import { UserDatabaseInvalid } from "../user-database/errors.ts";
 import type { UserDatabaseRepositoryHandler } from "../user-database/repository.ts";
+import {
+  isFiniteValue,
+  sqlIn,
+  sqlLiteral,
+  type FiniteValue,
+} from "./finite-domain.ts";
+
+const DOCKER_CACHE_STATE = Object.freeze({
+  reserved: "reserved", building: "building", published: "published", indexed: "indexed",
+  invalidated: "invalidated", deleting: "deleting", tombstoned: "tombstoned", unverified: "unverified",
+  prepared: "prepared", active: "active", releasing: "releasing", released: "released",
+  expiredUnverified: "expired-unverified", ended: "ended",
+} as const);
+const DOCKER_CACHE_KIND = Object.freeze({ taskBuild: "task-build", sandboxSetupPrefix: "sandbox-setup-prefix" } as const);
+const DOCKER_LEASE_KIND = Object.freeze({ build: "build", read: "read", handoff: "handoff" } as const);
+const DOCKER_CACHE_DOMAIN = Object.freeze({
+  providerFamily: "docker", adminProtocolVersion: 1, backendKind: "docker-images",
+  verifiedState: "verified-managed", setupDependency: "parent-backed",
+} as const);
+const DOCKER_RESERVATION_DISPOSITION = Object.freeze({ reserved: "reserved", contended: "contended" } as const);
+const DOCKER_CONTENTION_REASON = Object.freeze({ activeWriter: "active-writer", indexedGeneration: "indexed-generation" } as const);
+const DOCKER_RESERVATION_REASON = Object.freeze({
+  entryChanged: "entry-changed", entryMissing: "entry-missing",
+  entryLeaseRootOrCrossKindClaim: "entry-lease-root-or-cross-kind-claim",
+  activeOwnerOrCrossKindClaim: "active-owner-or-cross-kind-claim", activeDeleteConflict: "active-delete-conflict",
+} as const);
+const DOCKER_CONTENTION_REASONS = Object.freeze(Object.values(DOCKER_CONTENTION_REASON));
+const DOCKER_RESERVATION_REASONS = Object.freeze(Object.values(DOCKER_RESERVATION_REASON));
+const DOCKER_TASK_ENTRY_STATES = Object.freeze([
+  DOCKER_CACHE_STATE.indexed, DOCKER_CACHE_STATE.deleting, DOCKER_CACHE_STATE.tombstoned, DOCKER_CACHE_STATE.unverified,
+] as const);
+const DOCKER_SETUP_ENTRY_STATES = Object.freeze([
+  DOCKER_CACHE_STATE.reserved, DOCKER_CACHE_STATE.building, DOCKER_CACHE_STATE.published, DOCKER_CACHE_STATE.indexed,
+  DOCKER_CACHE_STATE.invalidated, DOCKER_CACHE_STATE.deleting, DOCKER_CACHE_STATE.tombstoned, DOCKER_CACHE_STATE.unverified,
+] as const);
+const DOCKER_SETUP_WRITER_STATES = Object.freeze([
+  DOCKER_CACHE_STATE.reserved, DOCKER_CACHE_STATE.building, DOCKER_CACHE_STATE.published, DOCKER_CACHE_STATE.deleting,
+] as const);
+const DOCKER_SETUP_STARTUP_STATES = Object.freeze([
+  DOCKER_CACHE_STATE.reserved, DOCKER_CACHE_STATE.building, DOCKER_CACHE_STATE.published,
+  DOCKER_CACHE_STATE.indexed, DOCKER_CACHE_STATE.deleting,
+] as const);
+const DOCKER_SETUP_RESERVABLE_STATES = Object.freeze([DOCKER_CACHE_STATE.reserved, DOCKER_CACHE_STATE.building] as const);
+const DOCKER_SETUP_PUBLICATION_STATES = Object.freeze([DOCKER_CACHE_STATE.published, DOCKER_CACHE_STATE.indexed] as const);
+const DOCKER_DELETE_SETTLEMENT_STATES = Object.freeze([
+  DOCKER_CACHE_STATE.indexed, DOCKER_CACHE_STATE.tombstoned, DOCKER_CACHE_STATE.unverified,
+] as const);
+const DOCKER_DELETE_RECOVERY_STATES = Object.freeze([DOCKER_CACHE_STATE.tombstoned, DOCKER_CACHE_STATE.unverified] as const);
+const DOCKER_DELETE_TRANSITION_STATES = Object.freeze([DOCKER_CACHE_STATE.tombstoned, DOCKER_CACHE_STATE.deleting] as const);
+const DOCKER_TASK_ROOT_STATES = Object.freeze([DOCKER_CACHE_STATE.prepared, DOCKER_CACHE_STATE.active] as const);
+const DOCKER_SETUP_ROOT_STATES = Object.freeze([
+  DOCKER_CACHE_STATE.prepared, DOCKER_CACHE_STATE.active, DOCKER_CACHE_STATE.releasing,
+] as const);
+const DOCKER_SETUP_LEASE_STATES = Object.freeze([
+  DOCKER_CACHE_STATE.active, DOCKER_CACHE_STATE.released, DOCKER_CACHE_STATE.expiredUnverified, DOCKER_CACHE_STATE.ended,
+] as const);
+const DOCKER_ACTIVE_SETUP_LEASE_STATES = Object.freeze([DOCKER_CACHE_STATE.active, DOCKER_CACHE_STATE.expiredUnverified] as const);
+const DOCKER_CACHE_KINDS = Object.freeze([DOCKER_CACHE_KIND.taskBuild, DOCKER_CACHE_KIND.sandboxSetupPrefix] as const);
+const DOCKER_SETUP_LEASE_KINDS = Object.freeze([DOCKER_LEASE_KIND.build, DOCKER_LEASE_KIND.read, DOCKER_LEASE_KIND.handoff] as const);
 
 export const DOCKER_CACHE_REPOSITORY = "docker-cache" as const;
 export const DOCKER_CACHE_REPOSITORY_REVISION = 1;
 
-export type DockerCacheEntryState = "indexed" | "deleting" | "tombstoned" | "unverified";
-export type DockerSetupPrefixEntryState =
-  | "reserved"
-  | "building"
-  | "published"
-  | "indexed"
-  | "invalidated"
-  | "deleting"
-  | "tombstoned"
-  | "unverified";
+export type DockerCacheEntryState = FiniteValue<typeof DOCKER_TASK_ENTRY_STATES>;
+export type DockerSetupPrefixEntryState = FiniteValue<typeof DOCKER_SETUP_ENTRY_STATES>;
 
 export interface DockerCacheDomainRow {
   readonly domainId: string;
@@ -25,12 +76,12 @@ export interface DockerCacheDomainRow {
   readonly sentinelId: string;
   readonly backendIdentity: string;
   readonly authorityEpoch: string;
-  readonly providerFamily: "docker";
-  readonly adminProtocolVersion: 1;
-  readonly backendKind: "docker-images";
+  readonly providerFamily: typeof DOCKER_CACHE_DOMAIN.providerFamily;
+  readonly adminProtocolVersion: typeof DOCKER_CACHE_DOMAIN.adminProtocolVersion;
+  readonly backendKind: typeof DOCKER_CACHE_DOMAIN.backendKind;
   readonly firstVerifiedAt: string;
   readonly lastVerifiedAt: string;
-  readonly lastState: "verified-managed";
+  readonly lastState: typeof DOCKER_CACHE_DOMAIN.verifiedState;
 }
 
 export interface DockerTaskBuildEntryRow {
@@ -64,13 +115,13 @@ export interface DockerTaskBuildRootRow {
   readonly holderBootId: string;
   readonly holderProcessStart: string;
   readonly generation: number;
-  readonly state: "prepared" | "active";
+  readonly state: FiniteValue<typeof DOCKER_TASK_ROOT_STATES>;
   readonly createdAt: string;
 }
 
 export interface DockerImageGcLockRow {
   readonly imageId: string;
-  readonly cacheKind: "task-build" | "sandbox-setup-prefix";
+  readonly cacheKind: FiniteValue<typeof DOCKER_CACHE_KINDS>;
   readonly planId: string;
   readonly entryId: string;
   readonly entryGeneration: number;
@@ -90,7 +141,7 @@ export interface DockerSetupPrefixEntryRow {
   readonly setupManifestDigest: string;
   readonly storageSchemaRevision: string;
   readonly artifactFormatRevision: string;
-  readonly dependency: "parent-backed";
+  readonly dependency: typeof DOCKER_CACHE_DOMAIN.setupDependency;
   readonly changeFrequency: number;
   readonly generation: number;
   readonly operationId: string;
@@ -105,7 +156,7 @@ export interface DockerSetupPrefixLeaseRow {
   readonly entryId: string;
   readonly setupPrefixKey: string;
   readonly generation: number;
-  readonly kind: "build" | "read" | "handoff";
+  readonly kind: FiniteValue<typeof DOCKER_SETUP_LEASE_KINDS>;
   readonly operationId: string;
   readonly holderHostId: string;
   readonly holderBootId: string;
@@ -114,7 +165,7 @@ export interface DockerSetupPrefixLeaseRow {
   readonly heartbeatSequence: number;
   readonly heartbeatAt: string;
   readonly expiresAt: string;
-  readonly state: "active" | "released" | "expired-unverified" | "ended";
+  readonly state: FiniteValue<typeof DOCKER_SETUP_LEASE_STATES>;
 }
 
 export interface DockerSetupPrefixRootRow {
@@ -125,7 +176,7 @@ export interface DockerSetupPrefixRootRow {
   readonly sandboxId: string;
   readonly sandboxResourceIdentity: string;
   readonly operationId: string;
-  readonly state: "prepared" | "active" | "releasing";
+  readonly state: FiniteValue<typeof DOCKER_SETUP_ROOT_STATES>;
   readonly createdAt: string;
 }
 
@@ -169,9 +220,9 @@ export type DockerCacheRepositoryRequest =
   | RepositoryRequestBase & { readonly operation: "task-get-plan"; readonly domainId: string; readonly planId: string }
   | RepositoryRequestBase & { readonly operation: "task-save-plan-outcome"; readonly domainId: string; readonly planId: string; readonly outcome: string }
   | RepositoryRequestBase & { readonly operation: "task-reserve-delete"; readonly domainId: string; readonly planId: string; readonly entry: DockerTaskBuildEntryRow; readonly evidenceDigest: string; readonly holder: DockerHolderIdentity; readonly createdAt: string }
-  | RepositoryRequestBase & { readonly operation: "task-settle-delete"; readonly domainId: string; readonly planId: string; readonly buildKey: string; readonly imageId: string; readonly generation: number; readonly state: "indexed" | "tombstoned" | "unverified" }
+  | RepositoryRequestBase & { readonly operation: "task-settle-delete"; readonly domainId: string; readonly planId: string; readonly buildKey: string; readonly imageId: string; readonly generation: number; readonly state: FiniteValue<typeof DOCKER_DELETE_SETTLEMENT_STATES> }
   | RepositoryRequestBase & { readonly operation: "task-list-delete-locks"; readonly domainId: string }
-  | RepositoryRequestBase & { readonly operation: "task-recover-delete"; readonly domainId: string; readonly lock: DockerImageGcLockRow; readonly buildKey: string; readonly state: "tombstoned" | "unverified" }
+  | RepositoryRequestBase & { readonly operation: "task-recover-delete"; readonly domainId: string; readonly lock: DockerImageGcLockRow; readonly buildKey: string; readonly state: FiniteValue<typeof DOCKER_DELETE_RECOVERY_STATES> }
   | RepositoryRequestBase & { readonly operation: "setup-startup-snapshot"; readonly domainId: string }
   | RepositoryRequestBase & { readonly operation: "setup-prune-leases"; readonly domainId: string; readonly deleteLeaseIds: readonly string[]; readonly unverifiableLeaseIds: readonly string[] }
   | RepositoryRequestBase & { readonly operation: "setup-startup-isolate"; readonly domainId: string; readonly entryId: string; readonly imageId: string | null }
@@ -192,7 +243,7 @@ export type DockerCacheRepositoryRequest =
   | RepositoryRequestBase & { readonly operation: "setup-image-claims"; readonly domainId: string; readonly imageId: string; readonly exceptEntryId: string }
   | RepositoryRequestBase & { readonly operation: "setup-list-reclaim-candidates"; readonly domainId: string; readonly replacementScope?: string; readonly exceptEntryId?: string }
   | RepositoryRequestBase & { readonly operation: "setup-reserve-delete"; readonly domainId: string; readonly entryId: string; readonly planId: string; readonly holder: DockerHolderIdentity; readonly createdAt: string }
-  | RepositoryRequestBase & { readonly operation: "setup-settle-delete"; readonly domainId: string; readonly entryId: string; readonly imageId: string; readonly generation: number; readonly state: "indexed" | "tombstoned" | "unverified" };
+  | RepositoryRequestBase & { readonly operation: "setup-settle-delete"; readonly domainId: string; readonly entryId: string; readonly imageId: string; readonly generation: number; readonly state: FiniteValue<typeof DOCKER_DELETE_SETTLEMENT_STATES> };
 
 type Result<Operation extends DockerCacheRepositoryRequest["operation"], Value extends object = Record<never, never>> = Readonly<{
   repository: typeof DOCKER_CACHE_REPOSITORY;
@@ -205,7 +256,7 @@ export type DockerCacheRepositoryResult =
   | Result<"list-domains", { readonly domains: readonly DockerCacheDomainRow[] }>
   | Result<"task-get-indexed", { readonly entry: DockerTaskBuildEntryRow | null }>
   | Result<"task-mark-unverified" | "task-publish" | "task-heartbeat" | "task-release-use" | "task-prune-owners" | "task-save-plan" | "task-save-plan-outcome" | "task-settle-delete" | "task-recover-delete" | "setup-prune-leases" | "setup-startup-isolate" | "setup-startup-validate" | "setup-release-lease" | "setup-mark-unverified" | "setup-publish-reserve" | "setup-publish-settle" | "setup-prepare-root" | "setup-activate-root" | "setup-remove-root" | "setup-begin-root-release" | "setup-finish-root-release" | "setup-mark-used" | "setup-settle-delete", { readonly changes: number }>
-  | Result<"task-acquire-use" | "task-reserve-delete" | "setup-reserve-delete", { readonly reserved: boolean; readonly reason?: string }>
+  | Result<"task-acquire-use" | "task-reserve-delete" | "setup-reserve-delete", { readonly reserved: boolean; readonly reason?: FiniteValue<typeof DOCKER_RESERVATION_REASONS> }>
   | Result<"task-list-entries", { readonly entries: readonly DockerTaskBuildEntryRow[] }>
   | Result<"task-list-owners", { readonly leases: readonly DockerTaskBuildLeaseRow[]; readonly roots: readonly DockerTaskBuildRootRow[] }>
   | Result<"task-read-safety-revision", { readonly revision: number }>
@@ -213,7 +264,7 @@ export type DockerCacheRepositoryResult =
   | Result<"task-list-delete-locks", { readonly locks: readonly DockerImageGcLockRow[] }>
   | Result<"setup-startup-snapshot", { readonly entries: readonly DockerSetupPrefixEntryRow[]; readonly leases: readonly DockerSetupPrefixLeaseRow[]; readonly locks: readonly DockerImageGcLockRow[] }>
   | Result<"setup-acquire-indexed", { readonly entry: DockerSetupPrefixEntryRow | null }>
-  | Result<"setup-reserve", { readonly state: "reserved"; readonly entry: DockerSetupPrefixEntryRow } | { readonly state: "contended"; readonly reason: "active-writer" | "indexed-generation" }>
+  | Result<"setup-reserve", { readonly state: typeof DOCKER_RESERVATION_DISPOSITION.reserved; readonly entry: DockerSetupPrefixEntryRow } | { readonly state: typeof DOCKER_RESERVATION_DISPOSITION.contended; readonly reason: FiniteValue<typeof DOCKER_CONTENTION_REASONS> }>
   | Result<"setup-heartbeat", { readonly changes: number }>
   | Result<"setup-image-claims", { readonly gcLocked: boolean; readonly taskBuildClaim: boolean; readonly siblingSetupPrefixClaim: boolean }>
   | Result<"setup-list-reclaim-candidates", { readonly entries: readonly DockerSetupPrefixEntryRow[] }>;
@@ -246,9 +297,9 @@ const CREATE_SCHEMA = `
 CREATE TABLE ${TABLES.domains} (
   domain_id TEXT PRIMARY KEY, owner_id TEXT NOT NULL, daemon_id TEXT NOT NULL, storage_driver TEXT NOT NULL,
   sentinel_id TEXT NOT NULL, backend_identity TEXT NOT NULL, authority_epoch TEXT NOT NULL,
-  provider_family TEXT NOT NULL CHECK(provider_family = 'docker'), admin_protocol_version INTEGER NOT NULL CHECK(admin_protocol_version = 1),
-  backend_kind TEXT NOT NULL CHECK(backend_kind = 'docker-images'), first_verified_at TEXT NOT NULL,
-  last_verified_at TEXT NOT NULL, last_state TEXT NOT NULL CHECK(last_state = 'verified-managed')
+  provider_family TEXT NOT NULL CHECK(provider_family = ${sqlLiteral(DOCKER_CACHE_DOMAIN.providerFamily)}), admin_protocol_version INTEGER NOT NULL CHECK(admin_protocol_version = ${DOCKER_CACHE_DOMAIN.adminProtocolVersion}),
+  backend_kind TEXT NOT NULL CHECK(backend_kind = ${sqlLiteral(DOCKER_CACHE_DOMAIN.backendKind)}), first_verified_at TEXT NOT NULL,
+  last_verified_at TEXT NOT NULL, last_state TEXT NOT NULL CHECK(last_state = ${sqlLiteral(DOCKER_CACHE_DOMAIN.verifiedState)})
 ) STRICT;
 CREATE TABLE ${TABLES.metadata} (
   domain_id TEXT NOT NULL, key TEXT NOT NULL, value TEXT NOT NULL, PRIMARY KEY(domain_id, key)
@@ -257,7 +308,7 @@ CREATE TABLE ${TABLES.taskEntries} (
   domain_id TEXT NOT NULL REFERENCES ${TABLES.domains}(domain_id), build_key TEXT NOT NULL, tag TEXT NOT NULL,
   image_id TEXT NOT NULL, created_at TEXT NOT NULL, last_successful_use_at TEXT, protected_until TEXT NOT NULL,
   manifest_digest TEXT NOT NULL, generation INTEGER NOT NULL, operation_id TEXT NOT NULL,
-  state TEXT NOT NULL CHECK(state IN ('indexed','deleting','tombstoned','unverified')),
+  state TEXT NOT NULL CHECK(state IN (${sqlIn(DOCKER_TASK_ENTRY_STATES)})),
   PRIMARY KEY(domain_id, build_key)
 ) STRICT;
 CREATE TABLE ${TABLES.taskLeases} (
@@ -269,7 +320,7 @@ CREATE TABLE ${TABLES.taskLeases} (
 CREATE TABLE ${TABLES.taskRoots} (
   domain_id TEXT NOT NULL, root_id TEXT NOT NULL, build_key TEXT NOT NULL, generation INTEGER NOT NULL,
   holder_boot_id TEXT NOT NULL, holder_pid INTEGER NOT NULL, holder_process_start TEXT NOT NULL,
-  state TEXT NOT NULL CHECK(state IN ('prepared','active')), created_at TEXT NOT NULL, PRIMARY KEY(domain_id, root_id),
+  state TEXT NOT NULL CHECK(state IN (${sqlIn(DOCKER_TASK_ROOT_STATES)})), created_at TEXT NOT NULL, PRIMARY KEY(domain_id, root_id),
   FOREIGN KEY(domain_id, build_key) REFERENCES ${TABLES.taskEntries}(domain_id, build_key)
 ) STRICT;
 CREATE TABLE ${TABLES.plans} (
@@ -278,7 +329,7 @@ CREATE TABLE ${TABLES.plans} (
 ) STRICT;
 CREATE TABLE ${TABLES.locks} (
   domain_id TEXT NOT NULL REFERENCES ${TABLES.domains}(domain_id), image_id TEXT NOT NULL,
-  cache_kind TEXT NOT NULL CHECK(cache_kind IN ('task-build','sandbox-setup-prefix')), plan_id TEXT NOT NULL,
+  cache_kind TEXT NOT NULL CHECK(cache_kind IN (${sqlIn(DOCKER_CACHE_KINDS)})), plan_id TEXT NOT NULL,
   entry_id TEXT NOT NULL, entry_generation INTEGER NOT NULL, holder_pid INTEGER NOT NULL,
   holder_boot_id TEXT NOT NULL, holder_process_start TEXT NOT NULL, created_at TEXT NOT NULL,
   PRIMARY KEY(domain_id, image_id)
@@ -287,13 +338,13 @@ CREATE TABLE ${TABLES.setupEntries} (
   domain_id TEXT NOT NULL REFERENCES ${TABLES.domains}(domain_id), entry_id TEXT NOT NULL, setup_prefix_key TEXT NOT NULL,
   base_image_id TEXT NOT NULL, image_id TEXT, declaration_json TEXT NOT NULL, declaration_digest TEXT NOT NULL,
   setup_manifest_digest TEXT NOT NULL, storage_schema_revision TEXT NOT NULL, artifact_format_revision TEXT NOT NULL,
-  dependency TEXT NOT NULL CHECK(dependency = 'parent-backed'), change_frequency REAL NOT NULL, generation INTEGER NOT NULL,
+  dependency TEXT NOT NULL CHECK(dependency = ${sqlLiteral(DOCKER_CACHE_DOMAIN.setupDependency)}), change_frequency REAL NOT NULL, generation INTEGER NOT NULL,
   operation_id TEXT NOT NULL, created_at TEXT NOT NULL, last_successful_use_at TEXT, protected_until TEXT NOT NULL,
-  state TEXT NOT NULL CHECK(state IN ('reserved','building','published','indexed','invalidated','deleting','tombstoned','unverified')),
+  state TEXT NOT NULL CHECK(state IN (${sqlIn(DOCKER_SETUP_ENTRY_STATES)})),
   PRIMARY KEY(domain_id, entry_id), UNIQUE(domain_id, setup_prefix_key, generation)
 ) STRICT;
 CREATE UNIQUE INDEX docker_setup_prefix_writer ON ${TABLES.setupEntries}(domain_id, setup_prefix_key)
-  WHERE state IN ('reserved','building','published','deleting');
+  WHERE state IN (${sqlIn(DOCKER_SETUP_WRITER_STATES)});
 CREATE TABLE ${TABLES.setupIndex} (
   domain_id TEXT NOT NULL, setup_prefix_key TEXT NOT NULL, entry_id TEXT NOT NULL,
   PRIMARY KEY(domain_id, setup_prefix_key), UNIQUE(domain_id, entry_id),
@@ -315,16 +366,16 @@ CREATE TABLE ${TABLES.setupHeads} (
 ) STRICT;
 CREATE TABLE ${TABLES.setupLeases} (
   domain_id TEXT NOT NULL, lease_id TEXT NOT NULL, entry_id TEXT NOT NULL, setup_prefix_key TEXT NOT NULL,
-  generation INTEGER NOT NULL, kind TEXT NOT NULL CHECK(kind IN ('build','read','handoff')), operation_id TEXT NOT NULL,
+  generation INTEGER NOT NULL, kind TEXT NOT NULL CHECK(kind IN (${sqlIn(DOCKER_SETUP_LEASE_KINDS)})), operation_id TEXT NOT NULL,
   holder_host_id TEXT NOT NULL, holder_boot_id TEXT NOT NULL, holder_pid INTEGER NOT NULL,
   holder_process_start TEXT NOT NULL, heartbeat_sequence INTEGER NOT NULL, heartbeat_at TEXT NOT NULL,
-  expires_at TEXT NOT NULL, state TEXT NOT NULL CHECK(state IN ('active','released','expired-unverified','ended')),
+  expires_at TEXT NOT NULL, state TEXT NOT NULL CHECK(state IN (${sqlIn(DOCKER_SETUP_LEASE_STATES)})),
   PRIMARY KEY(domain_id, lease_id), FOREIGN KEY(domain_id, entry_id) REFERENCES ${TABLES.setupEntries}(domain_id, entry_id)
 ) STRICT;
 CREATE TABLE ${TABLES.setupRoots} (
   domain_id TEXT NOT NULL, root_id TEXT NOT NULL, entry_id TEXT NOT NULL, setup_prefix_key TEXT NOT NULL,
   generation INTEGER NOT NULL, sandbox_id TEXT NOT NULL, sandbox_resource_identity TEXT NOT NULL,
-  operation_id TEXT NOT NULL, state TEXT NOT NULL CHECK(state IN ('prepared','active','releasing')),
+  operation_id TEXT NOT NULL, state TEXT NOT NULL CHECK(state IN (${sqlIn(DOCKER_SETUP_ROOT_STATES)})),
   created_at TEXT NOT NULL, PRIMARY KEY(domain_id, root_id),
   FOREIGN KEY(domain_id, entry_id) REFERENCES ${TABLES.setupEntries}(domain_id, entry_id)
 ) STRICT;
@@ -415,25 +466,25 @@ function record(value: unknown, label: string): Record<string, unknown> {
 function taskEntry(row: unknown): DockerTaskBuildEntryRow {
   const value = record(row, "task-build row");
   const state = exactString(value.state, "task-build state");
-  if (!["indexed", "deleting", "tombstoned", "unverified"].includes(state)) throw invalid(`docker-cache task-build state ${state} is invalid`);
+  if (!isFiniteValue(DOCKER_TASK_ENTRY_STATES, state)) throw invalid(`docker-cache task-build state ${state} is invalid`);
   return Object.freeze({
     buildKey: exactString(value.build_key, "build_key"), tag: exactString(value.tag, "tag"),
     imageId: exactString(value.image_id, "image_id"), createdAt: exactString(value.created_at, "created_at"),
     lastSuccessfulUseAt: nullableString(value.last_successful_use_at, "last_successful_use_at"),
     protectedUntil: exactString(value.protected_until, "protected_until"),
     manifestDigest: exactString(value.manifest_digest, "manifest_digest"), generation: exactInteger(value.generation, "generation"),
-    operationId: exactString(value.operation_id, "operation_id"), state: state as DockerCacheEntryState,
+    operationId: exactString(value.operation_id, "operation_id"), state,
   });
 }
 
 function setupEntry(row: unknown): DockerSetupPrefixEntryRow {
   const value = record(row, "setup-prefix row");
-  const state = exactString(value.state, "setup-prefix state") as DockerSetupPrefixEntryState;
-  if (!["reserved", "building", "published", "indexed", "invalidated", "deleting", "tombstoned", "unverified"].includes(state)) {
+  const state = exactString(value.state, "setup-prefix state");
+  if (!isFiniteValue(DOCKER_SETUP_ENTRY_STATES, state)) {
     throw invalid(`docker-cache setup-prefix state ${state} is invalid`);
   }
   const dependency = exactString(value.dependency, "dependency");
-  if (dependency !== "parent-backed") throw invalid(`docker-cache setup-prefix dependency ${dependency} is invalid`);
+  if (dependency !== DOCKER_CACHE_DOMAIN.setupDependency) throw invalid(`docker-cache setup-prefix dependency ${dependency} is invalid`);
   const changeFrequency = value.change_frequency;
   if (typeof changeFrequency !== "number" || !Number.isFinite(changeFrequency) || changeFrequency < 0) {
     throw invalid("docker-cache change_frequency is invalid");
@@ -465,7 +516,7 @@ function taskLease(row: unknown): DockerTaskBuildLeaseRow {
 function taskRoot(row: unknown): DockerTaskBuildRootRow {
   const value = record(row, "task-build root");
   const state = exactString(value.state, "root state");
-  if (state !== "prepared" && state !== "active") throw invalid(`docker-cache task root state ${state} is invalid`);
+  if (!isFiniteValue(DOCKER_TASK_ROOT_STATES, state)) throw invalid(`docker-cache task root state ${state} is invalid`);
   return Object.freeze({
     rootId: exactString(value.root_id, "root_id"), buildKey: exactString(value.build_key, "build_key"),
     holderPid: exactInteger(value.holder_pid, "holder_pid"), holderBootId: exactString(value.holder_boot_id, "holder_boot_id"),
@@ -477,9 +528,9 @@ function taskRoot(row: unknown): DockerTaskBuildRootRow {
 function setupLease(row: unknown): DockerSetupPrefixLeaseRow {
   const value = record(row, "setup-prefix lease");
   const kind = exactString(value.kind, "kind");
-  if (kind !== "build" && kind !== "read" && kind !== "handoff") throw invalid(`docker-cache setup-prefix lease kind ${kind} is invalid`);
+  if (!isFiniteValue(DOCKER_SETUP_LEASE_KINDS, kind)) throw invalid(`docker-cache setup-prefix lease kind ${kind} is invalid`);
   const state = exactString(value.state, "state");
-  if (state !== "active" && state !== "released" && state !== "expired-unverified" && state !== "ended") {
+  if (!isFiniteValue(DOCKER_SETUP_LEASE_STATES, state)) {
     throw invalid(`docker-cache setup-prefix lease state ${state} is invalid`);
   }
   return Object.freeze({
@@ -496,7 +547,7 @@ function setupLease(row: unknown): DockerSetupPrefixLeaseRow {
 function gcLock(row: unknown): DockerImageGcLockRow {
   const value = record(row, "GC lock");
   const cacheKind = exactString(value.cache_kind, "cache_kind");
-  if (cacheKind !== "task-build" && cacheKind !== "sandbox-setup-prefix") throw invalid(`docker-cache kind ${cacheKind} is invalid`);
+  if (!isFiniteValue(DOCKER_CACHE_KINDS, cacheKind)) throw invalid(`docker-cache kind ${cacheKind} is invalid`);
   return Object.freeze({
     imageId: exactString(value.image_id, "image_id"), cacheKind, planId: exactString(value.plan_id, "plan_id"),
     entryId: exactString(value.entry_id, "entry_id"), entryGeneration: exactInteger(value.entry_generation, "entry_generation"),
@@ -528,7 +579,7 @@ function manifestMatches(row: DockerSetupPrefixEntryRow, manifest: DockerSetupPr
     row.declarationJson === manifest.declarationJson && row.declarationDigest === manifest.declarationDigest &&
     row.setupManifestDigest === manifest.setupManifestDigest && row.storageSchemaRevision === manifest.storageSchemaRevision &&
     row.artifactFormatRevision === manifest.artifactFormatRevision && row.changeFrequency === manifest.changeFrequency &&
-    row.dependency === "parent-backed";
+    row.dependency === DOCKER_CACHE_DOMAIN.setupDependency;
 }
 
 function changes(value: number | bigint): number {
@@ -560,9 +611,10 @@ function domainRow(row: unknown): DockerCacheDomainRow {
     domainId: exactString(value.domain_id, "domain_id"), ownerId: exactString(value.owner_id, "owner_id"),
     daemonId: exactString(value.daemon_id, "daemon_id"), storageDriver: exactString(value.storage_driver, "storage_driver"),
     sentinelId: exactString(value.sentinel_id, "sentinel_id"), backendIdentity: exactString(value.backend_identity, "backend_identity"),
-    authorityEpoch: exactString(value.authority_epoch, "authority_epoch"), providerFamily: "docker", adminProtocolVersion: 1,
-    backendKind: "docker-images", firstVerifiedAt: exactString(value.first_verified_at, "first_verified_at"),
-    lastVerifiedAt: exactString(value.last_verified_at, "last_verified_at"), lastState: "verified-managed",
+    authorityEpoch: exactString(value.authority_epoch, "authority_epoch"), providerFamily: DOCKER_CACHE_DOMAIN.providerFamily,
+    adminProtocolVersion: DOCKER_CACHE_DOMAIN.adminProtocolVersion, backendKind: DOCKER_CACHE_DOMAIN.backendKind,
+    firstVerifiedAt: exactString(value.first_verified_at, "first_verified_at"),
+    lastVerifiedAt: exactString(value.last_verified_at, "last_verified_at"), lastState: DOCKER_CACHE_DOMAIN.verifiedState,
   });
 }
 
@@ -586,9 +638,9 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
           INSERT INTO ${TABLES.domains}(
             domain_id, owner_id, daemon_id, storage_driver, sentinel_id, backend_identity, authority_epoch,
             provider_family, admin_protocol_version, backend_kind, first_verified_at, last_verified_at, last_state
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, 'docker', 1, 'docker-images', ?, ?, 'verified-managed')
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ${sqlLiteral(DOCKER_CACHE_DOMAIN.providerFamily)}, ${DOCKER_CACHE_DOMAIN.adminProtocolVersion}, ${sqlLiteral(DOCKER_CACHE_DOMAIN.backendKind)}, ?, ?, ${sqlLiteral(DOCKER_CACHE_DOMAIN.verifiedState)})
           ON CONFLICT(domain_id) DO UPDATE SET
-            last_verified_at=excluded.last_verified_at, last_state='verified-managed'
+            last_verified_at=excluded.last_verified_at, last_state=${sqlLiteral(DOCKER_CACHE_DOMAIN.verifiedState)}
           WHERE owner_id=excluded.owner_id AND daemon_id=excluded.daemon_id AND storage_driver=excluded.storage_driver
             AND sentinel_id=excluded.sentinel_id AND backend_identity=excluded.backend_identity
         `).run(
@@ -614,12 +666,12 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
         domains: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.domains} ORDER BY first_verified_at, domain_id`).all().map(domainRow)),
       });
     case "task-get-indexed": {
-      const row = database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? AND build_key = ? AND state = 'indexed'`)
+      const row = database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? AND build_key = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.indexed)}`)
         .get(request.domainId, request.buildKey);
       return result(request.operation, { entry: row === undefined ? null : taskEntry(row) });
     }
     case "task-mark-unverified": {
-      const receipt = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = 'unverified' WHERE domain_id = ? AND build_key = ? AND state != 'tombstoned' AND (? IS NULL OR generation = ?)`)
+      const receipt = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = ${sqlLiteral(DOCKER_CACHE_STATE.unverified)} WHERE domain_id = ? AND build_key = ? AND state != ${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} AND (? IS NULL OR generation = ?)`)
         .run(request.domainId, request.buildKey, request.generation ?? null, request.generation ?? null);
       return result(request.operation, { changes: changes(receipt.changes) });
     }
@@ -635,13 +687,13 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
           INSERT INTO ${TABLES.taskEntries}(
             domain_id, build_key, tag, image_id, created_at, last_successful_use_at, protected_until,
             manifest_digest, generation, operation_id, state
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, 'indexed')
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ${sqlLiteral(DOCKER_CACHE_STATE.indexed)})
           ON CONFLICT(domain_id, build_key) DO UPDATE SET
             tag=excluded.tag, image_id=excluded.image_id, created_at=excluded.created_at,
             last_successful_use_at=excluded.last_successful_use_at, protected_until=excluded.protected_until,
             manifest_digest=excluded.manifest_digest,
             generation=CASE WHEN ${TABLES.taskEntries}.operation_id=excluded.operation_id THEN ${TABLES.taskEntries}.generation ELSE ${TABLES.taskEntries}.generation+1 END,
-            operation_id=excluded.operation_id, state='indexed'
+            operation_id=excluded.operation_id, state=${sqlLiteral(DOCKER_CACHE_STATE.indexed)}
         `).run(
           request.domainId, request.buildKey, request.tag, request.imageId, request.now, request.now,
           request.protectedUntil, request.manifestDigest, request.operationId,
@@ -653,7 +705,7 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     }
     case "task-acquire-use": {
       const reserved = transaction(database, () => {
-        const row = database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? AND build_key = ? AND state = 'indexed'`)
+        const row = database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? AND build_key = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.indexed)}`)
           .get(request.domainId, request.buildKey);
         if (row === undefined) return false;
         const entry = taskEntry(row);
@@ -664,13 +716,13 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
           .run(request.domainId, request.leaseId, request.buildKey, request.holder.pid, request.holder.bootId, request.holder.processStart, entry.generation, request.now, request.now);
         database.prepare(`INSERT INTO ${TABLES.taskRoots}(
           domain_id, root_id, build_key, generation, holder_boot_id, holder_pid, holder_process_start, state, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?)`)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ${sqlLiteral(DOCKER_CACHE_STATE.active)}, ?)`)
           .run(request.domainId, request.rootId, request.buildKey, entry.generation, request.holder.bootId, request.holder.pid, request.holder.processStart, request.now);
         database.prepare(`UPDATE ${TABLES.taskEntries} SET last_successful_use_at = ? WHERE domain_id = ? AND build_key = ?`)
           .run(request.now, request.domainId, request.buildKey);
         return true;
       });
-      return result(request.operation, reserved ? { reserved } : { reserved, reason: "entry-changed" });
+      return result(request.operation, reserved ? { reserved } : { reserved, reason: DOCKER_RESERVATION_REASON.entryChanged });
     }
     case "task-heartbeat": {
       const receipt = database.prepare(`UPDATE ${TABLES.taskLeases} SET heartbeat_at = ? WHERE domain_id = ? AND lease_id = ?`)
@@ -686,7 +738,7 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
       return result(request.operation, { changes: count });
     }
     case "task-list-entries": {
-      const where = request.includeTombstoned === true ? "" : "AND state != 'tombstoned'";
+      const where = request.includeTombstoned === true ? "" : `AND state != ${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)}`;
       const entries = database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? ${where} ORDER BY COALESCE(last_successful_use_at, created_at), created_at, build_key`)
         .all(request.domainId).map(taskEntry);
       return result(request.operation, { entries: Object.freeze(entries) });
@@ -735,21 +787,21 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     case "task-reserve-delete": {
       const outcome = transaction(database, () => {
         const row = database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? AND build_key = ?`).get(request.domainId, request.entry.buildKey);
-        if (row === undefined) return { reserved: false, reason: "entry-missing" } as const;
+        if (row === undefined) return { reserved: false, reason: DOCKER_RESERVATION_REASON.entryMissing } as const;
         const entry = taskEntry(row);
-        if (entry.state !== "indexed" || JSON.stringify(entry) !== JSON.stringify(request.entry)) return { reserved: false, reason: "entry-changed" } as const;
+        if (entry.state !== DOCKER_CACHE_STATE.indexed || JSON.stringify(entry) !== JSON.stringify(request.entry)) return { reserved: false, reason: DOCKER_RESERVATION_REASON.entryChanged } as const;
         const lease = database.prepare(`SELECT 1 FROM ${TABLES.taskLeases} WHERE domain_id = ? AND build_key = ? LIMIT 1`).get(request.domainId, entry.buildKey);
         const root = database.prepare(`SELECT 1 FROM ${TABLES.taskRoots} WHERE domain_id = ? AND build_key = ? LIMIT 1`).get(request.domainId, entry.buildKey);
-        const setupClaim = database.prepare(`SELECT 1 FROM ${TABLES.setupEntries} WHERE domain_id = ? AND image_id = ? AND state != 'tombstoned' LIMIT 1`).get(request.domainId, entry.imageId);
-        if (lease !== undefined || root !== undefined || setupClaim !== undefined) return { reserved: false, reason: "entry-lease-root-or-cross-kind-claim" } as const;
+        const setupClaim = database.prepare(`SELECT 1 FROM ${TABLES.setupEntries} WHERE domain_id = ? AND image_id = ? AND state != ${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} LIMIT 1`).get(request.domainId, entry.imageId);
+        if (lease !== undefined || root !== undefined || setupClaim !== undefined) return { reserved: false, reason: DOCKER_RESERVATION_REASON.entryLeaseRootOrCrossKindClaim } as const;
         const lock = database.prepare(`SELECT 1 FROM ${TABLES.locks} WHERE domain_id = ? AND image_id = ?`).get(request.domainId, entry.imageId);
-        if (lock !== undefined) return { reserved: false, reason: "active-delete-conflict" } as const;
+        if (lock !== undefined) return { reserved: false, reason: DOCKER_RESERVATION_REASON.activeDeleteConflict } as const;
         database.prepare(`INSERT INTO ${TABLES.locks}(
           domain_id, image_id, cache_kind, plan_id, entry_id, entry_generation,
           holder_pid, holder_boot_id, holder_process_start, created_at
-        ) VALUES (?, ?, 'task-build', ?, ?, ?, ?, ?, ?, ?)`)
+        ) VALUES (?, ?, ${sqlLiteral(DOCKER_CACHE_KIND.taskBuild)}, ?, ?, ?, ?, ?, ?, ?)`)
           .run(request.domainId, entry.imageId, request.planId, `task-build:${entry.buildKey}`, entry.generation, request.holder.pid, request.holder.bootId, request.holder.processStart, request.createdAt);
-        const marked = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = 'deleting' WHERE domain_id = ? AND build_key = ? AND generation = ? AND state = 'indexed'`)
+        const marked = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = ${sqlLiteral(DOCKER_CACHE_STATE.deleting)} WHERE domain_id = ? AND build_key = ? AND generation = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.indexed)}`)
           .run(request.domainId, entry.buildKey, entry.generation);
         if (marked.changes !== 1) throw invalid("task-build generation changed before deleting transition");
         return { reserved: true } as const;
@@ -758,9 +810,9 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     }
     case "task-settle-delete": {
       const count = transaction(database, () => {
-        const updated = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = ? WHERE domain_id = ? AND build_key = ? AND generation = ? AND image_id = ? AND state = 'deleting'`)
+        const updated = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = ? WHERE domain_id = ? AND build_key = ? AND generation = ? AND image_id = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.deleting)}`)
           .run(request.state, request.domainId, request.buildKey, request.generation, request.imageId);
-        database.prepare(`DELETE FROM ${TABLES.locks} WHERE domain_id = ? AND image_id = ? AND cache_kind = 'task-build' AND plan_id = ?`)
+        database.prepare(`DELETE FROM ${TABLES.locks} WHERE domain_id = ? AND image_id = ? AND cache_kind = ${sqlLiteral(DOCKER_CACHE_KIND.taskBuild)} AND plan_id = ?`)
           .run(request.domainId, request.imageId, request.planId);
         bump(database, request.domainId, "taskSafetyRevision");
         return changes(updated.changes);
@@ -769,13 +821,13 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     }
     case "task-list-delete-locks":
       return result(request.operation, {
-        locks: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.locks} WHERE domain_id = ? AND cache_kind = 'task-build' ORDER BY created_at, image_id LIMIT 128`).all(request.domainId).map(gcLock)),
+        locks: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.locks} WHERE domain_id = ? AND cache_kind = ${sqlLiteral(DOCKER_CACHE_KIND.taskBuild)} ORDER BY created_at, image_id LIMIT 128`).all(request.domainId).map(gcLock)),
       });
     case "task-recover-delete": {
       const count = transaction(database, () => {
-        const updated = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = ? WHERE domain_id = ? AND build_key = ? AND generation = ? AND image_id = ? AND state = 'deleting'`)
+        const updated = database.prepare(`UPDATE ${TABLES.taskEntries} SET state = ? WHERE domain_id = ? AND build_key = ? AND generation = ? AND image_id = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.deleting)}`)
           .run(request.state, request.domainId, request.buildKey, request.lock.entryGeneration, request.lock.imageId);
-        database.prepare(`DELETE FROM ${TABLES.locks} WHERE domain_id = ? AND image_id = ? AND cache_kind = 'task-build' AND plan_id = ? AND entry_id = ? AND entry_generation = ?`)
+        database.prepare(`DELETE FROM ${TABLES.locks} WHERE domain_id = ? AND image_id = ? AND cache_kind = ${sqlLiteral(DOCKER_CACHE_KIND.taskBuild)} AND plan_id = ? AND entry_id = ? AND entry_generation = ?`)
           .run(request.domainId, request.lock.imageId, request.lock.planId, request.lock.entryId, request.lock.entryGeneration);
         bump(database, request.domainId, "taskSafetyRevision");
         return changes(updated.changes);
@@ -784,15 +836,15 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     }
     case "setup-startup-snapshot":
       return result(request.operation, {
-        entries: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id = ? AND state IN ('reserved','building','published','indexed','deleting') ORDER BY setup_prefix_key, generation`).all(request.domainId).map(setupEntry)),
-        leases: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.setupLeases} WHERE domain_id = ? AND state IN ('active','expired-unverified') ORDER BY lease_id`).all(request.domainId).map(setupLease)),
-        locks: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.locks} WHERE domain_id = ? AND cache_kind = 'sandbox-setup-prefix' ORDER BY created_at, image_id LIMIT 128`).all(request.domainId).map(gcLock)),
+        entries: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id = ? AND state IN (${sqlIn(DOCKER_SETUP_STARTUP_STATES)}) ORDER BY setup_prefix_key, generation`).all(request.domainId).map(setupEntry)),
+        leases: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.setupLeases} WHERE domain_id = ? AND state IN (${sqlIn(DOCKER_ACTIVE_SETUP_LEASE_STATES)}) ORDER BY lease_id`).all(request.domainId).map(setupLease)),
+        locks: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.locks} WHERE domain_id = ? AND cache_kind = ${sqlLiteral(DOCKER_CACHE_KIND.sandboxSetupPrefix)} ORDER BY created_at, image_id LIMIT 128`).all(request.domainId).map(gcLock)),
       });
     case "setup-prune-leases": {
       const count = transaction(database, () => {
         let changed = 0;
         for (const leaseId of request.deleteLeaseIds) changed += changes(database.prepare(`DELETE FROM ${TABLES.setupLeases} WHERE domain_id = ? AND lease_id = ?`).run(request.domainId, leaseId).changes);
-        for (const leaseId of request.unverifiableLeaseIds) changed += changes(database.prepare(`UPDATE ${TABLES.setupLeases} SET state = 'expired-unverified' WHERE domain_id = ? AND lease_id = ? AND state = 'active'`).run(request.domainId, leaseId).changes);
+        for (const leaseId of request.unverifiableLeaseIds) changed += changes(database.prepare(`UPDATE ${TABLES.setupLeases} SET state = ${sqlLiteral(DOCKER_CACHE_STATE.expiredUnverified)} WHERE domain_id = ? AND lease_id = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.active)}`).run(request.domainId, leaseId).changes);
         return changed;
       });
       return result(request.operation, { changes: count });
@@ -800,7 +852,7 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     case "setup-startup-isolate": {
       const count = transaction(database, () => {
         database.prepare(`DELETE FROM ${TABLES.setupIndex} WHERE domain_id = ? AND entry_id = ?`).run(request.domainId, request.entryId);
-        const updated = database.prepare(`UPDATE ${TABLES.setupEntries} SET image_id = ?, state = 'unverified' WHERE domain_id = ? AND entry_id = ? AND state IN ('reserved','building')`)
+        const updated = database.prepare(`UPDATE ${TABLES.setupEntries} SET image_id = ?, state = ${sqlLiteral(DOCKER_CACHE_STATE.unverified)} WHERE domain_id = ? AND entry_id = ? AND state IN (${sqlIn(DOCKER_SETUP_RESERVABLE_STATES)})`)
           .run(request.imageId, request.domainId, request.entryId);
         bump(database, request.domainId, "setupPrefixSafetyRevision");
         return changes(updated.changes);
@@ -814,18 +866,18 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
         const entry = setupEntry(found);
         if (!request.valid) {
           database.prepare(`DELETE FROM ${TABLES.setupIndex} WHERE domain_id = ? AND entry_id = ?`).run(request.domainId, entry.entryId);
-          return changes(database.prepare(`UPDATE ${TABLES.setupEntries} SET state = 'unverified' WHERE domain_id = ? AND entry_id = ?`).run(request.domainId, entry.entryId).changes);
+          return changes(database.prepare(`UPDATE ${TABLES.setupEntries} SET state = ${sqlLiteral(DOCKER_CACHE_STATE.unverified)} WHERE domain_id = ? AND entry_id = ?`).run(request.domainId, entry.entryId).changes);
         }
-        if (entry.state === "published") {
+        if (entry.state === DOCKER_CACHE_STATE.published) {
           const active = database.prepare(`SELECT entry_id FROM ${TABLES.setupIndex} WHERE domain_id = ? AND setup_prefix_key = ?`).get(request.domainId, entry.setupPrefixKey);
           if (active === undefined || exactString(record(active, "setup index").entry_id, "entry_id") === entry.entryId) {
             database.prepare(`INSERT OR IGNORE INTO ${TABLES.setupIndex}(domain_id, setup_prefix_key, entry_id) VALUES (?, ?, ?)`).run(request.domainId, entry.setupPrefixKey, entry.entryId);
-            return changes(database.prepare(`UPDATE ${TABLES.setupEntries} SET state = 'indexed' WHERE domain_id = ? AND entry_id = ? AND state = 'published'`).run(request.domainId, entry.entryId).changes);
+            return changes(database.prepare(`UPDATE ${TABLES.setupEntries} SET state = ${sqlLiteral(DOCKER_CACHE_STATE.indexed)} WHERE domain_id = ? AND entry_id = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.published)}`).run(request.domainId, entry.entryId).changes);
           }
         }
         const active = database.prepare(`SELECT entry_id FROM ${TABLES.setupIndex} WHERE domain_id = ? AND setup_prefix_key = ?`).get(request.domainId, entry.setupPrefixKey);
         if (active === undefined || exactString(record(active, "setup index").entry_id, "entry_id") !== entry.entryId) {
-          return changes(database.prepare(`UPDATE ${TABLES.setupEntries} SET state = 'unverified' WHERE domain_id = ? AND entry_id = ?`).run(request.domainId, entry.entryId).changes);
+          return changes(database.prepare(`UPDATE ${TABLES.setupEntries} SET state = ${sqlLiteral(DOCKER_CACHE_STATE.unverified)} WHERE domain_id = ? AND entry_id = ?`).run(request.domainId, entry.entryId).changes);
         }
         return 0;
       });
@@ -837,12 +889,12 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
           .get(request.domainId, request.manifest.setupPrefixKey);
         if (found === undefined) return null;
         const row = setupEntry(found);
-        if (row.state !== "indexed" || (request.expectedEntryId !== undefined && row.entryId !== request.expectedEntryId) || !manifestMatches(row, request.manifest)) return null;
+        if (row.state !== DOCKER_CACHE_STATE.indexed || (request.expectedEntryId !== undefined && row.entryId !== request.expectedEntryId) || !manifestMatches(row, request.manifest)) return null;
         database.prepare(`INSERT INTO ${TABLES.setupLeases}(
           domain_id, lease_id, entry_id, setup_prefix_key, generation, kind, operation_id,
           holder_host_id, holder_boot_id, holder_pid, holder_process_start,
           heartbeat_sequence, heartbeat_at, expires_at, state
-        ) VALUES (?, ?, ?, ?, ?, 'handoff', ?, ?, ?, ?, ?, 0, ?, ?, 'active')`)
+        ) VALUES (?, ?, ?, ?, ?, ${sqlLiteral(DOCKER_LEASE_KIND.handoff)}, ?, ?, ?, ?, ?, 0, ?, ?, ${sqlLiteral(DOCKER_CACHE_STATE.active)})`)
           .run(request.domainId, request.leaseId, row.entryId, row.setupPrefixKey, row.generation, request.operationId, request.holder.hostId, request.holder.bootId, request.holder.pid, request.holder.processStart, request.now, request.expiresAt);
         return row;
       });
@@ -854,16 +906,16 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
           .get(request.domainId, request.manifest.setupPrefixKey);
         if (indexedRow !== undefined) {
           if (!manifestMatches(setupEntry(indexedRow), request.manifest)) throw invalid("indexed setup-prefix generation does not match requested manifest");
-          return { state: "contended", reason: "indexed-generation" } as const;
+        return { state: DOCKER_RESERVATION_DISPOSITION.contended, reason: DOCKER_CONTENTION_REASON.indexedGeneration } as const;
         }
-        const writerRow = database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id=? AND setup_prefix_key=? AND state IN ('reserved','building','published','deleting') ORDER BY generation DESC LIMIT 1`)
+        const writerRow = database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id=? AND setup_prefix_key=? AND state IN (${sqlIn(DOCKER_SETUP_WRITER_STATES)}) ORDER BY generation DESC LIMIT 1`)
           .get(request.domainId, request.manifest.setupPrefixKey);
         const writer = writerRow === undefined ? undefined : setupEntry(writerRow);
         if (writer !== undefined) {
           if (writer.operationId === request.operationId && !manifestMatches(writer, request.manifest)) throw invalid("operation id was reused with different setup-prefix metadata");
-          const lease = database.prepare(`SELECT 1 FROM ${TABLES.setupLeases} WHERE domain_id=? AND entry_id=? AND state IN ('active','expired-unverified') LIMIT 1`).get(request.domainId, writer.entryId);
-          if (writer.state === "published" || writer.state === "deleting" || lease !== undefined) return { state: "contended", reason: "active-writer" } as const;
-          database.prepare(`UPDATE ${TABLES.setupEntries} SET state='unverified' WHERE domain_id=? AND entry_id=? AND state IN ('reserved','building')`).run(request.domainId, writer.entryId);
+          const lease = database.prepare(`SELECT 1 FROM ${TABLES.setupLeases} WHERE domain_id=? AND entry_id=? AND state IN (${sqlIn(DOCKER_ACTIVE_SETUP_LEASE_STATES)}) LIMIT 1`).get(request.domainId, writer.entryId);
+          if (writer.state === DOCKER_CACHE_STATE.published || writer.state === DOCKER_CACHE_STATE.deleting || lease !== undefined) return { state: DOCKER_RESERVATION_DISPOSITION.contended, reason: DOCKER_CONTENTION_REASON.activeWriter } as const;
+          database.prepare(`UPDATE ${TABLES.setupEntries} SET state=${sqlLiteral(DOCKER_CACHE_STATE.unverified)} WHERE domain_id=? AND entry_id=? AND state IN (${sqlIn(DOCKER_SETUP_RESERVABLE_STATES)})`).run(request.domainId, writer.entryId);
           bump(database, request.domainId, "setupPrefixSafetyRevision");
         }
         const existingOperation = database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id=? AND setup_prefix_key=? AND operation_id=? ORDER BY generation DESC LIMIT 1`)
@@ -882,22 +934,22 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
           domain_id, entry_id, setup_prefix_key, base_image_id, image_id, declaration_json, declaration_digest,
           setup_manifest_digest, storage_schema_revision, artifact_format_revision, dependency, change_frequency,
           generation, operation_id, created_at, last_successful_use_at, protected_until, state
-        ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 'parent-backed', ?, ?, ?, ?, NULL, ?, 'building')`)
+        ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ${sqlLiteral(DOCKER_CACHE_DOMAIN.setupDependency)}, ?, ?, ?, ?, NULL, ?, ${sqlLiteral(DOCKER_CACHE_STATE.building)})`)
           .run(request.domainId, entryId, request.manifest.setupPrefixKey, request.manifest.baseImageId, request.manifest.declarationJson, request.manifest.declarationDigest, request.manifest.setupManifestDigest, request.manifest.storageSchemaRevision, request.manifest.artifactFormatRevision, request.manifest.changeFrequency, generation, request.operationId, request.now, request.protectedUntil);
         database.prepare(`INSERT INTO ${TABLES.setupScopes}(domain_id, entry_id, replacement_scope) VALUES (?, ?, ?)`).run(request.domainId, entryId, request.replacementScope);
         database.prepare(`INSERT INTO ${TABLES.setupLeases}(
           domain_id, lease_id, entry_id, setup_prefix_key, generation, kind, operation_id,
           holder_host_id, holder_boot_id, holder_pid, holder_process_start,
           heartbeat_sequence, heartbeat_at, expires_at, state
-        ) VALUES (?, ?, ?, ?, ?, 'build', ?, ?, ?, ?, ?, 0, ?, ?, 'active')`)
+        ) VALUES (?, ?, ?, ?, ?, ${sqlLiteral(DOCKER_LEASE_KIND.build)}, ?, ?, ?, ?, ?, 0, ?, ?, ${sqlLiteral(DOCKER_CACHE_STATE.active)})`)
           .run(request.domainId, request.leaseId, entryId, request.manifest.setupPrefixKey, generation, request.operationId, request.holder.hostId, request.holder.bootId, request.holder.pid, request.holder.processStart, request.now, request.expiresAt);
         const row = database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id=? AND entry_id=?`).get(request.domainId, entryId);
-        return { state: "reserved", entry: setupEntry(row) } as const;
+        return { state: DOCKER_RESERVATION_DISPOSITION.reserved, entry: setupEntry(row) } as const;
       });
       return result(request.operation, reserved);
     }
     case "setup-heartbeat": {
-      const receipt = database.prepare(`UPDATE ${TABLES.setupLeases} SET heartbeat_sequence=heartbeat_sequence+1, heartbeat_at=?, expires_at=? WHERE domain_id=? AND lease_id=? AND state='active'`)
+      const receipt = database.prepare(`UPDATE ${TABLES.setupLeases} SET heartbeat_sequence=heartbeat_sequence+1, heartbeat_at=?, expires_at=? WHERE domain_id=? AND lease_id=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.active)}`)
         .run(request.heartbeatAt, request.expiresAt, request.domainId, request.leaseId);
       return result(request.operation, { changes: changes(receipt.changes) });
     }
@@ -908,7 +960,7 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     case "setup-mark-unverified": {
       const count = transaction(database, () => {
         database.prepare(`DELETE FROM ${TABLES.setupIndex} WHERE domain_id=? AND entry_id=?`).run(request.domainId, request.entryId);
-        const receipt = database.prepare(`UPDATE ${TABLES.setupEntries} SET state='unverified' WHERE domain_id=? AND entry_id=? AND state NOT IN ('tombstoned','deleting')`).run(request.domainId, request.entryId);
+        const receipt = database.prepare(`UPDATE ${TABLES.setupEntries} SET state=${sqlLiteral(DOCKER_CACHE_STATE.unverified)} WHERE domain_id=? AND entry_id=? AND state NOT IN (${sqlIn(DOCKER_DELETE_TRANSITION_STATES)})`).run(request.domainId, request.entryId);
         bump(database, request.domainId, "setupPrefixSafetyRevision");
         return changes(receipt.changes);
       });
@@ -918,13 +970,13 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
       const count = transaction(database, () => {
         const lock = database.prepare(`SELECT cache_kind, plan_id FROM ${TABLES.locks} WHERE domain_id=? AND image_id=?`).get(request.domainId, request.imageId);
         if (lock !== undefined) throw invalid("exact setup-prefix image is fenced by an active GC plan");
-        const receipt = database.prepare(`UPDATE ${TABLES.setupEntries} SET image_id=?, state='published' WHERE domain_id=? AND entry_id=? AND operation_id=? AND generation=? AND state='building'`)
+        const receipt = database.prepare(`UPDATE ${TABLES.setupEntries} SET image_id=?, state=${sqlLiteral(DOCKER_CACHE_STATE.published)} WHERE domain_id=? AND entry_id=? AND operation_id=? AND generation=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.building)}`)
           .run(request.imageId, request.domainId, request.entryId, request.operationId, request.generation);
         if (receipt.changes !== 1) {
           const current = database.prepare(`SELECT image_id,state FROM ${TABLES.setupEntries} WHERE domain_id=? AND entry_id=? AND operation_id=? AND generation=?`)
             .get(request.domainId, request.entryId, request.operationId, request.generation);
           const value = current === undefined ? undefined : record(current, "setup publication");
-          if (value === undefined || value.image_id !== request.imageId || !["published", "indexed"].includes(String(value.state))) throw invalid("setup-prefix publication lost operation/generation fence");
+          if (value === undefined || value.image_id !== request.imageId || !isFiniteValue(DOCKER_SETUP_PUBLICATION_STATES, String(value.state))) throw invalid("setup-prefix publication lost operation/generation fence");
         }
         return changes(receipt.changes);
       });
@@ -935,10 +987,10 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
         const current = database.prepare(`SELECT state,image_id FROM ${TABLES.setupEntries} WHERE domain_id=? AND entry_id=?`).get(request.domainId, request.entryId);
         if (current === undefined) throw invalid("setup-prefix publication entry disappeared");
         const value = record(current, "setup publication");
-        if (value.state === "indexed" && value.image_id === request.imageId) return 0;
-        if (value.state !== "published" || value.image_id !== request.imageId) throw invalid("published setup-prefix identity changed before indexing");
+        if (value.state === DOCKER_CACHE_STATE.indexed && value.image_id === request.imageId) return 0;
+        if (value.state !== DOCKER_CACHE_STATE.published || value.image_id !== request.imageId) throw invalid("published setup-prefix identity changed before indexing");
         database.prepare(`INSERT INTO ${TABLES.setupIndex}(domain_id,setup_prefix_key,entry_id) VALUES (?,?,?)`).run(request.domainId, request.setupPrefixKey, request.entryId);
-        const updated = database.prepare(`UPDATE ${TABLES.setupEntries} SET state='indexed' WHERE domain_id=? AND entry_id=? AND state='published'`).run(request.domainId, request.entryId);
+        const updated = database.prepare(`UPDATE ${TABLES.setupEntries} SET state=${sqlLiteral(DOCKER_CACHE_STATE.indexed)} WHERE domain_id=? AND entry_id=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.published)}`).run(request.domainId, request.entryId);
         database.prepare(`INSERT INTO ${TABLES.setupHeads}(domain_id,replacement_scope,entry_id) SELECT domain_id,replacement_scope,entry_id FROM ${TABLES.setupScopes} WHERE domain_id=? AND entry_id=? ON CONFLICT(domain_id,replacement_scope) DO UPDATE SET entry_id=excluded.entry_id`)
           .run(request.domainId, request.entryId);
         bump(database, request.domainId, "setupPrefixSafetyRevision");
@@ -954,7 +1006,7 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
       return result(request.operation, { changes: changes(receipt.changes) });
     }
     case "setup-activate-root": {
-      const receipt = database.prepare(`UPDATE ${TABLES.setupRoots} SET sandbox_id=?,sandbox_resource_identity=?,state='active' WHERE domain_id=? AND root_id=? AND entry_id=? AND generation=? AND state='prepared'`)
+      const receipt = database.prepare(`UPDATE ${TABLES.setupRoots} SET sandbox_id=?,sandbox_resource_identity=?,state=${sqlLiteral(DOCKER_CACHE_STATE.active)} WHERE domain_id=? AND root_id=? AND entry_id=? AND generation=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.prepared)}`)
         .run(request.containerId, request.containerId, request.domainId, request.rootId, request.entryId, request.generation);
       return result(request.operation, { changes: changes(receipt.changes) });
     }
@@ -963,28 +1015,28 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
       return result(request.operation, { changes: changes(receipt.changes) });
     }
     case "setup-begin-root-release": {
-      const receipt = database.prepare(`UPDATE ${TABLES.setupRoots} SET state='releasing' WHERE domain_id=? AND root_id=? AND entry_id=? AND sandbox_resource_identity=? AND state IN ('prepared','active','releasing')`)
+      const receipt = database.prepare(`UPDATE ${TABLES.setupRoots} SET state=${sqlLiteral(DOCKER_CACHE_STATE.releasing)} WHERE domain_id=? AND root_id=? AND entry_id=? AND sandbox_resource_identity=? AND state IN (${sqlIn(DOCKER_SETUP_ROOT_STATES)})`)
         .run(request.domainId, request.rootId, request.entryId, request.containerId);
       return result(request.operation, { changes: changes(receipt.changes) });
     }
     case "setup-finish-root-release": {
-      const receipt = database.prepare(`DELETE FROM ${TABLES.setupRoots} WHERE domain_id=? AND root_id=? AND entry_id=? AND sandbox_resource_identity=? AND state='releasing'`)
+      const receipt = database.prepare(`DELETE FROM ${TABLES.setupRoots} WHERE domain_id=? AND root_id=? AND entry_id=? AND sandbox_resource_identity=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.releasing)}`)
         .run(request.domainId, request.rootId, request.entryId, request.containerId);
       return result(request.operation, { changes: changes(receipt.changes) });
     }
     case "setup-mark-used": {
-      const receipt = database.prepare(`UPDATE ${TABLES.setupEntries} SET last_successful_use_at=? WHERE domain_id=? AND entry_id=? AND generation=? AND state='indexed'`)
+      const receipt = database.prepare(`UPDATE ${TABLES.setupEntries} SET last_successful_use_at=? WHERE domain_id=? AND entry_id=? AND generation=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.indexed)}`)
         .run(request.usedAt, request.domainId, request.entryId, request.generation);
       return result(request.operation, { changes: changes(receipt.changes) });
     }
     case "setup-image-claims": {
       const gcLocked = database.prepare(`SELECT 1 FROM ${TABLES.locks} WHERE domain_id=? AND image_id=?`).get(request.domainId, request.imageId) !== undefined;
-      const taskBuildClaim = database.prepare(`SELECT 1 FROM ${TABLES.taskEntries} WHERE domain_id=? AND image_id=? AND state!='tombstoned' LIMIT 1`).get(request.domainId, request.imageId) !== undefined;
-      const siblingSetupPrefixClaim = database.prepare(`SELECT 1 FROM ${TABLES.setupEntries} WHERE domain_id=? AND image_id=? AND entry_id!=? AND state!='tombstoned' LIMIT 1`).get(request.domainId, request.imageId, request.exceptEntryId) !== undefined;
+      const taskBuildClaim = database.prepare(`SELECT 1 FROM ${TABLES.taskEntries} WHERE domain_id=? AND image_id=? AND state!=${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} LIMIT 1`).get(request.domainId, request.imageId) !== undefined;
+      const siblingSetupPrefixClaim = database.prepare(`SELECT 1 FROM ${TABLES.setupEntries} WHERE domain_id=? AND image_id=? AND entry_id!=? AND state!=${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} LIMIT 1`).get(request.domainId, request.imageId, request.exceptEntryId) !== undefined;
       return result(request.operation, { gcLocked, taskBuildClaim, siblingSetupPrefixClaim });
     }
     case "setup-list-reclaim-candidates": {
-      const entries = database.prepare(`SELECT entry.* FROM ${TABLES.setupEntries} entry JOIN ${TABLES.setupScopes} scope ON scope.domain_id=entry.domain_id AND scope.entry_id=entry.entry_id JOIN ${TABLES.setupHeads} head ON head.domain_id=scope.domain_id AND head.replacement_scope=scope.replacement_scope WHERE entry.domain_id=? AND entry.state='indexed' AND (? IS NULL OR scope.replacement_scope=?) AND (? IS NULL OR entry.entry_id!=?) AND entry.entry_id!=head.entry_id ORDER BY entry.created_at,entry.entry_id`)
+      const entries = database.prepare(`SELECT entry.* FROM ${TABLES.setupEntries} entry JOIN ${TABLES.setupScopes} scope ON scope.domain_id=entry.domain_id AND scope.entry_id=entry.entry_id JOIN ${TABLES.setupHeads} head ON head.domain_id=scope.domain_id AND head.replacement_scope=scope.replacement_scope WHERE entry.domain_id=? AND entry.state=${sqlLiteral(DOCKER_CACHE_STATE.indexed)} AND (? IS NULL OR scope.replacement_scope=?) AND (? IS NULL OR entry.entry_id!=?) AND entry.entry_id!=head.entry_id ORDER BY entry.created_at,entry.entry_id`)
         .all(request.domainId, request.replacementScope ?? null, request.replacementScope ?? null, request.exceptEntryId ?? null, request.exceptEntryId ?? null)
         .map(setupEntry);
       return result(request.operation, { entries: Object.freeze(entries) });
@@ -992,18 +1044,18 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     case "setup-reserve-delete": {
       const outcome = transaction(database, () => {
         const found = database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id=? AND entry_id=?`).get(request.domainId, request.entryId);
-        if (found === undefined) return { reserved: false, reason: "entry-missing" } as const;
+        if (found === undefined) return { reserved: false, reason: DOCKER_RESERVATION_REASON.entryMissing } as const;
         const entry = setupEntry(found);
-        if (entry.state !== "indexed" || entry.imageId === null) return { reserved: false, reason: "entry-changed" } as const;
-        const activeLease = database.prepare(`SELECT 1 FROM ${TABLES.setupLeases} WHERE domain_id=? AND entry_id=? AND state IN ('active','expired-unverified') LIMIT 1`).get(request.domainId, entry.entryId);
-        const activeRoot = database.prepare(`SELECT 1 FROM ${TABLES.setupRoots} WHERE domain_id=? AND entry_id=? AND state IN ('prepared','active','releasing') LIMIT 1`).get(request.domainId, entry.entryId);
-        const taskClaim = database.prepare(`SELECT 1 FROM ${TABLES.taskEntries} WHERE domain_id=? AND image_id=? AND state!='tombstoned' LIMIT 1`).get(request.domainId, entry.imageId);
-        const siblingClaim = database.prepare(`SELECT 1 FROM ${TABLES.setupEntries} WHERE domain_id=? AND image_id=? AND entry_id!=? AND state!='tombstoned' LIMIT 1`).get(request.domainId, entry.imageId, entry.entryId);
-        if (activeLease !== undefined || activeRoot !== undefined || taskClaim !== undefined || siblingClaim !== undefined) return { reserved: false, reason: "active-owner-or-cross-kind-claim" } as const;
-        if (database.prepare(`SELECT 1 FROM ${TABLES.locks} WHERE domain_id=? AND image_id=?`).get(request.domainId, entry.imageId) !== undefined) return { reserved: false, reason: "active-delete-conflict" } as const;
-        database.prepare(`INSERT INTO ${TABLES.locks}(domain_id,image_id,cache_kind,plan_id,entry_id,entry_generation,holder_pid,holder_boot_id,holder_process_start,created_at) VALUES (?,?,'sandbox-setup-prefix',?,?,?,?,?,?,?)`)
+        if (entry.state !== DOCKER_CACHE_STATE.indexed || entry.imageId === null) return { reserved: false, reason: DOCKER_RESERVATION_REASON.entryChanged } as const;
+        const activeLease = database.prepare(`SELECT 1 FROM ${TABLES.setupLeases} WHERE domain_id=? AND entry_id=? AND state IN (${sqlIn(DOCKER_ACTIVE_SETUP_LEASE_STATES)}) LIMIT 1`).get(request.domainId, entry.entryId);
+        const activeRoot = database.prepare(`SELECT 1 FROM ${TABLES.setupRoots} WHERE domain_id=? AND entry_id=? AND state IN (${sqlIn(DOCKER_SETUP_ROOT_STATES)}) LIMIT 1`).get(request.domainId, entry.entryId);
+        const taskClaim = database.prepare(`SELECT 1 FROM ${TABLES.taskEntries} WHERE domain_id=? AND image_id=? AND state!=${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} LIMIT 1`).get(request.domainId, entry.imageId);
+        const siblingClaim = database.prepare(`SELECT 1 FROM ${TABLES.setupEntries} WHERE domain_id=? AND image_id=? AND entry_id!=? AND state!=${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} LIMIT 1`).get(request.domainId, entry.imageId, entry.entryId);
+        if (activeLease !== undefined || activeRoot !== undefined || taskClaim !== undefined || siblingClaim !== undefined) return { reserved: false, reason: DOCKER_RESERVATION_REASON.activeOwnerOrCrossKindClaim } as const;
+        if (database.prepare(`SELECT 1 FROM ${TABLES.locks} WHERE domain_id=? AND image_id=?`).get(request.domainId, entry.imageId) !== undefined) return { reserved: false, reason: DOCKER_RESERVATION_REASON.activeDeleteConflict } as const;
+        database.prepare(`INSERT INTO ${TABLES.locks}(domain_id,image_id,cache_kind,plan_id,entry_id,entry_generation,holder_pid,holder_boot_id,holder_process_start,created_at) VALUES (?,?,${sqlLiteral(DOCKER_CACHE_KIND.sandboxSetupPrefix)},?,?,?,?,?,?,?)`)
           .run(request.domainId, entry.imageId, request.planId, entry.entryId, entry.generation, request.holder.pid, request.holder.bootId, request.holder.processStart, request.createdAt);
-        const marked = database.prepare(`UPDATE ${TABLES.setupEntries} SET state='deleting' WHERE domain_id=? AND entry_id=? AND generation=? AND state='indexed'`).run(request.domainId, entry.entryId, entry.generation);
+        const marked = database.prepare(`UPDATE ${TABLES.setupEntries} SET state=${sqlLiteral(DOCKER_CACHE_STATE.deleting)} WHERE domain_id=? AND entry_id=? AND generation=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.indexed)}`).run(request.domainId, entry.entryId, entry.generation);
         if (marked.changes !== 1) throw invalid("setup-prefix generation changed before deleting transition");
         database.prepare(`DELETE FROM ${TABLES.setupIndex} WHERE domain_id=? AND entry_id=?`).run(request.domainId, entry.entryId);
         return { reserved: true } as const;
@@ -1012,11 +1064,11 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
     }
     case "setup-settle-delete": {
       const count = transaction(database, () => {
-        const updated = database.prepare(`UPDATE ${TABLES.setupEntries} SET state=? WHERE domain_id=? AND entry_id=? AND generation=? AND image_id=? AND state='deleting'`)
+        const updated = database.prepare(`UPDATE ${TABLES.setupEntries} SET state=? WHERE domain_id=? AND entry_id=? AND generation=? AND image_id=? AND state=${sqlLiteral(DOCKER_CACHE_STATE.deleting)}`)
           .run(request.state, request.domainId, request.entryId, request.generation, request.imageId);
-        database.prepare(`DELETE FROM ${TABLES.locks} WHERE domain_id=? AND image_id=? AND cache_kind='sandbox-setup-prefix' AND entry_id=? AND entry_generation=?`)
+        database.prepare(`DELETE FROM ${TABLES.locks} WHERE domain_id=? AND image_id=? AND cache_kind=${sqlLiteral(DOCKER_CACHE_KIND.sandboxSetupPrefix)} AND entry_id=? AND entry_generation=?`)
           .run(request.domainId, request.imageId, request.entryId, request.generation);
-        if (request.state === "indexed") {
+        if (request.state === DOCKER_CACHE_STATE.indexed) {
           const row = database.prepare(`SELECT setup_prefix_key FROM ${TABLES.setupEntries} WHERE domain_id=? AND entry_id=?`).get(request.domainId, request.entryId);
           if (row !== undefined) database.prepare(`INSERT OR IGNORE INTO ${TABLES.setupIndex}(domain_id,setup_prefix_key,entry_id) VALUES (?,?,?)`).run(request.domainId, exactString(record(row, "setup key").setup_prefix_key, "setup_prefix_key"), request.entryId);
         }
@@ -1070,7 +1122,7 @@ function taskEntryValue(value: unknown): value is DockerTaskBuildEntryRow {
   return isObject(value) && strings(value, [
     "buildKey", "tag", "imageId", "createdAt", "protectedUntil", "manifestDigest", "operationId", "state",
   ]) && (value.lastSuccessfulUseAt === null || typeof value.lastSuccessfulUseAt === "string") &&
-    Number.isSafeInteger(value.generation) && ["indexed", "deleting", "tombstoned", "unverified"].includes(String(value.state));
+    Number.isSafeInteger(value.generation) && isFiniteValue(DOCKER_TASK_ENTRY_STATES, String(value.state));
 }
 
 function setupEntryValue(value: unknown): value is DockerSetupPrefixEntryRow {
@@ -1079,21 +1131,21 @@ function setupEntryValue(value: unknown): value is DockerSetupPrefixEntryRow {
     "storageSchemaRevision", "artifactFormatRevision", "dependency", "operationId", "createdAt", "protectedUntil", "state",
   ]) && (value.imageId === null || typeof value.imageId === "string") &&
     (value.lastSuccessfulUseAt === null || typeof value.lastSuccessfulUseAt === "string") &&
-    value.dependency === "parent-backed" && typeof value.changeFrequency === "number" && Number.isFinite(value.changeFrequency) &&
+    value.dependency === DOCKER_CACHE_DOMAIN.setupDependency && typeof value.changeFrequency === "number" && Number.isFinite(value.changeFrequency) &&
     Number.isSafeInteger(value.generation) &&
-    ["reserved", "building", "published", "indexed", "invalidated", "deleting", "tombstoned", "unverified"].includes(String(value.state));
+    isFiniteValue(DOCKER_SETUP_ENTRY_STATES, String(value.state));
 }
 
 function setupRootValue(value: unknown): value is DockerSetupPrefixRootRow {
   return isObject(value) && strings(value, [
     "rootId", "entryId", "setupPrefixKey", "sandboxId", "sandboxResourceIdentity", "operationId", "state", "createdAt",
-  ]) && Number.isSafeInteger(value.generation) && ["prepared", "active", "releasing"].includes(String(value.state));
+  ]) && Number.isSafeInteger(value.generation) && isFiniteValue(DOCKER_SETUP_ROOT_STATES, String(value.state));
 }
 
 function gcLockValue(value: unknown): value is DockerImageGcLockRow {
   return isObject(value) && strings(value, [
     "imageId", "cacheKind", "planId", "entryId", "holderBootId", "holderProcessStart", "createdAt",
-  ]) && ["task-build", "sandbox-setup-prefix"].includes(String(value.cacheKind)) &&
+  ]) && isFiniteValue(DOCKER_CACHE_KINDS, String(value.cacheKind)) &&
     Number.isSafeInteger(value.entryGeneration) && Number.isSafeInteger(value.holderPid);
 }
 
@@ -1108,7 +1160,9 @@ export function isDockerCacheRepositoryRequest(value: unknown): value is DockerC
       if (!isObject(value.domain) || !strings(value, ["candidateAuthorityEpoch", "verifiedAt"])) return false;
       const domain = value.domain;
       return strings(domain, ["domainId", "ownerId", "daemonId", "storageDriver", "sentinelId", "backendIdentity", "providerFamily", "backendKind"]) &&
-        domain.providerFamily === "docker" && domain.adminProtocolVersion === 1 && domain.backendKind === "docker-images";
+        domain.providerFamily === DOCKER_CACHE_DOMAIN.providerFamily &&
+        domain.adminProtocolVersion === DOCKER_CACHE_DOMAIN.adminProtocolVersion &&
+        domain.backendKind === DOCKER_CACHE_DOMAIN.backendKind;
     }
     case "task-get-indexed":
       return strings(value, ["domainId", "buildKey"]);
@@ -1142,10 +1196,10 @@ export function isDockerCacheRepositoryRequest(value: unknown): value is DockerC
       return strings(value, ["domainId", "planId", "evidenceDigest", "createdAt"]) && taskEntryValue(value.entry) && holderValue(value.holder);
     case "task-settle-delete":
       return strings(value, ["domainId", "planId", "buildKey", "imageId", "state"]) && Number.isSafeInteger(value.generation) &&
-        ["indexed", "tombstoned", "unverified"].includes(String(value.state));
+        isFiniteValue(DOCKER_DELETE_SETTLEMENT_STATES, String(value.state));
     case "task-recover-delete":
       return strings(value, ["domainId", "buildKey", "state"]) && gcLockValue(value.lock) &&
-        ["tombstoned", "unverified"].includes(String(value.state));
+        isFiniteValue(DOCKER_DELETE_RECOVERY_STATES, String(value.state));
     case "setup-prune-leases":
       return strings(value, ["domainId"]) && stringArray(value.deleteLeaseIds) && stringArray(value.unverifiableLeaseIds);
     case "setup-startup-isolate":
@@ -1185,7 +1239,7 @@ export function isDockerCacheRepositoryRequest(value: unknown): value is DockerC
       return strings(value, ["domainId", "entryId", "planId", "createdAt"]) && holderValue(value.holder);
     case "setup-settle-delete":
       return strings(value, ["domainId", "entryId", "imageId", "state"]) && Number.isSafeInteger(value.generation) &&
-        ["indexed", "tombstoned", "unverified"].includes(String(value.state));
+        isFiniteValue(DOCKER_DELETE_SETTLEMENT_STATES, String(value.state));
     default:
       return false;
   }
@@ -1200,7 +1254,8 @@ export function isDockerCacheRepositoryResult(value: unknown): value is DockerCa
       return isObject(value.domain) && strings(value.domain, [
         "domainId", "ownerId", "daemonId", "storageDriver", "sentinelId", "backendIdentity", "authorityEpoch",
         "providerFamily", "backendKind", "firstVerifiedAt", "lastVerifiedAt", "lastState",
-      ]) && value.domain.providerFamily === "docker" && value.domain.adminProtocolVersion === 1;
+      ]) && value.domain.providerFamily === DOCKER_CACHE_DOMAIN.providerFamily &&
+        value.domain.adminProtocolVersion === DOCKER_CACHE_DOMAIN.adminProtocolVersion;
     case "list-domains":
       return Array.isArray(value.domains) && value.domains.every((domain) =>
         isObject(domain) && strings(domain, ["domainId", "ownerId", "backendIdentity", "authorityEpoch"]));
@@ -1232,8 +1287,8 @@ export function isDockerCacheRepositoryResult(value: unknown): value is DockerCa
     case "setup-acquire-indexed":
       return value.entry === null || setupEntryValue(value.entry);
     case "setup-reserve":
-      return value.state === "reserved" ? setupEntryValue(value.entry) :
-        value.state === "contended" && ["active-writer", "indexed-generation"].includes(String(value.reason));
+      return value.state === DOCKER_RESERVATION_DISPOSITION.reserved ? setupEntryValue(value.entry) :
+        value.state === DOCKER_RESERVATION_DISPOSITION.contended && isFiniteValue(DOCKER_CONTENTION_REASONS, String(value.reason));
     case "setup-image-claims":
       return typeof value.gcLocked === "boolean" && typeof value.taskBuildClaim === "boolean" && typeof value.siblingSetupPrefixClaim === "boolean";
     case "setup-list-reclaim-candidates":
@@ -1241,7 +1296,8 @@ export function isDockerCacheRepositoryResult(value: unknown): value is DockerCa
     case "task-acquire-use":
     case "task-reserve-delete":
     case "setup-reserve-delete":
-      return typeof value.reserved === "boolean" && optionalString(value.reason);
+      return typeof value.reserved === "boolean" &&
+        (value.reason === undefined || isFiniteValue(DOCKER_RESERVATION_REASONS, String(value.reason)));
     case "task-mark-unverified":
     case "task-publish":
     case "task-heartbeat":

--- a/packages/niceeval/src/sandbox/e2b-cache-repository.ts
+++ b/packages/niceeval/src/sandbox/e2b-cache-repository.ts
@@ -2,6 +2,28 @@ import type { DatabaseSync } from "node:sqlite";
 import { Effect, type Scope } from "effect";
 import type { UserDatabase } from "../user-database/client.ts";
 import type { UserDatabaseFailure } from "../user-database/errors.ts";
+import {
+  isFiniteValue,
+  sqlIn,
+  sqlLiteral,
+  type FiniteValue,
+} from "./finite-domain.ts";
+
+const E2B_CACHE_STATE = Object.freeze({
+  building: "building", indexed: "indexed", unverified: "unverified",
+  deleting: "deleting", tombstoned: "tombstoned",
+} as const);
+const E2B_RESERVATION_DISPOSITION = Object.freeze({ reserved: "reserved" } as const);
+const E2B_CONTENTION_REASON = Object.freeze({ activeWriter: "active-writer", indexedGeneration: "indexed-generation" } as const);
+const E2B_CLEAR_DISPOSITION = Object.freeze({
+  missing: "missing", cleared: "cleared", activeRoot: "active-root", activeLease: "active-lease",
+} as const);
+const E2B_CONTENTION_REASONS = Object.freeze(Object.values(E2B_CONTENTION_REASON));
+const E2B_CLEAR_DISPOSITIONS = Object.freeze(Object.values(E2B_CLEAR_DISPOSITION));
+const E2B_CACHE_ENTRY_STATES = Object.freeze([
+  E2B_CACHE_STATE.building, E2B_CACHE_STATE.indexed, E2B_CACHE_STATE.unverified,
+  E2B_CACHE_STATE.deleting, E2B_CACHE_STATE.tombstoned,
+] as const);
 
 /**
  * The E2B snapshot registry is a first-party UserDatabase repository.  Its
@@ -10,7 +32,7 @@ import type { UserDatabaseFailure } from "../user-database/errors.ts";
  */
 export const E2B_CACHE_REPOSITORY = "e2b-cache" as const;
 
-export type E2BCacheEntryState = "building" | "indexed" | "unverified" | "deleting" | "tombstoned";
+export type E2BCacheEntryState = FiniteValue<typeof E2B_CACHE_ENTRY_STATES>;
 
 export interface E2BCacheEntry {
   readonly setupPrefixKey: string;
@@ -120,15 +142,15 @@ export type E2BCacheRequest =
 
 export type E2BCacheResult =
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "lookup"; readonly entry: E2BCacheEntry | null; readonly root: E2BCacheRoot | null }
-  | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "reserve"; readonly disposition: "reserved"; readonly generation: number }
-  | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "reserve"; readonly disposition: "active-writer" | "indexed-generation" }
+  | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "reserve"; readonly disposition: typeof E2B_RESERVATION_DISPOSITION.reserved; readonly generation: number }
+  | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "reserve"; readonly disposition: FiniteValue<typeof E2B_CONTENTION_REASONS> }
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "settle"; readonly settled: boolean }
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "abort"; readonly aborted: boolean }
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "settle-root"; readonly settled: boolean }
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "release-root"; readonly released: boolean }
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "adopt-root"; readonly adopted: boolean }
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "reconcile"; readonly cleanup: readonly E2BCacheSnapshotCleanup[] }
-  | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "clear"; readonly disposition: "missing" | "cleared" | "active-root" | "active-lease"; readonly cleanup: E2BCacheSnapshotCleanup | null }
+  | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "clear"; readonly disposition: FiniteValue<typeof E2B_CLEAR_DISPOSITIONS>; readonly cleanup: E2BCacheSnapshotCleanup | null }
   | { readonly repository: typeof E2B_CACHE_REPOSITORY; readonly operation: "settle-delete"; readonly settled: boolean };
 
 export type E2BCacheResultFor<Request extends E2BCacheRequest> = Extract<E2BCacheResult, { readonly operation: Request["operation"] }>;
@@ -204,7 +226,9 @@ export function isE2BCacheResult(value: unknown): value is E2BCacheResult {
         (Reflect.get(value, "root") === null || isRootResult(Reflect.get(value, "root")));
     case "reserve": {
       const disposition = Reflect.get(value, "disposition");
-      return disposition === "reserved" ? hasGeneration(value) : disposition === "active-writer" || disposition === "indexed-generation";
+      return disposition === E2B_RESERVATION_DISPOSITION.reserved
+        ? hasGeneration(value)
+        : typeof disposition === "string" && isFiniteValue(E2B_CONTENTION_REASONS, disposition);
     }
     case "settle":
       return typeof Reflect.get(value, "settled") === "boolean";
@@ -219,7 +243,7 @@ export function isE2BCacheResult(value: unknown): value is E2BCacheResult {
     case "reconcile":
       return Array.isArray(Reflect.get(value, "cleanup")) && (Reflect.get(value, "cleanup") as unknown[]).every(isCleanup);
     case "clear":
-      return ["missing", "cleared", "active-root", "active-lease"].includes(String(Reflect.get(value, "disposition"))) &&
+      return isFiniteValue(E2B_CLEAR_DISPOSITIONS, String(Reflect.get(value, "disposition"))) &&
         (Reflect.get(value, "cleanup") === null || isCleanup(Reflect.get(value, "cleanup")));
     case "settle-delete":
       return typeof Reflect.get(value, "settled") === "boolean";
@@ -243,10 +267,10 @@ const CreateEntries = `CREATE TABLE ${EntriesTable} (
   created_at TEXT NOT NULL,
   last_successful_use_at TEXT,
   replacement_scope TEXT NOT NULL,
-  state TEXT NOT NULL CHECK(state IN ('building','indexed','unverified','deleting','tombstoned')),
+  state TEXT NOT NULL CHECK(state IN (${sqlIn(E2B_CACHE_ENTRY_STATES)})),
   lease_id TEXT,
   lease_until TEXT,
-  CHECK ((state = 'building') = (lease_id IS NOT NULL AND lease_until IS NOT NULL))
+  CHECK ((state = ${sqlLiteral(E2B_CACHE_STATE.building)}) = (lease_id IS NOT NULL AND lease_until IS NOT NULL))
 ) STRICT`;
 const CreateRoots = `CREATE TABLE ${RootsTable} (
   root_id TEXT PRIMARY KEY,
@@ -293,7 +317,7 @@ function positiveIntegerField(row: object, name: string): number {
 
 function stateField(row: object): E2BCacheEntryState {
   const value = stringField(row, "state");
-  if (value === "building" || value === "indexed" || value === "unverified" || value === "deleting" || value === "tombstoned") return value;
+  if (isFiniteValue(E2B_CACHE_ENTRY_STATES, value)) return value;
   throw invalid("row has invalid state");
 }
 
@@ -312,10 +336,10 @@ function decodeEntry(value: unknown): E2BCacheEntry {
     leaseId: nullableStringField(value, "lease_id"),
     leaseUntil: nullableStringField(value, "lease_until"),
   } as const;
-  if ((entry.state === "building") !== (entry.leaseId !== null && entry.leaseUntil !== null)) {
+  if ((entry.state === E2B_CACHE_STATE.building) !== (entry.leaseId !== null && entry.leaseUntil !== null)) {
     throw invalid("entry lease does not agree with state");
   }
-  if (entry.state === "indexed" && entry.snapshotId === null) throw invalid("indexed entry has no snapshot id");
+  if (entry.state === E2B_CACHE_STATE.indexed && entry.snapshotId === null) throw invalid("indexed entry has no snapshot id");
   return Object.freeze(entry);
 }
 
@@ -348,8 +372,8 @@ function inTransaction<Result>(database: DatabaseSync, operation: () => Result):
 
 function expireLeases(database: DatabaseSync, now: string): void {
   database.prepare(
-    `UPDATE ${EntriesTable} SET state = 'unverified', lease_id = NULL, lease_until = NULL ` +
-      "WHERE state = 'building' AND lease_until <= ?",
+    `UPDATE ${EntriesTable} SET state = ${sqlLiteral(E2B_CACHE_STATE.unverified)}, lease_id = NULL, lease_until = NULL ` +
+      `WHERE state = ${sqlLiteral(E2B_CACHE_STATE.building)} AND lease_until <= ?`,
   ).run(now);
 }
 
@@ -408,9 +432,9 @@ function reconcile(database: DatabaseSync, request: Extract<E2BCacheRequest, { r
       WHERE entry.snapshot_id IS NOT NULL
         AND NOT EXISTS (SELECT 1 FROM ${RootsTable} WHERE ${RootsTable}.setup_prefix_key = entry.setup_prefix_key)
         AND (
-          entry.state = 'deleting'
+          entry.state = ${sqlLiteral(E2B_CACHE_STATE.deleting)}
           OR (
-            entry.state = 'indexed'
+            entry.state = ${sqlLiteral(E2B_CACHE_STATE.indexed)}
             AND entry.replacement_scope != ''
             AND entry.setup_prefix_key != head.setup_prefix_key
             AND (? IS NULL OR entry.replacement_scope = ?)
@@ -424,8 +448,8 @@ function reconcile(database: DatabaseSync, request: Extract<E2BCacheRequest, { r
       request.exceptSetupPrefixKey ?? null,
     ).map(decodeEntry);
     for (const entry of candidates) {
-      if (entry.state === "indexed") {
-        database.prepare(`UPDATE ${EntriesTable} SET state = 'deleting' WHERE setup_prefix_key = ? AND generation = ? AND state = 'indexed'`)
+      if (entry.state === E2B_CACHE_STATE.indexed) {
+        database.prepare(`UPDATE ${EntriesTable} SET state = ${sqlLiteral(E2B_CACHE_STATE.deleting)} WHERE setup_prefix_key = ? AND generation = ? AND state = ${sqlLiteral(E2B_CACHE_STATE.indexed)}`)
           .run(entry.setupPrefixKey, entry.generation);
       }
     }
@@ -442,7 +466,7 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
     return inTransaction(database, () => {
       expireLeases(database, request.now);
       const entry = database.prepare(
-        `SELECT * FROM ${EntriesTable} WHERE setup_prefix_key = ? AND base_identity = ? AND state = 'indexed'`,
+        `SELECT * FROM ${EntriesTable} WHERE setup_prefix_key = ? AND base_identity = ? AND state = ${sqlLiteral(E2B_CACHE_STATE.indexed)}`,
       ).get(request.setupPrefixKey, request.baseIdentity);
       if (entry === undefined) {
         return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "lookup" as const, entry: null, root: null });
@@ -466,11 +490,11 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
       const existing = database.prepare(`SELECT * FROM ${EntriesTable} WHERE setup_prefix_key = ?`).get(request.setupPrefixKey);
       if (existing !== undefined) {
         const entry = decodeEntry(existing);
-        if (entry.state === "indexed") {
-          return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "reserve" as const, disposition: "indexed-generation" as const });
+        if (entry.state === E2B_CACHE_STATE.indexed) {
+          return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "reserve" as const, disposition: E2B_CONTENTION_REASON.indexedGeneration });
         }
-        if (entry.state === "building") {
-          return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "reserve" as const, disposition: "active-writer" as const });
+        if (entry.state === E2B_CACHE_STATE.building) {
+          return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "reserve" as const, disposition: E2B_CONTENTION_REASON.activeWriter });
         }
       }
       const generation = nextGeneration(database);
@@ -478,7 +502,7 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
         INSERT INTO ${EntriesTable}(
           setup_prefix_key, base_identity, snapshot_id, declaration_digest, generation, created_at,
           last_successful_use_at, replacement_scope, state, lease_id, lease_until
-        ) VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, 'building', ?, ?)
+        ) VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, ${sqlLiteral(E2B_CACHE_STATE.building)}, ?, ?)
         ON CONFLICT(setup_prefix_key) DO UPDATE SET
           base_identity = excluded.base_identity,
           snapshot_id = NULL,
@@ -487,7 +511,7 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
           created_at = excluded.created_at,
           last_successful_use_at = NULL,
           replacement_scope = excluded.replacement_scope,
-          state = 'building',
+          state = ${sqlLiteral(E2B_CACHE_STATE.building)},
           lease_id = excluded.lease_id,
           lease_until = excluded.lease_until
       `).run(
@@ -500,14 +524,14 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
         request.leaseId,
         request.leaseUntil,
       );
-      return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "reserve" as const, disposition: "reserved" as const, generation });
+      return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "reserve" as const, disposition: E2B_RESERVATION_DISPOSITION.reserved, generation });
     });
   }
   if (request.operation === "settle") {
     return inTransaction(database, () => {
       const receipt = database.prepare(`
-        UPDATE ${EntriesTable} SET snapshot_id = ?, state = 'indexed', lease_id = NULL, lease_until = NULL
-        WHERE setup_prefix_key = ? AND generation = ? AND lease_id = ? AND state = 'building' AND lease_until > ?
+        UPDATE ${EntriesTable} SET snapshot_id = ?, state = ${sqlLiteral(E2B_CACHE_STATE.indexed)}, lease_id = NULL, lease_until = NULL
+        WHERE setup_prefix_key = ? AND generation = ? AND lease_id = ? AND state = ${sqlLiteral(E2B_CACHE_STATE.building)} AND lease_until > ?
       `).run(request.snapshotId, request.setupPrefixKey, request.generation, request.leaseId, request.now);
       if (receipt.changes === 1) {
         const entry = database.prepare(`SELECT replacement_scope FROM ${EntriesTable} WHERE setup_prefix_key = ?`).get(request.setupPrefixKey);
@@ -523,8 +547,8 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
   }
   if (request.operation === "abort") {
     const receipt = database.prepare(`
-      UPDATE ${EntriesTable} SET state = 'unverified', lease_id = NULL, lease_until = NULL
-      WHERE setup_prefix_key = ? AND generation = ? AND lease_id = ? AND state = 'building'
+      UPDATE ${EntriesTable} SET state = ${sqlLiteral(E2B_CACHE_STATE.unverified)}, lease_id = NULL, lease_until = NULL
+      WHERE setup_prefix_key = ? AND generation = ? AND lease_id = ? AND state = ${sqlLiteral(E2B_CACHE_STATE.building)}
     `).run(request.setupPrefixKey, request.generation, request.leaseId);
     return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "abort" as const, aborted: receipt.changes === 1 });
   }
@@ -534,7 +558,7 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
       if (!isRecord(root)) return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "settle-root" as const, settled: false });
       const setupPrefixKey = stringField(root, "setup_prefix_key");
       const updatedRoot = database.prepare(`UPDATE ${RootsTable} SET sandbox_id = ? WHERE root_id = ?`).run(request.sandboxId, request.rootId);
-      const updatedEntry = database.prepare(`UPDATE ${EntriesTable} SET last_successful_use_at = ? WHERE setup_prefix_key = ? AND state = 'indexed'`)
+      const updatedEntry = database.prepare(`UPDATE ${EntriesTable} SET last_successful_use_at = ? WHERE setup_prefix_key = ? AND state = ${sqlLiteral(E2B_CACHE_STATE.indexed)}`)
         .run(request.now, setupPrefixKey);
       return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "settle-root" as const, settled: updatedRoot.changes === 1 && updatedEntry.changes === 1 });
     });
@@ -548,7 +572,7 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
       const receipt = database.prepare(`
         INSERT INTO ${RootsTable}(root_id, setup_prefix_key, sandbox_id, created_at)
         SELECT ?, setup_prefix_key, ?, ? FROM ${EntriesTable}
-        WHERE setup_prefix_key = ? AND generation = ? AND snapshot_id = ? AND state = 'indexed'
+        WHERE setup_prefix_key = ? AND generation = ? AND snapshot_id = ? AND state = ${sqlLiteral(E2B_CACHE_STATE.indexed)}
       `).run(request.rootId, request.sandboxId, request.now, request.setupPrefixKey, request.generation, request.snapshotId);
       return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "adopt-root" as const, adopted: receipt.changes === 1 });
     });
@@ -559,29 +583,29 @@ function dispatch(database: DatabaseSync, request: E2BCacheRequest): E2BCacheRes
       expireLeases(database, request.now);
       const row = database.prepare(`SELECT * FROM ${EntriesTable} WHERE setup_prefix_key = ?`).get(request.setupPrefixKey);
       if (row === undefined) {
-        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: "missing" as const, cleanup: null });
+        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: E2B_CLEAR_DISPOSITION.missing, cleanup: null });
       }
       const entry = decodeEntry(row);
-      if (entry.state === "building") {
-        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: "active-lease" as const, cleanup: null });
+      if (entry.state === E2B_CACHE_STATE.building) {
+        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: E2B_CLEAR_DISPOSITION.activeLease, cleanup: null });
       }
       const activeRoot = database.prepare(`SELECT root_id FROM ${RootsTable} WHERE setup_prefix_key = ? LIMIT 1`).get(entry.setupPrefixKey);
       if (activeRoot !== undefined) {
-        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: "active-root" as const, cleanup: null });
+        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: E2B_CLEAR_DISPOSITION.activeRoot, cleanup: null });
       }
       if (entry.snapshotId === null) {
-        database.prepare(`UPDATE ${EntriesTable} SET state = 'tombstoned', lease_id = NULL, lease_until = NULL WHERE setup_prefix_key = ?`)
+        database.prepare(`UPDATE ${EntriesTable} SET state = ${sqlLiteral(E2B_CACHE_STATE.tombstoned)}, lease_id = NULL, lease_until = NULL WHERE setup_prefix_key = ?`)
           .run(entry.setupPrefixKey);
-        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: "cleared" as const, cleanup: null });
+        return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: E2B_CLEAR_DISPOSITION.cleared, cleanup: null });
       }
-      database.prepare(`UPDATE ${EntriesTable} SET state = 'deleting' WHERE setup_prefix_key = ? AND generation = ?`)
+      database.prepare(`UPDATE ${EntriesTable} SET state = ${sqlLiteral(E2B_CACHE_STATE.deleting)} WHERE setup_prefix_key = ? AND generation = ?`)
         .run(entry.setupPrefixKey, entry.generation);
-      return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: "cleared" as const, cleanup: cleanupFor(entry) });
+      return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "clear" as const, disposition: E2B_CLEAR_DISPOSITION.cleared, cleanup: cleanupFor(entry) });
     });
   }
   const receipt = database.prepare(`
-    UPDATE ${EntriesTable} SET state = CASE WHEN ? THEN 'tombstoned' ELSE 'deleting' END
-    WHERE setup_prefix_key = ? AND generation = ? AND state = 'deleting'
+    UPDATE ${EntriesTable} SET state = CASE WHEN ? THEN ${sqlLiteral(E2B_CACHE_STATE.tombstoned)} ELSE ${sqlLiteral(E2B_CACHE_STATE.deleting)} END
+    WHERE setup_prefix_key = ? AND generation = ? AND state = ${sqlLiteral(E2B_CACHE_STATE.deleting)}
   `).run(request.deleted ? 1 : 0, request.setupPrefixKey, request.generation);
   return Object.freeze({ repository: E2B_CACHE_REPOSITORY, operation: "settle-delete" as const, settled: receipt.changes === 1 });
 }

--- a/packages/niceeval/src/sandbox/finite-domain.ts
+++ b/packages/niceeval/src/sandbox/finite-domain.ts
@@ -1,0 +1,15 @@
+export type FiniteValue<Values extends readonly string[]> = Values[number];
+
+export function isFiniteValue<const Values extends readonly string[]>(values: Values, value: string): value is FiniteValue<Values> {
+  return (values as readonly string[]).includes(value);
+}
+
+/** SQLite DDL cannot bind CHECK values; this helper only performs SQL escaping. */
+export function sqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function sqlIn(values: readonly string[]): string {
+  if (values.length === 0) throw new Error("finite-domain SQL set cannot be empty");
+  return values.map(sqlLiteral).join(",");
+}

--- a/packages/niceeval/src/sandbox/incus/artifact.ts
+++ b/packages/niceeval/src/sandbox/incus/artifact.ts
@@ -9,11 +9,16 @@ import {
   transitionArtifactIntent,
   type ArtifactIntent,
 } from "./artifact-ledger.ts";
-import { acquireDomainAdmissionLock } from "./ledger.ts";
+import { acquireDomainAdmissionLock, currentOwner } from "./ledger.ts";
 import type { IncusRuntimePlan } from "./plan.ts";
 import type { IncusArtifactLocator, IncusRepository } from "./repository.ts";
 
 export type { IncusArtifactLocator } from "./repository.ts";
+
+export async function acquireCommittedIncusArtifactLease(repository: IncusRepository, artifact: ArtifactIntent): Promise<IncusArtifactLocator> {
+  const lease = await repository.acquireArtifactLease({ leaseId: randomUUID(), artifactId: artifact.artifactId, generation: artifact.generation, owner: currentOwner(), acquiredAt: new Date().toISOString() });
+  return Object.freeze({ artifactId: artifact.artifactId, generation: artifact.generation, project: artifact.project, instance: artifact.instance, dockerDataVolume: artifact.dockerDataVolume, setupPrefixKey: artifact.setupPrefixKey, manifestDigest: artifact.manifestDigest, consumerLeaseId: lease.leaseId });
+}
 
 export interface ArtifactIdentity {
   readonly executionDomainId: string; readonly artifactProject: string; readonly runtimeProject: string; readonly pool: string;
@@ -21,11 +26,13 @@ export interface ArtifactIdentity {
   readonly network: string; readonly baseFingerprint: string; readonly setupPrefixKey: string; readonly manifestDigest: string;
   readonly providerRevision: string; readonly guestInitRevision: string; readonly captureRevision: string;
   readonly coverage: string; readonly resourcesDigest: string;
+  readonly replacementScopeDigest: string;
 }
 
 export interface ArtifactPreparationIdentityInput {
   readonly setupPrefixKey: string; readonly manifestDigest: string; readonly providerRevision: string;
   readonly guestInitRevision: string; readonly captureRevision: string; readonly coverage: string; readonly resourcesDigest: string;
+  readonly replacementScopeDigest: string;
 }
 
 const ARTIFACT_PUBLICATION_LOCK_WAIT_MS = 15 * 60 * 1_000;
@@ -42,7 +49,8 @@ function samePreparationIdentity(intent: ArtifactIntent, identity: ArtifactIdent
     && intent.guestInitRevision === identity.guestInitRevision
     && intent.captureRevision === identity.captureRevision
     && intent.coverage === identity.coverage
-    && intent.resourcesDigest === identity.resourcesDigest;
+    && intent.resourcesDigest === identity.resourcesDigest
+    && intent.replacementScopeDigest === identity.replacementScopeDigest;
 }
 
 function exactPrefixLockId(identity: ArtifactIdentity): string {
@@ -66,7 +74,7 @@ export function incusArtifactPreparationIdentity(
     runtimeProject: plan.project, pool: plan.storagePool, network: plan.network, baseFingerprint: plan.imageFingerprint,
     setupPrefixKey: input.setupPrefixKey, manifestDigest: input.manifestDigest, providerRevision: input.providerRevision,
     guestInitRevision: input.guestInitRevision, captureRevision: input.captureRevision, coverage: input.coverage,
-    resourcesDigest: input.resourcesDigest });
+    resourcesDigest: input.resourcesDigest, replacementScopeDigest: input.replacementScopeDigest });
 }
 const artifactConfig = (a: ArtifactIntent): Record<string, string> => ({
   [INCUS_METADATA.allocationId]: a.artifactId, [INCUS_METADATA.generation]: String(a.generation),
@@ -74,8 +82,9 @@ const artifactConfig = (a: ArtifactIntent): Record<string, string> => ({
   [INCUS_METADATA.setupPrefixKey]: a.setupPrefixKey, [INCUS_METADATA.manifestDigest]: a.manifestDigest,
   [INCUS_METADATA.runtimeProject]: a.runtimeProject, [INCUS_METADATA.pool]: a.pool,
   [INCUS_METADATA.baseFingerprint]: a.baseFingerprint, [INCUS_METADATA.captureRevision]: a.captureRevision,
+  ...(a.replacementScopeDigest === undefined ? {} : { [INCUS_METADATA.replacementScopeDigest]: a.replacementScopeDigest }),
 });
-function matches(config: Readonly<Record<string, string>>, a: ArtifactIntent): boolean {
+export function artifactMetadataMatches(config: Readonly<Record<string, string>>, a: ArtifactIntent): boolean {
   const expected = artifactConfig(a); return Object.entries(expected).every(([key, value]) => config[key] === value);
 }
 function devices(pool: string, volume: string, network: string): Record<string, Record<string, string>> {
@@ -88,6 +97,8 @@ export async function reserveIncusArtifact(
   control: IncusControl,
   identity: ArtifactIdentity,
 ): Promise<ArtifactIntent> {
+  const capacityLock = await acquireDomainAdmissionLock(repository, identity.executionDomainId);
+  try {
   const intents = await listArtifactIntents(repository);
   const instances = await control.listInstances(identity.artifactProject);
   const volumes = await control.listVolumes(identity.artifactProject, identity.pool);
@@ -106,11 +117,18 @@ export async function reserveIncusArtifact(
       ["Keep the provider objects in place and restore or explicitly maintain the registry; never delete or adopt an unregistered artifact."],
     );
   }
+  const occupying = intents.filter((candidate) => candidate.executionDomainId === identity.executionDomainId && candidate.project === identity.artifactProject && candidate.state !== "released");
+  if (occupying.length >= identity.artifactMaxInstances) {
+    const superseded = occupying.some((candidate) => candidate.state === "committed" && candidate.replacementScopeDigest === identity.replacementScopeDigest);
+    if (!superseded) throw incusError("sandbox-capacity-unavailable", "Incus prepared artifact capacity is full and every committed artifact belongs to a still-current replacement lineage.", ["Raise artifactMaxInstances or reduce the active SetupPrefix working set; NiceEval will not evict a still-useful cache entry by age."]);
+  }
   const artifactId = randomUUID(); const now = new Date().toISOString();
   return reserveArtifactIntent(repository, { artifactId, generation: 1, project: identity.artifactProject, instance: `nea-${artifactId.replaceAll("-", "").slice(0, 20)}`,
     dockerDataVolume: `nea-${artifactId.replaceAll("-", "").slice(0, 18)}-dd`, setupPrefixKey: identity.setupPrefixKey, manifestDigest: identity.manifestDigest,
     state: "reserved", executionDomainId: identity.executionDomainId, runtimeProject: identity.runtimeProject, pool: identity.pool, baseFingerprint: identity.baseFingerprint,
-    providerRevision: identity.providerRevision, guestInitRevision: identity.guestInitRevision, captureRevision: identity.captureRevision, coverage: identity.coverage, resourcesDigest: identity.resourcesDigest, createdAt: now, updatedAt: now }, identity.artifactMaxInstances);
+    providerRevision: identity.providerRevision, guestInitRevision: identity.guestInitRevision, captureRevision: identity.captureRevision, coverage: identity.coverage, resourcesDigest: identity.resourcesDigest, replacementScopeDigest: identity.replacementScopeDigest, createdAt: now, updatedAt: now },
+    identity.artifactMaxInstances + (occupying.length >= identity.artifactMaxInstances ? 1 : 0));
+  } finally { await capacityLock.release(); }
 }
 
 /** Prefix order is supplied by the coordinator from deepest to shallowest, so selection remains pure and explicit. */
@@ -130,7 +148,10 @@ export async function lookupCommittedIncusArtifactForPrefixes(
       entry.setupPrefixKey === prefix.setupPrefixKey &&
       entry.manifestDigest === prefix.manifestDigest
     );
-    if (found !== undefined) return Object.freeze({ artifactId: found.artifactId, generation: found.generation, project: found.project, instance: found.instance, dockerDataVolume: found.dockerDataVolume, setupPrefixKey: found.setupPrefixKey, manifestDigest: found.manifestDigest });
+    if (found !== undefined) {
+      const touched = await transitionArtifactIntent(repository, found, { ...found, updatedAt: new Date().toISOString() });
+      return Object.freeze({ artifactId: touched.artifactId, generation: touched.generation, project: touched.project, instance: touched.instance, dockerDataVolume: touched.dockerDataVolume, setupPrefixKey: touched.setupPrefixKey, manifestDigest: touched.manifestDigest });
+    }
   }
   return undefined;
 }
@@ -149,10 +170,37 @@ export async function publishIncusArtifact(repository: IncusRepository, control:
   await control.copyInstance({ sourceProject: prepare.project, sourceName: prepare.instance, targetProject: artifact.project, targetName: artifact.instance, config: artifactConfig(publishing), devices: devices(identity.pool, artifact.dockerDataVolume, identity.network) });
   await control.updateVolumeConfig(artifact.project, identity.pool, artifact.dockerDataVolume, artifactConfig(publishing));
   const vm = await control.getInstance(artifact.project, artifact.instance); const volume = await control.getVolume(artifact.project, identity.pool, artifact.dockerDataVolume);
-  if (vm === undefined || volume === undefined || vm.status.toLowerCase() !== "stopped" || !matches(vm.config, publishing) || !matches(volume.config, publishing)) {
+  if (vm === undefined || volume === undefined || vm.status.toLowerCase() !== "stopped" || !artifactMetadataMatches(vm.config, publishing) || !artifactMetadataMatches(volume.config, publishing)) {
     await transitionArtifactIntent(repository, publishing, { ...publishing, state: "quarantined", updatedAt: new Date().toISOString() }); throw incusError("sandbox-artifact-unverified", "Published artifact tuple failed bidirectional metadata or stopped-state verification.", ["Reconcile and quarantine this artifact."]);
   }
   return transitionArtifactIntent(repository, publishing, { ...publishing, state: "committed", updatedAt: new Date().toISOString() });
+}
+
+async function reclaimSupersededIncusArtifacts(
+  repository: IncusRepository,
+  control: IncusControl,
+  head: ArtifactIntent,
+  previous: ArtifactIntent | undefined,
+): Promise<void> {
+  if (previous === undefined || previous.artifactId === head.artifactId) return;
+  const lock = await acquireDomainAdmissionLock(repository, head.executionDomainId);
+  try {
+    const candidate = await readArtifactIntent(repository, previous.artifactId);
+    if (candidate === undefined || candidate.generation !== previous.generation || (candidate.state !== "committed" && candidate.state !== "invalid") || candidate.replacementScopeDigest !== head.replacementScopeDigest) return;
+    if (candidate.state === "committed" && await repository.countArtifactLeases(candidate.artifactId, candidate.generation) !== 0) return;
+      const vm = await control.getInstance(candidate.project, candidate.instance);
+      const volume = await control.getVolume(candidate.project, candidate.pool, candidate.dockerDataVolume);
+      if ((vm !== undefined && (vm.status.toLowerCase() !== "stopped" || !artifactMetadataMatches(vm.config, candidate))) || (volume !== undefined && !artifactMetadataMatches(volume.config, candidate))) {
+        throw incusError("sandbox-artifact-unverified", "A superseded Incus artifact failed exact metadata verification.", ["The new generation remains committed; do not delete or adopt the drifted old tuple."]);
+      }
+      const requested = await repository.requestArtifactDestroy(candidate);
+      if (!requested.instanceAbsent && vm !== undefined) await control.deleteInstance(candidate.project, candidate.instance);
+      await control.waitAbsent(candidate.project, candidate.instance);
+      const afterInstance = await repository.observeArtifactDestroy(requested.intent, { instanceAbsent: true, volumeAbsent: requested.volumeAbsent });
+      if (!afterInstance.volumeAbsent && volume !== undefined) await control.deleteVolume(candidate.project, candidate.pool, candidate.dockerDataVolume);
+      await control.waitVolumeAbsent(candidate.project, candidate.pool, candidate.dockerDataVolume);
+      await repository.observeArtifactDestroy(afterInstance.intent, { instanceAbsent: true, volumeAbsent: true });
+  } finally { await lock.release(); }
 }
 
 /**
@@ -184,6 +232,10 @@ export async function publishOrReuseIncusArtifact(
       if (verified.state !== "committed") {
         throw incusError("sandbox-artifact-unverified", "The committed Incus artifact failed exact tuple verification.", ["Keep the drifted artifact quarantined and rebuild from a verified ancestor."]);
       }
+      if (verified.replacementScopeDigest !== undefined) {
+        const headed = await repository.replaceArtifactHead(verified);
+        await reclaimSupersededIncusArtifacts(repository, control, headed.intent, headed.previous);
+      }
       return verified;
     }
 
@@ -195,14 +247,23 @@ export async function publishOrReuseIncusArtifact(
     }
     if (inFlight[0] !== undefined) {
       const reconciled = await reconcileIncusArtifact(repository, control, inFlight[0]);
-      if (reconciled.state === "committed") return reconciled;
+      if (reconciled.state === "committed") {
+        if (reconciled.replacementScopeDigest !== undefined) {
+          const headed = await repository.replaceArtifactHead(reconciled);
+          await reclaimSupersededIncusArtifacts(repository, control, headed.intent, headed.previous);
+        }
+        return reconciled;
+      }
       if (reconciled.state === "quarantined") {
         throw incusError("sandbox-artifact-unverified", "The previous exact-prefix publication was quarantined during reconcile.", ["Retry from a verified ancestor after reviewing the quarantined exact object."]);
       }
     }
 
     const reserved = await reserveIncusArtifact(repository, control, identity);
-    return publishIncusArtifact(repository, control, reserved, prepare, identity);
+    const published = await publishIncusArtifact(repository, control, reserved, prepare, identity);
+    const headed = await repository.replaceArtifactHead(published);
+    await reclaimSupersededIncusArtifacts(repository, control, headed.intent, headed.previous);
+    return published;
   } finally {
     await lock.release();
   }
@@ -214,8 +275,8 @@ export async function quiesceIncusArtifact(control: IncusControl, project: strin
   if (result.exitCode !== 0) throw incusError("sandbox-artifact-unverified", `Artifact prepare VM ${JSON.stringify(instance)} did not pass the Docker/containerd quiesce barrier.`, ["Do not publish a live Docker daemon or its containers."]);
 }
 
-export async function lookupCommittedIncusArtifact(repository: IncusRepository, artifactId: string, generation: number): Promise<IncusArtifactLocator> {
-  const artifact = await requireCommittedArtifact(repository, artifactId, generation); return Object.freeze({ artifactId: artifact.artifactId, generation: artifact.generation, project: artifact.project, instance: artifact.instance, dockerDataVolume: artifact.dockerDataVolume, setupPrefixKey: artifact.setupPrefixKey, manifestDigest: artifact.manifestDigest });
+export async function lookupCommittedIncusArtifact(repository: IncusRepository, artifactId: string, generation: number): Promise<ArtifactIntent> {
+  return requireCommittedArtifact(repository, artifactId, generation);
 }
 
 /** Decode only the committed locator projection supplied by the Run coordinator. */
@@ -226,8 +287,9 @@ export async function decodeCommittedIncusArtifact(repository: IncusRepository, 
   const keys = ["artifactId", "generation", "project", "instance", "dockerDataVolume", "setupPrefixKey", "manifestDigest"] as const;
   if (Object.keys(record).length !== keys.length || !keys.every((key) => key in record) || typeof record.artifactId !== "string" || typeof record.generation !== "number" || !Number.isSafeInteger(record.generation) || record.generation < 1 || !["project", "instance", "dockerDataVolume", "setupPrefixKey", "manifestDigest"].every((key) => typeof record[key] === "string")) throw incusError("sandbox-artifact-unverified", "setupPrefixArtifact has an invalid Incus locator shape.", ["Pass only the exact locator returned by lookupCommittedIncusArtifactForPrefixes."]);
   const artifact = await lookupCommittedIncusArtifact(repository, record.artifactId, record.generation);
-  if (artifact.project !== expectedProject || !keys.every((key) => artifact[key] === record[key])) throw incusError("sandbox-artifact-unverified", "setupPrefixArtifact does not match the committed artifact ledger record or planned artifact project.", ["Re-run committed artifact lookup; do not synthesize a locator."]);
-  return artifact;
+  const persistedKeys = ["artifactId", "generation", "project", "instance", "dockerDataVolume", "setupPrefixKey", "manifestDigest"] as const;
+  if (artifact.project !== expectedProject || !persistedKeys.every((key) => artifact[key] === record[key])) throw incusError("sandbox-artifact-unverified", "setupPrefixArtifact does not match the committed artifact ledger record or planned artifact project.", ["Re-run committed artifact lookup; do not synthesize a locator."]);
+  return acquireCommittedIncusArtifactLease(repository, artifact);
 }
 
 export interface IncusPrepareAllocation {
@@ -242,25 +304,35 @@ export async function createIncusPrepareFromBase(control: IncusControl, plan: In
 }
 
 /** A parent artifact uses the same explicit cross-project clone path as a consumer. */
-export async function createIncusPrepareFromArtifact(control: IncusControl, parent: IncusArtifactLocator, prepare: IncusPrepareAllocation): Promise<void> {
-  await cloneIncusArtifactConsumer(control, parent, { project: prepare.project, pool: prepare.pool, network: prepare.network, instance: prepare.instance, volume: prepare.volume, config: prepare.config });
+export async function createIncusPrepareFromArtifact(repository: IncusRepository, control: IncusControl, parent: IncusArtifactLocator, prepare: IncusPrepareAllocation): Promise<void> {
+  await cloneIncusArtifactConsumer(repository, control, parent, { project: prepare.project, pool: prepare.pool, network: prepare.network, instance: prepare.instance, volume: prepare.volume, config: prepare.config });
 }
 
 /** Cross-project consumer clone. New volume source/name is explicit and never reuses the artifact source name. */
-export async function cloneIncusArtifactConsumer(control: IncusControl, artifact: IncusArtifactLocator, target: { readonly project: string; readonly pool: string; readonly network: string; readonly instance: string; readonly volume: string; readonly config: Readonly<Record<string, string>> }): Promise<void> {
+export async function cloneIncusArtifactConsumer(repository: IncusRepository, control: IncusControl, artifact: IncusArtifactLocator, target: { readonly project: string; readonly pool: string; readonly network: string; readonly instance: string; readonly volume: string; readonly config: Readonly<Record<string, string>> }): Promise<void> {
+  if (artifact.consumerLeaseId === undefined) throw incusError("sandbox-artifact-unverified", "Incus artifact clone requires a durable consumer lease.", ["Use only a locator returned by committed artifact lookup."]);
+  try {
   const vm = await control.getInstance(artifact.project, artifact.instance); const volume = await control.getVolume(artifact.project, target.pool, artifact.dockerDataVolume);
   if (vm === undefined || volume === undefined || vm.status.toLowerCase() !== "stopped" || vm.config[INCUS_METADATA.artifactState] !== "committed" || vm.config[INCUS_METADATA.manifestDigest] !== artifact.manifestDigest || volume.config[INCUS_METADATA.manifestDigest] !== artifact.manifestDigest) throw incusError("sandbox-artifact-unverified", "Committed artifact drifted or is missing; it is not consumable.", ["Invalidate and quarantine the artifact before retrying."]);
   // Incus owns the dependent-volume copy as part of the instance operation.
   await control.copyInstance({ sourceProject: artifact.project, sourceName: artifact.instance, targetProject: target.project, targetName: target.instance, config: target.config, devices: devices(target.pool, target.volume, target.network) });
   await control.updateVolumeConfig(target.project, target.pool, target.volume, target.config);
+  } finally {
+    await repository.releaseArtifactLease({ leaseId: artifact.consumerLeaseId, artifactId: artifact.artifactId, generation: artifact.generation, owner: currentOwner(), acquiredAt: "" });
+    const released = await repository.getArtifact(artifact.artifactId);
+    if (released?.replacementScopeDigest !== undefined) {
+      const head = await repository.getArtifactHead(released.replacementScopeDigest);
+      if (head !== undefined && head.artifactId !== released.artifactId) await reclaimSupersededIncusArtifacts(repository, control, head, released);
+    }
+  }
 }
 
 /** Reconcile is exact-object only. It never adopts similarly named objects or makes a drifted artifact warm. */
 export async function reconcileIncusArtifact(repository: IncusRepository, control: IncusControl, artifact: ArtifactIntent): Promise<ArtifactIntent> {
   const vm = await control.getInstance(artifact.project, artifact.instance);
   const volume = await control.getVolume(artifact.project, artifact.pool, artifact.dockerDataVolume);
-  const exactVm = vm !== undefined && matches(vm.config, artifact);
-  const exactVolume = volume !== undefined && matches(volume.config, artifact);
+  const exactVm = vm !== undefined && artifactMetadataMatches(vm.config, artifact);
+  const exactVolume = volume !== undefined && artifactMetadataMatches(volume.config, artifact);
   if (artifact.state === "committed") {
     if (exactVm && exactVolume && vm.status.toLowerCase() === "stopped") return artifact;
     return transitionArtifactIntent(repository, artifact, { ...artifact, state: "quarantined", updatedAt: new Date().toISOString() });

--- a/packages/niceeval/src/sandbox/incus/control.ts
+++ b/packages/niceeval/src/sandbox/incus/control.ts
@@ -39,6 +39,7 @@ export const INCUS_METADATA = Object.freeze({
   pool: "user.niceeval.pool",
   baseFingerprint: "user.niceeval.baseFingerprint",
   captureRevision: "user.niceeval.captureRevision",
+  replacementScopeDigest: "user.niceeval.replacementScopeDigest",
 });
 
 export interface IncusImage {

--- a/packages/niceeval/src/sandbox/incus/doctor.ts
+++ b/packages/niceeval/src/sandbox/incus/doctor.ts
@@ -13,6 +13,7 @@ import {
   parseIncusImageLocator,
 } from "./image.ts";
 import { countActiveAllocations, listAllocationIntents } from "./ledger.ts";
+import { listArtifactIntents } from "./artifact-ledger.ts";
 import { dockerExecutionCapability } from "./plan.ts";
 import { incusRepositoryHost, type IncusRepository } from "./repository.ts";
 
@@ -25,7 +26,8 @@ export type IncusDoctorCheckId =
   | "storage-pool"
   | "domain"
   | "trusted-image"
-  | "capacity";
+  | "capacity"
+  | "artifact-capacity";
 
 export interface IncusDoctorCheck {
   readonly id: IncusDoctorCheckId;
@@ -84,7 +86,7 @@ async function doctorIncusProviderWithRepository(
   const checks: IncusDoctorCheck[] = [];
   const remaining = (after: IncusDoctorCheckId): IncusDoctorReport => {
     const rest: IncusDoctorCheckId[] = [
-      "descriptor", "control", "project", "storage-pool", "domain", "trusted-image", "capacity",
+      "descriptor", "control", "project", "storage-pool", "domain", "trusted-image", "capacity", "artifact-capacity",
     ].filter((id) => !checks.some((entry) => entry.id === id) && id !== after) as IncusDoctorCheckId[];
     checks.push(...failRest(rest, "PREREQUISITE_FAILED", "the preceding diagnostic stage failed closed"));
     return Object.freeze({
@@ -104,6 +106,7 @@ async function doctorIncusProviderWithRepository(
     checks.push(check("descriptor", "FAIL", errorDetail(cause), errorCode(cause)));
     return remaining("descriptor");
   }
+
   const domain = domainByName(descriptor, domainName);
   if (domain === undefined) {
     checks.push(check(
@@ -269,6 +272,22 @@ async function doctorIncusProviderWithRepository(
   } catch (cause) {
     checks.push(check("capacity", "FAIL", errorDetail(cause), errorCode(cause)));
     return remaining("capacity");
+  }
+
+  try {
+    const artifacts = (await listArtifactIntents(repository)).filter((entry) =>
+      entry.executionDomainId === domain.executionDomainId && entry.project === domain.artifactProject &&
+      entry.state !== "released"
+    );
+    const free = Math.max(0, domain.artifactMaxInstances - artifacts.length);
+    if (free === 0) {
+      checks.push(check("artifact-capacity", "FAIL", `no free prepared artifact slots (${artifacts.length}/${domain.artifactMaxInstances})`, "sandbox-capacity-unavailable"));
+    } else {
+      checks.push(check("artifact-capacity", "PASS", `${free} free of ${domain.artifactMaxInstances}`));
+    }
+  } catch (cause) {
+    checks.push(check("artifact-capacity", "FAIL", errorDetail(cause), errorCode(cause)));
+    return remaining("artifact-capacity");
   }
 
   const failed = checks.some((entry) => entry.status === "FAIL");

--- a/packages/niceeval/src/sandbox/incus/materialize.ts
+++ b/packages/niceeval/src/sandbox/incus/materialize.ts
@@ -170,18 +170,6 @@ function preparationSemanticIdentity(plan: IncusRuntimePlan): JsonValue {
   });
 }
 
-function artifactLocator(intent: Awaited<ReturnType<typeof publishOrReuseIncusArtifact>>): IncusArtifactLocator {
-  return Object.freeze({
-    artifactId: intent.artifactId,
-    generation: intent.generation,
-    project: intent.project,
-    instance: intent.instance,
-    dockerDataVolume: intent.dockerDataVolume,
-    setupPrefixKey: intent.setupPrefixKey,
-    manifestDigest: intent.manifestDigest,
-  });
-}
-
 function preparationFailure(cause: unknown): SandboxRuntimeMaterializationError {
   const error = cause instanceof Error ? cause : new Error(String(cause));
   return new SandboxRuntimeMaterializationError({
@@ -296,7 +284,7 @@ async function createReadySandbox(
         config: configFor(creating),
       });
     } else {
-      await cloneIncusArtifactConsumer(control, artifact, {
+      await cloneIncusArtifactConsumer(repository, control, artifact, {
         project: plan.project, pool: plan.storagePool, network: plan.network,
         instance: name, volume: volumeName, config: configFor(creating),
       });
@@ -511,6 +499,7 @@ export function incusProviderModule(
               captureRevision: INCUS_ARTIFACT_FORMAT_REVISION,
               coverage: sandboxState.all,
               resourcesDigest: digestOf(preparationSemanticIdentity(plan)),
+              replacementScopeDigest: digestOf((operation.manifest.declarationMetadata as { readonly replacementScope: JsonValue }).replacementScope),
             });
             const control = await IncusControl.connectMutation();
             const committed = await publishOrReuseIncusArtifact(repository, control, {
@@ -518,7 +507,7 @@ export function incusProviderModule(
               instance: owned.sandbox.sandboxId,
               volume: dockerDataVolume,
             }, identity);
-            const locator = artifactLocator(committed);
+            const locator: IncusArtifactLocator = Object.freeze({ artifactId: committed.artifactId, generation: committed.generation, project: committed.project, instance: committed.instance, dockerDataVolume: committed.dockerDataVolume, setupPrefixKey: committed.setupPrefixKey, manifestDigest: committed.manifestDigest });
             return Object.freeze({
               locator: locator as unknown as JsonValue,
               setupPrefixKey: locator.setupPrefixKey,

--- a/packages/niceeval/src/sandbox/incus/repository.ts
+++ b/packages/niceeval/src/sandbox/incus/repository.ts
@@ -66,6 +66,7 @@ export interface IncusArtifactLocator {
   readonly dockerDataVolume: string;
   readonly setupPrefixKey: string;
   readonly manifestDigest: string;
+  readonly consumerLeaseId?: string;
 }
 
 export interface ArtifactIntent extends IncusArtifactLocator {
@@ -79,6 +80,7 @@ export interface ArtifactIntent extends IncusArtifactLocator {
   readonly captureRevision: string;
   readonly coverage: string;
   readonly resourcesDigest: string;
+  readonly replacementScopeDigest?: string;
   readonly createdAt: string;
   readonly updatedAt: string;
 }
@@ -86,6 +88,14 @@ export interface ArtifactIntent extends IncusArtifactLocator {
 export interface IncusAdmissionLease {
   readonly lockId: string;
   readonly fencingToken: number;
+  readonly owner: AllocationOwner;
+  readonly acquiredAt: string;
+}
+
+export interface IncusArtifactConsumerLease {
+  readonly leaseId: string;
+  readonly artifactId: string;
+  readonly generation: number;
   readonly owner: AllocationOwner;
   readonly acquiredAt: string;
 }
@@ -118,6 +128,13 @@ export type IncusRepositoryRequest =
       readonly expectedState: ArtifactState;
       readonly intent: ArtifactIntent;
     }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.head.replace"; readonly replacementScopeDigest: string; readonly artifactId: string; readonly generation: number }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.head.get"; readonly replacementScopeDigest: string }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.lease.acquire"; readonly lease: IncusArtifactConsumerLease }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.lease.release"; readonly leaseId: string; readonly artifactId: string; readonly generation: number }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.lease.count"; readonly artifactId: string; readonly generation: number }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.destroy.request"; readonly artifactId: string; readonly generation: number; readonly updatedAt: string }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.destroy.observe"; readonly artifactId: string; readonly generation: number; readonly instanceAbsent: boolean; readonly volumeAbsent: boolean; readonly updatedAt: string }
   | {
       readonly repository: typeof INCUS_REPOSITORY;
       readonly operation: "admission.acquire";
@@ -143,6 +160,12 @@ export type IncusRepositoryResult =
   | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.get"; readonly intent: ArtifactIntent | null }
   | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.list"; readonly intents: readonly ArtifactIntent[] }
   | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.transition"; readonly intent: ArtifactIntent }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.head.replace"; readonly intent: ArtifactIntent; readonly previous: ArtifactIntent | null }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.head.get"; readonly intent: ArtifactIntent | null }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.lease.acquire"; readonly lease: IncusArtifactConsumerLease }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.lease.release"; readonly released: boolean }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.lease.count"; readonly count: number }
+  | { readonly repository: typeof INCUS_REPOSITORY; readonly operation: "artifact.destroy.request" | "artifact.destroy.observe"; readonly intent: ArtifactIntent; readonly instanceAbsent: boolean; readonly volumeAbsent: boolean }
   | {
       readonly repository: typeof INCUS_REPOSITORY;
       readonly operation: "admission.acquire";
@@ -194,6 +217,7 @@ const ArtifactIntentSchema = Schema.Struct({
   captureRevision: Schema.String,
   coverage: Schema.String,
   resourcesDigest: Schema.String,
+  replacementScopeDigest: Schema.optional(Schema.String),
   createdAt: Schema.String,
   updatedAt: Schema.String,
 });
@@ -201,9 +225,15 @@ const ArtifactIntentSchema = Schema.Struct({
 const AllocationTable = "incus_allocation_intents";
 const ArtifactTable = "incus_artifact_intents";
 const AdmissionTable = "incus_admission_leases";
+const ArtifactHeadTable = "incus_artifact_replacement_heads";
+const ArtifactLeaseTable = "incus_artifact_consumer_leases";
+const ArtifactDestroyTable = "incus_artifact_destroy_receipts";
 const CreateAllocations = `CREATE TABLE ${AllocationTable} (allocation_id TEXT PRIMARY KEY, generation INTEGER NOT NULL CHECK (generation >= 1), state TEXT NOT NULL CHECK (state IN ('reserved','creating','ready','handed-off','destroy-requested','destroyed','lost')), execution_domain_id TEXT NOT NULL, project TEXT NOT NULL, payload TEXT NOT NULL) STRICT`;
 const CreateArtifacts = `CREATE TABLE ${ArtifactTable} (artifact_id TEXT PRIMARY KEY, generation INTEGER NOT NULL CHECK (generation >= 1), state TEXT NOT NULL CHECK (state IN ('reserved','preparing','publishing','committed','invalid','quarantined','released')), execution_domain_id TEXT NOT NULL, project TEXT NOT NULL, setup_prefix_key TEXT NOT NULL, manifest_digest TEXT NOT NULL, payload TEXT NOT NULL) STRICT`;
 const CreateAdmission = `CREATE TABLE ${AdmissionTable} (lock_id TEXT PRIMARY KEY, fencing_token INTEGER NOT NULL CHECK (fencing_token >= 1), owner_host TEXT NOT NULL, owner_pid INTEGER NOT NULL, owner_started_at TEXT NOT NULL, acquired_at TEXT NOT NULL) STRICT`;
+const CreateArtifactHeads = `CREATE TABLE ${ArtifactHeadTable} (replacement_scope_digest TEXT PRIMARY KEY, artifact_id TEXT NOT NULL, generation INTEGER NOT NULL CHECK (generation >= 1)) STRICT`;
+const CreateArtifactLeases = `CREATE TABLE ${ArtifactLeaseTable} (lease_id TEXT PRIMARY KEY, artifact_id TEXT NOT NULL, generation INTEGER NOT NULL CHECK (generation >= 1), owner_host TEXT NOT NULL, owner_pid INTEGER NOT NULL, owner_started_at TEXT NOT NULL, acquired_at TEXT NOT NULL) STRICT`;
+const CreateArtifactDestroy = `CREATE TABLE ${ArtifactDestroyTable} (artifact_id TEXT PRIMARY KEY, generation INTEGER NOT NULL CHECK (generation >= 1), instance_absent INTEGER NOT NULL CHECK (instance_absent IN (0,1)), volume_absent INTEGER NOT NULL CHECK (volume_absent IN (0,1)), updated_at TEXT NOT NULL) STRICT`;
 
 type IntentRow = { readonly generation: unknown; readonly state: unknown; readonly payload: unknown };
 type SchemaRow = { readonly type: string; readonly name: string; readonly tbl_name: string; readonly sql: string | null };
@@ -342,6 +372,7 @@ function sameArtifactIdentity(left: ArtifactIntent, right: ArtifactIntent): bool
     left.baseFingerprint === right.baseFingerprint && left.providerRevision === right.providerRevision &&
     left.guestInitRevision === right.guestInitRevision && left.captureRevision === right.captureRevision &&
     left.coverage === right.coverage && left.resourcesDigest === right.resourcesDigest &&
+    left.replacementScopeDigest === right.replacementScopeDigest &&
     left.createdAt === right.createdAt;
 }
 
@@ -366,26 +397,36 @@ const ArtifactTransitions: Readonly<Record<ArtifactState, ReadonlySet<ArtifactSt
 
 function assertCurrentSchema(database: DatabaseSync): void {
   const rows = database.prepare(
-    "SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE tbl_name IN (?, ?, ?) OR name IN (?, ?, ?) ORDER BY type, name",
-  ).all(AllocationTable, ArtifactTable, AdmissionTable, AllocationTable, ArtifactTable, AdmissionTable) as SchemaRow[];
+    "SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE tbl_name IN (?, ?, ?, ?, ?, ?) OR name IN (?, ?, ?, ?, ?, ?) ORDER BY type, name",
+  ).all(AllocationTable, ArtifactTable, AdmissionTable, ArtifactHeadTable, ArtifactLeaseTable, ArtifactDestroyTable,
+    AllocationTable, ArtifactTable, AdmissionTable, ArtifactHeadTable, ArtifactLeaseTable, ArtifactDestroyTable) as SchemaRow[];
   const expected = new Map([
     [AllocationTable, CreateAllocations],
     [ArtifactTable, CreateArtifacts],
     [AdmissionTable, CreateAdmission],
+    [ArtifactHeadTable, CreateArtifactHeads],
+    [ArtifactLeaseTable, CreateArtifactLeases],
+    [ArtifactDestroyTable, CreateArtifactDestroy],
   ]);
   const tables = rows.filter((row) => row.type === "table" && row.name === row.tbl_name && expected.has(row.name));
   const automaticIndexes = rows.filter((row) => row.type === "index" && expected.has(row.tbl_name) && row.sql === null);
-  if (rows.length !== 6 || tables.length !== 3 || automaticIndexes.length !== 3 ||
+  if (rows.length !== 12 || tables.length !== 6 || automaticIndexes.length !== 6 ||
     tables.some((row) => exactSql(row.sql ?? "") !== exactSql(expected.get(row.name) ?? ""))) {
-    throw invalid("Incus repository schema does not match revision 1");
+    throw invalid("Incus repository schema does not match revision 2");
   }
 }
 
 function migrateAdjacent(database: DatabaseSync, fromRevision: number): number {
-  if (fromRevision !== 0) throw invalid(`Incus repository has no migration from revision ${fromRevision}`);
-  database.exec(`${CreateAllocations}; ${CreateArtifacts}; ${CreateAdmission};`);
-  assertCurrentSchema(database);
-  return 1;
+  if (fromRevision === 0) {
+    database.exec(`${CreateAllocations}; ${CreateArtifacts}; ${CreateAdmission};`);
+    return 1;
+  }
+  if (fromRevision === 1) {
+    database.exec(`${CreateArtifactHeads}; ${CreateArtifactLeases}; ${CreateArtifactDestroy};`);
+    assertCurrentSchema(database);
+    return 2;
+  }
+  throw invalid(`Incus repository has no migration from revision ${fromRevision}`);
 }
 
 function getAllocation(database: DatabaseSync, allocationId: string): AllocationIntent | null {
@@ -445,7 +486,7 @@ function dispatch(database: DatabaseSync, request: IncusRepositoryRequest): Incu
       ).get(intent.executionDomainId, intent.setupPrefixKey, intent.manifestDigest);
       if (exact !== undefined) throw invalid("Incus artifact exact-prefix reservation is already owned");
       const count = database.prepare(
-        `SELECT COUNT(*) AS count FROM ${ArtifactTable} WHERE execution_domain_id = ? AND project = ? AND state NOT IN ('released','quarantined','invalid')`,
+        `SELECT COUNT(*) AS count FROM ${ArtifactTable} WHERE execution_domain_id = ? AND project = ? AND state <> 'released'`,
       ).get(intent.executionDomainId, intent.project) as { readonly count?: unknown } | undefined;
       if (count === undefined || !Number.isSafeInteger(count.count) || Number(count.count) >= request.maximumActive) {
         throw invalid("Incus artifact repository has no free reservation capacity");
@@ -486,6 +527,85 @@ function dispatch(database: DatabaseSync, request: IncusRepositoryRequest): Incu
       ).run(next.state, JSON.stringify(next), request.artifactId, request.expectedGeneration, request.expectedState);
       if (receipt.changes !== 1) throw invalid(`Incus artifact ${request.artifactId} transition failed its compare-and-swap`);
       return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, intent: next });
+    });
+  }
+  if (request.operation === "artifact.head.replace") {
+    return transaction(database, () => {
+      const intent = getArtifact(database, request.artifactId);
+      if (intent === null || intent.generation !== request.generation || intent.state !== "committed" || intent.replacementScopeDigest !== request.replacementScopeDigest) {
+        throw invalid("Incus replacement head must reference the exact committed artifact generation and scope");
+      }
+      const row = database.prepare(`SELECT artifact_id, generation FROM ${ArtifactHeadTable} WHERE replacement_scope_digest = ?`).get(request.replacementScopeDigest) as { readonly artifact_id?: unknown; readonly generation?: unknown } | undefined;
+      let previous = row === undefined || typeof row.artifact_id !== "string" || !Number.isSafeInteger(row.generation)
+        ? null
+        : getArtifact(database, row.artifact_id);
+      if (previous === null) {
+        previous = database.prepare(`SELECT generation, state, payload FROM ${ArtifactTable} WHERE artifact_id <> ? AND state = 'committed' ORDER BY artifact_id`).all(intent.artifactId)
+          .map(decodeArtifactRow).find((candidate) => candidate.replacementScopeDigest === request.replacementScopeDigest) ?? null;
+      }
+      database.prepare(`INSERT INTO ${ArtifactHeadTable}(replacement_scope_digest, artifact_id, generation) VALUES (?, ?, ?) ON CONFLICT(replacement_scope_digest) DO UPDATE SET artifact_id = excluded.artifact_id, generation = excluded.generation`)
+        .run(request.replacementScopeDigest, intent.artifactId, intent.generation);
+      return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, intent, previous });
+    });
+  }
+  if (request.operation === "artifact.head.get") {
+    const row = database.prepare(`SELECT artifact_id, generation FROM ${ArtifactHeadTable} WHERE replacement_scope_digest = ?`).get(request.replacementScopeDigest) as { readonly artifact_id?: unknown; readonly generation?: unknown } | undefined;
+    const intent = row === undefined || typeof row.artifact_id !== "string" || !Number.isSafeInteger(row.generation) ? null : getArtifact(database, row.artifact_id);
+    return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, intent });
+  }
+  if (request.operation === "artifact.lease.acquire") {
+    return transaction(database, () => {
+      const lease = request.lease;
+      const intent = getArtifact(database, lease.artifactId);
+      if (intent === null || intent.generation !== lease.generation || intent.state !== "committed") throw invalid("Incus consumer lease requires the exact committed artifact generation");
+      const receipt = database.prepare(`INSERT INTO ${ArtifactLeaseTable}(lease_id, artifact_id, generation, owner_host, owner_pid, owner_started_at, acquired_at) VALUES (?, ?, ?, ?, ?, ?, ?)`)
+        .run(lease.leaseId, lease.artifactId, lease.generation, lease.owner.host, lease.owner.pid, lease.owner.startedAt, lease.acquiredAt);
+      if (receipt.changes !== 1) throw invalid("Incus consumer lease was not inserted");
+      return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, lease });
+    });
+  }
+  if (request.operation === "artifact.lease.release") {
+    const receipt = database.prepare(`DELETE FROM ${ArtifactLeaseTable} WHERE lease_id = ? AND artifact_id = ? AND generation = ?`)
+      .run(request.leaseId, request.artifactId, request.generation);
+    return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, released: receipt.changes === 1 });
+  }
+  if (request.operation === "artifact.lease.count") {
+    const row = database.prepare(`SELECT COUNT(*) AS count FROM ${ArtifactLeaseTable} WHERE artifact_id = ? AND generation = ?`).get(request.artifactId, request.generation) as { readonly count?: unknown } | undefined;
+    if (row === undefined || !Number.isSafeInteger(row.count)) throw invalid("Incus consumer lease count is invalid");
+    return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, count: Number(row.count) });
+  }
+  if (request.operation === "artifact.destroy.request") {
+    return transaction(database, () => {
+      const current = getArtifact(database, request.artifactId);
+      if (current === null || current.generation !== request.generation || (current.state !== "committed" && current.state !== "invalid")) throw invalid("Incus artifact destroy request lost its exact generation/state fence");
+      const leases = database.prepare(`SELECT COUNT(*) AS count FROM ${ArtifactLeaseTable} WHERE artifact_id = ? AND generation = ?`).get(current.artifactId, current.generation) as { readonly count?: unknown } | undefined;
+      if (leases === undefined || leases.count !== 0) throw invalid("Incus artifact destroy request is blocked by a consumer lease");
+      const intent = current.state === "invalid" ? current : freezeArtifact({ ...current, state: "invalid", updatedAt: request.updatedAt });
+      if (current.state !== "invalid") {
+        const transition = database.prepare(`UPDATE ${ArtifactTable} SET state = ?, payload = ? WHERE artifact_id = ? AND generation = ? AND state = 'committed'`).run(intent.state, JSON.stringify(intent), intent.artifactId, intent.generation);
+        if (transition.changes !== 1) throw invalid("Incus artifact destroy request failed its compare-and-swap");
+      }
+      database.prepare(`INSERT INTO ${ArtifactDestroyTable}(artifact_id, generation, instance_absent, volume_absent, updated_at) VALUES (?, ?, 0, 0, ?) ON CONFLICT(artifact_id) DO NOTHING`).run(intent.artifactId, intent.generation, request.updatedAt);
+      const receipt = database.prepare(`SELECT instance_absent, volume_absent FROM ${ArtifactDestroyTable} WHERE artifact_id = ? AND generation = ?`).get(intent.artifactId, intent.generation) as { readonly instance_absent?: unknown; readonly volume_absent?: unknown } | undefined;
+      if (receipt === undefined) throw invalid("Incus artifact destroy receipt is missing");
+      return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, intent, instanceAbsent: receipt.instance_absent === 1, volumeAbsent: receipt.volume_absent === 1 });
+    });
+  }
+  if (request.operation === "artifact.destroy.observe") {
+    return transaction(database, () => {
+      const current = getArtifact(database, request.artifactId);
+      if (current === null || current.generation !== request.generation || current.state !== "invalid") throw invalid("Incus artifact destroy observation lost its exact invalid generation");
+      const receipt = database.prepare(`UPDATE ${ArtifactDestroyTable} SET instance_absent = MAX(instance_absent, ?), volume_absent = MAX(volume_absent, ?), updated_at = ? WHERE artifact_id = ? AND generation = ?`)
+        .run(request.instanceAbsent ? 1 : 0, request.volumeAbsent ? 1 : 0, request.updatedAt, current.artifactId, current.generation);
+      if (receipt.changes !== 1) throw invalid("Incus artifact destroy observation has no durable request");
+      const observed = database.prepare(`SELECT instance_absent, volume_absent FROM ${ArtifactDestroyTable} WHERE artifact_id = ? AND generation = ?`).get(current.artifactId, current.generation) as { readonly instance_absent?: unknown; readonly volume_absent?: unknown };
+      const instanceAbsent = observed.instance_absent === 1; const volumeAbsent = observed.volume_absent === 1;
+      const intent = instanceAbsent && volumeAbsent ? freezeArtifact({ ...current, state: "released", updatedAt: request.updatedAt }) : current;
+      if (intent.state === "released") {
+        const transition = database.prepare(`UPDATE ${ArtifactTable} SET state = ?, payload = ? WHERE artifact_id = ? AND generation = ? AND state = 'invalid'`).run(intent.state, JSON.stringify(intent), intent.artifactId, intent.generation);
+        if (transition.changes !== 1) throw invalid("Incus artifact release failed its compare-and-swap");
+      }
+      return Object.freeze({ repository: INCUS_REPOSITORY, operation: request.operation, intent, instanceAbsent, volumeAbsent });
     });
   }
   if (request.operation === "admission.acquire") {
@@ -533,7 +653,7 @@ function dispatch(database: DatabaseSync, request: IncusRepositoryRequest): Incu
 
 export const incusRepositoryHandler = Object.freeze({
   id: INCUS_REPOSITORY,
-  currentRevision: 1,
+  currentRevision: 2,
   migrateAdjacent,
   assertCurrentSchema,
   dispatch,
@@ -570,6 +690,12 @@ function isLease(value: unknown): value is IncusAdmissionLease {
     isOwner(value.owner) && typeof value.acquiredAt === "string";
 }
 
+function isConsumerLease(value: unknown): value is IncusArtifactConsumerLease {
+  return record(value) && keysAre(value, ["leaseId", "artifactId", "generation", "owner", "acquiredAt"]) &&
+    typeof value.leaseId === "string" && typeof value.artifactId === "string" &&
+    Number.isSafeInteger(value.generation) && Number(value.generation) > 0 && isOwner(value.owner) && typeof value.acquiredAt === "string";
+}
+
 /** Worker-side hostile-message decoder. It accepts no SQL, table, or dynamic operation. */
 export function isIncusRepositoryRequest(value: unknown): value is IncusRepositoryRequest {
   if (!record(value) || value.repository !== INCUS_REPOSITORY || typeof value.operation !== "string") return false;
@@ -598,6 +724,27 @@ export function isIncusRepositoryRequest(value: unknown): value is IncusReposito
     return keysAre(value, ["repository", "operation", "artifactId", "expectedGeneration", "expectedState", "intent"]) &&
       typeof value.artifactId === "string" && Number.isSafeInteger(value.expectedGeneration) && Number(value.expectedGeneration) > 0 &&
       (ARTIFACT_STATES as readonly unknown[]).includes(value.expectedState) && isArtifactIntent(value.intent);
+  }
+  if (value.operation === "artifact.head.replace") {
+    return keysAre(value, ["repository", "operation", "replacementScopeDigest", "artifactId", "generation"]) &&
+      typeof value.replacementScopeDigest === "string" && typeof value.artifactId === "string" && Number.isSafeInteger(value.generation) && Number(value.generation) > 0;
+  }
+  if (value.operation === "artifact.head.get") {
+    return keysAre(value, ["repository", "operation", "replacementScopeDigest"]) && typeof value.replacementScopeDigest === "string";
+  }
+  if (value.operation === "artifact.lease.acquire") {
+    return keysAre(value, ["repository", "operation", "lease"]) && isConsumerLease(value.lease);
+  }
+  if (value.operation === "artifact.lease.release" || value.operation === "artifact.lease.count") {
+    const expected = value.operation === "artifact.lease.release" ? ["repository", "operation", "leaseId", "artifactId", "generation"] : ["repository", "operation", "artifactId", "generation"];
+    return keysAre(value, expected) && (value.operation !== "artifact.lease.release" || typeof value.leaseId === "string") &&
+      typeof value.artifactId === "string" && Number.isSafeInteger(value.generation) && Number(value.generation) > 0;
+  }
+  if (value.operation === "artifact.destroy.request") {
+    return keysAre(value, ["repository", "operation", "artifactId", "generation", "updatedAt"]) && typeof value.artifactId === "string" && Number.isSafeInteger(value.generation) && Number(value.generation) > 0 && typeof value.updatedAt === "string";
+  }
+  if (value.operation === "artifact.destroy.observe") {
+    return keysAre(value, ["repository", "operation", "artifactId", "generation", "instanceAbsent", "volumeAbsent", "updatedAt"]) && typeof value.artifactId === "string" && Number.isSafeInteger(value.generation) && Number(value.generation) > 0 && typeof value.instanceAbsent === "boolean" && typeof value.volumeAbsent === "boolean" && typeof value.updatedAt === "string";
   }
   if (value.operation === "admission.acquire") {
     return (keysAre(value, ["repository", "operation", "lockId", "owner", "acquiredAt"]) ||
@@ -635,6 +782,24 @@ export function isIncusRepositoryResult(value: unknown): value is IncusRepositor
     return keysAre(value, ["repository", "operation", "intents"]) &&
       Array.isArray(value.intents) && value.intents.every(isArtifactIntent);
   }
+  if (value.operation === "artifact.head.replace") {
+    return keysAre(value, ["repository", "operation", "intent", "previous"]) && isArtifactIntent(value.intent) && (value.previous === null || isArtifactIntent(value.previous));
+  }
+  if (value.operation === "artifact.head.get") {
+    return keysAre(value, ["repository", "operation", "intent"]) && (value.intent === null || isArtifactIntent(value.intent));
+  }
+  if (value.operation === "artifact.lease.acquire") {
+    return keysAre(value, ["repository", "operation", "lease"]) && isConsumerLease(value.lease);
+  }
+  if (value.operation === "artifact.lease.release") {
+    return keysAre(value, ["repository", "operation", "released"]) && typeof value.released === "boolean";
+  }
+  if (value.operation === "artifact.lease.count") {
+    return keysAre(value, ["repository", "operation", "count"]) && Number.isSafeInteger(value.count) && Number(value.count) >= 0;
+  }
+  if (value.operation === "artifact.destroy.request" || value.operation === "artifact.destroy.observe") {
+    return keysAre(value, ["repository", "operation", "intent", "instanceAbsent", "volumeAbsent"]) && isArtifactIntent(value.intent) && typeof value.instanceAbsent === "boolean" && typeof value.volumeAbsent === "boolean";
+  }
   if (value.operation === "admission.acquire") {
     return keysAre(value, ["repository", "operation", "acquired", "lease"]) &&
       typeof value.acquired === "boolean" && isLease(value.lease);
@@ -652,6 +817,13 @@ export interface IncusRepository {
   readonly getArtifact: (artifactId: string) => Promise<ArtifactIntent | undefined>;
   readonly listArtifacts: () => Promise<readonly ArtifactIntent[]>;
   readonly transitionArtifact: (current: ArtifactIntent, next: ArtifactIntent) => Promise<ArtifactIntent>;
+  readonly replaceArtifactHead: (intent: ArtifactIntent) => Promise<{ readonly intent: ArtifactIntent; readonly previous?: ArtifactIntent }>;
+  readonly getArtifactHead: (replacementScopeDigest: string) => Promise<ArtifactIntent | undefined>;
+  readonly acquireArtifactLease: (lease: IncusArtifactConsumerLease) => Promise<IncusArtifactConsumerLease>;
+  readonly releaseArtifactLease: (lease: IncusArtifactConsumerLease) => Promise<boolean>;
+  readonly countArtifactLeases: (artifactId: string, generation: number) => Promise<number>;
+  readonly requestArtifactDestroy: (intent: ArtifactIntent) => Promise<{ readonly intent: ArtifactIntent; readonly instanceAbsent: boolean; readonly volumeAbsent: boolean }>;
+  readonly observeArtifactDestroy: (intent: ArtifactIntent, observation: { readonly instanceAbsent: boolean; readonly volumeAbsent: boolean }) => Promise<{ readonly intent: ArtifactIntent; readonly instanceAbsent: boolean; readonly volumeAbsent: boolean }>;
   readonly acquireAdmission: (lockId: string, owner: AllocationOwner, expected?: IncusAdmissionLease) => Promise<{ readonly acquired: boolean; readonly lease: IncusAdmissionLease }>;
   readonly releaseAdmission: (lease: IncusAdmissionLease) => Promise<boolean>;
 }
@@ -693,6 +865,17 @@ function makeIncusRepository(database: UserDatabase, run: RunRepositoryEffect): 
       expectedState: current.state,
       intent,
     })).intent,
+    replaceArtifactHead: async (intent: ArtifactIntent) => {
+      if (intent.replacementScopeDigest === undefined) throw invalid("Incus artifact has no replacement scope digest");
+      const result = await call({ repository: INCUS_REPOSITORY, operation: "artifact.head.replace", replacementScopeDigest: intent.replacementScopeDigest, artifactId: intent.artifactId, generation: intent.generation });
+      return Object.freeze({ intent: result.intent, ...(result.previous === null ? {} : { previous: result.previous }) });
+    },
+    getArtifactHead: async (replacementScopeDigest: string) => (await call({ repository: INCUS_REPOSITORY, operation: "artifact.head.get", replacementScopeDigest })).intent ?? undefined,
+    acquireArtifactLease: async (lease: IncusArtifactConsumerLease) => (await call({ repository: INCUS_REPOSITORY, operation: "artifact.lease.acquire", lease })).lease,
+    releaseArtifactLease: async (lease: IncusArtifactConsumerLease) => (await call({ repository: INCUS_REPOSITORY, operation: "artifact.lease.release", leaseId: lease.leaseId, artifactId: lease.artifactId, generation: lease.generation })).released,
+    countArtifactLeases: async (artifactId: string, generation: number) => (await call({ repository: INCUS_REPOSITORY, operation: "artifact.lease.count", artifactId, generation })).count,
+    requestArtifactDestroy: async (intent: ArtifactIntent) => call({ repository: INCUS_REPOSITORY, operation: "artifact.destroy.request", artifactId: intent.artifactId, generation: intent.generation, updatedAt: new Date().toISOString() }),
+    observeArtifactDestroy: async (intent: ArtifactIntent, observation: { readonly instanceAbsent: boolean; readonly volumeAbsent: boolean }) => call({ repository: INCUS_REPOSITORY, operation: "artifact.destroy.observe", artifactId: intent.artifactId, generation: intent.generation, ...observation, updatedAt: new Date().toISOString() }),
     acquireAdmission: async (lockId: string, owner: AllocationOwner, expected?: IncusAdmissionLease) => {
       const result = await call({
         repository: INCUS_REPOSITORY,

--- a/packages/niceeval/src/shared/evaluation.ts
+++ b/packages/niceeval/src/shared/evaluation.ts
@@ -1,0 +1,2 @@
+export const EVALUATION_KINDS = ["pass", "score"] as const;
+export type EvaluationKind = (typeof EVALUATION_KINDS)[number];

--- a/packages/niceeval/src/shared/types.ts
+++ b/packages/niceeval/src/shared/types.ts
@@ -26,7 +26,11 @@ export type JsonMatch =
   | { readonly [key: string]: JsonMatch };
 
 /** 一次 Attempt 的互斥终态；跳过是已结束但不构成可执行结论的结果。 */
-export type Verdict = "passed" | "failed" | "errored" | "skipped";
+export const VERDICTS = ["passed", "failed", "errored", "skipped"] as const;
+export type Verdict = (typeof VERDICTS)[number];
+export const VERDICT_PROJECTION_STATE = Object.freeze({ unknown: "unknown" as const });
+export const PROJECTED_VERDICTS = [...VERDICTS, VERDICT_PROJECTION_STATE.unknown] as const;
+export type ProjectedVerdict = (typeof PROJECTED_VERDICTS)[number];
 
 /**
  * eval 源码里一次调用的位置(`t.send` / 各断言),运行期从栈回溯抠出来(见 src/source-loc.ts)。

--- a/packages/niceeval/src/shared/verdict.ts
+++ b/packages/niceeval/src/shared/verdict.ts
@@ -5,9 +5,11 @@
 import type { Verdict } from "./types.ts";
 
 /** A consumer needs exactly the sealed four-state Verdict. */
+import type { EvaluationKind } from "./evaluation.ts";
+
 export interface VerdictLike {
   readonly verdict: Verdict;
-  readonly evaluationKind?: "pass" | "score";
+  readonly evaluationKind?: EvaluationKind;
   readonly scoreResult?: {
     readonly status: "scored" | "invalid" | "unavailable" | "errored" | "skipped";
   };

--- a/packages/niceeval/src/show/model.ts
+++ b/packages/niceeval/src/show/model.ts
@@ -13,12 +13,15 @@ import type {
   InspectionScoredValue,
   InspectionTraceDetailResult,
 } from "../inspection/index.ts";
+import type { AttemptOutcome as RecordAttemptOutcome, MembershipAction as RecordMembershipAction } from "../record/model/core.ts";
+import type { Verdict as PublicVerdict } from "../shared/types.ts";
+import type { AgentTurnOutcome as ReceiptAgentTurnOutcome, SANDBOX_COMMAND_PHASES } from "../record/family/protocol-values.ts";
 
 export type MetricState = "available" | "partial" | "unavailable" | "empty" | "unsupported" | "failed";
-export type Verdict = "passed" | "failed" | "errored" | "skipped";
-export type MembershipAction = "executed" | "carried" | "accepted" | "not-dispatched" | "interrupted";
-export type AttemptOutcome = "completed" | "errored" | "cancelled" | "interrupted";
-export type AgentTurnOutcome = "completed" | "failed" | "cancelled" | "interrupted";
+export type Verdict = PublicVerdict;
+export type MembershipAction = RecordMembershipAction;
+export type AttemptOutcome = RecordAttemptOutcome;
+export type AgentTurnOutcome = ReceiptAgentTurnOutcome;
 export type SectionState = "available" | "not-recorded" | "partial" | "unavailable";
 export type ProjectionState = "complete" | "partial" | "not-recorded" | "invalid";
 export type SourceState = "available" | "not-recorded" | "invalid";
@@ -29,7 +32,7 @@ export type SourceContent =
 export type AssertionSource =
   | { readonly state: "mapped"; readonly sourceItemId: string; readonly sha256: string }
   | { readonly state: "unmapped"; readonly reason: "source-snapshot-not-recorded" | "position-unrepresentable" };
-export type CommandPhase = "attempt.setup" | "sandbox.prepare" | "agent.ensure" | "eval.run" | "sandbox.command" | "attempt.teardown";
+export type CommandPhase = (typeof SANDBOX_COMMAND_PHASES)[number];
 export type CommandOutcome = "exited" | "terminated" | "not-started";
 export type Metric = { readonly state: MetricState; readonly value: number | null };
 export type Aggregate = {

--- a/packages/niceeval/src/view/app/legacy/client/types.ts
+++ b/packages/niceeval/src/view/app/legacy/client/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
+import type { Locale as SupportedLocale } from "../../../../i18n/core.ts";
 
-export type Locale = "en" | "zh-CN";
+export type Locale = SupportedLocale;
 
 export interface LocalizedText {
   readonly en: string;

--- a/packages/niceeval/src/view/app/legacy/report/components/attempt-detail/compute.ts
+++ b/packages/niceeval/src/view/app/legacy/report/components/attempt-detail/compute.ts
@@ -47,7 +47,7 @@ export interface AttemptCapabilitiesView {
 export interface AttemptSummaryData {
   readonly experimentId: string;
   readonly identity: AttemptIdentityView;
-  readonly verdict: "passed" | "failed" | "errored" | "skipped" | "unknown";
+  readonly verdict: import("../../../../../../shared/types.ts").ProjectedVerdict;
   readonly startedAt?: string;
   readonly durationMs: number | null;
   readonly observedCostUSD?: number;

--- a/packages/niceeval/src/view/app/legacy/report/definition/cell.tsx
+++ b/packages/niceeval/src/view/app/legacy/report/definition/cell.tsx
@@ -3,6 +3,7 @@
 // 读取 Sample、Analysis、SQLite snapshot 或 repository。
 
 import type { MetricFormat } from "../model/format.ts";
+import type { Verdict as PublicVerdict } from "../../../../../shared/types.ts";
 import {
   formatMetricScalar,
   formatPlainNumber,
@@ -20,7 +21,7 @@ import {
 
 /** Plain closed locator identity used by the old table props. */
 export type AttemptLocator = string;
-export type Verdict = "passed" | "failed" | "errored" | "skipped";
+export type Verdict = PublicVerdict;
 
 export type MetricState =
   | "available"

--- a/packages/niceeval/src/view/app/legacy/report/model/locale.ts
+++ b/packages/niceeval/src/view/app/legacy/report/model/locale.ts
@@ -13,7 +13,9 @@ export type ReportLocale = string;
 export const DEFAULT_REPORT_LOCALE: ReportLocale = "en";
 
 /** 官方固定文案覆盖的 locale 全集。 */
-export const DISPLAY_LOCALES: readonly ReportLocale[] = ["en", "zh-CN"];
+import { LOCALES } from "../../../../../i18n/core.ts";
+
+export const DISPLAY_LOCALES: readonly ReportLocale[] = LOCALES;
 
 /**
  * LocalizedText 的确定回退:取当前 locale;缺失时取 en;仍缺失时取按 locale 键字典序的

--- a/packages/repo-tools/src/cli.ts
+++ b/packages/repo-tools/src/cli.ts
@@ -19,10 +19,13 @@ import {
   workCommandContribution,
 } from "./docs/index.js";
 import { checkExamples, syncExamples } from "./examples/index.js";
-import { NodeFeedbackStoreLive, runFeedbackCommand } from "./feedback/index.js";
-import { NodeMemoryStoreLive, runMemoryCommand } from "./memory/index.js";
+import { FEEDBACK_CLOSURE_KINDS, FEEDBACK_MEMORY_RELATION_KINDS, NodeFeedbackStoreLive, runFeedbackCommand } from "./feedback/index.js";
+import { MEMORY_KINDS, NodeMemoryStoreLive, PROBLEM_RESOLUTION_KINDS, runMemoryCommand } from "./memory/index.js";
 import {
   makeNodePrLive,
+  PR_BODY_CASE_DIRECTIONS,
+  PR_BODY_CASE_SECTIONS,
+  PR_BODY_TEST_PURPOSES,
   prBodyCommandContribution,
 } from "./pr/index.js";
 import {
@@ -173,7 +176,7 @@ const feedbackShow = Command.make("show", {
 const feedbackLink = Command.make("link", {
   id: Args.string("feedback-id"),
   memory: Options.string("memory"),
-  kind: Options.choice("kind", ["investigation", "root-cause", "decision", "delivery"] as const),
+  kind: Options.choice("kind", FEEDBACK_MEMORY_RELATION_KINDS),
   dryRun: dryRunOption,
   json: jsonOption,
 }, ({ dryRun, id, json, kind, memory }) => runFeedbackCommand({
@@ -215,7 +218,7 @@ const feedbackRetire = Command.make("retire", {
 
 const feedbackClose = Command.make("close", {
   id: Args.string("feedback-id"),
-  kind: Options.choice("kind", ["fixed", "delivered", "duplicate", "declined", "invalid", "external-fixed"] as const),
+  kind: Options.choice("kind", FEEDBACK_CLOSURE_KINDS),
   memory: Options.string("memory").pipe(Options.withDescription("Related Memory ID."), Options.optional),
   target: Options.string("target").pipe(Options.withDescription("Delivered repository ref."), Options.optional),
   proof: Options.string("proof").pipe(
@@ -284,7 +287,7 @@ const feedback = Command.make("feedback").pipe(
 const memoryAdd = Command.make("add", {
   id: Args.string("memory-id"),
   title: Options.string("title"),
-  kind: Options.choice("kind", ["problem", "decision", "insight"] as const),
+  kind: Options.choice("kind", MEMORY_KINDS),
   createdAt: Options.string("created-at").pipe(
     Options.withDescription("Creation date (YYYY-MM-DD); defaults to today."),
     Options.optional,
@@ -338,7 +341,7 @@ const memorySearch = Command.make("search", {
 
 const memoryResolve = Command.make("resolve", {
   id: Args.string("memory-id"),
-  kind: Options.choice("kind", ["fixed", "not-a-bug", "wont-fix", "external-fixed"] as const),
+  kind: Options.choice("kind", PROBLEM_RESOLUTION_KINDS),
   proof: Options.string("proof").pipe(
     Options.atLeast(1),
     Options.withDescription("Resolution evidence; repeat for each proof item."),
@@ -474,14 +477,8 @@ const prEditProblem = Command.make("problem", {
   userOutcome,
 }, json)).pipe(Command.withDescription("Set the four required Problem fields."));
 
-const prCaseSectionOption = Options.choice("section", [
-  "public-api",
-  "cli",
-  "report-components",
-  "observable-behavior",
-  "package-scripts",
-] as const).pipe(Options.withDescription("PR template section owned by this case."));
-const prCaseDirectionOption = Options.choice("direction", ["removed", "added", "changed"] as const);
+const prCaseSectionOption = Options.choice("section", PR_BODY_CASE_SECTIONS).pipe(Options.withDescription("PR template section owned by this case."));
+const prCaseDirectionOption = Options.choice("direction", PR_BODY_CASE_DIRECTIONS);
 const prCaseNameOption = Options.string("name").pipe(Options.withDescription("Stable Case heading."));
 
 const prEditCaseSet = Command.make("set", {
@@ -552,7 +549,7 @@ const prEditTestSet = Command.make("set", {
   pr: prNumberOption.pipe(Options.optional),
   source: sourceOption.pipe(Options.optional),
   path: Options.string("path"),
-  purpose: Options.choice("purpose", ["feature", "bug regression", "feature + bug regression"] as const),
+  purpose: Options.choice("purpose", PR_BODY_TEST_PURPOSES),
   protects: Options.string("protects"),
   runs: Options.string("runs"),
   asserts: Options.string("asserts"),

--- a/packages/repo-tools/src/docs/design/domain.ts
+++ b/packages/repo-tools/src/docs/design/domain.ts
@@ -52,9 +52,7 @@ import {
   type DesignTemplateBundle,
   type GeneratedDesignPackage,
 } from "./template.js";
-import { decodeDesignCommandInput, type DesignCommandInput, type DesignPage } from "./schema.js";
-
-const PAGE_ORDER: readonly DesignPage[] = ["library", "cli", "architecture", "lifecycle", "use-case"];
+import { DESIGN_PAGE_ORDER, decodeDesignCommandInput, type DesignCommandInput, type DesignPage } from "./schema.js";
 
 export type DesignCommandError = DesignDomainError | TraceError | TraceCoordinationError;
 
@@ -156,7 +154,7 @@ function stateOf(design: TraceNode): DesignDecisionState {
 
 function pagesForPlan(root: string, plan: TraceNode, bundle: DesignTemplateBundle): readonly DesignPage[] {
   const packageRoot = dirname(plan.path);
-  return PAGE_ORDER.filter((page) => (bundle.featureDesign.manifest.optionalFiles[page] ?? [])
+  return DESIGN_PAGE_ORDER.filter((page) => (bundle.featureDesign.manifest.optionalFiles[page] ?? [])
     .every((path) => existsSync(resolve(root, packageRoot, path))));
 }
 
@@ -196,7 +194,7 @@ function normalizeCreate(input: Extract<DesignCommandInput, { readonly command: 
     title: input.title,
     plans: input.plans ?? 2,
     cases: input.cases ?? false,
-    pages: PAGE_ORDER.filter((page) => (input.pages ?? []).includes(page)),
+    pages: DESIGN_PAGE_ORDER.filter((page) => (input.pages ?? []).includes(page)),
     dryRun: input.dryRun ?? false,
   };
 }
@@ -565,7 +563,7 @@ function filesystemPlanReceipts(
           selector: entry.name,
           ref,
           title: displayPlanTitle(title),
-          pages: PAGE_ORDER.filter((page) => (bundle.featureDesign.manifest.optionalFiles[page] ?? [])
+          pages: DESIGN_PAGE_ORDER.filter((page) => (bundle.featureDesign.manifest.optionalFiles[page] ?? [])
             .every((path) => existsSync(resolve(root, packageRoot, entry.name, path)))),
         } satisfies DesignPlanReceipt;
       })

--- a/packages/repo-tools/src/docs/design/schema.ts
+++ b/packages/repo-tools/src/docs/design/schema.ts
@@ -3,7 +3,8 @@ import { Effect, Schema, SchemaIssue } from "effect";
 import { DesignInputInvalid } from "./errors.js";
 
 const NonEmptyTrimmedString = Schema.String.check(Schema.isTrimmed(), Schema.isMinLength(1));
-export const DesignPageSchema = Schema.Literals(["library", "cli", "architecture", "lifecycle", "use-case"]);
+export const DESIGN_PAGE_ORDER = ["library", "cli", "architecture", "lifecycle", "use-case"] as const;
+export const DesignPageSchema = Schema.Literals(DESIGN_PAGE_ORDER);
 export type DesignPage = typeof DesignPageSchema.Type;
 
 const CanonicalTemplatePathSchema = Schema.String.pipe(

--- a/packages/repo-tools/src/docs/design/template.ts
+++ b/packages/repo-tools/src/docs/design/template.ts
@@ -24,14 +24,13 @@ import type {
   DesignManifestDigests,
   DesignPlanReceipt,
 } from "./model.js";
-import { DocsTemplateManifestSchema, type DesignPage, type DocsTemplateManifest } from "./schema.js";
+import { DESIGN_PAGE_ORDER, DocsTemplateManifestSchema, type DesignPage, type DocsTemplateManifest } from "./schema.js";
 
 export const DESIGN_PROJECTION_START = "<!-- niceeval.docs-index/v1:start -->";
 export const DESIGN_PROJECTION_END = "<!-- niceeval.docs-index/v1:end -->";
 export const DESIGN_DECISION_TEMPLATE = "docs/_template/design-decision";
 export const FEATURE_DESIGN_TEMPLATE = "docs/_template/feature-design";
 const MANIFEST_FILE = "manifest.json";
-const PAGE_ORDER: readonly DesignPage[] = ["library", "cli", "architecture", "lifecycle", "use-case"];
 
 interface LoadedTemplate {
   readonly path: string;
@@ -168,7 +167,7 @@ function loadTemplate(
 export function loadDesignTemplates(root: string): Effect.Effect<DesignTemplateBundle, DesignManifestInvalid> {
   return Effect.all({
     designDecision: loadTemplate(root, DESIGN_DECISION_TEMPLATE, ["design"], ["cases"]),
-    featureDesign: loadTemplate(root, FEATURE_DESIGN_TEMPLATE, ["feature", "roadmap", "design-plan"], PAGE_ORDER),
+    featureDesign: loadTemplate(root, FEATURE_DESIGN_TEMPLATE, ["feature", "roadmap", "design-plan"], DESIGN_PAGE_ORDER),
   }).pipe(Effect.map(({ designDecision, featureDesign }) => ({
     designDecision,
     featureDesign,
@@ -287,7 +286,7 @@ export function generateDesignPackage(input: {
   readonly pages: readonly DesignPage[];
 }): GeneratedDesignPackage {
   const packageRoot = `docs/design/${input.slug}`;
-  const pages = PAGE_ORDER.filter((page) => input.pages.includes(page));
+  const pages = DESIGN_PAGE_ORDER.filter((page) => input.pages.includes(page));
   const plans: DesignPlanReceipt[] = Array.from({ length: input.planCount }, (_, index) => {
     const selector = `PLAN-${index + 1}`;
     return {

--- a/packages/repo-tools/src/docs/model.ts
+++ b/packages/repo-tools/src/docs/model.ts
@@ -2,7 +2,8 @@ import { Schema } from "effect";
 
 const NonEmptyTrimmedString = Schema.String.check(Schema.isTrimmed(), Schema.isMinLength(1));
 
-export const TermScopeSchema = Schema.Union([Schema.Literal("docs"), Schema.Literal("all"), Schema.Literal("site")]);
+export const TERM_SCOPES = ["docs", "all", "site"] as const;
+export const TermScopeSchema = Schema.Literals(TERM_SCOPES);
 export type TermScope = typeof TermScopeSchema.Type;
 
 export const BannedTermSchema = Schema.Struct({

--- a/packages/repo-tools/src/docs/terms-command.ts
+++ b/packages/repo-tools/src/docs/terms-command.ts
@@ -8,7 +8,7 @@ import {
   type TerminalDeliverySink,
 } from "./contribution.js";
 import { renderDocsDomainFailure } from "./errors.js";
-import type { TermScope, TermsReceipt } from "./model.js";
+import { TERM_SCOPES, type TermScope, type TermsReceipt } from "./model.js";
 import {
   addDocumentationTerm,
   checkDocumentationTerms,
@@ -24,7 +24,7 @@ const dryRunOption = Options.boolean("dry-run").pipe(
   Options.withDefault(false),
   Options.withDescription("Return the exact planned document without writing it."),
 );
-const scopeOption = Options.choice("scope", ["docs", "all", "site"] as const).pipe(
+const scopeOption = Options.choice("scope", TERM_SCOPES).pipe(
   Options.withDescription("Select design docs, both documentation surfaces, or the public site."),
 );
 

--- a/packages/repo-tools/src/docs/trace/compiler.ts
+++ b/packages/repo-tools/src/docs/trace/compiler.ts
@@ -31,8 +31,9 @@ import type {
   TraceSnapshot,
   TraceTest,
 } from "./model.js";
+import { ADOPTABLE_DOCS_NODE_KINDS, DOCS_NODE_KINDS } from "./model.js";
 
-const kinds = Schema.Literals(["feature", "roadmap", "engineering", "design", "design-plan", "use-case"]);
+const kinds = Schema.Literals(DOCS_NODE_KINDS);
 const refSchema = RepoRefSchema;
 const refsSchema = Schema.Array(refSchema).pipe(
   Schema.check(Schema.isMinLength(1), Schema.makeFilter<readonly string[]>((value) => new Set(value).size === value.length, { message: "must be unique" })),
@@ -614,7 +615,7 @@ function validateFeedbackRelations(
         target,
         snapshot,
         documents,
-        ["roadmap", "feature", "use-case", "engineering"],
+        ADOPTABLE_DOCS_NODE_KINDS,
       );
     }
     for (const relation of entry.memoryRelations) {

--- a/packages/repo-tools/src/docs/trace/model.ts
+++ b/packages/repo-tools/src/docs/trace/model.ts
@@ -1,4 +1,9 @@
-export type DocsNodeKind = "feature" | "roadmap" | "engineering" | "design" | "design-plan" | "use-case";
+import type { FeedbackMemoryRelation } from "../../feedback/schema.js";
+import type { MemoryV1, PromotionKind } from "../../memory/schema.js";
+
+export const DOCS_NODE_KINDS = ["feature", "roadmap", "engineering", "design", "design-plan", "use-case"] as const;
+export type DocsNodeKind = typeof DOCS_NODE_KINDS[number];
+export const ADOPTABLE_DOCS_NODE_KINDS = ["roadmap", "feature", "use-case", "engineering"] as const satisfies readonly DocsNodeKind[];
 export type TraceScope = "feature" | "use-case";
 export type TracePageRole = "overview" | "library" | "cli" | "architecture" | "lifecycle" | "reference" | "supporting";
 
@@ -65,16 +70,13 @@ export interface TraceFeedback {
     readonly current: readonly string[];
     readonly history: readonly { readonly target: string; readonly commit: string }[];
   };
-  readonly memoryRelations: readonly {
-    readonly kind: "investigation" | "root-cause" | "decision" | "delivery";
-    readonly memory: string;
-  }[];
+  readonly memoryRelations: readonly FeedbackMemoryRelation[];
   /** Digest of the complete decoded metadata, including closure credentials. */
   readonly metadataDigest: string;
 }
 
 export interface TraceMemoryPromotion {
-  readonly kind: "roadmap" | "feature" | "use-case" | "engineering";
+  readonly kind: PromotionKind;
   readonly current: readonly string[];
   readonly history: readonly { readonly target: string; readonly commit: string }[];
 }
@@ -83,8 +85,8 @@ export interface TraceMemory {
   readonly path: string;
   readonly id: string;
   readonly title: string;
-  readonly kind: "problem" | "decision" | "insight" | "legacy/unstructured";
-  readonly state?: "open" | "resolved" | "adopted" | "current" | "superseded";
+  readonly kind: MemoryV1["kind"]["type"] | "legacy/unstructured";
+  readonly state?: MemoryV1["kind"]["state"];
   readonly promotions: readonly TraceMemoryPromotion[];
   /** Digest of decoded structured metadata. Legacy body bytes intentionally do not participate. */
   readonly metadataDigest?: string;
@@ -140,7 +142,7 @@ export interface TraceFeedbackAdoption extends TraceTargetRelation {
 
 export interface TraceFeedbackMemoryRelation extends TraceTargetRelation {
   readonly via: "feedback-memory-relation";
-  readonly kind: "investigation" | "root-cause" | "decision" | "delivery";
+  readonly kind: FeedbackMemoryRelation["kind"];
   readonly feedback: TraceFeedbackSummary;
   readonly memory: TraceMemorySummary;
 }

--- a/packages/repo-tools/src/feedback/repository.ts
+++ b/packages/repo-tools/src/feedback/repository.ts
@@ -22,7 +22,7 @@ import { parse } from "yaml";
 
 import { parseRepoRef, validateRepoRefTarget, type RepoRef, type ValidatedRepoRefTarget } from "../docs/trace/ref.js";
 import { traceDigest } from "../docs/trace/relation-mutation.js";
-import type { DocsNodeKind, TraceSnapshot } from "../docs/trace/model.js";
+import { ADOPTABLE_DOCS_NODE_KINDS, type TraceSnapshot } from "../docs/trace/model.js";
 import { decodeMemoryDocument } from "../memory/codec.js";
 import { decodeFeedbackDocument, encodeFeedbackDocument, type FeedbackDocument } from "./codec.js";
 import {
@@ -52,7 +52,6 @@ export interface FeedbackCheckReceipt { readonly ok: boolean; readonly checked: 
 export interface ArtifactCopy { readonly relativePath: string; readonly sourcePath: string }
 export interface StagedFeedback { readonly stage: string; readonly target: string }
 
-const ADOPTION_KINDS = ["roadmap", "feature", "use-case", "engineering"] as const satisfies readonly DocsNodeKind[];
 const message = (cause: unknown): string => cause instanceof Error ? cause.message : String(cause);
 const digestText = (value: string): string => traceDigest(value);
 
@@ -214,7 +213,7 @@ export class FeedbackRepository {
 
   validateTarget(snapshot: TraceSnapshot, target: unknown): ValidatedRepoRefTarget {
     const source = this.targetSource(target);
-    const validated = validateRepoRefTarget(snapshot, target, ADOPTION_KINDS, source.source);
+    const validated = validateRepoRefTarget(snapshot, target, ADOPTABLE_DOCS_NODE_KINDS, source.source);
     if (Result.isFailure(validated)) throw new FeedbackReferenceConflict({ operation: "target", path: source.path, message: String(validated.failure) });
     return validated.success;
   }

--- a/packages/repo-tools/src/feedback/schema.ts
+++ b/packages/repo-tools/src/feedback/schema.ts
@@ -15,8 +15,26 @@ export const FeedbackSourceSchema = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("dev"), repository: NonEmpty, commit: Schema.optional(NonEmpty) }),
 ]);
 
+export const FEEDBACK_MEMORY_RELATION_KINDS = ["investigation", "root-cause", "decision", "delivery"] as const;
+export const FeedbackClosureKind = Object.freeze({
+  Fixed: "fixed",
+  Delivered: "delivered",
+  Duplicate: "duplicate",
+  Declined: "declined",
+  Invalid: "invalid",
+  ExternalFixed: "external-fixed",
+} as const);
+export const FEEDBACK_CLOSURE_KINDS = [
+  FeedbackClosureKind.Fixed,
+  FeedbackClosureKind.Delivered,
+  FeedbackClosureKind.Duplicate,
+  FeedbackClosureKind.Declined,
+  FeedbackClosureKind.Invalid,
+  FeedbackClosureKind.ExternalFixed,
+] as const;
+
 export const FeedbackMemoryRelationSchema = Schema.Struct({
-  kind: Schema.Literals(["investigation", "root-cause", "decision", "delivery"]),
+  kind: Schema.Literals(FEEDBACK_MEMORY_RELATION_KINDS),
   memory: MemoryId,
 });
 const UniqueFeedbackMemoryRelations = Schema.Array(FeedbackMemoryRelationSchema).check(Schema.makeFilter(
@@ -25,12 +43,12 @@ const UniqueFeedbackMemoryRelations = Schema.Array(FeedbackMemoryRelationSchema)
 ));
 
 export const FeedbackClosureSchema = Schema.Union([
-  Schema.Struct({ kind: Schema.Literal("fixed"), memory: MemoryId, proof: Schema.NonEmptyArray(NonEmpty) }),
-  Schema.Struct({ kind: Schema.Literal("delivered"), memory: MemoryId, target: RepoRefSchema, proof: Schema.NonEmptyArray(NonEmpty) }),
-  Schema.Struct({ kind: Schema.Literal("duplicate"), canonical: NonEmpty }),
-  Schema.Struct({ kind: Schema.Literal("declined"), memory: MemoryId }),
-  Schema.Struct({ kind: Schema.Literal("invalid"), evidence: Schema.NonEmptyArray(NonEmpty) }),
-  Schema.Struct({ kind: Schema.Literal("external-fixed"), dependency: NonEmpty, version: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Fixed), memory: MemoryId, proof: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Delivered), memory: MemoryId, target: RepoRefSchema, proof: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Duplicate), canonical: NonEmpty }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Declined), memory: MemoryId }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Invalid), evidence: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.ExternalFixed), dependency: NonEmpty, version: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
 ]);
 
 export const FeedbackAdoptionsSchema = Schema.Struct({
@@ -62,12 +80,12 @@ export const FeedbackCreateSchema = Schema.Struct({ ...FeedbackFields, adoptions
 export type FeedbackCreate = typeof FeedbackCreateSchema.Type;
 
 const FeedbackV1ClosureSchema = Schema.Union([
-  Schema.Struct({ kind: Schema.Literal("fixed"), memory: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
-  Schema.Struct({ kind: Schema.Literal("delivered"), memory: NonEmpty, target: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
-  Schema.Struct({ kind: Schema.Literal("duplicate"), canonical: NonEmpty }),
-  Schema.Struct({ kind: Schema.Literal("declined"), memory: NonEmpty }),
-  Schema.Struct({ kind: Schema.Literal("invalid"), evidence: Schema.NonEmptyArray(NonEmpty) }),
-  Schema.Struct({ kind: Schema.Literal("external-fixed"), dependency: NonEmpty, version: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Fixed), memory: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Delivered), memory: NonEmpty, target: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Duplicate), canonical: NonEmpty }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Declined), memory: NonEmpty }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.Invalid), evidence: Schema.NonEmptyArray(NonEmpty) }),
+  Schema.Struct({ kind: Schema.Literal(FeedbackClosureKind.ExternalFixed), dependency: NonEmpty, version: NonEmpty, proof: Schema.NonEmptyArray(NonEmpty) }),
 ]);
 
 /** Historical source decoder used only by the one-time v1 → v2 receipt verifier. */

--- a/packages/repo-tools/src/memory/repository.ts
+++ b/packages/repo-tools/src/memory/repository.ts
@@ -4,7 +4,7 @@ import { join, relative, resolve, sep } from "node:path";
 import { Effect, Result } from "effect";
 
 import { parseRepoRef, validateRepoRefTarget, type RepoRef, type ValidatedRepoRefTarget } from "../docs/trace/ref.js";
-import type { DocsNodeKind, TraceSnapshot } from "../docs/trace/model.js";
+import { ADOPTABLE_DOCS_NODE_KINDS, type TraceSnapshot } from "../docs/trace/model.js";
 import { decodeMemoryDocument, encodeMemoryDocument } from "./codec.js";
 import {
   LegacyMemoryReadOnly,
@@ -18,7 +18,6 @@ import {
 import type { MemoryDocument, MemoryV1, ProblemResolution, PromotionKind } from "./schema.js";
 import { promoteMemory, reopenProblem, resolveProblem, retirePromotion, supersedeMemory } from "./state.js";
 
-const PROMOTION_KINDS = ["roadmap", "feature", "use-case", "engineering"] as const satisfies readonly DocsNodeKind[];
 const message = (cause: unknown): string => cause instanceof Error ? cause.message : String(cause);
 export interface MemoryCheckReceipt { readonly ok: boolean; readonly checked: number; readonly legacy: number; readonly findings: readonly string[] }
 
@@ -150,7 +149,7 @@ export class MemoryRepository {
 
   validateTarget(snapshot: TraceSnapshot, target: unknown): ValidatedRepoRefTarget & { readonly kind: PromotionKind } {
     const source = this.targetSource(target);
-    const validated = validateRepoRefTarget(snapshot, target, PROMOTION_KINDS, source.source);
+    const validated = validateRepoRefTarget(snapshot, target, ADOPTABLE_DOCS_NODE_KINDS, source.source);
     if (Result.isFailure(validated)) throw new MemoryReferenceConflict({ operation: "target", path: source.path, message: validated.failure.message });
     const kind = validated.success.kind;
     if (kind !== "roadmap" && kind !== "feature" && kind !== "use-case" && kind !== "engineering") {

--- a/packages/repo-tools/src/memory/schema.ts
+++ b/packages/repo-tools/src/memory/schema.ts
@@ -1,17 +1,26 @@
 import { Schema } from "effect";
 
 import { RepoRefSchema } from "../docs/trace/ref.js";
+import { ADOPTABLE_DOCS_NODE_KINDS } from "../docs/trace/model.js";
 
 const NonEmpty = Schema.String.check(Schema.isTrimmed(), Schema.isMinLength(1));
 const UniqueRepoRefs = Schema.UniqueArray(RepoRefSchema);
 
+export const PROBLEM_RESOLUTION_KINDS = ["fixed", "not-a-bug", "wont-fix", "external-fixed"] as const;
+export const MemoryKind = Object.freeze({
+  Problem: "problem",
+  Decision: "decision",
+  Insight: "insight",
+} as const);
+export const MEMORY_KINDS = [MemoryKind.Problem, MemoryKind.Decision, MemoryKind.Insight] as const;
+
 export const ProblemResolutionSchema = Schema.Struct({
-  kind: Schema.Literals(["fixed", "not-a-bug", "wont-fix", "external-fixed"]),
+  kind: Schema.Literals(PROBLEM_RESOLUTION_KINDS),
   proof: Schema.NonEmptyArray(NonEmpty),
 });
 export type ProblemResolution = typeof ProblemResolutionSchema.Type;
 
-export const PromotionKindSchema = Schema.Literals(["roadmap", "feature", "use-case", "engineering"]);
+export const PromotionKindSchema = Schema.Literals(ADOPTABLE_DOCS_NODE_KINDS);
 export type PromotionKind = typeof PromotionKindSchema.Type;
 
 export const PromotionSchema = Schema.Struct({
@@ -22,9 +31,9 @@ export const PromotionSchema = Schema.Struct({
 export type Promotion = typeof PromotionSchema.Type;
 
 export const MemoryKindSchema = Schema.Union([
-  Schema.Struct({ type: Schema.Literal("problem"), state: Schema.Literals(["open", "resolved"]), resolution: Schema.optional(ProblemResolutionSchema) }),
-  Schema.Struct({ type: Schema.Literal("decision"), state: Schema.Literals(["adopted", "superseded"]), supersededBy: Schema.optional(NonEmpty) }),
-  Schema.Struct({ type: Schema.Literal("insight"), state: Schema.Literals(["current", "superseded"]), supersededBy: Schema.optional(NonEmpty) }),
+  Schema.Struct({ type: Schema.Literal(MemoryKind.Problem), state: Schema.Literals(["open", "resolved"]), resolution: Schema.optional(ProblemResolutionSchema) }),
+  Schema.Struct({ type: Schema.Literal(MemoryKind.Decision), state: Schema.Literals(["adopted", "superseded"]), supersededBy: Schema.optional(NonEmpty) }),
+  Schema.Struct({ type: Schema.Literal(MemoryKind.Insight), state: Schema.Literals(["current", "superseded"]), supersededBy: Schema.optional(NonEmpty) }),
 ]);
 
 export const MemoryV1Schema = Schema.Struct({

--- a/packages/repo-tools/src/pr/domain.ts
+++ b/packages/repo-tools/src/pr/domain.ts
@@ -23,6 +23,7 @@ import {
 import {
   DEFAULT_PR_BODY_BUDGET,
   GITHUB_BODY_LIMIT,
+  PR_BODY_TEST_PURPOSES,
   type ByteReport,
   type DraftMetadata,
   type EditPrBodyInput,
@@ -409,7 +410,7 @@ export function validatePrBodyStructure(
   }
   for (const match of body.matchAll(/^- Purpose:\s*(.+)$/gm)) {
     const purpose = match[1]!.trim().replace(/^`|`$/g, "");
-    if (!["feature", "bug regression", "feature + bug regression"].includes(purpose)) {
+    if (!(PR_BODY_TEST_PURPOSES as readonly string[]).includes(purpose)) {
       errors.push(`invalid test Purpose: ${purpose}`);
     }
   }

--- a/packages/repo-tools/src/pr/index.ts
+++ b/packages/repo-tools/src/pr/index.ts
@@ -7,6 +7,7 @@ export {
   GITHUB_BODY_LIMIT,
   PR_BODY_CASE_DIRECTIONS,
   PR_BODY_CASE_SECTIONS,
+  PR_BODY_TEST_PURPOSES,
   type ByteReport,
   type ByteReportRow,
   type EditPrBodyInput,
@@ -18,6 +19,7 @@ export {
   type PrBodyInput,
   type PrBodyOutcome,
   type PrBodyProblem,
+  type PrBodyTestPurpose,
   type RenderedBody,
 } from "./model.js";
 export { makeNodePrGitHubLive, makeNodePrGitLive, makeNodePrLive, NodePrFileSystemLive } from "./node.js";

--- a/packages/repo-tools/src/pr/model.ts
+++ b/packages/repo-tools/src/pr/model.ts
@@ -14,6 +14,8 @@ export type PrBodyCaseSection = typeof PR_BODY_CASE_SECTIONS[number];
 
 export const PR_BODY_CASE_DIRECTIONS = ["removed", "added", "changed"] as const;
 export type PrBodyCaseDirection = typeof PR_BODY_CASE_DIRECTIONS[number];
+export const PR_BODY_TEST_PURPOSES = ["feature", "bug regression", "feature + bug regression"] as const;
+export type PrBodyTestPurpose = typeof PR_BODY_TEST_PURPOSES[number];
 
 interface EditLocationInput {
   readonly pr?: number | undefined;
@@ -47,7 +49,7 @@ export interface EditTestSetInput extends EditLocationInput {
   readonly command: "edit";
   readonly operation: "test-set";
   readonly path: string;
-  readonly purpose: string;
+  readonly purpose: PrBodyTestPurpose;
   readonly protects: string;
   readonly runs: string;
   readonly asserts: string;
@@ -130,7 +132,7 @@ export interface FragmentSpec {
 
 export interface TestDirective {
   readonly path: string;
-  readonly purpose: string;
+  readonly purpose: PrBodyTestPurpose;
   readonly protects: string;
   readonly runs: string;
   readonly asserts: string;

--- a/packages/repo-tools/src/pr/schema.ts
+++ b/packages/repo-tools/src/pr/schema.ts
@@ -9,7 +9,7 @@ import type {
   PrBodyInput,
   TestDirective,
 } from "./model.js";
-import { PR_BODY_CASE_DIRECTIONS, PR_BODY_CASE_SECTIONS } from "./model.js";
+import { PR_BODY_CASE_DIRECTIONS, PR_BODY_CASE_SECTIONS, PR_BODY_TEST_PURPOSES } from "./model.js";
 
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0));
 
@@ -80,7 +80,7 @@ const FragmentSpecSchema = Schema.Struct({
 
 const TestDirectiveFields = {
   path: Schema.NonEmptyString,
-  purpose: Schema.NonEmptyString,
+  purpose: Schema.Literals(PR_BODY_TEST_PURPOSES),
   protects: Schema.NonEmptyString,
   runs: Schema.NonEmptyString,
   asserts: Schema.NonEmptyString,


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 250d50b5cf81af4333f06cd87749711c5f20b4d8
templateSha256: 0b13a59152cd3a8d61875b2cbdd6a622f2a8a56978a3f4fa8772356f5607c9af
head: 065adf9b791a576b4faceaa7d49f477f89727a7e
-->

## Problem

- User goal: 让有限状态、类别和协议值由各自领域唯一拥有，并保留每个 Sandbox Provider 的独立演化能力。
- Current limitation: 相同有限集合曾在 TypeScript、Effect Schema、SQL、CLI、producer 与 projection 中重复维护，容易产生静默漂移；Docker 与 E2B 的内部状态还可能被错误地合并为共享 taxonomy。
- Required capability: 为每个 bounded context 建立具名 canonical value owner，让类型、Schema、SQL 与消费者派生使用；Provider 内部状态机保持独立，只共享无领域语义的机械 helper。
- User outcome: 修改有限集合时只需更新所属 owner，编译器和解码边界能发现遗漏，同时 Docker、E2B 与 Incus 可以继续采用最适合自身资源生命周期的术语。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790433026&installation_model_id=431746&pr_number=176&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F176&signature=e3fd5ed06025cc7a9c95bd525e166f0f8302c72be88e4e8b3392f700bf3bf120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
