### PR TITLE
fix(show): 保留默认总览中的已封口实验分数

### DIFF
--- a/apps/docs-site/zh/tutorials/viewing-results.mdx
+++ b/apps/docs-site/zh/tutorials/viewing-results.mdx
@@ -14,6 +14,10 @@ niceeval show
 
 不带 selector 时，`show` 输出当前 sealed cutoff 的 Overview。它按 Experiment、评估用例和 Attempt 展开汇总，并保留通过率、分数、coverage、缺失项和 issues。先从这里找出需要继续查看的 Experiment、Run 或 Attempt locator。
 
+Overview 来自项目 canonical Record 中已封口的结果。即使当前源码或当前安装候选的 identity 已经改变，
+`show` 也会保留每个逻辑 slot 的最新结果，不会把存在的历史显示为 `Observed 0/0`。这表示结果可查看，
+不表示它已通过当前 target 的复用资格检查。
+
 ## 缩小到一个 Experiment 或 Run
 
 ```sh

--- a/docs/engineering/testing/e2e/case-relations.md
+++ b/docs/engineering/testing/e2e/case-relations.md
@@ -123,6 +123,12 @@ pnpm run repo docs test
 移动源码/sidecar ownership 并保持 ID；`case retire` 要求 inventory 已不再包含它，或同事务包含删除计划。relation
 retire 只移出 current 并追加 history。无 physical delete、任意 patch、bulk replace 或 history rewrite。
 
+存量 current regression 可以没有正式 evidence index。`regression add` 取得同一关系的新 red、takeover 与 inventory 后，
+只补齐 evidence index 与受管 receipts，不先 retire、不重写 relation history。同一 current relation 已有 evidence 时，
+重复 `add` 仍返回 RelationAlreadyCurrent。
+每次发布的 evidence 目录同时绑定受管 red 与 takeover ID。retire 后重新 `add` 会写入新一代不可变目录，
+保留 history 引用的旧 receipts。
+
 `list` 叶子是 selector；默认只列 current，`--history` 另列 history/tombstone。pattern 可匹配 selector、title、
 owner/contract、Feature/Use Case、Memory 和 Issue；输出 selector 均可原样传给 `show`。`show` 重新 collection 并验证
 path guard，返回 runner title、executor、owner、contract、精确 Feature/Use Case、relations、正式 certificate 与 findings。
@@ -171,6 +177,9 @@ interface TakeoverCertificateV1 {
 red 是同一 caseId 在旧 candidate 或最小逆补丁上的 formal regression；green 是修复 candidate 的同一 caseId
 formal pass。certificate 全部 observation 绑定同一 candidate、case/sidecar、fixture/seed/lockfile/image 策略，
 cleanup 全 true、invocation ID 唯一且没有 test retry。selector 不匹配、diagnostic mode、缺项或 digest 分叉均失败。
+
+核验 fixed Problem 时仍要求测试源码与 receipt 一致。red、green 与全部 reliability receipt 必须绑定同一份
+sidecar source。登记或退役 relation 后追加的 sidecar history 不使已经发布的 runner evidence 失效。
 
 root runner 成功生成 red 后，把 candidate bytes 与 formal receipt 复制进 Git-private bundle，并返回 `nered_...`。完整 takeover 矩阵通过后，同样复制 candidate bytes、七份 formal receipt 与 certificate，并返回 `netake_...`。bundle 绑定当前实现指纹；实现变化、文件缺失或字节 digest 分叉时 ID 失效。调用方不传 artifact 路径、不编辑 JSON，也不能只重算自校验 digest 冒充 runner provenance。
 

--- a/docs/feature/inspection/architecture.md
+++ b/docs/feature/inspection/architecture.md
@@ -41,6 +41,11 @@ Run 的列表 operation 只有 `run.list`，详情 operation 只有 `run.get`。
 用户面 Results 由内部 `overview.get` 一次关闭 totals、Experiment aggregates、Eval cells、members、MetricValue、coverage、
 issues 与 locators。
 
+默认 `overview.get` 在 canonical Record 中按 `experimentId + evalId + attemptOrdinal` 选择每个逻辑 Slot
+的最新 sealed occurrence。当前工作树、当前安装的候选与 execution identity 不参与这个 Record selection；
+它们只影响 Experiment planning 的 reuse 资格。因此 Node `show`、machine `query` 与 browser View 在相同
+`PublicationCutoff` 上得到同一个默认 Overview，Host 不得用当前项目计划另建 selection 门。
+
 每个 member、cell 与 aggregate 都带 USD cost `MetricValue`。它只汇总已发布且有可用成本的 Attempt，并保留 samples、total、
 state、issues 与 refs。没有成本的 Attempt 不是零。
 `experiment.get` 只交付 exact Experiment 的 aggregate 与 cells。`runs.compare` 固定提供 `side-by-side`、`exact`、

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -235,6 +235,12 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
   Eval 使用相对标签；每个 Experiment 小节仍显示一次完整 ID，每个可下钻 Attempt 显示完整稳定 locator。
   Attempt 表只保留 `Eval`、`Attempt` 与 `Score`，不显示 membership action 或 origin/reference relation。这些 provenance
   仍由具名 operation 保留并可在 Run/Attempt 下钻中查看。
+
+  这个无 selector Overview 对项目 canonical Record 中的 sealed Run 进行聚合：它按
+  `experimentId + evalId + attemptOrdinal` 选择每个逻辑 slot 的最新 occurrence。当前工作树、当前安装的候选
+  或它们的 execution identity 变化不会把已封口结果从 Overview 移除，也不会把存在的 Record 显示为
+  `Observed 0/0`。Overview 表达 Record 已发布的最新结果，不声称它们可为当前 target 复用；复用资格仍由
+  Experiment planning 和 `accept` 的 identity 规则裁决。
 - 一个或多个 `--experiment` 逐个调用 exact `experiment.get`，格式化指定 Experiment 的 aggregate、Eval cells 和 Attempt locators。
   CLI 不得调用 `overview.get` 后按 `experimentId` 过滤。
 - 一个或多个 `--run` 逐个调用 exact `run.overview`，并且只消费这一份闭合 result。

--- a/docs/feature/inspection/use-case/比较质量与成本.md
+++ b/docs/feature/inspection/use-case/比较质量与成本.md
@@ -84,11 +84,13 @@ Experiment harness/v-next
 
 这组 Summary 与 Attempts 来自 `experiment.get`，不是 renderer 对默认 Results 的二次筛选或补值。
 
-默认 Results 回答“当前项目配置下已经采用了什么”，不是“所有历史运行曾经出现过什么”。当 Eval 内容、
-Experiment 配置或 Sandbox identity 改变时，同名旧 Attempt 会立即退出默认 Results；用户仍可用原 Run ID 或 locator
-核对历史事实。审阅确认旧证据仍适用于新 target 后，显式执行 `niceeval accept @<locator>`，新的 Run 以
-`accepted` reference binding 连接当前 target identity，随后它才重新进入默认 `show`。未 accept 的其它 Experiment
-即使引用同一个已变更 Eval，也继续隐藏。
+默认 Results 回答“canonical Record 中每个逻辑 slot 最新发布了什么”。当 Eval 内容、Experiment 配置、
+Sandbox identity 或当前安装的候选变化时，已封口 Attempt 仍留在 Overview；因此无 selector `niceeval show` 不会仅因
+当前 identity 与 Record 不同就返回 `Observed 0/0`。用户可以从 Overview 继续下钻 Run ID 或 locator，并根据
+Run identity 判断结果属于哪次运行。
+
+Overview 可见不等于当前 target 可复用。Experiment planning 仍以 execution identity 判断 `reuse | gap`；
+`niceeval accept @<locator>` 只在用户确认旧证据适用时发布当前 target identity 的 reference Member，不作为查看已发布结果的前置条件。
 
 ```json
 {

--- a/e2e/inspection/test/show-cli.test.ts
+++ b/e2e/inspection/test/show-cli.test.ts
@@ -329,20 +329,30 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(changedPlan.stdout).toContain("identity-mismatch");
       expect(changedPlan.stdout).toContain(`niceeval accept ${locator}`);
 
-      const staleOverview = await niceeval.run(["show"]);
-      expect(staleOverview.exitCode, staleOverview.diagnostic()).toBe(0);
-      expect(staleOverview.stdout).not.toContain(locator);
-      expect(staleOverview.stdout).not.toContain(alternateLocator);
-      expect(staleOverview.stdout).toContain("Observed   0/0");
-
-      const accepted = await niceeval.run(["accept", locator]);
-      expect(accepted.exitCode, accepted.diagnostic()).toBe(0);
-      expect(accepted.stdout).toContain(`Accepted source Attempt ${locator} into new Run `);
-
-      const adoptedOverview = await niceeval.run(["show"]);
-      expect(adoptedOverview.exitCode, adoptedOverview.diagnostic()).toBe(0);
-      expect(adoptedOverview.stdout).toContain(locator);
-      expect(adoptedOverview.stdout).not.toContain(alternateLocator);
+      const historicalOverview = await niceeval.run(["show"]);
+      expect(historicalOverview.exitCode, historicalOverview.diagnostic()).toBe(0);
+      expectHumanText(historicalOverview.stdout);
+      expectInOrder(historicalOverview.stdout, ["Totals", "Experiments"]);
+      expectInOrder(historicalOverview.stdout, [
+        "harness",
+        "Experiment",
+        "Observed",
+        "Pass rate",
+        "Score",
+        "alternate",
+        "canary",
+      ]);
+      expect(historicalOverview.stdout).toContain(`Experiment ${mainExperimentId}`);
+      expect(historicalOverview.stdout).toContain(`Experiment ${alternateExperimentId}`);
+      expect(historicalOverview.stdout).toContain(locator);
+      expect(historicalOverview.stdout).toContain(alternateLocator);
+      expect(historicalOverview.stdout).toMatch(
+        new RegExp(`^\\s*inspection\\s+${locator}\\s+37\\.11\\s*$`, "mu"),
+      );
+      expect(historicalOverview.stdout).toMatch(
+        new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+37\\.11\\s*$`, "mu"),
+      );
+      expect(historicalOverview.stdout).not.toContain("Observed   0/0");
     },
   );
 });

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/certificate.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "candidateSha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+  "greenReceipt": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-1.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-2.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-4.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-6.json",
+    "singleCase": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "sha256:39248ab4962e31618210148892dc381ae3d8b3dd7dc3ce5bc8e1fe7a0f440ed9"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/green.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/green.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-MkrGJs/runs/takeover/target-single/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1570964 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1570965 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1571011 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "2e874b9e-75a7-4a2f-aaa7-6425ac8388c2",
+  "receiptSha256": "150f0cd686898cfe05586836ebc4ece38f79cb2b8b287cf1285852d46b4ae172"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/inventory.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/inventory.json
@@ -1,0 +1,45 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "inspection",
+  "argv": [
+    "/nix/store/bfqsxlviikq7vlp36kasy5hhamlxlkd2-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-nAeNYP/repos/inspection/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+  "files": [
+    "e2e/inspection/test/inspection-query.test.ts",
+    "e2e/inspection/test/show-cli.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/inspection-query.test.ts",
+      "titlePath": [
+        "machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]"
+      ],
+      "caseId": "necase_79TQ9VGG316D8FK0"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-cli.test.ts",
+      "titlePath": [
+        "用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]"
+      ],
+      "caseId": "necase_9FHHSQTVB492P8DS"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/certificate.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "candidateSha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+  "greenReceipt": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-1.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-2.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-4.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-6.json",
+    "singleCase": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/generation-takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/generation-takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/generation-takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/generation-takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/generation-takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/generation-takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree-brave-cloud-5cc8/artifacts/e2e/repo-tool-backfill/generation-takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "910624f388a87092f37ab85c98cdafc1d4e40b3a78a68ab995bad38d001c6fe5"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/green.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/green.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-9vTnLt/runs/takeover/target-single/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1593558 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1593559 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1593588 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "9e9ce303-16fd-4b14-909d-81426e143969",
+  "receiptSha256": "48de63b6ef8a46bb6e4960b93895b42ee7aefe96e310c612e99a8bc8c45cbe92"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/inventory.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/inventory.json
@@ -1,0 +1,45 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "inspection",
+  "argv": [
+    "/nix/store/bfqsxlviikq7vlp36kasy5hhamlxlkd2-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-rIXiZ3/repos/inspection/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+  "files": [
+    "e2e/inspection/test/inspection-query.test.ts",
+    "e2e/inspection/test/show-cli.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/inspection-query.test.ts",
+      "titlePath": [
+        "machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]"
+      ],
+      "caseId": "necase_79TQ9VGG316D8FK0"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-cli.test.ts",
+      "titlePath": [
+        "用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]"
+      ],
+      "caseId": "necase_9FHHSQTVB492P8DS"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/red.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/red.json
@@ -1,0 +1,52 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "263c764a3d31da80e45bf7743766d8e316d0d051",
+    "sha256": "8e7ac92b85e595303d754b7baeab50c4d95cf70c19a74904e3afb159d19cd5be",
+    "sri": "sha512-vON6FLzwBmrQWDBtDMbkl30HHrOGwGyjXbOmBJ6Xp3EZ0Wq3xMTDbH3ta0p5niKUaMN77HFK65RqD0xPSmd4Xg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-rdyK1a/runs/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 1585121 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "59b75166-f143-4a4e-81e5-371d7dfe888e",
+  "receiptSha256": "3524e57e28d15205ac8a5ee0dcc997c054af32cb6a4dbdf5f15d6f51f9e352f1"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-1.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-1.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-9vTnLt/runs/takeover/isolated-copy-1/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1587078 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1587079 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1587111 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "724f88b2-3456-4125-a521-1aa2e4f119f4",
+  "receiptSha256": "4664c41f521f3d6d1ad5a491adc955331d52912e83c10c384a7d669640107f44"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-2.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-2.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-9vTnLt/runs/takeover/isolated-copy-2/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1588079 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1588080 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1588143 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "bf12deba-2cc2-45eb-99c4-0be55f1a708f",
+  "receiptSha256": "f03537b65d785698aaa7b680c95b1aa4280261cf32b8935dfa93fd14d170e78c"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-3.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-3.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-9vTnLt/runs/takeover/isolated-copy-3/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1588943 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1588944 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1588991 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "0b29cbd7-fb59-4c46-a37b-dcdd6e26455b",
+  "receiptSha256": "1fa6ef1bd3e5ddf6a206e5cf5a2220f3e9b921ee59e593e71d0c3933731ddcc7"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-4.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-4.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-9vTnLt/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1589969 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1589970 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1590005 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1590854 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "360cb8e6-8412-46cd-aa13-d7f65313dd57",
+  "receiptSha256": "70ab7e4bf25a33d66e2dcee10d0117275afee2cc1698eb79dbc0d9d5ed1d2b7c"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-5.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-5.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-9vTnLt/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1589969 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1589970 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1590005 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1590854 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "74a3dd72-405a-4f3f-a395-35d403293b82",
+  "receiptSha256": "b438fcb80c2d7e3185936b630689ca35b52475599f9178756e59ceeb32068273"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-6.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/reliability-6.json
@@ -1,0 +1,62 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "d9c9debc544f2ab5fb6cdab9f26ba64b43a6c463a588c18433a2c4d4ccc3b3ea"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-9vTnLt/runs/takeover/repo-default-parallel/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1591791 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1591792 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1591828 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "f8fdac23-78d2-4ded-89a9-4126faa789d8",
+  "receiptSha256": "c812a1e1ab9d4380f6e16f43b57c74f709d75b3ea22d24d1b4772f8634c3a024"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/red.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/red.json
@@ -1,0 +1,52 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "263c764a3d31da80e45bf7743766d8e316d0d051",
+    "sha256": "8e7ac92b85e595303d754b7baeab50c4d95cf70c19a74904e3afb159d19cd5be",
+    "sri": "sha512-vON6FLzwBmrQWDBtDMbkl30HHrOGwGyjXbOmBJ6Xp3EZ0Wq3xMTDbH3ta0p5niKUaMN77HFK65RqD0xPSmd4Xg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-BFyDdM/runs/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 1562944 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1ea284d5-b7a4-4cca-815e-688a1e4f4b23",
+  "receiptSha256": "bdf43f827b158d686e2ea9270fae8cd197318e4e853adce6c1c8adbf7fe968e3"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-1.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-1.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-MkrGJs/runs/takeover/isolated-copy-1/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1564195 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1564196 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1564226 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "5a08d3fe-397b-40af-affc-75a6a5156124",
+  "receiptSha256": "26de43d59e1c2b71f80df67891300a2bb1339788973f089554fa9848d758e3b8"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-2.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-2.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-MkrGJs/runs/takeover/isolated-copy-2/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1565039 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1565040 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1565097 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "f9b90230-af10-45fa-aa21-ec95357500e9",
+  "receiptSha256": "eb3c7a2691d357f2c81503eec91049a8f6d2a2e6b4ca0cf0254372f5b4ce2581"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-3.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-3.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-MkrGJs/runs/takeover/isolated-copy-3/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1565993 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1565994 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1566039 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "202ce988-272e-4090-989c-55866a267d88",
+  "receiptSha256": "fd5cd226950640c465ab2c1dd3b630876c152da06a20a1e6300112e227b104dc"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-4.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-4.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-MkrGJs/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1566905 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1566906 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1566950 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1567868 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "7ffef977-e215-4174-b625-c17aa94296d9",
+  "receiptSha256": "f66db3e0064cc036dfcb92a5e71dbe001bb1c8d4039365565d65c2564c1e769a"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-5.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-5.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-MkrGJs/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1566905 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1566906 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1566950 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1567868 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1427cf04-c7c2-4357-977b-37fa757af5c4",
+  "receiptSha256": "8dca9f746526ceb37e9aa485d16ca8afc382c27d4301d6e311bcf0dad3656bf8"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-6.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/reliability-6.json
@@ -1,0 +1,62 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4",
+  "candidate": {
+    "gitSha": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "sha256": "dd8cafca9100cfed1e20204868aeb0c50580c72d75060b14425b6730dd946f88",
+    "sri": "sha512-xi/oFliZWSHQvC8ql8kIeIeRBBo1s1JalHR8nr8/QGT9XyOIwJ6gXu/dqHgR2upUXmFhXEtabDz9ueJ0cPrJrg=="
+  },
+  "source": {
+    "checkout": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+    "testFileSha256": "dfdd89299b5bc47e53769c09602efeb8384720048e5d26796884a1172a2018d0",
+    "sidecarSha256": "c51479dd6d2022f136115c7f9af7c131adc1edc93668fc2d86419ac63c4cec96"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-MkrGJs/runs/takeover/repo-default-parallel/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1568733 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1568734 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1568771 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "fb43c8af-2648-430f-9fe0-b0ff63439613",
+  "receiptSha256": "cd455911c06558c6f490685c75d68edb4775fca7d0722053eeab7ce7b564baca"
+}

--- a/e2e/inspection/test/show-cli.test.ts.cases.evidence.json
+++ b/e2e/inspection/test/show-cli.test.ts.cases.evidence.json
@@ -1,0 +1,51 @@
+{
+  "format": "niceeval.e2e-case-evidence-index/v1",
+  "current": {
+    "necase_9FHHSQTVB492P8DS": {
+      "memory/show-overview-includes-stale-execution-identity.md": {
+        "red": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/red.json",
+          "digest": "sha256:24049ef11472b35a3b49b7a740e63a0b971dbfd12483793b77fa3a8ef78e786e"
+        },
+        "green": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/green.json",
+          "digest": "sha256:bed1071286bc856fbe6a4f08a58d6d131ff35378614d36589c5f35a027794a9f"
+        },
+        "certificate": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/certificate.json",
+          "digest": "sha256:0b007e3147901b8d9ca57732799f545c0ee88e4fb085741af1bdb9f745f401ca"
+        },
+        "inventory": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/inventory.json",
+          "digest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e"
+        }
+      }
+    }
+  },
+  "history": [
+    {
+      "caseId": "necase_9FHHSQTVB492P8DS",
+      "memory": "memory/show-overview-includes-stale-execution-identity.md",
+      "evidence": {
+        "red": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/red.json",
+          "digest": "sha256:f9c6bcf3d5d3751e7a9380f7fc35111958d06f9435d6fac82507915d3ea30eb1"
+        },
+        "green": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/green.json",
+          "digest": "sha256:fd504cd0efaae6081d3346b4dbf142ceaf0b8a0cf194500d6ba4bfe59f5c2892"
+        },
+        "certificate": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/certificate.json",
+          "digest": "sha256:bb1d4c75503db65ed29455af064195d510b98d160565f2fb7d4871e64aca8ccd"
+        },
+        "inventory": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/inventory.json",
+          "digest": "sha256:ec5c7b87e5c99ca41304bdbcfe9adcf5b1115f1fd715faa8557a6b0fa0b88cd4"
+        }
+      },
+      "reason": "Replace evidence normalized with the wrong signature digest format.",
+      "retiredAtCommit": "9a13f58f8a6c51e7341f5eac83e96e06362005d9"
+    }
+  ]
+}

--- a/e2e/inspection/test/show-cli.test.ts.cases.json
+++ b/e2e/inspection/test/show-cli.test.ts.cases.json
@@ -22,6 +22,25 @@
         "legacySourceDigest": "sha256:da9318a68d2044324f7c9b092cfeeb6651db4bdc19b1d7d14411df176f0cf06d",
         "mappingDigest": "sha256:3f47cf12dfb7eedf325b5ad2020b991db79e015c6e0f9f26766fadfac51a4402"
       }
+    },
+    {
+      "caseId": "necase_9FHHSQTVB492P8DS",
+      "atCommit": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+      "transactionId": "netxn_d6418483ce15419e86361dc4a86cb5fb",
+      "action": "regression-retired",
+      "from": {
+        "memory": "memory/show-overview-includes-stale-execution-identity.md"
+      },
+      "reason": "Replace evidence normalized with the wrong signature digest format."
+    },
+    {
+      "caseId": "necase_9FHHSQTVB492P8DS",
+      "atCommit": "9a13f58f8a6c51e7341f5eac83e96e06362005d9",
+      "transactionId": "netxn_1a30ad02ef734438816b80045f3eeb29",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/show-overview-includes-stale-execution-identity.md"
+      }
     }
   ],
   "tombstones": []

--- a/memory/show-overview-includes-stale-execution-identity.md
+++ b/memory/show-overview-includes-stale-execution-identity.md
@@ -5,7 +5,13 @@ title: Show Overview includes stale execution identity
 createdAt: 2026-08-28
 kind:
   type: problem
-  state: open
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - nered_JD97KAZABC4G7GCT
+      - netake_T7KP4ABHNZN939NR
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS"]}
 promotions: []
 ---
 ## Problem

--- a/memory/show-overview-includes-stale-execution-identity.md
+++ b/memory/show-overview-includes-stale-execution-identity.md
@@ -10,20 +10,21 @@ promotions: []
 ---
 ## Problem
 
-`niceeval show` 的默认 Overview 按 `Experiment ID + Eval ID + attempt ordinal` 选择 Record 中最新的 sealed Slot。当前 Eval、Experiment 或 Sandbox 配置改变并产生新的 execution identity 后，旧 Attempt 仍会显示成当前结果。
+`niceeval show` 的默认 Overview 在打开 canonical Record 后，又用当前项目计划的 `executionIdentityDigest` 过滤 sealed Slot。只要当前源码或物化候选 identity 变化，Record 中仍存在的结果就会从人读 Overview 消失，并显示成 `Observed 0/0`。
 
-这会让用户误以为已经退役或尚未采用的结果仍适用于当前项目。历史 Run 和 Attempt 应继续支持 exact 下钻，但不应在当前结果 Overview 中冒充当前 target。
+这破坏了 `show` 作为 Record Overview 的读取职责。用户不能从默认终端入口看到已经发布的最新结果，只能预先知道 Run ID 后逐个下钻，或改用 machine `overview.get`。
 
 ## Root cause
 
-Inspection Overview 只从 Record facts 选择每个逻辑位置的最新 occurrence，没有用当前项目计划生成的 `executionIdentityDigest` 限定 slot。现有 Show E2E 只验证刚产出的当前结果，Accept E2E 只验证 reference Member，没有覆盖 identity 改变后的默认可见性。
+2026-08-28 的 stale-result 修复把“结果是否可查看”和“结果能否为当前 target 复用”合并成同一个 identity gate。Experiment planning 的 reuse eligibility 被下沉到 Inspection selection，导致 operational `show` 与 query/View 对同一 canonical Record 得到不同的默认 Overview。
 
 ## Expected resolution
 
-安装后的公开 CLI 应证明：结果初次运行后可见；改变 Eval identity 后旧结果从默认 `niceeval show` 消失；执行 `niceeval accept @<locator>` 后，accepted reference Member 以当前 target identity 再次进入默认 Overview。`--run` 和 Attempt locator 仍可精确读取历史事实。
+安装后的公开 CLI 应证明：一次 Run 封口后，无参数 `niceeval show` 显示该结果；改变 Eval、Experiment、Sandbox 或物化候选 identity 后，同一 sealed result 仍留在默认 Overview，且不会退化为 `Observed 0/0`。`exp --dry` 仍独立报告 `identity-mismatch`，只有 reuse 或 adoption 需要满足当前 target identity。
+
+`--run` 和 Attempt locator 继续提供 exact 下钻。默认 Overview 按 `experimentId + evalId + attemptOrdinal` 选择 canonical Record 中每个逻辑 Slot 的最新 sealed occurrence。
 
 ## Resolution history
-
 <!-- niceeval.memory-resolution-history/v1 -->
 
 ### Reopened at `c8c394dfdfc89c95392c842a7ccccbdc0f9358bb`

--- a/packages/niceeval/src/inspection/index.ts
+++ b/packages/niceeval/src/inspection/index.ts
@@ -40,11 +40,8 @@ export {
 } from "./protocol.ts";
 export {
   selectInspectionOperation,
-  selectShowInspectionOperation,
   InspectionOperationError,
 } from "./select.ts";
-export type { ShowCurrentInspectionPolicy } from "./select.ts";
-export type { InspectionCurrentTargetSlot } from "./overview.ts";
 export {
   openInspectionSource,
   openHostOwnedInspectionSource,

--- a/packages/niceeval/src/inspection/overview.ts
+++ b/packages/niceeval/src/inspection/overview.ts
@@ -144,13 +144,6 @@ interface SelectedSlot {
   readonly analysis: AttemptAnalysis;
 }
 
-export interface InspectionCurrentTargetSlot {
-  readonly experimentId: string;
-  readonly evalId: string;
-  readonly attemptOrdinal: number;
-  readonly executionIdentityDigest: string;
-}
-
 interface AttemptAnalysis {
   readonly assertionsState: InspectionAssertionsRead["state"] | "attempt-missing";
   readonly evaluationKind: "pass" | "points" | null;
@@ -184,11 +177,10 @@ interface OperationalMetric {
  */
 export function selectInspectionOverview(
   facts: InspectionFactSource | readonly LoadedInspectionRun[],
-  currentTargets?: readonly InspectionCurrentTargetSlot[],
   supportingRuns?: readonly LoadedInspectionRun[],
 ): InspectionOverview {
   const runs = isLoadedInspectionRuns(facts) ? facts : loadInspectionRuns(facts);
-  const selected = selectLatestSlots(runs, currentTargets, supportingRuns ?? runs);
+  const selected = selectLatestSlots(runs, supportingRuns ?? runs);
   const cells = groupSelectedSlots(selected, ({ target, slot }) =>
     `${target.run.experimentId}\u0000${slot.evalId}`)
     .map((slots) => makeCell(slots));
@@ -215,20 +207,12 @@ function isLoadedInspectionRuns(
 
 function selectLatestSlots(
   runs: readonly LoadedInspectionRun[],
-  currentTargets?: readonly InspectionCurrentTargetSlot[],
   resolutionRuns: readonly LoadedInspectionRun[] = runs,
 ): readonly SelectedSlot[] {
-  const currentByKey: ReadonlyMap<string, string> | undefined = currentTargets === undefined
-    ? undefined
-    : new Map(currentTargets.map((target) => [
-      `${target.experimentId}\u0000${target.evalId}\u0000${target.attemptOrdinal}`,
-      target.executionIdentityDigest,
-    ] as const));
   const latest = new Map<string, { readonly target: LoadedInspectionRun; readonly slot: RecordSlotIdentity }>();
   for (const target of runs) {
     for (const slot of target.run.expectedSlots) {
       const key = `${target.run.experimentId}\u0000${slot.evalId}\u0000${slot.attemptOrdinal}`;
-      if (currentByKey !== undefined && currentByKey.get(key) !== slot.executionIdentityDigest) continue;
       const current = latest.get(key);
       if (current === undefined || compareOccurrence(target, current.target) > 0) {
         latest.set(key, Object.freeze({ target, slot }));

--- a/packages/niceeval/src/inspection/select.ts
+++ b/packages/niceeval/src/inspection/select.ts
@@ -42,10 +42,7 @@ import {
   type LoadedInspectionRun,
   type ResolvedInspectionAttempt,
 } from "./facts.ts";
-import {
-  selectInspectionOverview,
-  type InspectionCurrentTargetSlot,
-} from "./overview.ts";
+import { selectInspectionOverview } from "./overview.ts";
 import type { InspectionFactSource } from "./source.ts";
 import { projectAttemptSources } from "./sources.ts";
 import { projectAttemptDiff } from "./diff.ts";
@@ -135,33 +132,6 @@ export function selectInspectionOperation(
   );
 }
 
-export interface ShowCurrentInspectionPolicy {
-  readonly mode: "current-project";
-  readonly targets: readonly InspectionCurrentTargetSlot[];
-}
-
-/** Show-only projection policy; machine query and View always inspect sealed history. */
-export function selectShowInspectionOperation(
-  facts: InspectionFactSource,
-  operation: InspectionOperationFor<"overview.get">,
-  policy: ShowCurrentInspectionPolicy,
-): InspectionSuccessDocumentFor<"overview.get">;
-export function selectShowInspectionOperation(
-  facts: InspectionFactSource,
-  operation: InspectionOperationFor<"experiment.get">,
-  policy: ShowCurrentInspectionPolicy,
-): InspectionSuccessDocumentFor<"experiment.get">;
-export function selectShowInspectionOperation(
-  facts: InspectionFactSource,
-  operation: InspectionOperationFor<"overview.get"> | InspectionOperationFor<"experiment.get">,
-  policy: ShowCurrentInspectionPolicy,
-): InspectionSuccessDocumentFor<"overview.get"> | InspectionSuccessDocumentFor<"experiment.get"> {
-  return evaluateInspectionSuccess(
-    operation.kind,
-    () => selectOperation(facts, operation, policy.targets),
-  );
-}
-
 /** Internal CLI explanation over the same selected facts and cutoff. */
 export function explainInspectionOperation(
   facts: InspectionFactSource,
@@ -190,7 +160,6 @@ export function explainInspectionOperation(
 function selectOperation(
   source: InspectionFactSource,
   operation: InspectionOperation,
-  currentTargets?: readonly InspectionCurrentTargetSlot[],
 ): unknown {
   switch (operation.kind) {
     case "overview.get": {
@@ -204,13 +173,13 @@ function selectOperation(
         overview: decodeRequiredResult(
           operation.kind,
           InspectionOverviewResultSchema,
-          selectInspectionOverview(selection.selected, currentTargets, supporting),
+          selectInspectionOverview(selection.selected, supporting),
         ),
       });
     }
     case "experiment.get": {
       const selected = loadInspectionRuns(source);
-      const overview = selectInspectionOverview(selected, currentTargets);
+      const overview = selectInspectionOverview(selected);
       const experiment = overview.experiments.find(({ experimentId }) =>
         experimentId === operation.experimentId);
       if (experiment === undefined) {

--- a/packages/niceeval/src/show/contribution.ts
+++ b/packages/niceeval/src/show/contribution.ts
@@ -10,8 +10,6 @@ import {
   CliFeatureError,
   type CliCommandContribution,
 } from "../cli/contribution.ts";
-import { ProjectConfiguration } from "../cli/project-configuration.ts";
-import { experimentHost, type ExperimentHostRequirements } from "../experiment/host/index.ts";
 import {
   InspectionIntegrityError,
   InspectionOperationError,
@@ -19,7 +17,6 @@ import {
   openInspectionSource,
   operationalInspectionSource,
   selectInspectionOperation,
-  selectShowInspectionOperation,
 } from "../inspection/index.ts";
 import {
   ExperimentIdSchema,
@@ -126,7 +123,7 @@ Attempt details:
 
   --help, -h                    Print show help.
 `;
-type Requirements = CliArguments | CliInvocationFacts | CliOutput | ProjectConfiguration | ExperimentHostRequirements;
+type Requirements = CliArguments | CliInvocationFacts | CliOutput;
 type Error = CliFeatureError;
 const failure = (operation: string, cause: unknown) => {
   const detail = cause instanceof InspectionIntegrityError
@@ -228,31 +225,6 @@ function runShow(
     const inspectionSource = typeof parsed.values.record === "string"
       ? externalInspectionSource(facts.cwd, parsed.values.record)
       : operationalInspectionSource(facts.cwd);
-    const currentTargets = runIds.length > 0 || decodedLocator !== undefined
-      ? undefined
-      : yield* Effect.gen(function* () {
-        const project = yield* ProjectConfiguration;
-        const config = yield* project.load(facts.cwd).pipe(
-          Effect.mapError((cause) => failure("load config", cause)),
-        );
-        const plan = yield* experimentHost.invocation.plan({
-          cwd: facts.cwd,
-          config,
-          preview: true,
-        }).pipe(Effect.mapError((cause) => failure("plan current targets", cause)));
-        if (plan.status !== "ready" || plan.dry === undefined) {
-          return yield* Effect.fail(failure(
-            "plan current targets",
-            new Error("Current project does not contain a runnable Experiment selection."),
-          ));
-        }
-        return Object.freeze(plan.dry.slots.map(({ target }) => Object.freeze({
-          experimentId: target.experimentId,
-          evalId: target.evalId,
-          attemptOrdinal: target.attempt,
-          executionIdentityDigest: target.executionIdentityDigest,
-        })));
-      });
     return yield* Effect.scoped(
       Effect.gen(function* () {
         const opened = yield* openInspectionSource(inspectionSource).pipe(
@@ -280,11 +252,7 @@ function runShow(
           experimentIds.length === 0
         ) {
           const document = yield* select("overview.get", () =>
-            selectShowInspectionOperation(
-              opened,
-              { kind: "overview.get" },
-              { mode: "current-project", targets: requireCurrentTargets(currentTargets) },
-            ),
+            selectInspectionOperation(opened, { kind: "overview.get" }),
           );
           yield* write(
             "stdout",
@@ -316,10 +284,10 @@ function runShow(
           const rendered: string[] = [];
           for (const experimentId of experimentIds) {
             const document = yield* select("experiment.get", () =>
-              selectShowInspectionOperation(opened, {
+              selectInspectionOperation(opened, {
                 kind: "experiment.get",
                 experimentId,
-              }, { mode: "current-project", targets: requireCurrentTargets(currentTargets) }),
+              }),
             );
             rendered.push(
               renderExperiment(
@@ -470,12 +438,6 @@ function parseRunIds(
   return Object.freeze(output.sort(compareIdentity));
 }
 
-function requireCurrentTargets<A>(targets: readonly A[] | undefined): readonly A[] {
-  if (targets === undefined) {
-    throw new Error("Show current-project policy was not prepared.");
-  }
-  return targets;
-}
 function parseExperimentIds(
   value: string | boolean | string[] | undefined,
 ): readonly Schema.Schema.Type<typeof ExperimentIdSchema>[] | string {

--- a/packages/repo-tools/src/docs/test-case/cli-runtime.ts
+++ b/packages/repo-tools/src/docs/test-case/cli-runtime.ts
@@ -35,6 +35,7 @@ export interface RetireIssueInput extends MutationFlags { readonly selector: str
 export class CaseCliError extends Error { readonly name = "CaseCliError"; constructor(readonly code: string, message: string) { super(message); } }
 const optional = <A>(value: Maybe<A>): A | undefined => Option.isOption(value) ? Option.getOrUndefined(value) : value;
 const sha = (value: string): string => `sha256:${createHash("sha256").update(value).digest("hex")}`;
+const signatureSha = (value: string): string => createHash("sha256").update(value).digest("hex");
 const canonicalJson = (value: unknown): string => {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
   if (value !== null && typeof value === "object") {
@@ -257,8 +258,6 @@ function addRegression(action: AddRegressionInput, parsed: CaseSelector) {
     const relationPath = sidecarPath(parsed.path);
     const before = decodeSidecar(relationPath);
     const relationDigest = assertExpected(relationPath, undefined);
-    const planned = planCaseRelation(before, { _tag: "AddRegression", selector: parsed, memory: action.memory }, audit());
-    const next = Result.match(planned, { onFailure: (error) => fail(error._tag, JSON.stringify(error)), onSuccess: (value) => value });
     const indexPath = evidencePath(parsed.path);
     const indexDigest = assertExpected(indexPath, undefined);
     const index = existsSync(absolute(indexPath))
@@ -266,7 +265,27 @@ function addRegression(action: AddRegressionInput, parsed: CaseSelector) {
       : { format: "niceeval.e2e-case-evidence-index/v1", current: {} };
     if (index.format !== "niceeval.e2e-case-evidence-index/v1") fail("EvidenceMismatch", `${indexPath} has an unknown format`);
     const currentCase = index.current[parsed.caseId] ?? {};
-    const evidenceRoot = `${parsed.path}.case-evidence/${parsed.caseId}/${action.memory.replaceAll("/", "_")}`;
+    const selected = selectCurrentCase(before, parsed);
+    const relation = Result.match(selected, {
+      onFailure: (error) => fail(error._tag, JSON.stringify(error)),
+      onSuccess: (value) => value,
+    });
+    const relationAlreadyCurrent = relation.regressions.includes(action.memory);
+    if (relationAlreadyCurrent && currentCase[action.memory] !== undefined) {
+      fail("RelationAlreadyCurrent", JSON.stringify({
+        selector: action.selector,
+        relation: "regression",
+        value: action.memory,
+        _tag: "RelationAlreadyCurrent",
+      }));
+    }
+    const next = relationAlreadyCurrent
+      ? before
+      : Result.match(
+          planCaseRelation(before, { _tag: "AddRegression", selector: parsed, memory: action.memory }, audit()),
+          { onFailure: (error) => fail(error._tag, JSON.stringify(error)), onSuccess: (value) => value },
+        );
+    const evidenceRoot = `${parsed.path}.case-evidence/${parsed.caseId}/${action.memory.replaceAll("/", "_")}/${action.red}-${action.takeover}`;
     const inventoryEvidencePath = `${evidenceRoot}/inventory.json`;
     const copied = [
       { value: verified.red, path: `${evidenceRoot}/red.json` },
@@ -286,7 +305,7 @@ function addRegression(action: AddRegressionInput, parsed: CaseSelector) {
       },
     };
     delete normalizedCertificateUnsigned.certificateSha256;
-    const normalizedCertificate = { ...normalizedCertificateUnsigned, certificateSha256: sha(canonicalJson(normalizedCertificateUnsigned)) };
+    const normalizedCertificate = { ...normalizedCertificateUnsigned, certificateSha256: signatureSha(canonicalJson(normalizedCertificateUnsigned)) };
     const certificatePath = `${evidenceRoot}/certificate.json`;
     const evidence = {
       red: { path: copied[0]!.path, digest: traceDigest(`${JSON.stringify(verified.red, null, 2)}\n`) },
@@ -296,7 +315,9 @@ function addRegression(action: AddRegressionInput, parsed: CaseSelector) {
     };
     const nextIndex = { ...index, current: { ...index.current, [parsed.caseId]: { ...currentCase, [action.memory]: evidence } } };
     return publish("test-regression-add", action.dryRun, [
-      { path: relationPath, bytes: encodeCaseRelationsSidecar(next), expectedDigest: relationDigest },
+      ...(relationAlreadyCurrent
+        ? []
+        : [{ path: relationPath, bytes: encodeCaseRelationsSidecar(next), expectedDigest: relationDigest }]),
       { path: indexPath, bytes: `${JSON.stringify(nextIndex, null, 2)}\n`, expectedDigest: indexDigest },
       { path: inventoryEvidencePath, bytes: `${JSON.stringify(verified.inventory, null, 2)}\n`, expectedDigest: null },
       ...copied.map((item) => ({ path: item.path, bytes: `${JSON.stringify(item.value, null, 2)}\n`, expectedDigest: null })),

--- a/packages/repo-tools/src/memory/repository.ts
+++ b/packages/repo-tools/src/memory/repository.ts
@@ -96,6 +96,8 @@ const canonicalJson = (value: unknown): string => {
   return JSON.stringify(value);
 };
 const canonicalDigest = (value: unknown): string => `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+const canonicalSignatureDigest = (value: unknown): string => createHash("sha256").update(canonicalJson(value)).digest("hex");
+const sourceDigest = (value: string | Uint8Array): string => createHash("sha256").update(value).digest("hex");
 
 const RESOLUTION_HISTORY_MARKER = "<!-- niceeval.memory-resolution-history/v1 -->";
 const FIXED_EVIDENCE_CREDENTIAL = "niceeval.fixed-evidence/v1:";
@@ -330,7 +332,7 @@ export class MemoryRepository {
       const declared = document[field];
       const unsigned = { ...document };
       delete unsigned[field];
-      if (declared !== canonicalDigest(unsigned)) throw new MemoryReferenceConflict({
+      if (declared !== canonicalSignatureDigest(unsigned)) throw new MemoryReferenceConflict({
         operation: "resolve", path, message: `${field} does not match the evidence contents`,
       });
       return document;
@@ -359,7 +361,7 @@ export class MemoryRepository {
     for (const test of related) {
       const sidecarPath = `${test.path}.cases.json`;
       const indexPath = `${test.path}.cases.evidence.json`;
-      const sidecar = this.targetSource(sidecarPath);
+      this.targetSource(sidecarPath);
       const testFile = this.targetSource(test.path);
       preimages.add(sidecarPath);
       preimages.add(test.path);
@@ -382,14 +384,16 @@ export class MemoryRepository {
         });
         const value = decodeSigned(path, FormalReceiptSchema, "receiptSha256");
         if (value.selector !== test.selector || value.caseId !== test.caseId || value.inventoryDigest !== inventoryInput.digest ||
-          value.cleanup.ok !== true || value.source.testFileSha256 !== traceDigest(testFile.source) ||
-          value.source.sidecarSha256 !== traceDigest(sidecar.source)) {
+          value.cleanup.ok !== true || value.source.testFileSha256 !== sourceDigest(testFile.source)) {
           throw new MemoryReferenceConflict({ operation: "resolve", path, message: "formal receipt diverges from selector, inventory, or current source digests" });
         }
         return value;
       };
       const red = receipt(entry.red.path, entry.red.digest);
       const green = receipt(entry.green.path, entry.green.digest);
+      if (red.source.sidecarSha256 !== green.source.sidecarSha256) throw new MemoryReferenceConflict({
+        operation: "resolve", path: indexPath, message: "formal red and green evidence diverge from the same sidecar source",
+      });
       if (red.observation !== "red" || red.result.disposition !== "regression" || green.observation !== "green" || green.result.disposition !== "pass") {
         throw new MemoryReferenceConflict({ operation: "resolve", path: indexPath, message: "fixed evidence requires a formal red regression and green pass" });
       }
@@ -408,15 +412,17 @@ export class MemoryRepository {
         ...certificate.observations.isolatedCopies,
         ...certificate.observations.sameCopy,
         certificate.observations.defaultParallel,
-        certificate.observations.singleCase,
       ];
-      if (new Set(reliabilityPaths).size !== 7) throw new MemoryReferenceConflict({
+      if (new Set(reliabilityPaths).size !== 6) throw new MemoryReferenceConflict({
         operation: "resolve", path: entry.certificate.path, message: "takeover certificate reuses reliability receipts",
       });
       const reliability = reliabilityPaths.map((path) => receipt(path));
       if (reliability.some((item) => item.observation !== "reliability" || item.result.disposition !== "pass" || item.candidate.sha256 !== green.candidate.sha256)) {
         throw new MemoryReferenceConflict({ operation: "resolve", path: entry.certificate.path, message: "takeover receipts do not all pass on the green candidate" });
       }
+      if (reliability.some((item) => item.source.sidecarSha256 !== green.source.sidecarSha256)) throw new MemoryReferenceConflict({
+        operation: "resolve", path: entry.certificate.path, message: "takeover receipts diverge from the green sidecar source",
+      });
       const invocationIds = [red.invocationId, green.invocationId, ...reliability.map((item) => item.invocationId)];
       if (new Set(invocationIds).size !== invocationIds.length) throw new MemoryReferenceConflict({
         operation: "resolve", path: entry.certificate.path, message: "formal evidence reuses an invocation identity",

--- a/packages/repo-tools/src/pr/domain.ts
+++ b/packages/repo-tools/src/pr/domain.ts
@@ -582,7 +582,8 @@ function expandTestDirective(
       const contractTarget = /^Contract: \[[^\]]+\]\(([^)]+)\)$/m.exec(block)?.[1];
       if (contractTarget === undefined) return yield* new PrTestRelationInvalid({ selector: item.selector, message: `current owner has no canonical Contract link: ${relation.owner}` });
       const contract = relative(root, resolve(root, dirname(ownerPath), contractTarget)).replaceAll("\\", "/");
-      if (!(yield* fileSystem.exists(resolve(root, contract)))) return yield* new PrTestRelationInvalid({ selector: item.selector, message: `canonical contract does not exist: ${contract}` });
+      const contractPath = contract.split("#", 1)[0]!;
+      if (!(yield* fileSystem.exists(resolve(root, contractPath)))) return yield* new PrTestRelationInvalid({ selector: item.selector, message: `canonical contract does not exist: ${contract}` });
       if (item.regression !== undefined && !relation.regressions.includes(item.regression)) return yield* new PrTestRelationInvalid({ selector: item.selector, message: `declared regression is not current: ${item.regression}` });
       narratives.push([
         `#### \`${item.selector}\``,


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 42b4332ebaf62805e3d50a67ff3d435c6dec53cc
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: 2f63577d4603e17bd89f9f5c17530f7f97904fe2
-->

## Problem

- User goal: 在候选身份变化后，仍能直接用 niceeval show 查看已封口实验的总分与实验表。
- Current limitation: 默认 show 把 overview 限定为当前源码身份，历史结果虽仍存在，却显示 Observed 0/0 且没有实验分数；同时存量 regression 关系无法补登记正式证据。
- Required capability: 默认 overview 需要从全部已封口结果汇总展示，并让 repo tool 能为既有 regression 安全回填、校验和保留多代正式证据。
- User outcome: 用户无需记住 Run ID 即可查看实验分数表，维护者也能用受管命令完成 regression evidence 与 fixed Memory 生命周期。

## Use cases

### Changed

#### Case: 候选身份变化后查看完整实验总览

##### Starting state

```text
一个项目已有 harness/alternate 与 harness/canary 两个已封口实验；当前候选身份随后发生变化。
```

##### Action

```sh
pnpm exec niceeval show
```

##### Result

```text
NiceEval results
  Totals

  Observed   2/2
  Score      37.11

  Experiments

  Experiment         Attempts  Score
  harness/alternate  1         37.11
  harness/canary     1         37.11
```

默认入口继续汇总已封口结果并显示每个实验的分数。显式 Run 查看仍可用于限定集合；执行复用继续独立按当前 identity 判定，不会采用旧身份结果。 [Canonical Use Case](docs/feature/inspection/use-case/比较质量与成本.md).

## CLI

### Changed

#### Case: 默认 show 保留已封口实验分数

##### Before

```sh
pnpm exec niceeval show
```

```text
NiceEval results
  Totals

  Observed   0/0
  Score      empty
```

##### After

```sh
pnpm exec niceeval show
```

```text
NiceEval results
  Totals

  Observed   2/2
  Score      37.11

  Experiments

  Experiment         Attempts  Score
  harness/alternate  1         37.11
  harness/canary     1         37.11
```

##### User impact

候选或源码 identity 变化不再把已封口结果从默认 overview 隐藏；用户无需逐个传入 Run ID，复用安全边界仍保持不变。

## Package scripts

### Changed

#### Case: 为存量 regression 回填正式证据

##### Before

```sh
pnpm run repo docs test regression add 'e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS' --memory memory/show-overview-includes-stale-execution-identity.md --red nered_... --takeover netake_... --inventory neinv_...
```

```text
RelationAlreadyCurrent
```

##### After

```sh
pnpm run repo docs test regression add 'e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS' --memory memory/show-overview-includes-stale-execution-identity.md --red nered_... --takeover netake_... --inventory neinv_...
```

```text
committed: true
operation: test-regression-add
```

##### User impact

已有 current relation 但缺少 evidence index 时可直接补齐，不需要先 retire；证据签名、receipt 矩阵和后续 Memory fixed 校验使用同一受管链路。

## Tests

### `e2e/inspection/test/show-cli.test.ts`

#### `e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS`

候选 identity 变化后，默认 show 仍显示全部已封口实验及其分数表。 It exercises 安装候选后的 pnpm exec niceeval show CLI。 and asserts stdout 包含 2/2、Experiments、harness/alternate、harness/canary 与各自 37.11 分，且不再出现 0/0。. Deleting this case would allow 显式 --run 仍限定查看集合，执行结果复用仍由 identity eligibility 单独控制。. The final contract is [docs/feature/inspection/cli.md#niceeval-show](docs/feature/inspection/cli.md#niceeval-show). It also prevents the regression recorded in [memory/show-overview-includes-stale-execution-identity.md](memory/show-overview-includes-stale-execution-identity.md).

```ts
// rerun: pnpm e2e test --repo inspection -- --run test/show-cli.test.ts

import { only } from "@niceeval/testkit";
import { readFileSync, writeFileSync } from "node:fs";
import { join } from "node:path";
import { expect, test } from "vitest";
import { inspectionCaseArtifacts, inspectionE2E } from "./support.ts";

function expectHumanText(stdout: string): void {
  expect(stdout.trim()).not.toBe("");
  expect(() => JSON.parse(stdout)).toThrow();
}

function expectInOrder(stdout: string, values: readonly string[]): void {
  let cursor = 0;
  for (const value of values) {
    const position = stdout.indexOf(value, cursor);
    expect(
      position,
      `expected ${JSON.stringify(value)} after byte ${cursor} in:\n${stdout}`,
    ).toBeGreaterThanOrEqual(cursor);
    cursor = position + value.length;
  }
}

interface FailedShowResult {
  readonly exitCode: number;
  readonly stdout: string;
  readonly stderr: string;
  diagnostic(): string;
}

function expectShowFailure(
  result: FailedShowResult,
  stderrValues: readonly string[],
): void {
  expect(result.exitCode, result.diagnostic()).not.toBe(0);
  expect(result.stdout, result.diagnostic()).toBe("");
  expect(result.stderr.trim(), result.diagnostic()).not.toBe("");
  for (const value of stderrValues) {
    expect(result.stderr, result.diagnostic()).toContain(value);
  }
}

function stableIdentity(stdout: string, label: string): string {
  const escaped = label.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
  const identity = stdout.match(new RegExp(`^\\s*${escaped}\\s+(\\S+)\\s*$`, "mu"))?.[1];
  expect(identity, `expected ${label} in stable identity index:\n${stdout}`).toBeDefined();
  if (identity === undefined) throw new Error(`expected ${label} stable identity`);
  expect(identity).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
  return identity;
}

test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]", async () => {
  await inspectionE2E.case(
    "show-terminal-review",
    { artifacts: inspectionCaseArtifacts() },
    async ({ commands: { niceeval }, paths }) => {
      const mainExperimentId = "harness/canary";
      const alternateExperimentId = "harness/alternate";
      const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
      expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
      expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const mainRunId = only(mainProduced.expReceipt().createdRunIds, () => true, mainProduced.diagnostic());
      const attempt = only(
        mainProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        mainProduced.diagnostic(),
      );
      expect(attempt).toMatchObject({ verdict: "passed" });
      const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;

      const alternateProduced = await niceeval.run(["exp", alternateExperimentId, "--rerun", "all", "--json"]);
      expect(alternateProduced.exitCode, alternateProduced.diagnostic()).toBe(0);
      expect(alternateProduced.expReceipt(), alternateProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const alternateRunId = only(
        alternateProduced.expReceipt().createdRunIds,
        () => true,
        alternateProduced.diagnostic(),
      );
      const alternateAttempt = only(
        alternateProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        alternateProduced.diagnostic(),
      );
      expect(alternateAttempt).toMatchObject({ verdict: "passed" });
      const alternateLocator = alternateAttempt.locator.startsWith("@")
        ? alternateAttempt.locator
        : `@${alternateAttempt.locator}`;

      const overview = await niceeval.run(["show"]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      expectHumanText(overview.stdout);
      expectInOrder(overview.stdout, ["Totals", "Experiments"]);
      expectInOrder(overview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}\n  Eval`);
      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}\n  Eval`);
      expect(overview.stdout).toMatch(/Eval\s+Attempt\s+Score/u);
      expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
      expect(overview.stdout).toContain(locator);
      expect(overview.stdout).toContain(alternateLocator);
      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${locator}\\s+37\\.11\\s*$`, "mu"));
      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+37\\.11\\s*$`, "mu"));
      expect(overview.stdout).toContain("100%");

      const run = await niceeval.run(["show", "--run", mainRunId]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      expectHumanText(run.stdout);
      expect(run.stdout).toContain(mainRunId);
      expectInOrder(run.stdout, [mainExperimentId, "inspection", locator]);

      const runs = await niceeval.run([
        "show",
        "--run",
        alternateRunId,
        "--run",
        mainRunId,
      ]);
      expect(runs.exitCode, runs.diagnostic()).toBe(0);
      expectHumanText(runs.stdout);
      expect(runs.stdout).toContain(`Run ${mainRunId}`);
      expect(runs.stdout).toContain(`Run ${alternateRunId}`);
      expect(runs.stdout).toContain(locator);
      expect(runs.stdout).toContain(alternateLocator);
      expect(runs.stdout.match(/^Run /gmu)).toHaveLength(2);

      const atomicRunsFailure = await niceeval.run([
        "show",
        "--run",
        mainRunId,
        "--run",
        "missing-run",
      ]);
      expectShowFailure(atomicRunsFailure, ["missing-run"]);

      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId]);
      expect(mainExperiment.exitCode, mainExperiment.diagnostic()).toBe(0);
      expectHumanText(mainExperiment.stdout);
      expect(mainExperiment.stdout).toContain(mainExperimentId);
      expect(mainExperiment.stdout).toContain(locator);
      expect(mainExperiment.stdout).not.toContain(alternateLocator);

      const experiments = await niceeval.run([
        "show",
        "--experiment",
        alternateExperimentId,
        "--experiment",
        mainExperimentId,
      ]);
      expect(experiments.exitCode, experiments.diagnostic()).toBe(0);
      expectHumanText(experiments.stdout);
      expect(experiments.stdout).toContain(mainExperimentId);
      expect(experiments.stdout).toContain(alternateExperimentId);
      expect(experiments.stdout).toContain(locator);
      expect(experiments.stdout).toContain(alternateLocator);

      const missingExperiment = await niceeval.run([
        "show",
        "--experiment",
        mainExperimentId,
        "--experiment",
        "does-not-exist",
      ]);
      expectShowFailure(missingExperiment, ["does-not-exist"]);

      const attemptOverview = await niceeval.run(["show", locator]);
      expect(attemptOverview.exitCode, attemptOverview.diagnostic()).toBe(0);
      expectHumanText(attemptOverview.stdout);
      expect(attemptOverview.stdout).toContain(locator);
      expectInOrder(attemptOverview.stdout, [mainExperimentId, "inspection", "Outcome", "Score", "Evidence"]);
      expect(attemptOverview.stdout).toContain("passed");
      expect(attemptOverview.stdout).toContain("Inspection tool occurrence");
      expect(attemptOverview.stdout).toContain("Compact score contribution");
      expect(attemptOverview.stdout).toContain("Mismatched Boolean contributes zero");
      expect(attemptOverview.stdout).toContain("Measurement contributes three points");
      expect(attemptOverview.stdout).toContain("Collection evidence remains bounded");
      expect(attemptOverview.stdout).toMatch(/assertions\s+(?:available|partial)\s+·\s+5 entries/u);
      expect(attemptOverview.stdout).toMatch(/coverage\s+.+/u);
      expect(attemptOverview.stdout).toMatch(/limitations\s+.+/u);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --source`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --execution`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --timing`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --usage`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --diff`);

      const source = await niceeval.run(["show", locator, "--source"]);
      expect(source.exitCode, source.diagnostic()).toBe(0);
      expectHumanText(source.stdout);
      expect(source.stdout).toContain("Captured source");
      expect(source.stdout).toContain("inspection.eval.ts");
      expect(source.stdout).toContain("Inspection tool occurrence");
      const sourceIdentity = source.stdout.match(/inspection\.eval\.ts · (\S+) · \d+ bytes/u)?.[1];
      expect(sourceIdentity, source.diagnostic()).toBeDefined();
      if (sourceIdentity === undefined) throw new Error("expected captured source identity");
      expect(source.stdout.split(sourceIdentity).length - 1).toBeGreaterThan(1);
      expect(source.stdout).toMatch(
        new RegExp(`Assertion source facts[\\s\\S]+mapped · ${sourceIdentity} · [0-9a-f]{64}`, "u"),
      );

      const execution = await niceeval.run(["show", locator, "--execution"]);
      expect(execution.exitCode, execution.diagnostic()).toBe(0);
      expectHumanText(execution.stdout);
      expect(execution.stdout).toContain(locator);
      expect(execution.stdout).toContain("Conversation · partial");
      expect(execution.stdout).toContain("Commands ·");
      expect(execution.stdout).toContain("Stable identities");
      expect(execution.stdout).toContain("inspection_fixture");
      expect(execution.stdout).toContain("inspection-tool-input");
      expect(execution.stdout).toContain("inspection-tool-result");
      const itemIdentity = stableIdentity(execution.stdout, "item");
      const toolIdentity = stableIdentity(execution.stdout, "tool occurrence");
      const commandIdentity = stableIdentity(execution.stdout, "command");
      expect(execution.stdout.split(itemIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(toolIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(commandIdentity).length - 1).toBeGreaterThan(1);

      const itemDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        itemIdentity,
      ]);
      expect(itemDetail.exitCode, itemDetail.diagnostic()).toBe(0);
      expectHumanText(itemDetail.stdout);
      expect(itemDetail.stdout).toContain(locator);
      expect(itemDetail.stdout).toContain(itemIdentity);
      expect(itemDetail.stdout).toContain("item");

      const toolDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        toolIdentity,
      ]);
      expect(toolDetail.exitCode, toolDetail.diagnostic()).toBe(0);
      expectHumanText(toolDetail.stdout);
      expect(toolDetail.stdout).toContain(locator);
      expect(toolDetail.stdout).toContain(toolIdentity);
      expect(toolDetail.stdout).toContain("inspection_fixture");
      expect(toolDetail.stdout).toContain("inspection-tool-input");
      expect(toolDetail.stdout).toContain("inspection-tool-result");

      const commandDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        commandIdentity,
      ]);
      expect(commandDetail.exitCode, commandDetail.diagnostic()).toBe(0);
      expectHumanText(commandDetail.stdout);
      expect(commandDetail.stdout).toContain(locator);
      expect(commandDetail.stdout).toContain(commandIdentity);
      expect(commandDetail.stdout).toMatch(/invocation|command/iu);
      expect(commandDetail.stdout).toMatch(/outcome|exit/iu);

      const timing = await niceeval.run(["show", locator, "--timing"]);
      expect(timing.exitCode, timing.diagnostic()).toBe(0);
      expectHumanText(timing.stdout);
      expect(timing.stdout).toContain(locator);
      expect(timing.stdout).toMatch(/timing/iu);
      expect(timing.stdout).toContain("eval.run");

      const usage = await niceeval.run(["show", locator, "--usage"]);
      expect(usage.exitCode, usage.diagnostic()).toBe(0);
      expectHumanText(usage.stdout);
      expect(usage.stdout).toContain(locator);
      expect(usage.stdout).toMatch(/usage/iu);
      expect(usage.stdout).toMatch(/input(?: tokens)?\s+10/iu);
      expect(usage.stdout).toMatch(/output(?: tokens)?\s+5/iu);
      expect(usage.stdout).toMatch(/requests?\s+1/iu);

      const diff = await niceeval.run(["show", locator, "--diff"]);
      expect(diff.exitCode, diff.diagnostic()).toBe(0);
      expectHumanText(diff.stdout);
      expect(diff.stdout).toContain(locator);
      expect(diff.stdout).toMatch(/diff/iu);
      expect(diff.stdout).toContain("complete");
      expect(diff.stdout).toContain("inspection-agent-change.txt");
      expect(diff.stdout).toContain("created");

      const usageErrors: readonly {
        readonly argv: readonly string[];
        readonly stderr: readonly string[];
      }[] = [
        { argv: ["show", locator, "--source", "--execution"], stderr: ["--source", "--execution"] },
        { argv: ["show", locator, "--expand", itemIdentity], stderr: ["--expand", "--execution"] },
        { argv: ["show", locator, "--run", mainRunId], stderr: ["--run"] },
        { argv: ["show", locator, "--experiment", mainExperimentId], stderr: ["--experiment"] },
        { argv: ["show", locator, "--timing", "--usage"], stderr: ["--timing", "--usage"] },
        { argv: ["show", locator, "--source", "--diff"], stderr: ["--source", "--diff"] },
        { argv: ["show", locator, "--execution", "--expand", "item_missing"], stderr: ["item_missing"] },
        { argv: ["show", locator, "--execution", "--expand", "t1.c1"], stderr: ["stable", "itemId"] },
        { argv: ["show", locator, "--execution", "--expand", "cmd1"], stderr: ["stable", "commandId"] },
        { argv: ["show", locator, "--json"], stderr: ["--json"] },
        { argv: ["show", locator, "--report", "standard"], stderr: ["--report"] },
        { argv: ["show", "@does-not-exist"], stderr: ["does-not-exist"] },
      ];
      for (const usageError of usageErrors) {
        expectShowFailure(
          await niceeval.run([...usageError.argv]),
          usageError.stderr,
        );
      }

      const evalPath = join(paths.projectRoot, "evals", "inspection.eval.ts");
      const evalSource = readFileSync(evalPath, "utf8");
      expect(evalSource).toContain("inspection-fixture");
      writeFileSync(
        evalPath,
        evalSource.replace("inspection-fixture", "inspection-fixture-after-review"),
        "utf8",
      );

      const changedPlan = await niceeval.run(["exp", mainExperimentId, "--dry"]);
      expect(changedPlan.exitCode, changedPlan.diagnostic()).toBe(0);
      expect(changedPlan.stdout).toContain("identity-mismatch");
      expect(changedPlan.stdout).toContain(`niceeval accept ${locator}`);

      const historicalOverview = await niceeval.run(["show"]);
      expect(historicalOverview.exitCode, historicalOverview.diagnostic()).toBe(0);
      expectHumanText(historicalOverview.stdout);
      expectInOrder(historicalOverview.stdout, ["Totals", "Experiments"]);
      expectInOrder(historicalOverview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(historicalOverview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(historicalOverview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(historicalOverview.stdout).toContain(locator);
      expect(historicalOverview.stdout).toContain(alternateLocator);
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*inspection\\s+${locator}\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).not.toContain("Observed   0/0");
    },
  );
});
```
