### PR TITLE
feat(sandbox): 汇总并展示准备前缀缓存

### DIFF
--- a/docs/engineering/testing/e2e/README.md
+++ b/docs/engineering/testing/e2e/README.md
@@ -270,7 +270,7 @@ Contract: [准备可复用评测](../../../feature/sandbox/use-case/Sandbox复�
 Docker Sandbox，`$HOME` 中的 Group 状态得以保留而工作目录会重置；运行结束后两台 owned Sandbox 都已释放。
 测试只通过安装后 CLI 的 result 事件与固定 `query run --request <request>` 读回公开结果，不读取 `.niceeval/` 私有布局。
 
-### Sandbox setup-prefix cache
+### Sandbox setup-prefix cache {#sandbox-setup-prefix-cache}
 
 <!-- niceeval.e2e-owner-contract/v1 -->
 Contract: [Sandbox · 准备前缀的身份与验证边界](../../../feature/sandbox/architecture.md#准备前缀的身份与验证边界)

--- a/docs/engineering/testing/e2e/cli.md
+++ b/docs/engineering/testing/e2e/cli.md
@@ -77,7 +77,8 @@ Then：
 #### cli-cache-inventory
 
 <!-- niceeval.e2e-owner-contract/v1 -->
-Contract: [experiments](../../../feature/experiments/README.md)
+Contract: [docs/feature/sandbox/cli.md](../../../feature/sandbox/cli.md)
+<!-- niceeval.e2e-owner-history/v1 action=set from=docs/feature/experiments/README.md at=7c23d9957a9e3433dc82db65a18099b60823e133 -->
 
 Given Docker 的共享 BuildKit builder 报告总容量和 Provider reclaimable estimate，但没有 NiceEval Domain identity、entry 或 lease。
 

--- a/docs/engineering/testing/unit/sandbox.md
+++ b/docs/engineering/testing/unit/sandbox.md
@@ -33,4 +33,10 @@
 
 最小矩阵区分：指数退避的 0.5x / 1.5x 边界与最大次数共同证明有限退避；确定性错误第一次立即失败且不进入睡眠。
 
+### Docker cache owner 存活投影
+
+真实 setup-prefix inventory 与 GC 保护结果由 Lifecycle E2E 通过安装后的 CLI 拥有。进程崩溃后遗留 claim 的
+存活分类依赖瞬时宿主 PID、container 与 image 事实，E2E 无法在不引入竞态的情况下固定检查时刻；最小 Unit 只区分
+verified-live、unverified 与无 owner 三类投影，防止遗留 claim 被误报为 active。它不复制 inventory 枚举或 GC 候选算法。
+
 其它 Sandbox 行为不保留 Unit。真实运行条件能观察的结果归 E2E；无法可靠运行的 Docker-in-Docker 行为按不自动化处置。

--- a/docs/feature/experiments/cli.md
+++ b/docs/feature/experiments/cli.md
@@ -89,7 +89,9 @@ custom provider / case 也只显示 `Opaque`。build args、env value、credenti
 Human 的结构化字段在统一终端出口把 C0、C1、ESC 与 tab/carriage return 可见化为转义文本；这条规则作用于 panel 标题、metadata、template、owner、locator、label、condition 与 Shell 行。JSON 保留结构化原值，由 JSON string escaping 防止控制序列直接写入终端。
 `ACTIVE` 的自由文本采用更严格的短命边界：去掉 VT、ANSI、C0 与 C1，折叠空白，并在已知 secret 脱敏后截到 256 UTF-8 bytes。
 
-`--json` 输出单个 `{ format: "niceeval.debug-plan/v1", schemaVersion: 1, experimentId, evalIds, setupPrefixPlan, commandPlan }` 文档；单 pair 继续带 `evalId`。`setupPrefixPlan` 按 prefix identity 去重所选 Eval 的消费者，所有节点固定写 `lookup: "not-probed"`，不把静态 planning 冒充库存探测。它不带 dry matrix、reuse、carry 或 Plugin audit 顶层字段。Locator 使用 `_tag: "Exact" | "Redacted" | "Opaque"`。前两种带非空、字段名唯一的 `fields`；`Redacted` 另带只指向已有字段的 `redactions`，`Opaque` 带结构化 `reason`。
+`--json` 输出单个 `{ format: "niceeval.debug-plan/v1", schemaVersion: 1, experimentId, evalIds, setupPrefixPlan, commandPlan }` 文档；单 pair 继续带 `evalId`。`setupPrefixPlan` 按 prefix identity 去重所选 Eval 的消费者，所有节点固定写 `lookup: "not-probed"`，不把静态 planning 冒充库存探测。
+
+该文档不带 dry matrix、reuse、carry 或 Plugin audit 顶层字段。Locator 使用 `_tag: "Exact" | "Redacted" | "Opaque"`。前两种带非空、字段名唯一的 `fields`；`Redacted` 另带只指向已有字段的 `redactions`，`Opaque` 带结构化 `reason`。
 
 真实 `exp` 结束页与机器 receipt 从同一个稳定 `setupPrefixes` summary 读取准备结果。它按本次 Invocation 的唯一 setup-prefix node 计数 `total / hit / prepared / failed`；多个 Eval 或 Attempt 消费同一 node 不重复计数，也不与 result reuse、`sandboxReuse` 或 task-build cache 合并。运行中的 activity 仍只是 live 反馈，不承担最终结算。
 

--- a/docs/feature/experiments/cli.md
+++ b/docs/feature/experiments/cli.md
@@ -93,7 +93,7 @@ Human 的结构化字段在统一终端出口把 C0、C1、ESC 与 tab/carriage 
 
 该文档不带 dry matrix、reuse、carry 或 Plugin audit 顶层字段。Locator 使用 `_tag: "Exact" | "Redacted" | "Opaque"`。前两种带非空、字段名唯一的 `fields`；`Redacted` 另带只指向已有字段的 `redactions`，`Opaque` 带结构化 `reason`。
 
-真实 `exp` 结束页与机器 receipt 从同一个稳定 `setupPrefixes` summary 读取准备结果。它按本次 Invocation 的唯一 setup-prefix node 计数 `total / hit / prepared / failed`；多个 Eval 或 Attempt 消费同一 node 不重复计数，也不与 result reuse、`sandboxReuse` 或 task-build cache 合并。运行中的 activity 仍只是 live 反馈，不承担最终结算。
+真实 `exp` 结束页与机器 terminal envelope 的 `summary.setupPrefixes` 从同一份稳定结算读取准备结果。它按本次 Invocation 的唯一 setup-prefix node 计数 `total / hit / prepared / failed`；多个 Eval 或 Attempt 消费同一 node 不重复计数，也不与 result reuse、`sandboxReuse` 或 task-build cache 合并。运行中的 activity 仍只是 live 反馈，不承担最终结算。
 
 `debug` 不执行 Experiment、Plugin、Sandbox 或 Agent 的 before、after、cleanup、test、ensure 或 finalizer,也不 lookup cache、不创建 Invocation、Run、持久事实、锁、Sandbox 或 build。它会加载 `.env`、求值受信任定义与 Experiment 的 `evals` predicate；Provider planner 也可以读文件、调用只读 CLI、查询 Docker control plane 或远端 API。NiceEval 保证自己不发起资源变更，但不能保证受信任模块求值或远端服务不产生自身副作用、审计日志或缓存。
 

--- a/docs/feature/experiments/cli.md
+++ b/docs/feature/experiments/cli.md
@@ -44,7 +44,7 @@ Assertions/Observability 缺失、partial、损坏或不支持，或 timing 超�
 
 ### `debug`
 
-`debug` 通过具名只读 `experimentHost.debug()` 显示一个 `Eval × Experiment` 配对的生命周期命令计划。CLI
+`debug` 通过具名只读 `experimentHost.debug()` 显示所选 Experiment 的生命周期命令计划。Eval selector 可省略；省略时规划该 Experiment 自己选中的全部 Eval，给出同一棵批量 command plan。提供 selector 时继续显示唯一 `Eval × Experiment` 配对。CLI
 不直连 Runner，也不附带 dry matrix、reuse 或 carry。两个 selector 都必须唯一：精确 ID 优先，否则允许唯一
 前缀；零命中或多命中会在 physical planning 前列出排序后的精确候选。
 
@@ -89,7 +89,9 @@ custom provider / case 也只显示 `Opaque`。build args、env value、credenti
 Human 的结构化字段在统一终端出口把 C0、C1、ESC 与 tab/carriage return 可见化为转义文本；这条规则作用于 panel 标题、metadata、template、owner、locator、label、condition 与 Shell 行。JSON 保留结构化原值，由 JSON string escaping 防止控制序列直接写入终端。
 `ACTIVE` 的自由文本采用更严格的短命边界：去掉 VT、ANSI、C0 与 C1，折叠空白，并在已知 secret 脱敏后截到 256 UTF-8 bytes。
 
-`--json` 输出单个 `{ format: "niceeval.debug-plan/v1", schemaVersion: 1, experimentId, evalId, commandPlan }` 文档。它不带 dry matrix、reuse、carry 或 Plugin audit 顶层字段。Locator 使用 `_tag: "Exact" | "Redacted" | "Opaque"`。前两种带非空、字段名唯一的 `fields`；`Redacted` 另带只指向已有字段的 `redactions`，`Opaque` 带结构化 `reason`。
+`--json` 输出单个 `{ format: "niceeval.debug-plan/v1", schemaVersion: 1, experimentId, evalIds, setupPrefixPlan, commandPlan }` 文档；单 pair 继续带 `evalId`。`setupPrefixPlan` 按 prefix identity 去重所选 Eval 的消费者，所有节点固定写 `lookup: "not-probed"`，不把静态 planning 冒充库存探测。它不带 dry matrix、reuse、carry 或 Plugin audit 顶层字段。Locator 使用 `_tag: "Exact" | "Redacted" | "Opaque"`。前两种带非空、字段名唯一的 `fields`；`Redacted` 另带只指向已有字段的 `redactions`，`Opaque` 带结构化 `reason`。
+
+真实 `exp` 结束页与机器 receipt 从同一个稳定 `setupPrefixes` summary 读取准备结果。它按本次 Invocation 的唯一 setup-prefix node 计数 `total / hit / prepared / failed`；多个 Eval 或 Attempt 消费同一 node 不重复计数，也不与 result reuse、`sandboxReuse` 或 task-build cache 合并。运行中的 activity 仍只是 live 反馈，不承担最终结算。
 
 `debug` 不执行 Experiment、Plugin、Sandbox 或 Agent 的 before、after、cleanup、test、ensure 或 finalizer,也不 lookup cache、不创建 Invocation、Run、持久事实、锁、Sandbox 或 build。它会加载 `.env`、求值受信任定义与 Experiment 的 `evals` predicate；Provider planner 也可以读文件、调用只读 CLI、查询 Docker control plane 或远端 API。NiceEval 保证自己不发起资源变更，但不能保证受信任模块求值或远端服务不产生自身副作用、审计日志或缓存。
 

--- a/docs/feature/experiments/cli.md
+++ b/docs/feature/experiments/cli.md
@@ -89,7 +89,7 @@ custom provider / case 也只显示 `Opaque`。build args、env value、credenti
 Human 的结构化字段在统一终端出口把 C0、C1、ESC 与 tab/carriage return 可见化为转义文本；这条规则作用于 panel 标题、metadata、template、owner、locator、label、condition 与 Shell 行。JSON 保留结构化原值，由 JSON string escaping 防止控制序列直接写入终端。
 `ACTIVE` 的自由文本采用更严格的短命边界：去掉 VT、ANSI、C0 与 C1，折叠空白，并在已知 secret 脱敏后截到 256 UTF-8 bytes。
 
-`--json` 输出单个 `{ format: "niceeval.debug-plan/v1", schemaVersion: 1, experimentId, evalIds, setupPrefixPlan, commandPlan }` 文档；单 pair 继续带 `evalId`。`setupPrefixPlan` 按 prefix identity 去重所选 Eval 的消费者，所有节点固定写 `lookup: "not-probed"`，不把静态 planning 冒充库存探测。
+`--json` 输出单个 `{ experimentId, evalIds, setupPrefixPlan, commandPlan }` 计划对象；单 pair 继续带 `evalId`。它是当前 CLI 版本的即时调试结果，不声明 `format`、`schemaVersion` 或跨版本解码协议。`setupPrefixPlan` 按 prefix identity 去重所选 Eval 的消费者，所有节点固定写 `lookup: "not-probed"`，不把静态 planning 冒充库存探测。
 
 该文档不带 dry matrix、reuse、carry 或 Plugin audit 顶层字段。Locator 使用 `_tag: "Exact" | "Redacted" | "Opaque"`。前两种带非空、字段名唯一的 `fields`；`Redacted` 另带只指向已有字段的 `redactions`，`Opaque` 带结构化 `reason`。
 

--- a/docs/feature/experiments/use-case/选择评测/预览并收窄.md
+++ b/docs/feature/experiments/use-case/选择评测/预览并收窄.md
@@ -49,7 +49,7 @@ relations: {}
 
    需要在花费前核对这个 Experiment 的 Sandbox 准备前缀时，使用 `niceeval debug <experiment> --json`。省略 Eval selector 会规划该 Experiment 选中的全部 Eval，`setupPrefixPlan` 按 prefix identity 去重消费者。
 
-   这份静态计划固定标记 `lookup: "not-probed"`，不会把计划写成真实 cache hit。正式 `niceeval exp` 结束后，Human 摘要与机器 receipt 的 `setupPrefixes` 按唯一 prefix node 结算 `total / hit / prepared / failed`，不与历史结果沿用或物理 Sandbox 复用混算。
+   这份静态计划固定标记 `lookup: "not-probed"`，不会把计划写成真实 cache hit。正式 `niceeval exp` 结束后，Human 摘要与机器 terminal envelope 的 `summary.setupPrefixes` 按唯一 prefix node 结算 `total / hit / prepared / failed`，不与历史结果沿用或物理 Sandbox 复用混算。
 5. 选择器写错、第二个位置参数没有选中 Eval，或 argv 不能形成命令时，都在建立 Invocation 前以非零状态结束；没有 receipt。零命中只给可浏览的目录清单，不摊平打印每个已发现 id：
 
    ```sh

--- a/docs/feature/experiments/use-case/选择评测/预览并收窄.md
+++ b/docs/feature/experiments/use-case/选择评测/预览并收窄.md
@@ -46,8 +46,10 @@ relations: {}
 
 4. 计划与预期一致后去掉 `--dry` 实跑。
    `--dry` 只打印计划(人读文本或 `--json` 单文档),不运行、不落盘,也不写 JUnit(见 [CLI · 哪些参数改变什么](../../cli.md#哪些参数改变什么))。
-   需要在花费前核对这个 Experiment 的 Sandbox 准备前缀时，使用 `niceeval debug <experiment> --json`；省略 Eval selector 会规划该 Experiment 选中的全部 Eval，`setupPrefixPlan` 按 prefix identity 去重消费者。这份静态计划固定标记 `lookup: "not-probed"`，不会把计划写成真实 cache hit。
-   正式 `niceeval exp` 结束后，Human 摘要与机器 receipt 的 `setupPrefixes` 再按本次 Invocation 的唯一 prefix node 结算 `total / hit / prepared / failed`，不与历史结果沿用或物理 Sandbox 复用混算。
+
+   需要在花费前核对这个 Experiment 的 Sandbox 准备前缀时，使用 `niceeval debug <experiment> --json`。省略 Eval selector 会规划该 Experiment 选中的全部 Eval，`setupPrefixPlan` 按 prefix identity 去重消费者。
+
+   这份静态计划固定标记 `lookup: "not-probed"`，不会把计划写成真实 cache hit。正式 `niceeval exp` 结束后，Human 摘要与机器 receipt 的 `setupPrefixes` 按唯一 prefix node 结算 `total / hit / prepared / failed`，不与历史结果沿用或物理 Sandbox 复用混算。
 5. 选择器写错、第二个位置参数没有选中 Eval，或 argv 不能形成命令时，都在建立 Invocation 前以非零状态结束；没有 receipt。零命中只给可浏览的目录清单，不摊平打印每个已发现 id：
 
    ```sh

--- a/docs/feature/experiments/use-case/选择评测/预览并收窄.md
+++ b/docs/feature/experiments/use-case/选择评测/预览并收窄.md
@@ -46,6 +46,8 @@ relations: {}
 
 4. 计划与预期一致后去掉 `--dry` 实跑。
    `--dry` 只打印计划(人读文本或 `--json` 单文档),不运行、不落盘,也不写 JUnit(见 [CLI · 哪些参数改变什么](../../cli.md#哪些参数改变什么))。
+   需要在花费前核对这个 Experiment 的 Sandbox 准备前缀时，使用 `niceeval debug <experiment> --json`；省略 Eval selector 会规划该 Experiment 选中的全部 Eval，`setupPrefixPlan` 按 prefix identity 去重消费者。这份静态计划固定标记 `lookup: "not-probed"`，不会把计划写成真实 cache hit。
+   正式 `niceeval exp` 结束后，Human 摘要与机器 receipt 的 `setupPrefixes` 再按本次 Invocation 的唯一 prefix node 结算 `total / hit / prepared / failed`，不与历史结果沿用或物理 Sandbox 复用混算。
 5. 选择器写错、第二个位置参数没有选中 Eval，或 argv 不能形成命令时，都在建立 Invocation 前以非零状态结束；没有 receipt。零命中只给可浏览的目录清单，不摊平打印每个已发现 id：
 
    ```sh

--- a/docs/feature/sandbox/architecture.md
+++ b/docs/feature/sandbox/architecture.md
@@ -498,3 +498,9 @@ Sandbox 预热与 Sandbox 复用是 [Runner](../../runner.md) 的调度职责。
 - [Library](library.md) —— 使用侧 API：路径、root、before action、自定义 provider。
 - [Nested Docker](nested-docker/README.md) —— requirement、Incus VM、DestroyOnly 与 doctor。
 - [Runner](../../runner.md) —— 预热与复用的调度职责。
+
+## Docker-owned cache inventory projection
+
+Docker cache repository 以单个只读 inventory operation 在同一 transaction snapshot 中列出 task-build 与 setup-prefix entry 及其 active lease/root。该 operation 不做 startup reconcile、lease prune、provider mutation 或 GC planning。Docker administration 再复核 task-build image identity，并把两类 entry 投影为以 `kind` 判别的公开联合；Setup Prefix 只采用 registry 已有 state，不因 inventory 改变 generation 或索引。
+
+公开 identity 只包含定位 artifact 所需的 task build key/tag/image id，或 setup entry id/key/image/base image id；计数只聚合 entry-local lease/root。holder、operation lineage、声明正文和 GC lock 留在 repository 内部。Setup Prefix 的公开归属不扩大 GC：现有 task-build plan/apply 是唯一删除入口。

--- a/docs/feature/sandbox/cli.md
+++ b/docs/feature/sandbox/cli.md
@@ -195,3 +195,9 @@ origin Attempt 的 FileChanges 是折叠后的 agent 归因增量;留存现场�
 - [Architecture](architecture.md) —— 留存决策在 attempt 收尾链里的位置、注册表、各 provider 的留存语义。
 - [Record · Architecture](../run/architecture.md) —— `sandbox` 字段(provider、实例 id、是否留存)。
 - [CLI 内部架构](../../cli.md) —— 命令分派、中断路径与「不留无主沙箱」。
+
+## Docker image cache inventory
+
+`niceeval docker cache inventory` 只读展示同一 `verified-managed` Docker images Domain 中由 NiceEval 登记的两类 entry：`task-build` 与 `sandbox-setup-prefix`。JSON 的 `entries` 是以 `kind` 判别的联合；每项稳定显示自身 identity、当前 state、lease/root 数、创建时间、最后成功使用时间与保护截止时间。Domain 摘要另按两种 kind 给出计数。Human 输出逐项显示同一组安全字段，不输出声明正文、holder identity、operation id 或其它内部恢复资料。
+
+Setup Prefix 进入 inventory 只授予可见性，不把它纳入 `docker cache gc`：现有 preview/apply 仍只产生和回收 `task-build` 候选。共享 BuildKit 仍是独立的 `unverified` Provider observation。

--- a/docs/feature/sandbox/use-case/起点与准备/共享分支准备.md
+++ b/docs/feature/sandbox/use-case/起点与准备/共享分支准备.md
@@ -15,3 +15,5 @@ cost(1) + cost(2) + max(cost(3), cost(4))
 ```
 
 并行数同时受 `maxSetupPrefixConcurrency` / `--max-setup-prefix-concurrency` 与 Provider `scheduling.lane.limit` 限制。所有可参与的 prefix 节点都结算后，Run 才派发 Attempt；某节点失败只阻断它的 descendants，另一分支仍可结算和派发。普通 Docker、Docker Profile、E2B、Vercel 与 custom provider 不会因这个用例被假定拥有 `PreparedArtifact` 能力。
+
+需要核对宿主上由 NiceEval 拥有的准备前缀时，我运行 `niceeval docker cache inventory`。同一 Docker images Domain 把该 artifact 作为 `sandbox-setup-prefix` entry 展示，并给出 identity、state、lease/root 数与时间字段；这项只读归属不会让 `docker cache gc` 回收准备前缀。

--- a/e2e/cli/evals/sandbox-action-debug/eval-group.ts
+++ b/e2e/cli/evals/sandbox-action-debug/eval-group.ts
@@ -4,9 +4,10 @@ import {
   plannedDebugAction,
 } from "../../src/sandbox-action-debug.ts";
 import plan from "./plan.eval.ts";
+import secondary from "./secondary.eval.ts";
 
 export default defineEvalGroup({
-  evals: [plan],
+  evals: [plan, secondary],
   onUnavailable: "stop-group",
   sandbox: sandboxLayer()
     .before(plannedDebugAction("frequency-low", 10))

--- a/e2e/cli/evals/sandbox-action-debug/secondary.eval.ts
+++ b/e2e/cli/evals/sandbox-action-debug/secondary.eval.ts
@@ -7,7 +7,7 @@ import {
 
 export default defineEval({
   description: "Second Sandbox action debug planning fixture",
-  sandbox: sandboxLayer().before(plannedDebugAction("tie-eval-secondary", 100)),
+  sandbox: sandboxLayer().before(plannedDebugAction("tie-eval", 100)),
   async test() {
     recordSandboxActionDebugSideEffect("secondary-eval-test");
   },

--- a/e2e/cli/evals/sandbox-action-debug/secondary.eval.ts
+++ b/e2e/cli/evals/sandbox-action-debug/secondary.eval.ts
@@ -7,7 +7,7 @@ import {
 
 export default defineEval({
   description: "Second Sandbox action debug planning fixture",
-  sandbox: sandboxLayer().before(plannedDebugAction("tie-eval", 100)),
+  sandbox: sandboxLayer().before(plannedDebugAction("tie-eval-secondary", 100)),
   async test() {
     recordSandboxActionDebugSideEffect("secondary-eval-test");
   },

--- a/e2e/cli/evals/sandbox-action-debug/secondary.eval.ts
+++ b/e2e/cli/evals/sandbox-action-debug/secondary.eval.ts
@@ -1,0 +1,14 @@
+import { defineEval } from "niceeval";
+import { sandboxLayer } from "niceeval/sandbox";
+import {
+  plannedDebugAction,
+  recordSandboxActionDebugSideEffect,
+} from "../../src/sandbox-action-debug.ts";
+
+export default defineEval({
+  description: "Second Sandbox action debug planning fixture",
+  sandbox: sandboxLayer().before(plannedDebugAction("tie-eval-secondary", 100)),
+  async test() {
+    recordSandboxActionDebugSideEffect("secondary-eval-test");
+  },
+});

--- a/e2e/cli/experiments/sandbox-action-debug.ts
+++ b/e2e/cli/experiments/sandbox-action-debug.ts
@@ -40,7 +40,7 @@ export default defineExperiment({
   description: "Structured Sandbox action debug plan",
   agent: sandboxActionDebugAgent,
   sandbox,
-  evals: ["sandbox-action-debug/plan"],
+  evals: ["sandbox-action-debug/plan", "sandbox-action-debug/secondary"],
   setup() {
     recordSandboxActionDebugSideEffect("experiment-setup");
   },

--- a/e2e/cli/test/cache-inventory.test.ts
+++ b/e2e/cli/test/cache-inventory.test.ts
@@ -52,6 +52,7 @@ test("共享 BuildKit 容量只作为未验证 Provider observation 展示 [neca
       backendKind: "docker-images",
       state: "verified-managed",
       entryCount: 0,
+      entryKinds: { taskBuild: 0, sandboxSetupPrefix: 0 },
     }]);
     expect(document.providerObservations).toEqual([{
       scope: "provider",

--- a/e2e/cli/test/sandbox-action-debug.test.ts
+++ b/e2e/cli/test/sandbox-action-debug.test.ts
@@ -415,20 +415,15 @@ test("debug 交付统一且无副作用的 Sandbox action 计划 [necase_NVHTZ20
       setupPrefixPlan: expect.objectContaining({ lookup: "not-probed" }),
     }));
     expect(wholeDocument).not.toHaveProperty("evalId");
-    const sharedNodes = wholeDocument.setupPrefixPlan.nodes.filter((node) => {
-      const evalIds = node.consumers.map((consumer) => consumer.evalId);
-      return evalIds.includes("sandbox-action-debug/plan") &&
-        evalIds.includes("sandbox-action-debug/secondary");
-    });
-    expect(sharedNodes.length, "shared setup-prefix identities must be emitted once").toBeGreaterThan(0);
-    for (const node of sharedNodes) {
-      expect(node.consumers).toEqual([
-        { experimentId: "sandbox-action-debug", evalId: "sandbox-action-debug/plan" },
-        { experimentId: "sandbox-action-debug", evalId: "sandbox-action-debug/secondary" },
-      ]);
-      expect(wholeDocument.setupPrefixPlan.nodes.filter((candidate) =>
-        candidate.prefixIdentity === node.prefixIdentity)).toHaveLength(1);
-    }
+    expect(new Set(wholeDocument.setupPrefixPlan.nodes.map((node) => node.prefixIdentity)).size)
+      .toBe(wholeDocument.setupPrefixPlan.nodes.length);
+    const consumerEvalIds = new Set(wholeDocument.setupPrefixPlan.nodes.flatMap((node) =>
+      node.consumers.map((consumer) => consumer.evalId)));
+    expect(consumerEvalIds).toEqual(new Set([
+      "sandbox-action-debug/plan",
+      "sandbox-action-debug/secondary",
+    ]));
+    expect(consumerEvalIds).not.toContain("*");
 
     await expect(access(sideEffects)).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/e2e/cli/test/sandbox-action-debug.test.ts
+++ b/e2e/cli/test/sandbox-action-debug.test.ts
@@ -18,6 +18,8 @@ interface DebugPlanDocument {
   readonly schemaVersion: 1;
   readonly experimentId: string;
   readonly evalId: string;
+  readonly evalIds: readonly string[];
+  readonly setupPrefixPlan: { readonly lookup: "not-probed"; readonly nodes: readonly JsonRecord[] };
   readonly commandPlan: unknown;
 }
 
@@ -127,7 +129,10 @@ test("debug 交付统一且无副作用的 Sandbox action 计划 [necase_NVHTZ20
       schemaVersion: 1,
       experimentId: "sandbox-action-debug",
       evalId: "sandbox-action-debug/plan",
+      evalIds: ["sandbox-action-debug/plan"],
     }));
+    expect(document.setupPrefixPlan.lookup).toBe("not-probed");
+    expect(document.setupPrefixPlan.nodes.every((node) => node.lookup === "not-probed")).toBe(true);
 
     const nodes = actionNodes(document.commandPlan);
     const byId = new Map(nodes.map((node) => [actionId(node)!, node]));
@@ -396,6 +401,14 @@ test("debug 交付统一且无副作用的 Sandbox action 计划 [necase_NVHTZ20
     expect(invalid.stderr).toContain("invalid-cycle-a");
     expect(invalid.stderr).toContain("invalid-cycle-b");
     expect(invalid.stderr).not.toContain("defect");
+
+    const wholeExperiment = await niceeval.run(["debug", "sandbox-action-debug", "--json"]);
+    expect(wholeExperiment.exitCode, wholeExperiment.diagnostic()).toBe(0);
+    expect(wholeExperiment.json<DebugPlanDocument>()).toEqual(expect.objectContaining({
+      experimentId: "sandbox-action-debug",
+      evalIds: ["sandbox-action-debug/plan"],
+      setupPrefixPlan: expect.objectContaining({ lookup: "not-probed" }),
+    }));
 
     await expect(access(sideEffects)).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/e2e/cli/test/sandbox-action-debug.test.ts
+++ b/e2e/cli/test/sandbox-action-debug.test.ts
@@ -14,8 +14,6 @@ const EPHEMERAL_SETUP_PREFIX_REASON =
   "Persistent setup-prefix cache is unsupported for Docker Profile sandboxes and for read-only rootfs or tmpfs surfaces.";
 
 interface DebugPlanDocument {
-  readonly format: "niceeval.debug-plan/v1";
-  readonly schemaVersion: 1;
   readonly experimentId: string;
   readonly evalId: string;
   readonly evalIds: readonly string[];
@@ -125,12 +123,12 @@ test("debug 交付统一且无副作用的 Sandbox action 计划 [necase_NVHTZ20
     expect(receipt.stderr).toBe("");
     const document = receipt.json<DebugPlanDocument>();
     expect(document).toEqual(expect.objectContaining({
-      format: "niceeval.debug-plan/v1",
-      schemaVersion: 1,
       experimentId: "sandbox-action-debug",
       evalId: "sandbox-action-debug/plan",
       evalIds: ["sandbox-action-debug/plan"],
     }));
+    expect(document).not.toHaveProperty("format");
+    expect(document).not.toHaveProperty("schemaVersion");
     expect(document.setupPrefixPlan.lookup).toBe("not-probed");
     expect(document.setupPrefixPlan.nodes.every((node) => node.lookup === "not-probed")).toBe(true);
 

--- a/e2e/cli/test/sandbox-action-debug.test.ts
+++ b/e2e/cli/test/sandbox-action-debug.test.ts
@@ -15,9 +15,15 @@ const EPHEMERAL_SETUP_PREFIX_REASON =
 
 interface DebugPlanDocument {
   readonly experimentId: string;
-  readonly evalId: string;
+  readonly evalId?: string;
   readonly evalIds: readonly string[];
-  readonly setupPrefixPlan: { readonly lookup: "not-probed"; readonly nodes: readonly JsonRecord[] };
+  readonly setupPrefixPlan: {
+    readonly lookup: "not-probed";
+    readonly nodes: readonly (JsonRecord & {
+      readonly prefixIdentity: string;
+      readonly consumers: readonly { readonly experimentId: string; readonly evalId: string }[];
+    })[];
+  };
   readonly commandPlan: unknown;
 }
 
@@ -402,11 +408,27 @@ test("debug 交付统一且无副作用的 Sandbox action 计划 [necase_NVHTZ20
 
     const wholeExperiment = await niceeval.run(["debug", "sandbox-action-debug", "--json"]);
     expect(wholeExperiment.exitCode, wholeExperiment.diagnostic()).toBe(0);
-    expect(wholeExperiment.json<DebugPlanDocument>()).toEqual(expect.objectContaining({
+    const wholeDocument = wholeExperiment.json<DebugPlanDocument>();
+    expect(wholeDocument).toEqual(expect.objectContaining({
       experimentId: "sandbox-action-debug",
-      evalIds: ["sandbox-action-debug/plan"],
+      evalIds: ["sandbox-action-debug/plan", "sandbox-action-debug/secondary"],
       setupPrefixPlan: expect.objectContaining({ lookup: "not-probed" }),
     }));
+    expect(wholeDocument).not.toHaveProperty("evalId");
+    const sharedNodes = wholeDocument.setupPrefixPlan.nodes.filter((node) => {
+      const evalIds = node.consumers.map((consumer) => consumer.evalId);
+      return evalIds.includes("sandbox-action-debug/plan") &&
+        evalIds.includes("sandbox-action-debug/secondary");
+    });
+    expect(sharedNodes.length, "shared setup-prefix identities must be emitted once").toBeGreaterThan(0);
+    for (const node of sharedNodes) {
+      expect(node.consumers).toEqual([
+        { experimentId: "sandbox-action-debug", evalId: "sandbox-action-debug/plan" },
+        { experimentId: "sandbox-action-debug", evalId: "sandbox-action-debug/secondary" },
+      ]);
+      expect(wholeDocument.setupPrefixPlan.nodes.filter((candidate) =>
+        candidate.prefixIdentity === node.prefixIdentity)).toHaveLength(1);
+    }
 
     await expect(access(sideEffects)).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/e2e/lifecycle/test/pty-terminal-cleanup.test.ts
+++ b/e2e/lifecycle/test/pty-terminal-cleanup.test.ts
@@ -72,7 +72,7 @@ test("PTY rejects a sentinel first checked after candidate exit when whileRunnin
 test("PTY timeout kills a TERM-ignoring candidate and its descendant, then proves all owned groups terminal [necase_VWGZRFWXF18HCYQE]", async () => {
   const pty = await startPty(
     [node, "-e", "const { spawn } = require('node:child_process'); spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' }); process.stdout.write('cleanup-ready\\n'); process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"],
-    { timeoutMs: 250, graceMs: 200 },
+    { timeoutMs: 3_000, graceMs: 200 },
   );
   await pty.waitForText("cleanup-ready", { timeoutMs: 2_000, whileRunning: true });
   const receipt = await pty.wait();

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -280,7 +280,7 @@ async function assertSetupPrefixInventory(root: string, niceevalHome: string): P
       state: "indexed",
       identity: {
         entryId: expect.any(String),
-        setupPrefixKey: expect.stringMatching(/^[a-f0-9]{64}$/u),
+        setupPrefixKey: expect.stringMatching(/^prefix:[a-f0-9]{64}$/u),
         imageId: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
         baseImageId: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
       },

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -327,6 +327,7 @@ async function inspectCompletedInvocation(
 ): Promise<{
   readonly evidence: SetupPrefixEvidence;
   readonly diagnostic: string;
+  readonly setupPrefixes: SetupPrefixSummary;
 }> {
   const mode = options.mode ?? "default";
   expect(run.exitCode, run.diagnostic()).toBe(0);

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -35,6 +35,32 @@ interface IncusJournalRecord {
   };
 }
 
+interface SetupPrefixSummary {
+  readonly total: number;
+  readonly hit: number;
+  readonly prepared: number;
+  readonly failed: number;
+}
+
+function setupPrefixSummary(receipt: ProcessReceipt): SetupPrefixSummary {
+  const terminal = receipt.ndjson<Record<string, unknown>>().at(-1);
+  expect(terminal, receipt.diagnostic()).toMatchObject({ type: "receipt" });
+  const summary = terminal?.summary as { readonly setupPrefixes?: SetupPrefixSummary } | undefined;
+  expect(summary?.setupPrefixes, "terminal JSON envelope must project the invocation summary").toEqual({
+    total: expect.any(Number),
+    hit: expect.any(Number),
+    prepared: expect.any(Number),
+    failed: expect.any(Number),
+  });
+  const setup = summary!.setupPrefixes!;
+  expect(setup.total, receipt.diagnostic()).toBe(setup.hit + setup.prepared + setup.failed);
+  return setup;
+}
+
+function humanSetupPrefixLine(summary: SetupPrefixSummary): string {
+  return `Setup prefixes: ${summary.hit} hit · ${summary.prepared} prepared · ${summary.failed} failed (${summary.total} total)`;
+}
+
 const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
 const docker = command(["docker"]);
 const binary = resolve("node_modules/.bin/niceeval");
@@ -236,6 +262,7 @@ async function invokeDetailed(
 ): Promise<{
   readonly evidence: SetupPrefixEvidence;
   readonly diagnostic: string;
+  readonly setupPrefixes: SetupPrefixSummary;
 }> {
   const invocationEnv = invocationEnvironment(root, publicEnv, options);
   const run = await niceeval.run(["exp", "setup-prefix-cache", "--rerun", "all", "--json"], {
@@ -260,6 +287,9 @@ async function inspectCompletedInvocation(
   const mode = options.mode ?? "default";
   expect(run.exitCode, run.diagnostic()).toBe(0);
   expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
+  expect(run.expReceipt(), "InvocationReceipt must remain a lightweight hand-off")
+    .not.toHaveProperty("setupPrefixes");
+  const setupPrefixes = setupPrefixSummary(run);
   const evaluation = only(
     run.expEvalEvents(),
     (event) => event.evalId === "setup-prefix-cache",
@@ -292,7 +322,7 @@ async function inspectCompletedInvocation(
     middleVersion: options.middleVersion ?? "alpha",
   });
   await waitForSandboxGone(evidence.sandboxId, root);
-  return { evidence, diagnostic: run.diagnostic() };
+  return { evidence, diagnostic: run.diagnostic(), setupPrefixes };
 }
 
 async function interruptAfterPublishedLayer(
@@ -387,6 +417,9 @@ test.concurrent("独立 Invocation 只重新执行变化的 Sandbox setup 后缀
 
       const changedDemandRun = await invokeDetailed(root, "v2", "PUBLIC_MODE=alpha\n", { niceevalHome });
       const changedDemand = changedDemandRun.evidence;
+      expect(changedDemandRun.setupPrefixes.hit).toBe(changedDemandRun.setupPrefixes.total);
+      expect(changedDemandRun.setupPrefixes.prepared).toBe(0);
+      expect(changedDemandRun.setupPrefixes.failed).toBe(0);
       const demandDiagnostic = `${coldRun.diagnostic}\n${changedDemandRun.diagnostic}`;
       expect(changedDemand.buildToken, demandDiagnostic).toBe(cold.buildToken);
       expect(changedDemand.fixtureToken, demandDiagnostic).toBe(cold.fixtureToken);
@@ -397,6 +430,9 @@ test.concurrent("独立 Invocation 只重新执行变化的 Sandbox setup 后缀
         middleVersion: "beta",
         niceevalHome,
       });
+      expect(changedMiddle.setupPrefixes.hit).toBeGreaterThan(0);
+      expect(changedMiddle.setupPrefixes.prepared).toBeGreaterThan(0);
+      expect(changedMiddle.setupPrefixes.failed).toBe(0);
       expect(changedMiddle.evidence.buildToken).toBe(cold.buildToken);
       expect(changedMiddle.evidence.fixtureToken).toBe(cold.fixtureToken);
       expect(changedMiddle.evidence.middleToken).not.toBe(changedDemand.middleToken);
@@ -410,6 +446,17 @@ test.concurrent("独立 Invocation 只重新执行变化的 Sandbox setup 后缀
       expect(changedEnv.evidence.fixtureToken).toBe(cold.fixtureToken);
       expect(changedEnv.evidence.middleToken).toBe(changedMiddle.evidence.middleToken);
       expect(changedEnv.evidence.envToken).not.toBe(changedMiddle.evidence.envToken);
+
+      const human = await niceeval.run(["exp", "setup-prefix-cache", "--rerun", "all"], {
+        cwd: root,
+        env: invocationEnvironment(root, "PUBLIC_MODE=beta\n", {
+          middleVersion: "beta",
+          niceevalHome,
+        }),
+        timeoutMs: 360_000,
+      });
+      expect(human.exitCode, human.diagnostic()).toBe(0);
+      expect(human.stdout).toContain(humanSetupPrefixLine(changedDemandRun.setupPrefixes));
 
       expect(new Set([
         cold.sandboxId,

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -273,6 +273,64 @@ async function invokeDetailed(
   return inspectCompletedInvocation(root, demand, publicEnv, options, invocationEnv, run);
 }
 
+async function assertSetupPrefixInventory(root: string, niceevalHome: string): Promise<void> {
+  const env = { NICEEVAL_HOME: niceevalHome };
+  const inventory = await niceeval.run(["docker", "cache", "inventory", "--json"], { cwd: root, env });
+  expect(inventory.exitCode, inventory.diagnostic()).toBe(0);
+  const document = JSON.parse(inventory.stdout) as {
+    readonly domains: readonly { readonly domainId: string; readonly entryKinds: { readonly sandboxSetupPrefix: number } }[];
+  };
+  const domain = only(document.domains, (candidate) => candidate.entryKinds.sandboxSetupPrefix > 0, inventory.diagnostic());
+  const detail = await niceeval.run([
+    "docker", "cache", "inventory", "--domain", domain.domainId, "--json",
+  ], { cwd: root, env });
+  expect(detail.exitCode, detail.diagnostic()).toBe(0);
+  const entries = (JSON.parse(detail.stdout) as { readonly entries: readonly Record<string, unknown>[] }).entries
+    .filter((entry) => entry.kind === "sandbox-setup-prefix");
+  expect(entries.length, detail.diagnostic()).toBeGreaterThan(0);
+  for (const entry of entries) {
+    expect(entry).toMatchObject({
+      kind: "sandbox-setup-prefix",
+      state: "indexed",
+      identity: {
+        entryId: expect.any(String),
+        setupPrefixKey: expect.stringMatching(/^[a-f0-9]{64}$/u),
+        imageId: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+        baseImageId: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
+      },
+      leaseCount: 0,
+      rootCount: 0,
+      liveLeaseCount: 0,
+      unverifiedLeaseCount: 0,
+      liveRootCount: 0,
+      unverifiedRootCount: 0,
+    });
+    expect(Object.keys(entry).sort()).toEqual([
+      "createdAt", "identity", "kind", "lastSuccessfulUseAt", "leaseCount", "liveLeaseCount",
+      "liveRootCount", "protectedUntil", "rootCount", "state", "unverifiedLeaseCount", "unverifiedRootCount",
+    ]);
+  }
+  expect(detail.stdout).not.toMatch(/declaration|holder|operationId|manifestDigest/iu);
+
+  const human = await niceeval.run(["docker", "cache", "inventory", "--domain", domain.domainId], { cwd: root, env });
+  expect(human.exitCode, human.diagnostic()).toBe(0);
+  expect(human.stdout).toContain("sandbox-setup-prefix · indexed");
+  expect(human.stdout).toContain("0 leases (0 live, 0 unverified) · 0 roots (0 live, 0 unverified)");
+  expect(human.stdout).not.toMatch(/declaration|holder|operationId|manifestDigest/iu);
+
+  const preview = await niceeval.run([
+    "docker", "cache", "gc", "--domain", domain.domainId, "--json",
+  ], { cwd: root, env });
+  expect(preview.exitCode, preview.diagnostic()).toBe(0);
+  const plan = (JSON.parse(preview.stdout) as { readonly plan: { readonly planId: string; readonly candidates: readonly unknown[] } }).plan;
+  expect(plan.candidates).toEqual([]);
+  const apply = await niceeval.run([
+    "docker", "cache", "gc", "--domain", domain.domainId, "--apply", plan.planId, "--json",
+  ], { cwd: root, env });
+  expect(apply.exitCode, apply.diagnostic()).toBe(0);
+  expect(JSON.parse(apply.stdout)).toMatchObject({ format: "niceeval.cache-gc-outcome", outcomes: [] });
+}
+
 async function inspectCompletedInvocation(
   root: string,
   demand: "v1" | "v2",
@@ -408,6 +466,7 @@ test.concurrent("独立 Invocation 只重新执行变化的 Sandbox setup 后缀
 
       const coldRun = await invokeDetailed(root, "v1", "PUBLIC_MODE=alpha\n", { niceevalHome });
       const cold = coldRun.evidence;
+      await assertSetupPrefixInventory(root, niceevalHome);
 
       const evalPath = join(root, "evals/setup-prefix-cache.eval.ts");
       const originalEval = await readFile(evalPath, "utf8");

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -35,24 +35,10 @@ interface IncusJournalRecord {
   };
 }
 
-interface SetupPrefixSummary {
-  readonly total: number;
-  readonly hit: number;
-  readonly prepared: number;
-  readonly failed: number;
-}
+type SetupPrefixSummary = ReturnType<ProcessReceipt["expTerminal"]>["summary"]["setupPrefixes"];
 
 function setupPrefixSummary(receipt: ProcessReceipt): SetupPrefixSummary {
-  const terminal = receipt.ndjson<Record<string, unknown>>().at(-1);
-  expect(terminal, receipt.diagnostic()).toMatchObject({ type: "receipt" });
-  const summary = terminal?.summary as { readonly setupPrefixes?: SetupPrefixSummary } | undefined;
-  expect(summary?.setupPrefixes, "terminal JSON envelope must project the invocation summary").toEqual({
-    total: expect.any(Number),
-    hit: expect.any(Number),
-    prepared: expect.any(Number),
-    failed: expect.any(Number),
-  });
-  const setup = summary!.setupPrefixes!;
+  const setup = receipt.expTerminal().summary.setupPrefixes;
   expect(setup.total, receipt.diagnostic()).toBe(setup.hit + setup.prepared + setup.failed);
   return setup;
 }

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -476,8 +476,8 @@ test.concurrent("独立 Invocation 只重新执行变化的 Sandbox setup 后缀
         middleVersion: "beta",
         niceevalHome,
       });
-      expect(changedMiddle.setupPrefixes.hit).toBeGreaterThan(0);
-      expect(changedMiddle.setupPrefixes.prepared).toBeGreaterThan(0);
+      expect(changedMiddle.setupPrefixes.hit).toBe(0);
+      expect(changedMiddle.setupPrefixes.prepared).toBe(changedMiddle.setupPrefixes.total);
       expect(changedMiddle.setupPrefixes.failed).toBe(0);
       expect(changedMiddle.evidence.buildToken).toBe(cold.buildToken);
       expect(changedMiddle.evidence.fixtureToken).toBe(cold.fixtureToken);

--- a/e2e/runner/agents/timing.ts
+++ b/e2e/runner/agents/timing.ts
@@ -95,13 +95,13 @@ export const completionPersistenceFailureAgent = defineAgent({
   }),
   teardown: () => Effect.tryPromise({
     try: async () => {
-      const recordRoot = join(process.cwd(), ".niceeval");
-      const staging = (await readdir(recordRoot))
+      const projectRoot = process.cwd();
+      const staging = (await readdir(projectRoot))
         .filter((entry) => /^record-staging-[0-9a-f-]+\.sqlite$/.test(entry));
       if (staging.length !== 1) {
         throw new Error(`expected one active staging database, found ${staging.length}`);
       }
-      await truncate(join(recordRoot, staging[0]!), 0);
+      await truncate(join(projectRoot, staging[0]!), 0);
     },
     catch: (cause) => cause,
   }),

--- a/e2e/runner/agents/timing.ts
+++ b/e2e/runner/agents/timing.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
-import { appendFile } from "node:fs/promises";
+import { appendFile, readdir, truncate } from "node:fs/promises";
+import { join } from "node:path";
 import {
   completeEvidenceCoverage,
   defineAgent,
@@ -80,4 +81,28 @@ export const sendAndTeardownFailureAgent = defineAgent({
   teardown: (context) => lifecycleReceipt(context, "teardown").pipe(
     Effect.andThen(Effect.fail(new Error("runner lifecycle teardown secondary failure"))),
   ),
+});
+
+export const completionPersistenceFailureAgent = defineAgent({
+  name: "runner-completion-persistence-failure",
+  evidenceCoverage,
+  send: (_input, ctx) => Effect.sync(() => {
+    if (ctx.signal.aborted) throw new Error("runner persistence fixture send aborted");
+    return {
+      status: "completed",
+      events: [{ type: "message", role: "assistant", text: "runner-persistence-ok" }],
+    };
+  }),
+  teardown: () => Effect.tryPromise({
+    try: async () => {
+      const recordRoot = join(process.cwd(), ".niceeval");
+      const staging = (await readdir(recordRoot))
+        .filter((entry) => /^record-staging-[0-9a-f-]+\.sqlite$/.test(entry));
+      if (staging.length !== 1) {
+        throw new Error(`expected one active staging database, found ${staging.length}`);
+      }
+      await truncate(join(recordRoot, staging[0]!), 0);
+    },
+    catch: (cause) => cause,
+  }),
 });

--- a/e2e/runner/experiments/completion-persistence-failure.ts
+++ b/e2e/runner/experiments/completion-persistence-failure.ts
@@ -1,0 +1,8 @@
+import { defineExperiment } from "niceeval";
+import { completionPersistenceFailureAgent } from "../agents/timing.ts";
+
+export default defineExperiment({
+  description: "completion persistence failure",
+  agent: completionPersistenceFailureAgent,
+  evals: ["timing/basic"],
+});

--- a/e2e/runner/test/timing.test.ts
+++ b/e2e/runner/test/timing.test.ts
@@ -160,3 +160,32 @@ test("通用 Runner 公开 Agent setup、send、teardown 的完成与失败关�
     },
   );
 });
+
+test("Attempt 完成无法持久化时终态不提供不可检查的 locator [necase_EP0HS2HD783EN64J]", async () => {
+  await runnerE2E.case(
+    "completion-persistence-failure",
+    { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
+    async ({ commands: { niceeval }, paths }) => {
+      const run = await niceeval.run([
+        "exp", "completion-persistence-failure", "--rerun", "all", "--json",
+      ]);
+      expect(run.exitCode, run.diagnostic()).toBe(1);
+
+      const terminalOutput = `${run.stdout}\n${run.stderr}`;
+      const leakedLocator = terminalOutput.match(/@1[0-9A-HJKMNP-TV-Z]{12}/)?.[0];
+      if (leakedLocator !== undefined) {
+        const request = await writeInspectionRequest(
+          paths.projectRoot,
+          "unpublished-attempt-trace",
+          { kind: "attempt.trace", locator: leakedLocator },
+        );
+        const queried = await niceeval.run(["query", "run", "--request", request]);
+        expect(queried.exitCode, queried.diagnostic()).not.toBe(0);
+        expect(`${queried.stdout}\n${queried.stderr}`).toMatch(/not found|not-found/i);
+      }
+
+      expect(leakedLocator, run.diagnostic()).toBeUndefined();
+      expect(terminalOutput).toMatch(/publication|persistence/i);
+    },
+  );
+});

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/certificate.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "candidateSha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+  "greenReceipt": "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-1.json",
+      "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-2.json",
+      "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-4.json",
+      "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-6.json",
+    "singleCase": "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/polish-docker-cache/artifacts/e2e/locator-takeover-final/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/polish-docker-cache/artifacts/e2e/locator-takeover-final/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/polish-docker-cache/artifacts/e2e/locator-takeover-final/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/polish-docker-cache/artifacts/e2e/locator-takeover-final/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/polish-docker-cache/artifacts/e2e/locator-takeover-final/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/polish-docker-cache/artifacts/e2e/locator-takeover-final/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/polish-docker-cache/artifacts/e2e/locator-takeover-final/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "66ffe09de6789b46fb048bf4837c79681622ed381f11890e13434b8a3159ccfd"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/green.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/green.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+    "sri": "sha512-y0K+C1mcqGBsWRejiDGiSTHoLLEODCvlAquaDULPJPhQdAoosGautoyJAbnacXqS+oZG0eYnxHFN5kukkO5qXA=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/timing.test.ts",
+      "--testNamePattern",
+      "^Attempt 完成无法持久化时终态不提供不可检查的 locator \\[necase_EP0HS2HD783EN64J\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-ysKsYw/runs/takeover/target-single/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2715532 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2715533 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2715578 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2715623 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "475a1bd8-3b82-4c9f-a3ac-09d2d97a44b2",
+  "receiptSha256": "ad90890707c65f740c2df36b94c38b2e0c2f22655b931b34281ad3f1a27960bb"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/inventory.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/inventory.json
@@ -1,0 +1,310 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "runner",
+  "argv": [
+    "/nix/store/bfqsxlviikq7vlp36kasy5hhamlxlkd2-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-KLmWJ2/repos/runner/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.0_@types+node@24.13.3_esbuild@0.28.1_jiti@2.7.0_tsx@4.23.9_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+  "files": [
+    "e2e/runner/test/accept-reanchor.test.ts",
+    "e2e/runner/test/carry-partial-reuse.test.ts",
+    "e2e/runner/test/fresh-sandbox-provider-stop.test.ts",
+    "e2e/runner/test/group-or-stop-dispatch.test.ts",
+    "e2e/runner/test/group-wave-gap-dispatch.test.ts",
+    "e2e/runner/test/history-dedup.test.ts",
+    "e2e/runner/test/max-concurrency-invocation-local.test.ts",
+    "e2e/runner/test/provider-capacity-queue.test.ts",
+    "e2e/runner/test/provider-lane.test.ts",
+    "e2e/runner/test/shared-state-lifecycle.test.ts",
+    "e2e/runner/test/shared-state-recovery.test.ts",
+    "e2e/runner/test/shared-state-scheduler.test.ts",
+    "e2e/runner/test/shared-state-startup-authority.test.ts",
+    "e2e/runner/test/shared-state-zombie-owner-recovery.test.ts",
+    "e2e/runner/test/timing.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/accept-reanchor.test.ts",
+      "titlePath": [
+        "审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 verdict/evidence 与审计 provenance [necase_FEJ6CWPP9EWWY2F6]"
+      ],
+      "caseId": "necase_FEJ6CWPP9EWWY2F6"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/carry-partial-reuse.test.ts",
+      "titlePath": [
+        "改变一个 Eval 后只重新派发该 identity，未改变的 Eval 继续携带 [necase_Q3G99190B9YX4TW3]"
+      ],
+      "caseId": "necase_Q3G99190B9YX4TW3"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/carry-partial-reuse.test.ts",
+      "titlePath": [
+        "未声明 sharedState 保持公开 carry；声明或变更 key 作废 carry [necase_18CRTCDWKQD3YJR7]"
+      ],
+      "caseId": "necase_18CRTCDWKQD3YJR7"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/fresh-sandbox-provider-stop.test.ts",
+      "titlePath": [
+        "fresh custom Provider group.stop 失败保留 sharedState，普通输出与 Run diagnostic 不泄露 owner token [necase_9E2KVHJXB3FTA8AE]"
+      ],
+      "caseId": "necase_9E2KVHJXB3FTA8AE"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/group-or-stop-dispatch.test.ts",
+      "titlePath": [
+        "orStop 只结束当前 Eval，三个 Group lane 仍可并行派发 [necase_JRJ0FVDAN2QKHY28]"
+      ],
+      "caseId": "necase_JRJ0FVDAN2QKHY28"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/group-wave-gap-dispatch.test.ts",
+      "titlePath": [
+        "空闲 Group lane 不等待慢 lane 的下一槽位即可继续派发 [necase_6BCCEKGMA7ZY0QMG]"
+      ],
+      "caseId": "necase_6BCCEKGMA7ZY0QMG"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/history-dedup.test.ts",
+      "titlePath": [
+        "两次同时运行同一实验时，后开始的那次不重复跑已经完成的题目 [necase_ZJFWH6XRX2EZWS5J]"
+      ],
+      "caseId": "necase_ZJFWH6XRX2EZWS5J"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/history-dedup.test.ts",
+      "titlePath": [
+        "强制重跑追加 identity，carry run 不在 history 复制旧 attempt [necase_HP9NWW0YWAV48X1P]"
+      ],
+      "caseId": "necase_HP9NWW0YWAV48X1P"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/max-concurrency-invocation-local.test.ts",
+      "titlePath": [
+        "并行运行同一 Experiment 时，每次 Invocation 保有自己的并发额度 [necase_YAJ06RV7ZR47KAZD]"
+      ],
+      "caseId": "necase_YAJ06RV7ZR47KAZD"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/provider-capacity-queue.test.ts",
+      "titlePath": [
+        "等待 Docker profile 容量时保持排队且不阻塞其它 Provider [necase_VXE9ARZNBMZ6V0JT]"
+      ],
+      "caseId": "necase_VXE9ARZNBMZ6V0JT"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/provider-lane.test.ts",
+      "titlePath": [
+        "等待 sharedState 不占用同一 exclusive provider lane，无关 Experiment 仍可进入 Agent [necase_EZDHV0MV2FA9SX7X]"
+      ],
+      "caseId": "necase_EZDHV0MV2FA9SX7X"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "fresh Sandbox 的 Attempt after 失败也保留 sharedState，直到公开显式恢复 [necase_PV16QF2DMTKR229Z]"
+      ],
+      "caseId": "necase_PV16QF2DMTKR229Z"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "复用 Sandbox 的 Attempt after 失败也会保留 sharedState，直到公开显式恢复 [necase_FFVQ9YEXTRJGGVA5]"
+      ],
+      "caseId": "necase_FFVQ9YEXTRJGGVA5"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "复用 Sandbox 的每条 Attempt after 与 Experiment teardown 完成后才交出 sharedState [necase_JDW5GFSRDDAP19P8]"
+      ],
+      "caseId": "necase_JDW5GFSRDDAP19P8"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "相同 sharedState.key 在前一 Experiment teardown 后才允许下一 Experiment 进入 setup [necase_400VHE4GK3DNPNPC]"
+      ],
+      "caseId": "necase_400VHE4GK3DNPNPC"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "作者删除 sharedState 声明后仍可按遗留 key 执行一次公开恢复 [necase_PKDDGWJF9WG1GKMC]"
+      ],
+      "caseId": "necase_PKDDGWJF9WG1GKMC"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "作者改掉 sharedState key 后，旧 key 仍以 immutable evidence 只清理自己的 teardown 登记 [necase_A2699428EFNX2V13]"
+      ],
+      "caseId": "necase_A2699428EFNX2V13"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "实际 Experiment teardown 失败会保留 lease，等待者只能取消或走显式恢复 [necase_BXJ9903T6J56JE4K]"
+      ],
+      "caseId": "necase_BXJ9903T6J56JE4K"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "崩溃的 recovery 可由新 actor 显式续接，旧 token 不会删除新 holder [necase_7XAMTKFQJZ58EZQ5]"
+      ],
+      "caseId": "necase_7XAMTKFQJZ58EZQ5"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "旧 teardown 登记删不掉时 recovery 保持 closed，等待者不能先进入 [necase_X1F0QN5F124T2HQH]"
+      ],
+      "caseId": "necase_X1F0QN5F124T2HQH"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "显式 recovery 拒绝 JSON，并在两种帮助入口公开全部参数 [necase_8JE0MDKWV5A2SWA2]"
+      ],
+      "caseId": "necase_8JE0MDKWV5A2SWA2"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "暂停的 owner 不会因 heartbeat 年龄失权，等待者可 SIGINT 取消且恢复后才交接 [necase_933F8H9VHA6V8153]"
+      ],
+      "caseId": "necase_933F8H9VHA6V8153"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "缺少 teardown 的显式 recovery 不改变 active generation [necase_KWHHT498E861HWMH]"
+      ],
+      "caseId": "necase_KWHHT498E861HWMH"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "非函数 teardown 被公开 CLI 拒绝，遗留 owner 不会被释放 [necase_8GR53E938YVF6VVW]"
+      ],
+      "caseId": "necase_8GR53E938YVF6VVW"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-scheduler.test.ts",
+      "titlePath": [
+        "同 Invocation 的同 key waiter 不占有限 worker，holder 后继 Attempt 能继续启动 [necase_3T4GYG4AH3XJMQHE]"
+      ],
+      "caseId": "necase_3T4GYG4AH3XJMQHE"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-startup-authority.test.ts",
+      "titlePath": [
+        "full-carry 的 selected Experiment 也在同 key authority 后才补遗留 teardown [necase_MZECYXY0CYDG8HFQ]"
+      ],
+      "caseId": "necase_MZECYXY0CYDG8HFQ"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-startup-authority.test.ts",
+      "titlePath": [
+        "启动期遗留 teardown 先取得同 key authority，健康等待只发无 token 的 info [necase_YJQZERNET06GJ98S]"
+      ],
+      "caseId": "necase_YJQZERNET06GJ98S"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-zombie-owner-recovery.test.ts",
+      "titlePath": [
+        "explicit recovery accepts a terminal Linux zombie owner but still runs its compensating teardown [necase_KFXCHWB9075701RA]"
+      ],
+      "caseId": "necase_KFXCHWB9075701RA"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/timing.test.ts",
+      "titlePath": [
+        "Attempt 完成无法持久化时终态不提供不可检查的 locator [necase_EP0HS2HD783EN64J]"
+      ],
+      "caseId": "necase_EP0HS2HD783EN64J"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/timing.test.ts",
+      "titlePath": [
+        "通用 Runner 公开 Agent setup、send、teardown 的完成与失败关系 [necase_21VCRD4WKW8K1E66]"
+      ],
+      "caseId": "necase_21VCRD4WKW8K1E66"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/red.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/red.json
@@ -1,0 +1,54 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "2c79e2285a225a92dec158d8c11e030b3014739d8f7a46ed342b1088b1c0de42",
+    "sri": "sha512-vgEf4gAIWqhD/kbEMXwTb4RVPOGUO57WekKWwz0sIwlesck+xMnWQzytAg7O8HR+k2/1q7pohzayd8ce1YWg/w=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/timing.test.ts",
+      "--testNamePattern",
+      "^Attempt 完成无法持久化时终态不提供不可检查的 locator \\[necase_EP0HS2HD783EN64J\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-8LLVBK/runs/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 2718372 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "fd92414e-7fb3-46e0-8a3a-4df68c809ca6",
+  "receiptSha256": "5c844d90c2b280d9de46f641a5a9181fd4c8ee23a5fabafd1456bf2c94a2a691"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-1.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-1.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+    "sri": "sha512-y0K+C1mcqGBsWRejiDGiSTHoLLEODCvlAquaDULPJPhQdAoosGautoyJAbnacXqS+oZG0eYnxHFN5kukkO5qXA=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/timing.test.ts",
+      "--testNamePattern",
+      "^Attempt 完成无法持久化时终态不提供不可检查的 locator \\[necase_EP0HS2HD783EN64J\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-ysKsYw/runs/takeover/isolated-copy-1/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2658563 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2658564 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2658610 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2658656 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1d0c03db-1b80-49be-a4c1-f030980e1435",
+  "receiptSha256": "f2a24c7013fa1432db9960c3f8d946d53ac771e7aae9746e5eda6ffdce107a2b"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-2.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-2.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+    "sri": "sha512-y0K+C1mcqGBsWRejiDGiSTHoLLEODCvlAquaDULPJPhQdAoosGautoyJAbnacXqS+oZG0eYnxHFN5kukkO5qXA=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/timing.test.ts",
+      "--testNamePattern",
+      "^Attempt 完成无法持久化时终态不提供不可检查的 locator \\[necase_EP0HS2HD783EN64J\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-ysKsYw/runs/takeover/isolated-copy-2/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2658872 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2658873 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2658919 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2658947 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "39f7a5ee-a281-4083-91d1-51e930f8c662",
+  "receiptSha256": "68935e29ddd87aa4ade61be022480d89b358a1e0c5a48cf5b0d3b15d9e7714b0"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-3.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-3.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+    "sri": "sha512-y0K+C1mcqGBsWRejiDGiSTHoLLEODCvlAquaDULPJPhQdAoosGautoyJAbnacXqS+oZG0eYnxHFN5kukkO5qXA=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/timing.test.ts",
+      "--testNamePattern",
+      "^Attempt 完成无法持久化时终态不提供不可检查的 locator \\[necase_EP0HS2HD783EN64J\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-ysKsYw/runs/takeover/isolated-copy-3/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659060 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659061 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2659111 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2659139 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "a6cb776f-eb2e-4a32-9b8e-dbdbcef90eef",
+  "receiptSha256": "08b630813ee134663b97ac2bf1d0a9e667cdd0092065ac41173329382bdf79f0"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-4.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-4.json
@@ -1,0 +1,79 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+    "sri": "sha512-y0K+C1mcqGBsWRejiDGiSTHoLLEODCvlAquaDULPJPhQdAoosGautoyJAbnacXqS+oZG0eYnxHFN5kukkO5qXA=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/timing.test.ts",
+      "--testNamePattern",
+      "^Attempt 完成无法持久化时终态不提供不可检查的 locator \\[necase_EP0HS2HD783EN64J\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-ysKsYw/runs/takeover/same-copy/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659270 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659271 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2659318 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2659348 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2659477 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "58b615e6-8269-4538-bef3-b71aa7a8707c",
+  "receiptSha256": "8abedde950a07d34bff74afc76a4f801364fa87b60c927fda61fe088a52d2859"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-5.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-5.json
@@ -1,0 +1,79 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+    "sri": "sha512-y0K+C1mcqGBsWRejiDGiSTHoLLEODCvlAquaDULPJPhQdAoosGautoyJAbnacXqS+oZG0eYnxHFN5kukkO5qXA=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/timing.test.ts",
+      "--testNamePattern",
+      "^Attempt 完成无法持久化时终态不提供不可检查的 locator \\[necase_EP0HS2HD783EN64J\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-ysKsYw/runs/takeover/same-copy/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659270 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659271 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2659318 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2659348 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2659477 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "c38add26-cbae-4003-851d-b46f150853c6",
+  "receiptSha256": "43fae7ebb7016c58759cd09350b0963d44114d4ae09824cbf6d0d5e167fd4579"
+}

--- a/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-6.json
+++ b/e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/reliability-6.json
@@ -1,0 +1,70 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J",
+  "caseId": "necase_EP0HS2HD783EN64J",
+  "inventoryDigest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d",
+  "candidate": {
+    "gitSha": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "sha256": "8f7c28663c6ddd38190bf8577000e0908aa84efa7a18d02e6fdf993a1073c696",
+    "sri": "sha512-y0K+C1mcqGBsWRejiDGiSTHoLLEODCvlAquaDULPJPhQdAoosGautoyJAbnacXqS+oZG0eYnxHFN5kukkO5qXA=="
+  },
+  "source": {
+    "checkout": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+    "testFileSha256": "453bca50513bf5d70eabeddf68bd486386627d39afa83c85a18a539ad06b0d04",
+    "sidecarSha256": "e6c3a955407fe3899d074672873865a15e2a29eab59952114094bb509cb90298"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-ysKsYw/runs/takeover/repo-default-parallel/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659621 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2659622 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2659670 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2659699 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "f879836a-b13c-4a80-a0a5-05fc266215bd",
+  "receiptSha256": "8422f6588c937ef244a0266a1f1d8f0d4da6b868bbcb364f8c031bdf607e5836"
+}

--- a/e2e/runner/test/timing.test.ts.cases.evidence.json
+++ b/e2e/runner/test/timing.test.ts.cases.evidence.json
@@ -1,0 +1,25 @@
+{
+  "format": "niceeval.e2e-case-evidence-index/v1",
+  "current": {
+    "necase_EP0HS2HD783EN64J": {
+      "memory/unpublished-attempt-locator.md": {
+        "red": {
+          "path": "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/red.json",
+          "digest": "sha256:b6213d714d9eddb6f6a64193d0b285b131835ff588910dfed2ee66b6fb196177"
+        },
+        "green": {
+          "path": "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/green.json",
+          "digest": "sha256:a4c0eed2fbd2e8bf1034809d41b0ad7d6028e8740b1a698e0accaec4b2b9cc0a"
+        },
+        "certificate": {
+          "path": "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/certificate.json",
+          "digest": "sha256:bb876120ce6c447dcb7479ce268441d76fb7567bca92e0aabf33edc44593d78d"
+        },
+        "inventory": {
+          "path": "e2e/runner/test/timing.test.ts.case-evidence/necase_EP0HS2HD783EN64J/memory_unpublished-attempt-locator.md/nered_W2VKAM0W4M5JQHNX-netake_GJJA4SEJARRRNT6W/inventory.json",
+          "digest": "sha256:4012e90bd6175bd8746f7f136ad5b89c4b28352aa8085c598d65c4ac8aa2f08d"
+        }
+      }
+    }
+  }
+}

--- a/e2e/runner/test/timing.test.ts.cases.json
+++ b/e2e/runner/test/timing.test.ts.cases.json
@@ -6,6 +6,11 @@
       "owner": "docs/engineering/testing/e2e/runner.md#runner-generic-timing",
       "regressions": [],
       "issues": []
+    },
+    "necase_EP0HS2HD783EN64J": {
+      "owner": "docs/engineering/testing/e2e/runner.md#runner-generic-timing",
+      "regressions": [],
+      "issues": []
     }
   },
   "history": [
@@ -18,6 +23,15 @@
         "owner": "docs/engineering/testing/e2e/runner.md#runner-generic-timing",
         "legacySourceDigest": "sha256:c3e14bfa018d4abd3703c2f3431f3f277393179c797753c108a5b4449aca610b",
         "mappingDigest": "sha256:1776e203db366aebf5c5178f85fecd7ed63715a50862e49c74cdee27d16c52e6"
+      }
+    },
+    {
+      "caseId": "necase_EP0HS2HD783EN64J",
+      "atCommit": "872661b0bdda9a9623318c735eb5ce2f9eaf9380",
+      "transactionId": "netxn_287d9c9c4207468f877d3a72462d02a8",
+      "action": "case-attached",
+      "to": {
+        "owner": "docs/engineering/testing/e2e/runner.md#runner-generic-timing"
       }
     }
   ],

--- a/e2e/runner/test/timing.test.ts.cases.json
+++ b/e2e/runner/test/timing.test.ts.cases.json
@@ -9,7 +9,9 @@
     },
     "necase_EP0HS2HD783EN64J": {
       "owner": "docs/engineering/testing/e2e/runner.md#runner-generic-timing",
-      "regressions": [],
+      "regressions": [
+        "memory/unpublished-attempt-locator.md"
+      ],
       "issues": []
     }
   },
@@ -32,6 +34,15 @@
       "action": "case-attached",
       "to": {
         "owner": "docs/engineering/testing/e2e/runner.md#runner-generic-timing"
+      }
+    },
+    {
+      "caseId": "necase_EP0HS2HD783EN64J",
+      "atCommit": "6e9f38e871b5e1732ff9c4efdaf565c9a43b61ab",
+      "transactionId": "netxn_4769ba5deb71407b8aa4bdcfdcc610b8",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/unpublished-attempt-locator.md"
       }
     }
   ],

--- a/lint/docs/memory-index.lint.ts
+++ b/lint/docs/memory-index.lint.ts
@@ -2,17 +2,24 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-// memory/ 的召回全靠 INDEX.md:漏索引的条目等于不存在,所以覆盖率由测试保证,
-// 不引入生成脚本——写 memory 的人(通常是 agent)顺手加一行索引即可。
+// Structured Memory is discovered through the managed CLI. INDEX.md remains the
+// recall owner only for legacy Markdown entries that predate niceeval.memory/v1.
 const MEMORY_DIR = join(import.meta.dirname, "../..", "memory");
 
+const isStructuredMemory = (filename: string): boolean =>
+  readFileSync(join(MEMORY_DIR, filename), "utf8").startsWith(
+    "---\nformat: niceeval.memory/v1\n",
+  );
+
 describe("memory/INDEX.md", () => {
-  it("每个 memory 条目都有索引行", () => {
+  it("每个 legacy memory 条目都有索引行", () => {
     const index = readFileSync(join(MEMORY_DIR, "INDEX.md"), "utf8");
     const entries = readdirSync(MEMORY_DIR).filter(
       (f) => f.endsWith(".md") && f !== "INDEX.md",
     );
-    const missing = entries.filter((f) => !index.includes(`](${f})`));
+    const missing = entries.filter(
+      (f) => !isStructuredMemory(f) && !index.includes(`](${f})`),
+    );
     expect(missing, "这些条目没有出现在 memory/INDEX.md 里").toEqual([]);
   });
 

--- a/memory/unpublished-attempt-locator.md
+++ b/memory/unpublished-attempt-locator.md
@@ -5,7 +5,13 @@ title: Failed Attempt persistence exposed an unqueryable locator
 createdAt: 2026-08-30
 kind:
   type: problem
-  state: open
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - nered_W2VKAM0W4M5JQHNX
+      - netake_GJJA4SEJARRRNT6W
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J"]}
 promotions: []
 ---
 ## Observation

--- a/memory/unpublished-attempt-locator.md
+++ b/memory/unpublished-attempt-locator.md
@@ -1,0 +1,23 @@
+---
+format: niceeval.memory/v1
+id: unpublished-attempt-locator
+title: Failed Attempt persistence exposed an unqueryable locator
+createdAt: 2026-08-30
+kind:
+  type: problem
+  state: open
+promotions: []
+---
+## Observation
+
+When final Attempt persistence fails after reservation, `niceeval exp --json` prints the reserved `@...` locator even though no published Attempt is available through `niceeval query run` or `niceeval show`.
+
+Formal public-entry red evidence: `nered_282DW0QTHQTZ3CS8` for `e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J`.
+
+## Root cause
+
+The Runner copied the reservation locator into `EvalResult` before `completeAttemptOrMarkIncomplete` succeeded. The Record coordinator intentionally converted the completion write error into an incomplete result and retained it for invocation publication failure, but the feedback path still treated the provisional locator as public and emitted a permanent failure event.
+
+## Required behavior
+
+Only a successfully persisted Attempt may contribute a public locator. A completion write failure must keep the invocation failed, omit an inspectable locator, and render an explicit persistence/publication diagnostic instead of `[object Object]`.

--- a/memory/unpublished-attempt-locator.md
+++ b/memory/unpublished-attempt-locator.md
@@ -18,7 +18,7 @@ promotions: []
 
 When final Attempt persistence fails after reservation, `niceeval exp --json` prints the reserved `@...` locator even though no published Attempt is available through `niceeval query run` or `niceeval show`.
 
-Formal public-entry red evidence: `nered_282DW0QTHQTZ3CS8` for `e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J`.
+Formal public-entry red evidence: `nered_W2VKAM0W4M5JQHNX` for `e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J`.
 
 ## Root cause
 

--- a/packages/niceeval/src/docker/cache-administration.ts
+++ b/packages/niceeval/src/docker/cache-administration.ts
@@ -19,9 +19,41 @@ export interface DockerCapacityObservation {
   readonly reason: string;
 }
 
+export interface DockerTaskBuildInventoryEntry {
+  readonly kind: "task-build";
+  readonly state: "active-leased" | "cold-reusable" | "unverified";
+  readonly identity: { readonly buildKey: string; readonly tag: string; readonly imageId: string };
+  readonly leaseCount: number;
+  readonly rootCount: number;
+  readonly createdAt: string;
+  readonly lastSuccessfulUseAt: string | null;
+  readonly protectedUntil: string;
+}
+
+export interface DockerSetupPrefixInventoryEntry {
+  readonly kind: "sandbox-setup-prefix";
+  readonly state: "reserved" | "building" | "published" | "indexed" | "invalidated" | "deleting" | "tombstoned" | "unverified";
+  readonly identity: { readonly entryId: string; readonly setupPrefixKey: string; readonly imageId: string | null; readonly baseImageId: string };
+  readonly leaseCount: number;
+  readonly rootCount: number;
+  readonly createdAt: string;
+  readonly lastSuccessfulUseAt: string | null;
+  readonly protectedUntil: string;
+}
+
+export type DockerCacheInventoryEntry = DockerTaskBuildInventoryEntry | DockerSetupPrefixInventoryEntry;
+
+export interface DockerCacheDomainInventory {
+  readonly domainId: string;
+  readonly providerFamily: "docker";
+  readonly backendKind: "docker-images";
+  readonly state: "verified-managed";
+  readonly entries: readonly DockerCacheInventoryEntry[];
+}
+
 export interface DockerCacheDomainAdministration {
   readonly descriptor: DockerCacheDomainDescriptor;
-  inventory(): Effect.Effect<unknown, Error>;
+  inventory(): Effect.Effect<DockerCacheDomainInventory, Error>;
   planGc(): Effect.Effect<unknown, Error>;
   applyGc(planId: string): Effect.Effect<unknown, Error>;
 }

--- a/packages/niceeval/src/docker/cache-administration.ts
+++ b/packages/niceeval/src/docker/cache-administration.ts
@@ -25,6 +25,10 @@ export interface DockerTaskBuildInventoryEntry {
   readonly identity: { readonly buildKey: string; readonly tag: string; readonly imageId: string };
   readonly leaseCount: number;
   readonly rootCount: number;
+  readonly liveLeaseCount: number;
+  readonly unverifiedLeaseCount: number;
+  readonly liveRootCount: number;
+  readonly unverifiedRootCount: number;
   readonly createdAt: string;
   readonly lastSuccessfulUseAt: string | null;
   readonly protectedUntil: string;
@@ -36,6 +40,10 @@ export interface DockerSetupPrefixInventoryEntry {
   readonly identity: { readonly entryId: string; readonly setupPrefixKey: string; readonly imageId: string | null; readonly baseImageId: string };
   readonly leaseCount: number;
   readonly rootCount: number;
+  readonly liveLeaseCount: number;
+  readonly unverifiedLeaseCount: number;
+  readonly liveRootCount: number;
+  readonly unverifiedRootCount: number;
   readonly createdAt: string;
   readonly lastSuccessfulUseAt: string | null;
   readonly protectedUntil: string;

--- a/packages/niceeval/src/docker/cli/contribution.ts
+++ b/packages/niceeval/src/docker/cli/contribution.ts
@@ -87,7 +87,9 @@ function humanInventoryEntry(entry: DockerCacheInventoryEntry): string {
     ? `${entry.identity.buildKey.slice(0, 12)} · ${entry.identity.tag} · ${entry.identity.imageId}`
     : `${entry.identity.entryId} · ${entry.identity.setupPrefixKey.slice(0, 12)} · ${entry.identity.imageId ?? "image pending"}`;
   return `  ${entry.kind} · ${entry.state} · ${identity}\n` +
-    `    ${entry.leaseCount} leases · ${entry.rootCount} roots · created ${entry.createdAt} · last used ${entry.lastSuccessfulUseAt ?? "never"} · protected until ${entry.protectedUntil}\n`;
+    `    ${entry.leaseCount} leases (${entry.liveLeaseCount} live, ${entry.unverifiedLeaseCount} unverified) · ` +
+    `${entry.rootCount} roots (${entry.liveRootCount} live, ${entry.unverifiedRootCount} unverified) · ` +
+    `created ${entry.createdAt} · last used ${entry.lastSuccessfulUseAt ?? "never"} · protected until ${entry.protectedUntil}\n`;
 }
 
 interface GcPlan {

--- a/packages/niceeval/src/docker/cli/contribution.ts
+++ b/packages/niceeval/src/docker/cli/contribution.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { CliArguments, CliOutput, type CliOptionDefinition } from "../../cli/application.ts";
 import { CliFeatureError, type CliCommandContribution } from "../../cli/contribution.ts";
-import { DockerCacheAdministration } from "../cache-administration.ts";
+import { DockerCacheAdministration, type DockerCacheDomainInventory, type DockerCacheInventoryEntry } from "../cache-administration.ts";
 import { runDockerProfileCommand } from "../../sandbox/docker-profile/cli.ts";
 
 export const DOCKER_OPTIONS = Object.freeze({
@@ -80,11 +80,14 @@ function humanSize(value: number | null): string {
   return `${amount.toFixed(amount >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
 }
 
-interface CacheInventory {
-  readonly domainId: string;
-  readonly backendKind: string;
-  readonly state: string;
-  readonly entries: readonly unknown[];
+type CacheInventory = DockerCacheDomainInventory;
+
+function humanInventoryEntry(entry: DockerCacheInventoryEntry): string {
+  const identity = entry.kind === "task-build"
+    ? `${entry.identity.buildKey.slice(0, 12)} · ${entry.identity.tag} · ${entry.identity.imageId}`
+    : `${entry.identity.entryId} · ${entry.identity.setupPrefixKey.slice(0, 12)} · ${entry.identity.imageId ?? "image pending"}`;
+  return `  ${entry.kind} · ${entry.state} · ${identity}\n` +
+    `    ${entry.leaseCount} leases · ${entry.rootCount} roots · created ${entry.createdAt} · last used ${entry.lastSuccessfulUseAt ?? "never"} · protected until ${entry.protectedUntil}\n`;
 }
 
 interface GcPlan {
@@ -189,7 +192,14 @@ function cacheCommand(
         schemaVersion: 1,
         scope: selected === undefined ? { kind: "domains" } : { kind: "domain", domainId: selected.domainId },
         domains: [
-          ...inventories.map(({ entries, ...domain }) => ({ ...domain, entryCount: entries.length })),
+          ...inventories.map(({ entries, ...domain }) => ({
+            ...domain,
+            entryCount: entries.length,
+            entryKinds: {
+              taskBuild: entries.filter(({ kind }) => kind === "task-build").length,
+              sandboxSetupPrefix: entries.filter(({ kind }) => kind === "sandbox-setup-prefix").length,
+            },
+          })),
           ...descriptors.filter(({ state }) => state === "unavailable" || state === "unverified")
             .map((descriptor) => ({ ...descriptor, entryCount: null })),
         ],
@@ -202,7 +212,7 @@ function cacheCommand(
     const observation = observations[0];
     const text = taskDomain === undefined
       ? "No managed Docker image cache domains.\n"
-      : `Docker images · managed · ${taskDomain.domainId} · ${taskDomain.entries.length} entries\n`;
+      : `Docker images · managed · ${taskDomain.domainId} · ${taskDomain.entries.length} entries\n${taskDomain.entries.map(humanInventoryEntry).join("")}`;
     yield* output("stdout", observation === undefined ? text : text +
       `BuildKit · unverified shared-builder capacity\n` +
       `  total ${humanSize(observation.totalBytes)} · provider reclaimable estimate ${humanSize(observation.reclaimableEstimateBytes)}\n` +

--- a/packages/niceeval/src/experiment/host/cli/contribution.ts
+++ b/packages/niceeval/src/experiment/host/cli/contribution.ts
@@ -890,8 +890,6 @@ const debugCommand: CliCommandContribution<ExperimentCliRequirements, Experiment
       case "planned":
         yield* write("stdout", input.values.json === true
           ? jsonDocument({
-              format: "niceeval.debug-plan/v1",
-              schemaVersion: 1,
               experimentId: result.experimentId,
               ...(result.evalId === undefined ? {} : { evalId: result.evalId }),
               evalIds: result.evalIds,

--- a/packages/niceeval/src/experiment/host/cli/contribution.ts
+++ b/packages/niceeval/src/experiment/host/cli/contribution.ts
@@ -182,8 +182,8 @@ Recovery options:
   -h, --help                     show this help
 `;
 
-const DEBUG_HELP = `Inspect one Experiment lifecycle plan:
-  niceeval debug <experiment-selector> <eval-selector> [--json]
+const DEBUG_HELP = `Inspect an Experiment lifecycle plan:
+  niceeval debug <experiment-selector> [eval-selector] [--json]
 
 Options:
   --json       write the command-plan machine document
@@ -381,8 +381,8 @@ function teardownFailure(operation: string, cause: unknown, recoveryKey?: string
   return failure(operation, cause, 1, display);
 }
 
-function invocationText(result: { readonly receipt: { readonly invocationId: string; readonly createdRunIds: readonly string[]; readonly completion: string }; readonly summary: { readonly passed: number; readonly failed: number; readonly skipped: number; readonly errored: number } }): string {
-  return `Invocation ${result.receipt.invocationId} · ${result.receipt.completion}\nRuns: ${result.receipt.createdRunIds.join(", ") || "none"}\nResults: ${result.summary.passed} passed · ${result.summary.failed} failed · ${result.summary.errored} errored · ${result.summary.skipped} skipped\n`;
+function invocationText(result: { readonly receipt: { readonly invocationId: string; readonly createdRunIds: readonly string[]; readonly completion: string }; readonly summary: { readonly passed: number; readonly failed: number; readonly skipped: number; readonly errored: number; readonly setupPrefixes: { readonly total: number; readonly hit: number; readonly prepared: number; readonly failed: number } } }): string {
+  return `Invocation ${result.receipt.invocationId} · ${result.receipt.completion}\nRuns: ${result.receipt.createdRunIds.join(", ") || "none"}\nResults: ${result.summary.passed} passed · ${result.summary.failed} failed · ${result.summary.errored} errored · ${result.summary.skipped} skipped\nSetup prefixes: ${result.summary.setupPrefixes.hit} hit · ${result.summary.setupPrefixes.prepared} prepared · ${result.summary.setupPrefixes.failed} failed (${result.summary.setupPrefixes.total} total)\n`;
 }
 
 function dryRows(plan: { readonly slots: readonly { readonly state: "reuse" | "gap"; readonly target: { readonly runId: string; readonly slotId: string; readonly experimentId: string; readonly evalId: string; readonly evalGroupId?: string; readonly evalGroupIndex?: number; readonly attempt: number }; readonly comparisons: readonly unknown[]; readonly reason?: string; readonly scope?: string }[]; readonly readbacks: readonly CurrentReuseReadbackSnapshot[]; readonly lockedPairs: readonly string[] }) {
@@ -852,13 +852,18 @@ const debugCommand: CliCommandContribution<ExperimentCliRequirements, Experiment
     const input = yield* parsed(argv, DEBUG_CLI_OPTIONS);
     if (input.values.help === true) return yield* write("stdout", DEBUG_HELP).pipe(Effect.as(0));
     const [experimentSelector, evalSelector] = input.positionals;
-    if (experimentSelector === undefined || evalSelector === undefined || input.positionals.length !== 2) {
-      return yield* write("stderr", `error: niceeval debug expects exactly one Experiment selector and one Eval selector
-  fix: niceeval debug <experiment> <eval> [--json]
+    if (experimentSelector === undefined || input.positionals.length > 2) {
+      return yield* write("stderr", `error: niceeval debug expects one Experiment selector and an optional Eval selector
+  fix: niceeval debug <experiment> [eval] [--json]
 `).pipe(Effect.as(1));
     }
     const { invocation, config } = yield* factsAndConfig();
-    const result = yield* experimentHost.debug({ cwd: invocation.cwd, config, experimentSelector, evalSelector }).pipe(
+    const result = yield* experimentHost.debug({
+      cwd: invocation.cwd,
+      config,
+      experimentSelector,
+      ...(evalSelector === undefined ? {} : { evalSelector }),
+    }).pipe(
       Effect.mapError((cause) => failure("debug", cause)),
     );
     switch (result.status) {
@@ -888,14 +893,16 @@ const debugCommand: CliCommandContribution<ExperimentCliRequirements, Experiment
               format: "niceeval.debug-plan/v1",
               schemaVersion: 1,
               experimentId: result.experimentId,
-              evalId: result.evalId,
+              ...(result.evalId === undefined ? {} : { evalId: result.evalId }),
+              evalIds: result.evalIds,
+              setupPrefixPlan: result.setupPrefixPlan,
               commandPlan: result.commandPlan,
             })
-          : renderHumanCommandPlan(result.commandPlan, {
+          : `Setup-prefix plan: ${result.setupPrefixPlan.nodes.length} unique nodes · cache lookup not-probed\n${renderHumanCommandPlan(result.commandPlan, {
               isTTY: invocation.stdout.isTTY,
               noColor: invocation.noColor,
               width: invocation.stdout.columns,
-            }));
+            })}`);
         return 0;
     }
   }),

--- a/packages/niceeval/src/experiment/host/cli/output-protocol.ts
+++ b/packages/niceeval/src/experiment/host/cli/output-protocol.ts
@@ -1,0 +1,55 @@
+import { Schema } from "effect";
+
+const NonNegativeIntegerSchema = Schema.Number.pipe(
+  Schema.check(Schema.makeFilter((value) => Number.isSafeInteger(value) && value >= 0)),
+);
+
+const NonNegativeNumberSchema = Schema.Number.pipe(
+  Schema.check(Schema.makeFilter((value) => Number.isFinite(value) && value >= 0)),
+);
+
+export const ExpInvocationReceiptSchema = Schema.Struct({
+  invocationId: Schema.String,
+  createdRunIds: Schema.Array(Schema.String),
+  publicationCutoff: Schema.String,
+  startedAt: Schema.String,
+  completedAt: Schema.optional(Schema.String),
+  completion: Schema.Literals(["completed", "interrupted", "failed"]),
+});
+
+export const ExpTerminalSummarySchema = Schema.Struct({
+  startedAt: Schema.String,
+  completedAt: Schema.String,
+  passed: NonNegativeIntegerSchema,
+  failed: NonNegativeIntegerSchema,
+  skipped: NonNegativeIntegerSchema,
+  errored: NonNegativeIntegerSchema,
+  durationMs: NonNegativeNumberSchema,
+  inputTokens: Schema.optional(NonNegativeIntegerSchema),
+  outputTokens: Schema.optional(NonNegativeIntegerSchema),
+  estimatedCostUSD: Schema.optional(NonNegativeNumberSchema),
+  setupPrefixes: Schema.Struct({
+    total: NonNegativeIntegerSchema,
+    hit: NonNegativeIntegerSchema,
+    prepared: NonNegativeIntegerSchema,
+    failed: NonNegativeIntegerSchema,
+  }),
+});
+
+export const ExpTerminalEventSchema = Schema.Struct({
+  type: Schema.Literal("receipt"),
+  receipt: ExpInvocationReceiptSchema,
+  summary: ExpTerminalSummarySchema,
+});
+
+export type ExpInvocationReceipt = Schema.Schema.Type<typeof ExpInvocationReceiptSchema>;
+export type ExpTerminalSummary = Schema.Schema.Type<typeof ExpTerminalSummarySchema>;
+export type ExpTerminalEvent = Schema.Schema.Type<typeof ExpTerminalEventSchema>;
+
+/** Strictly decode the sole terminal envelope written by `niceeval exp --json`. */
+export function decodeExpTerminalEvent(input: unknown): ExpTerminalEvent {
+  return Schema.decodeUnknownSync(ExpTerminalEventSchema, {
+    errors: "all",
+    onExcessProperty: "error",
+  })(input);
+}

--- a/packages/niceeval/src/experiment/host/index.ts
+++ b/packages/niceeval/src/experiment/host/index.ts
@@ -30,6 +30,15 @@ import { ExperimentHostError, type ExperimentHostHighLevelSDK } from "./types.ts
 
 export * from "./types.ts";
 export { decodeExpPlanDocument, ExpPlanDocumentSchema, type ExpPlanDocument } from "./cli/plan-protocol.ts";
+export {
+  decodeExpTerminalEvent,
+  ExpInvocationReceiptSchema,
+  ExpTerminalEventSchema,
+  ExpTerminalSummarySchema,
+  type ExpInvocationReceipt,
+  type ExpTerminalEvent,
+  type ExpTerminalSummary,
+} from "./cli/output-protocol.ts";
 
 /**
  * Public, supported high-level Host composition SDK for the NiceEval CLI,

--- a/packages/niceeval/src/experiment/host/index.ts
+++ b/packages/niceeval/src/experiment/host/index.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { assembleCommandPlan, type CommandPlan } from "../../runner/command-plan.ts";
+import { assembleCommandPlan, setupPrefixPlanOf, type CommandPlan, type SetupPrefixPlan } from "../../runner/command-plan.ts";
 import { discoverEvals, discoverExperiments } from "../../runner/discover.ts";
 import { planProjectTarget } from "../../runner/fingerprint.ts";
 import { resolveExperimentEvals } from "../../runner/eval-selection.ts";
@@ -100,15 +100,18 @@ export interface ExperimentHostDebugPlanRequest {
   readonly cwd: string;
   readonly config: Config;
   readonly experimentSelector: string;
-  readonly evalSelector: string;
+  readonly evalSelector?: string;
 }
 
 /** A fully closed, read-only lifecycle plan for exactly one Experiment × Eval pair. */
 export interface ExperimentHostDebugPlan {
   readonly status: "planned";
   readonly experimentId: string;
-  readonly evalId: string;
+  /** Retained for the existing single-pair response. */
+  readonly evalId?: string;
+  readonly evalIds: readonly string[];
   readonly commandPlan: CommandPlan;
+  readonly setupPrefixPlan: SetupPrefixPlan;
 }
 
 /**
@@ -222,17 +225,19 @@ function debug(
     const experiment = selection.experiment;
     const selectorEvalIds = new Set(selection.selectorEvalIds);
     const selectorEvals = listed.evals.filter((evalDef) => selectorEvalIds.has(evalDef.id));
-    const selectedEvals = uniqueExactOrPrefix(selectorEvals, input.evalSelector, (evalDef) => evalDef.id)
+    const selectedEvals = (input.evalSelector === undefined
+      ? selectorEvals
+      : uniqueExactOrPrefix(selectorEvals, input.evalSelector, (evalDef) => evalDef.id))
       .slice().sort((left, right) => left.id.localeCompare(right.id));
     if (selectedEvals.length === 0) {
       return Object.freeze({
         status: "eval-no-match" as const,
-        selector: input.evalSelector,
+        selector: input.evalSelector ?? "",
         experimentId: experiment.id,
         candidates: Object.freeze(selectorEvals.map((evalDef) => evalDef.id).sort()),
       });
     }
-    if (selectedEvals.length > 1) {
+    if (input.evalSelector !== undefined && selectedEvals.length > 1) {
       return Object.freeze({
         status: "eval-ambiguous" as const,
         selector: input.evalSelector,
@@ -241,29 +246,33 @@ function debug(
       });
     }
 
-    const evalDef = selectedEvals[0]!;
-    const run = debugAgentRun(experiment, evalDef.id, input.config);
+    const runs = selectedEvals.map((evalDef) => debugAgentRun(experiment, evalDef.id, input.config));
     const target = yield* planProjectTarget(
       listed.evals,
-      [run],
+      runs,
       input.config.timeoutMs,
       { configJudge: input.config.judge },
     );
     const commandPlan = assembleCommandPlan({
-      rows: [{
+      rows: selectedEvals.map((evalDef) => {
+        const run = runs.find((candidate) => candidate.selectedEvalIds.includes(evalDef.id))!;
+        return {
         experimentId: experiment.id,
         evalId: evalDef.id,
         ...(evalDef.evalGroup === undefined ? {} : { evalGroupId: evalDef.evalGroup.id }),
         attempts: run.attempts,
         dispatch: [{ attempts: Array.from({ length: run.attempts }, (_, attempt) => attempt) }],
-      }],
+        };
+      }),
       preparedPairsByKey: target.preparedPairsByKey,
     });
     return Object.freeze({
       status: "planned" as const,
       experimentId: experiment.id,
-      evalId: evalDef.id,
+      ...(selectedEvals.length === 1 ? { evalId: selectedEvals[0]!.id } : {}),
+      evalIds: Object.freeze(selectedEvals.map((evalDef) => evalDef.id)),
       commandPlan,
+      setupPrefixPlan: setupPrefixPlanOf(commandPlan),
     });
   }).pipe(Effect.mapError((cause) => new ExperimentHostError({
     operation: "debug",

--- a/packages/niceeval/src/experiment/host/operations.ts
+++ b/packages/niceeval/src/experiment/host/operations.ts
@@ -796,7 +796,6 @@ export function runInvocation(
         startedAt: receipt.startedAt,
         ...(receipt.completedAt === undefined ? {} : { completedAt: receipt.completedAt }),
         completion: receipt.completion,
-        setupPrefixes: receipt.setupPrefixes,
       }),
       summary: summaryOf(summary),
       ...(completion === undefined ? {} : {

--- a/packages/niceeval/src/experiment/host/operations.ts
+++ b/packages/niceeval/src/experiment/host/operations.ts
@@ -669,6 +669,7 @@ function summaryOf(summary: InvocationSummary): ExperimentHostInvocationSummary 
     ...(summary.usage?.inputTokens === undefined ? {} : { inputTokens: summary.usage.inputTokens }),
     ...(summary.usage?.outputTokens === undefined ? {} : { outputTokens: summary.usage.outputTokens }),
     ...(summary.estimatedCostUSD === undefined ? {} : { estimatedCostUSD: summary.estimatedCostUSD }),
+    setupPrefixes: summary.setupPrefixes,
   });
 }
 
@@ -795,6 +796,7 @@ export function runInvocation(
         startedAt: receipt.startedAt,
         ...(receipt.completedAt === undefined ? {} : { completedAt: receipt.completedAt }),
         completion: receipt.completion,
+        setupPrefixes: receipt.setupPrefixes,
       }),
       summary: summaryOf(summary),
       ...(completion === undefined ? {} : {

--- a/packages/niceeval/src/experiment/host/types.ts
+++ b/packages/niceeval/src/experiment/host/types.ts
@@ -256,7 +256,6 @@ export interface ExperimentHostInvocationReceipt {
   readonly startedAt: string;
   readonly completedAt?: string;
   readonly completion: "completed" | "interrupted" | "failed";
-  readonly setupPrefixes: SetupPrefixPreparationSummary;
 }
 
 export interface ExperimentHostInvocationSummary {

--- a/packages/niceeval/src/experiment/host/types.ts
+++ b/packages/niceeval/src/experiment/host/types.ts
@@ -5,6 +5,7 @@ import type { FeedbackCoordinator } from "../../runner/feedback/coordinator.ts";
 import type { InvocationCompletion } from "../../runner/types.ts";
 import type { SessionListDocument, SessionShowDocument } from "../../runner/session.ts";
 import type { CurrentReuseReadbackSnapshot } from "../../runner/reuse-readback.ts";
+import type { SetupPrefixPreparationSummary } from "../../runner/setup-prefix-preparation.ts";
 
 export type ExperimentHostJsonValue =
   | null
@@ -255,6 +256,7 @@ export interface ExperimentHostInvocationReceipt {
   readonly startedAt: string;
   readonly completedAt?: string;
   readonly completion: "completed" | "interrupted" | "failed";
+  readonly setupPrefixes: SetupPrefixPreparationSummary;
 }
 
 export interface ExperimentHostInvocationSummary {
@@ -267,6 +269,7 @@ export interface ExperimentHostInvocationSummary {
   readonly inputTokens?: number;
   readonly outputTokens?: number;
   readonly estimatedCostUSD?: number;
+  readonly setupPrefixes: SetupPrefixPreparationSummary;
 }
 
 export interface ExperimentHostInvocationResult {

--- a/packages/niceeval/src/runner/command-plan.test.ts
+++ b/packages/niceeval/src/runner/command-plan.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { setupPrefixPlanOf, type CommandPlan, type CommandPlanStep } from "./command-plan.ts";
+
+const cachedStep = (prefixIdentity: string): CommandPlanStep => ({
+  phase: "sandbox.before",
+  truth: "exact",
+  cache: {
+    lookup: "not-probed",
+    capability: "persistent",
+    prefixIdentity,
+    runtime: { status: "pending", finalKey: "not-probed" },
+    eligibility: { status: "eligible" },
+    state: {
+      declared: "all",
+      cumulative: "all",
+      providerCoverage: "all",
+      barrier: "none",
+    },
+  },
+});
+
+describe("setupPrefixPlanOf", () => {
+  it("deduplicates selected consumers without probing cache inventory", () => {
+    const commandPlan: CommandPlan = {
+      completeness: "complete",
+      opaqueCount: 0,
+      redactedCount: 0,
+      experiments: [{
+        experimentId: "experiment",
+        activation: "conditional",
+        beforeLanes: [],
+        afterLanes: [],
+        lanes: [{
+          id: "lane",
+          kind: "eval",
+          ordering: "independent",
+          slots: [
+            { evalId: "eval/a", attempt: 0, action: "dispatch", steps: [cachedStep("prefix:a")] },
+            { evalId: "eval/b", attempt: 0, action: "dispatch", steps: [cachedStep("prefix:a")] },
+          ],
+        }],
+      }],
+    };
+
+    expect(setupPrefixPlanOf(commandPlan)).toEqual({
+      lookup: "not-probed",
+      nodes: [{
+        prefixIdentity: "prefix:a",
+        lookup: "not-probed",
+        capability: "persistent",
+        eligibility: { status: "eligible" },
+        consumers: [
+          { experimentId: "experiment", evalId: "eval/a" },
+          { experimentId: "experiment", evalId: "eval/b" },
+        ],
+      }],
+    });
+  });
+});

--- a/packages/niceeval/src/runner/command-plan.test.ts
+++ b/packages/niceeval/src/runner/command-plan.test.ts
@@ -30,7 +30,7 @@ describe("setupPrefixPlanOf", () => {
       experiments: [{
         experimentId: "experiment",
         activation: "conditional",
-        beforeLanes: [],
+        beforeLanes: [cachedStep("prefix:shared")],
         afterLanes: [],
         lanes: [{
           id: "lane",
@@ -48,6 +48,15 @@ describe("setupPrefixPlanOf", () => {
       lookup: "not-probed",
       nodes: [{
         prefixIdentity: "prefix:a",
+        lookup: "not-probed",
+        capability: "persistent",
+        eligibility: { status: "eligible" },
+        consumers: [
+          { experimentId: "experiment", evalId: "eval/a" },
+          { experimentId: "experiment", evalId: "eval/b" },
+        ],
+      }, {
+        prefixIdentity: "prefix:shared",
         lookup: "not-probed",
         capability: "persistent",
         eligibility: { status: "eligible" },

--- a/packages/niceeval/src/runner/command-plan.test.ts
+++ b/packages/niceeval/src/runner/command-plan.test.ts
@@ -1,3 +1,5 @@
+// cases: docs/engineering/testing/unit/experiments-runner.md
+
 import { describe, expect, it } from "vitest";
 import { setupPrefixPlanOf, type CommandPlan, type CommandPlanStep } from "./command-plan.ts";
 

--- a/packages/niceeval/src/runner/command-plan.ts
+++ b/packages/niceeval/src/runner/command-plan.ts
@@ -217,11 +217,27 @@ export function setupPrefixPlanOf(commandPlan: CommandPlan): SetupPrefixPlan {
     }
     for (const child of step.children ?? []) visit(child, experimentId, evalId);
   };
+  const visitForConsumers = (
+    step: CommandPlanStep,
+    experimentId: string,
+    evalIds: readonly string[],
+  ): void => {
+    for (const evalId of evalIds) visit(step, experimentId, evalId);
+  };
   for (const experiment of commandPlan.experiments) {
-    for (const step of experiment.beforeLanes) visit(step, experiment.experimentId, "*");
+    const experimentEvalIds = [...new Set(experiment.lanes.flatMap((lane) =>
+      lane.slots.map((slot) => slot.evalId)))];
+    for (const step of experiment.beforeLanes) {
+      visitForConsumers(step, experiment.experimentId, experimentEvalIds);
+    }
     for (const lane of experiment.lanes) {
-      for (const step of "beforeSlots" in lane ? lane.beforeSlots : []) visit(step, experiment.experimentId, "*");
-      for (const step of lane.physicalLifecycleTemplate?.enter ?? []) visit(step, experiment.experimentId, "*");
+      const laneEvalIds = [...new Set(lane.slots.map((slot) => slot.evalId))];
+      for (const step of "beforeSlots" in lane ? lane.beforeSlots : []) {
+        visitForConsumers(step, experiment.experimentId, laneEvalIds);
+      }
+      for (const step of lane.physicalLifecycleTemplate?.enter ?? []) {
+        visitForConsumers(step, experiment.experimentId, laneEvalIds);
+      }
       for (const slot of lane.slots) for (const step of slot.steps) visit(step, experiment.experimentId, slot.evalId);
     }
   }

--- a/packages/niceeval/src/runner/command-plan.ts
+++ b/packages/niceeval/src/runner/command-plan.ts
@@ -189,6 +189,57 @@ export interface CommandPlan {
   readonly experiments: readonly CommandPlanExperiment[];
 }
 
+export interface SetupPrefixPlanNode {
+  readonly prefixIdentity: string;
+  readonly lookup: "not-probed";
+  readonly capability: CommandPlanCacheCapability;
+  readonly eligibility: NonNullable<CommandPlanStep["cache"]>["eligibility"];
+  readonly consumers: readonly { readonly experimentId: string; readonly evalId: string }[];
+}
+
+export interface SetupPrefixPlan {
+  readonly lookup: "not-probed";
+  readonly nodes: readonly SetupPrefixPlanNode[];
+}
+
+/** Deduplicate the selected command plan by the setup-prefix declaration identity. */
+export function setupPrefixPlanOf(commandPlan: CommandPlan): SetupPrefixPlan {
+  const nodes = new Map<string, {
+    cache: NonNullable<CommandPlanStep["cache"]>;
+    consumers: Map<string, { readonly experimentId: string; readonly evalId: string }>;
+  }>();
+  const visit = (step: CommandPlanStep, experimentId: string, evalId: string): void => {
+    const cache = step.cache;
+    if (cache?.prefixIdentity !== undefined) {
+      const existing = nodes.get(cache.prefixIdentity) ?? { cache, consumers: new Map() };
+      existing.consumers.set(`${experimentId}\0${evalId}`, Object.freeze({ experimentId, evalId }));
+      nodes.set(cache.prefixIdentity, existing);
+    }
+    for (const child of step.children ?? []) visit(child, experimentId, evalId);
+  };
+  for (const experiment of commandPlan.experiments) {
+    for (const step of experiment.beforeLanes) visit(step, experiment.experimentId, "*");
+    for (const lane of experiment.lanes) {
+      for (const step of "beforeSlots" in lane ? lane.beforeSlots : []) visit(step, experiment.experimentId, "*");
+      for (const step of lane.physicalLifecycleTemplate?.enter ?? []) visit(step, experiment.experimentId, "*");
+      for (const slot of lane.slots) for (const step of slot.steps) visit(step, experiment.experimentId, slot.evalId);
+    }
+  }
+  return Object.freeze({
+    lookup: "not-probed" as const,
+    nodes: Object.freeze([...nodes.entries()].sort(([left], [right]) => left.localeCompare(right)).map(
+      ([prefixIdentity, node]) => Object.freeze({
+        prefixIdentity,
+        lookup: "not-probed" as const,
+        capability: node.cache.capability,
+        eligibility: node.cache.eligibility,
+        consumers: Object.freeze([...node.consumers.values()].sort((left, right) =>
+          left.experimentId.localeCompare(right.experimentId) || left.evalId.localeCompare(right.evalId))),
+      }),
+    )),
+  });
+}
+
 export interface CommandPlanRowInput {
   readonly experimentId: string;
   readonly evalId: string;

--- a/packages/niceeval/src/runner/feedback/human.ts
+++ b/packages/niceeval/src/runner/feedback/human.ts
@@ -580,6 +580,10 @@ function buildSummaryLines(
             : `${summary.passed} passed · ${summary.failed} failed · ${summary.errored} errored  (${state.reused} reused)`,
     },
     { kind: "line", text: formatSummaryCostLine(state) },
+    {
+      kind: "line",
+      text: `Setup prefixes: ${summary.setupPrefixes.hit} hit · ${summary.setupPrefixes.prepared} prepared · ${summary.setupPrefixes.failed} failed (${summary.setupPrefixes.total} total)`,
+    },
   ];
   const blocks: string[][] = [
     renderPanel({ title: verdictWord, meta: formatElapsed(summary.durationMs), rows: summaryRows, width: panel.width, mode: panel.mode }),

--- a/packages/niceeval/src/runner/feedback/json.ts
+++ b/packages/niceeval/src/runner/feedback/json.ts
@@ -35,13 +35,14 @@ import type {
   RunFeedbackState,
 } from "../types.ts";
 import type { JsonValue, Verdict } from "../../shared/types.ts";
+import type { ExpTerminalSummary } from "../../experiment/host/cli/output-protocol.ts";
 import { evalConclusionRows, type EvalConclusionRow } from "./eval-conclusions.ts";
 
 /** `ExpEvent`/`ExpPlanDocument` 的 `format`/`schemaVersion` —— 只在破坏性形状变更时递增
  *  (见 cli.md「事件与计划文档的 TypeScript 形状」)。 */
 const EXP_STREAM_FORMAT = "niceeval.exp";
 const EXP_PLAN_FORMAT = "niceeval.exp-plan";
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const EXP_PLAN_SCHEMA_VERSION = 4;
 
 /** 连续无永久事件多久才追加一条 `progress` 心跳(cli.md「机器怎么读:--json」:「连续 30 秒
@@ -201,7 +202,7 @@ export interface LockWaitEvent {
 export interface ReceiptEvent {
   type: "receipt";
   receipt: InvocationReceipt;
-  summary: InvocationSummary;
+  summary: ExpTerminalSummary;
 }
 
 /** `niceeval exp --json` 唯一公开事件词表；新增事件必须先进入已采纳文档与这个闭合联合。 */
@@ -225,6 +226,22 @@ export type ExpEvent =
 
 function writeEvent(io: FeedbackIO, event: ExpEvent): void {
   io.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+function terminalSummary(summary: InvocationSummary): ExpTerminalSummary {
+  return Object.freeze({
+    startedAt: summary.startedAt,
+    completedAt: summary.completedAt,
+    passed: summary.passed,
+    failed: summary.failed,
+    skipped: summary.skipped,
+    errored: summary.errored,
+    durationMs: summary.durationMs,
+    ...(summary.usage?.inputTokens === undefined ? {} : { inputTokens: summary.usage.inputTokens }),
+    ...(summary.usage?.outputTokens === undefined ? {} : { outputTokens: summary.usage.outputTokens }),
+    ...(summary.estimatedCostUSD === undefined ? {} : { estimatedCostUSD: summary.estimatedCostUSD }),
+    setupPrefixes: summary.setupPrefixes,
+  });
 }
 
 /**
@@ -420,7 +437,11 @@ export function createJsonRenderer(options: JsonRendererOptions): FeedbackRender
           if (pendingSummary === undefined) {
             throw new Error("A receipt cannot be rendered before its invocation summary");
           }
-          writeEvent(io, { type: "receipt", receipt: event.receipt, summary: pendingSummary });
+          writeEvent(io, {
+            type: "receipt",
+            receipt: event.receipt,
+            summary: terminalSummary(pendingSummary),
+          });
           return;
 
         default: {

--- a/packages/niceeval/src/runner/feedback/json.ts
+++ b/packages/niceeval/src/runner/feedback/json.ts
@@ -201,6 +201,7 @@ export interface LockWaitEvent {
 export interface ReceiptEvent {
   type: "receipt";
   receipt: InvocationReceipt;
+  summary: InvocationSummary;
 }
 
 /** `niceeval exp --json` 唯一公开事件词表；新增事件必须先进入已采纳文档与这个闭合联合。 */
@@ -416,7 +417,10 @@ export function createJsonRenderer(options: JsonRendererOptions): FeedbackRender
 
         case "receipt":
           writeEvalConclusions(io, pendingSummary, state);
-          writeEvent(io, { type: "receipt", receipt: event.receipt });
+          if (pendingSummary === undefined) {
+            throw new Error("A receipt cannot be rendered before its invocation summary");
+          }
+          writeEvent(io, { type: "receipt", receipt: event.receipt, summary: pendingSummary });
           return;
 
         default: {

--- a/packages/niceeval/src/runner/record.ts
+++ b/packages/niceeval/src/runner/record.ts
@@ -159,6 +159,11 @@ export interface RunnerRecordMembershipStateInvalid {
   readonly slotId: SlotId;
 }
 
+export interface RunnerRecordAttemptPublicationFailed {
+  readonly code: "runner-record-attempt-publication-failed";
+  readonly message: "Attempt publication failed because NiceEval could not persist the completed result.";
+}
+
 /** A seal return without its durable marker is never a publish receipt. */
 export interface RunnerRecordPublishStateInvalid {
   readonly code: "runner-record-publish-state-invalid";
@@ -192,6 +197,7 @@ export type RunnerRecordWriteError =
   | RunnerRecordAttemptInvalid
   | RunnerRecordUnsealedAttempt
   | RunnerRecordMembershipStateInvalid
+  | RunnerRecordAttemptPublicationFailed
   | RunnerRecordPublishStateInvalid
   | RunnerRecordTargetIdentityInvalid
   | RunnerRecordAssertionsInvalid
@@ -305,6 +311,13 @@ function unsealedAttempt(slotId: SlotId): RunnerRecordUnsealedAttempt {
 
 function membershipStateInvalid(slotId: SlotId): RunnerRecordMembershipStateInvalid {
   return Object.freeze({ code: "runner-record-membership-state-invalid" as const, slotId });
+}
+
+function attemptPublicationFailed(): RunnerRecordAttemptPublicationFailed {
+  return Object.freeze({
+    code: "runner-record-attempt-publication-failed" as const,
+    message: "Attempt publication failed because NiceEval could not persist the completed result." as const,
+  });
 }
 
 function publishStateInvalid(runId: RunId): RunnerRecordPublishStateInvalid {
@@ -748,8 +761,11 @@ export function openRunnerRecordCoordinator(input: {
       reserveAttempt,
       noteSealedOrMarkIncomplete,
       completeAttemptOrMarkIncomplete: (attempt: Attempt, result: EvalResult) => completeAttempt(attempt, result).pipe(
-        Effect.catch((error) => Effect.sync(() => {
-          noteFailure(error, targetForAttempt(attempt)?.recordRun ?? runForAttempt(attempt));
+        Effect.catch(() => Effect.sync(() => {
+          noteFailure(
+            attemptPublicationFailed(),
+            targetForAttempt(attempt)?.recordRun ?? runForAttempt(attempt),
+          );
           return undefined;
         })),
       ),

--- a/packages/niceeval/src/runner/record.ts
+++ b/packages/niceeval/src/runner/record.ts
@@ -761,9 +761,11 @@ export function openRunnerRecordCoordinator(input: {
       reserveAttempt,
       noteSealedOrMarkIncomplete,
       completeAttemptOrMarkIncomplete: (attempt: Attempt, result: EvalResult) => completeAttempt(attempt, result).pipe(
-        Effect.catch(() => Effect.sync(() => {
+        Effect.catch((error) => Effect.sync(() => {
           noteFailure(
-            attemptPublicationFailed(),
+            error.code === "runner-record-assertions-invalid"
+              ? error
+              : attemptPublicationFailed(),
             targetForAttempt(attempt)?.recordRun ?? runForAttempt(attempt),
           );
           return undefined;

--- a/packages/niceeval/src/runner/report.ts
+++ b/packages/niceeval/src/runner/report.ts
@@ -64,7 +64,14 @@ export function emitReporterEvent(
 export function filterSummary(summary: InvocationSummary, ids: ReadonlySet<string>): InvocationSummary {
   const results = summary.results.filter((r) => ids.has(r.id));
   const reusedAttempts = summary.reusedAttempts.filter((attempt) => ids.has(attempt.target.evalId));
-  const sub = summarize(results, reusedAttempts, summary.startedAt, summary.durationMs, summary.name);
+  const sub = summarize(
+    results,
+    reusedAttempts,
+    summary.startedAt,
+    summary.durationMs,
+    summary.name,
+    summary.setupPrefixes,
+  );
   // completedAt 用原值(summarize 会重新取 now);name 等其余字段原样保留。
   return { ...summary, ...sub, completedAt: summary.completedAt };
 }
@@ -119,6 +126,7 @@ export function summarize(
   startedAt: string,
   durationMs: number,
   name?: LocalizedText,
+  setupPrefixes: InvocationSummary["setupPrefixes"] = Object.freeze({ total: 0, hit: 0, prepared: 0, failed: 0 }),
 ): InvocationSummary {
   const counts = { passed: 0, failed: 0, skipped: 0, errored: 0 };
   let inTok = 0;
@@ -151,5 +159,6 @@ export function summarize(
     estimatedCostUSD: hasEstimatedCost ? cost : undefined,
     reusedAttempts: Object.freeze([...reusedAttempts]),
     results,
+    setupPrefixes,
   };
 }

--- a/packages/niceeval/src/runner/run.ts
+++ b/packages/niceeval/src/runner/run.ts
@@ -2925,8 +2925,6 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
             // errored result, without inventing unavailable rich families.
             let locator: string | undefined;
             if (reservedRecordAttempt !== undefined) {
-              locator = reservedRecordAttempt.locator;
-              result.locator = locator;
               const recordAttempt = yield* recordCoordinator.completeAttemptOrMarkIncomplete(a, result);
               if (recordAttempt !== undefined) {
                 locator = recordAttempt.locator;

--- a/packages/niceeval/src/runner/run.ts
+++ b/packages/niceeval/src/runner/run.ts
@@ -3333,7 +3333,6 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
         startedAt,
         completedAt: new Date(receiptCompletedAtMs).toISOString(),
         completion: interrupted ? "interrupted" : "completed",
-        setupPrefixes: setupPrefixPreparation.summary,
       } satisfies InvocationReceipt);
     }),
   ).pipe(

--- a/packages/niceeval/src/runner/run.ts
+++ b/packages/niceeval/src/runner/run.ts
@@ -3333,6 +3333,7 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
         startedAt,
         completedAt: new Date(receiptCompletedAtMs).toISOString(),
         completion: interrupted ? "interrupted" : "completed",
+        setupPrefixes: setupPrefixPreparation.summary,
       } satisfies InvocationReceipt);
     }),
   ).pipe(
@@ -3378,7 +3379,14 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
       a.attempt - b.attempt,
   );
 
-  const summary = summarize(results, reusedAttempts, startedAt, Date.now() - t0, opts.config.name);
+  const summary = summarize(
+    results,
+    reusedAttempts,
+    startedAt,
+    Date.now() - t0,
+    opts.config.name,
+    setupPrefixPreparation.summary,
+  );
   yield* emitReporterEvent(reporters, { type: "invocation:summary", summary });
   for (const reg of reporters) {
     // required reporter(显式 --junit)在这一步失败,不能中断其它

--- a/packages/niceeval/src/runner/setup-prefix-preparation.ts
+++ b/packages/niceeval/src/runner/setup-prefix-preparation.ts
@@ -38,6 +38,14 @@ export interface PreparedSetupPrefixUse {
 export interface SetupPrefixPreparationResult {
   readonly preparedByPair: ReadonlyMap<string, PreparedSetupPrefixUse>;
   readonly failuresByPair: ReadonlyMap<string, Error>;
+  readonly summary: SetupPrefixPreparationSummary;
+}
+
+export interface SetupPrefixPreparationSummary {
+  readonly total: number;
+  readonly hit: number;
+  readonly prepared: number;
+  readonly failed: number;
 }
 
 export const SANDBOX_SETUP_PREFIX_ACTIVITY = "sandbox.setup-prefix.prepare" as const;
@@ -368,6 +376,7 @@ export function prepareSetupPrefixes(
     const completions = new Map<string, Deferred.Deferred<NodeResult>>();
     for (const node of nodes.values()) completions.set(node.key, yield* Deferred.make<NodeResult>());
     const claimed = new Set<string>();
+    const outcomes = new Map<string, "hit" | "prepared" | "failed">();
 
     const resolveNode = (key: string): Effect.Effect<NodeResult> => Effect.suspend(() => {
       const completion = completions.get(key)!;
@@ -388,6 +397,7 @@ export function prepareSetupPrefixes(
           lookupPreparationNode(node),
         )));
         if (Result.isFailure(lookup)) {
+          outcomes.set(node.key, "failed");
           const failed = Result.fail(lookup.failure);
           options.onActivity?.({
             ...activity,
@@ -399,6 +409,7 @@ export function prepareSetupPrefixes(
           return failed;
         }
         if (lookup.success !== undefined) {
+          outcomes.set(node.key, "hit");
           const hit = Result.succeed(lookup.success);
           options.onActivity?.({
             ...activity,
@@ -417,6 +428,7 @@ export function prepareSetupPrefixes(
           ? undefined
           : yield* resolveNode(node.parentKey);
         if (parentResult !== undefined && Result.isFailure(parentResult)) {
+          outcomes.set(node.key, "failed");
           const blocked = Result.fail(parentResult.failure);
           options.onActivity?.({
             ...activity,
@@ -437,6 +449,7 @@ export function prepareSetupPrefixes(
           ),
         )));
         const durationMs = Math.max(0, Date.now() - startedAt);
+        outcomes.set(node.key, Result.isFailure(result) ? "failed" : result.success.outcome);
         options.onActivity?.(Result.isFailure(result)
           ? { ...activity, status: "failed", outcome: "failed", durationMs }
           : { ...activity, status: "done", outcome: result.success.outcome, durationMs });
@@ -460,7 +473,17 @@ export function prepareSetupPrefixes(
         for (const pairKey of target.pairKeys) preparedByPair.set(pairKey, result.success.use);
       }
     }
-    return Object.freeze({ preparedByPair, failuresByPair });
+    const settled = [...outcomes.values()];
+    return Object.freeze({
+      preparedByPair,
+      failuresByPair,
+      summary: Object.freeze({
+        total: nodes.size,
+        hit: settled.filter((outcome) => outcome === "hit").length,
+        prepared: settled.filter((outcome) => outcome === "prepared").length,
+        failed: settled.filter((outcome) => outcome === "failed").length,
+      }),
+    });
   });
   return options.signal === undefined
     ? program

--- a/packages/niceeval/src/runner/types.ts
+++ b/packages/niceeval/src/runner/types.ts
@@ -564,7 +564,6 @@ export interface InvocationReceipt {
   readonly startedAt: string;
   readonly completedAt?: string;
   readonly completion: "completed" | "interrupted" | "failed";
-  readonly setupPrefixes: SetupPrefixPreparationSummary;
 }
 
 /** onInvocationStart 的运行规模:去重后 eval 数 × 配置(agent×model×flags)数 → 总 attempt 数。 */

--- a/packages/niceeval/src/runner/types.ts
+++ b/packages/niceeval/src/runner/types.ts
@@ -25,6 +25,7 @@ import type { CapturedEvalSource } from "./eval-source.ts";
 import type { AttemptLocator } from "../attempt-locator.ts";
 import type { RecordRoot } from "../record/platform/root.ts";
 import type { CurrentReusedAttemptReadback } from "./reuse-readback.ts";
+import type { SetupPrefixPreparationSummary } from "./setup-prefix-preparation.ts";
 import type { PluginInstance, PluginOnUnavailable } from "../plugin/contracts.ts";
 
 // ───────────────────────── 结果 / 报告 ─────────────────────────
@@ -547,6 +548,8 @@ export interface InvocationSummary {
   /** Current Record readbacks adopted by this invocation; these are never recreated EvalResults. */
   reusedAttempts: readonly CurrentReusedAttemptReadback[];
   results: EvalResult[];
+  /** Unique provider-native setup-prefix nodes settled before Attempt dispatch. */
+  setupPrefixes: SetupPrefixPreparationSummary;
 }
 
 /**
@@ -561,6 +564,7 @@ export interface InvocationReceipt {
   readonly startedAt: string;
   readonly completedAt?: string;
   readonly completion: "completed" | "interrupted" | "failed";
+  readonly setupPrefixes: SetupPrefixPreparationSummary;
 }
 
 /** onInvocationStart 的运行规模:去重后 eval 数 × 配置(agent×model×flags)数 → 总 attempt 数。 */

--- a/packages/niceeval/src/sandbox/docker-cache-repository.ts
+++ b/packages/niceeval/src/sandbox/docker-cache-repository.ts
@@ -206,6 +206,7 @@ export type DockerCacheRepositoryRequest =
   | RepositoryRequestBase & { readonly operation: "ensure-owner"; readonly candidateOwnerId: string }
   | RepositoryRequestBase & { readonly operation: "verify-domain"; readonly domain: Omit<DockerCacheDomainRow, "authorityEpoch" | "firstVerifiedAt" | "lastVerifiedAt" | "lastState">; readonly candidateAuthorityEpoch: string; readonly verifiedAt: string }
   | RepositoryRequestBase & { readonly operation: "list-domains" }
+  | RepositoryRequestBase & { readonly operation: "list-inventory"; readonly domainId: string }
   | RepositoryRequestBase & { readonly operation: "task-get-indexed"; readonly domainId: string; readonly buildKey: string }
   | RepositoryRequestBase & { readonly operation: "task-mark-unverified"; readonly domainId: string; readonly buildKey: string; readonly generation?: number }
   | RepositoryRequestBase & { readonly operation: "task-publish"; readonly domainId: string; readonly buildKey: string; readonly tag: string; readonly imageId: string; readonly manifestDigest: string; readonly operationId: string; readonly now: string; readonly protectedUntil: string }
@@ -254,6 +255,14 @@ export type DockerCacheRepositoryResult =
   | Result<"ensure-owner", { readonly ownerId: string }>
   | Result<"verify-domain", { readonly domain: DockerCacheDomainRow }>
   | Result<"list-domains", { readonly domains: readonly DockerCacheDomainRow[] }>
+  | Result<"list-inventory", {
+    readonly taskEntries: readonly DockerTaskBuildEntryRow[];
+    readonly taskLeases: readonly DockerTaskBuildLeaseRow[];
+    readonly taskRoots: readonly DockerTaskBuildRootRow[];
+    readonly setupEntries: readonly DockerSetupPrefixEntryRow[];
+    readonly setupLeases: readonly DockerSetupPrefixLeaseRow[];
+    readonly setupRoots: readonly DockerSetupPrefixRootRow[];
+  }>
   | Result<"task-get-indexed", { readonly entry: DockerTaskBuildEntryRow | null }>
   | Result<"task-mark-unverified" | "task-publish" | "task-heartbeat" | "task-release-use" | "task-prune-owners" | "task-save-plan" | "task-save-plan-outcome" | "task-settle-delete" | "task-recover-delete" | "setup-prune-leases" | "setup-startup-isolate" | "setup-startup-validate" | "setup-release-lease" | "setup-mark-unverified" | "setup-publish-reserve" | "setup-publish-settle" | "setup-prepare-root" | "setup-activate-root" | "setup-remove-root" | "setup-begin-root-release" | "setup-finish-root-release" | "setup-mark-used" | "setup-settle-delete", { readonly changes: number }>
   | Result<"task-acquire-use" | "task-reserve-delete" | "setup-reserve-delete", { readonly reserved: boolean; readonly reason?: FiniteValue<typeof DOCKER_RESERVATION_REASONS> }>
@@ -544,6 +553,19 @@ function setupLease(row: unknown): DockerSetupPrefixLeaseRow {
   });
 }
 
+function setupRoot(row: unknown): DockerSetupPrefixRootRow {
+  const value = record(row, "setup-prefix root");
+  const state = exactString(value.state, "state");
+  if (!isFiniteValue(DOCKER_SETUP_ROOT_STATES, state)) throw invalid(`docker-cache setup-prefix root state ${state} is invalid`);
+  return Object.freeze({
+    rootId: exactString(value.root_id, "root_id"), entryId: exactString(value.entry_id, "entry_id"),
+    setupPrefixKey: exactString(value.setup_prefix_key, "setup_prefix_key"), generation: exactInteger(value.generation, "generation"),
+    sandboxId: exactString(value.sandbox_id, "sandbox_id"),
+    sandboxResourceIdentity: exactString(value.sandbox_resource_identity, "sandbox_resource_identity"),
+    operationId: exactString(value.operation_id, "operation_id"), state, createdAt: exactString(value.created_at, "created_at"),
+  });
+}
+
 function gcLock(row: unknown): DockerImageGcLockRow {
   const value = record(row, "GC lock");
   const cacheKind = exactString(value.cache_kind, "cache_kind");
@@ -558,6 +580,18 @@ function gcLock(row: unknown): DockerImageGcLockRow {
 
 function transaction<A>(database: DatabaseSync, run: () => A): A {
   database.exec("BEGIN IMMEDIATE");
+  try {
+    const result = run();
+    database.exec("COMMIT");
+    return result;
+  } catch (cause) {
+    if (database.isTransaction) database.exec("ROLLBACK");
+    throw cause;
+  }
+}
+
+function readTransaction<A>(database: DatabaseSync, run: () => A): A {
+  database.exec("BEGIN");
   try {
     const result = run();
     database.exec("COMMIT");
@@ -663,6 +697,15 @@ function dispatch(database: DatabaseSync, request: DockerCacheRepositoryRequest)
       return result(request.operation, {
         domains: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.domains} ORDER BY first_verified_at, domain_id`).all().map(domainRow)),
       });
+    case "list-inventory":
+      return readTransaction(database, () => result(request.operation, {
+        taskEntries: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? AND state != ${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} ORDER BY build_key`).all(request.domainId).map(taskEntry)),
+        taskLeases: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.taskLeases} WHERE domain_id = ? ORDER BY lease_id`).all(request.domainId).map(taskLease)),
+        taskRoots: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.taskRoots} WHERE domain_id = ? ORDER BY root_id`).all(request.domainId).map(taskRoot)),
+        setupEntries: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.setupEntries} WHERE domain_id = ? AND state != ${sqlLiteral(DOCKER_CACHE_STATE.tombstoned)} ORDER BY setup_prefix_key, generation`).all(request.domainId).map(setupEntry)),
+        setupLeases: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.setupLeases} WHERE domain_id = ? AND state IN (${sqlIn(DOCKER_ACTIVE_SETUP_LEASE_STATES)}) ORDER BY lease_id`).all(request.domainId).map(setupLease)),
+        setupRoots: Object.freeze(database.prepare(`SELECT * FROM ${TABLES.setupRoots} WHERE domain_id = ? AND state IN (${sqlIn(DOCKER_SETUP_ROOT_STATES)}) ORDER BY root_id`).all(request.domainId).map(setupRoot)),
+      }));
     case "task-get-indexed": {
       const row = database.prepare(`SELECT * FROM ${TABLES.taskEntries} WHERE domain_id = ? AND build_key = ? AND state = ${sqlLiteral(DOCKER_CACHE_STATE.indexed)}`)
         .get(request.domainId, request.buildKey);
@@ -1151,6 +1194,8 @@ export function isDockerCacheRepositoryRequest(value: unknown): value is DockerC
   switch (value.operation) {
     case "list-domains":
       return true;
+    case "list-inventory":
+      return strings(value, ["domainId"]);
     case "ensure-owner":
       return strings(value, ["candidateOwnerId"]);
     case "verify-domain": {
@@ -1256,6 +1301,20 @@ export function isDockerCacheRepositoryResult(value: unknown): value is DockerCa
     case "list-domains":
       return Array.isArray(value.domains) && value.domains.every((domain) =>
         isObject(domain) && strings(domain, ["domainId", "ownerId", "backendIdentity", "authorityEpoch"]));
+    case "list-inventory":
+      return Array.isArray(value.taskEntries) && value.taskEntries.every(taskEntryValue) &&
+        Array.isArray(value.taskLeases) && value.taskLeases.every((lease) =>
+          isObject(lease) && strings(lease, ["leaseId", "buildKey", "holderBootId", "holderProcessStart", "createdAt", "heartbeatAt"]) &&
+            Number.isSafeInteger(lease.holderPid) && Number.isSafeInteger(lease.generation)) &&
+        Array.isArray(value.taskRoots) && value.taskRoots.every((root) =>
+          isObject(root) && strings(root, ["rootId", "buildKey", "holderBootId", "holderProcessStart", "state", "createdAt"]) &&
+            Number.isSafeInteger(root.holderPid) && Number.isSafeInteger(root.generation)) &&
+        Array.isArray(value.setupEntries) && value.setupEntries.every(setupEntryValue) &&
+        Array.isArray(value.setupLeases) && value.setupLeases.every((lease) => isObject(lease) && strings(lease, [
+          "leaseId", "entryId", "setupPrefixKey", "kind", "operationId", "holderHostId", "holderBootId",
+          "holderProcessStart", "heartbeatAt", "expiresAt", "state",
+        ]) && Number.isSafeInteger(lease.generation) && Number.isSafeInteger(lease.holderPid) && Number.isSafeInteger(lease.heartbeatSequence)) &&
+        Array.isArray(value.setupRoots) && value.setupRoots.every(setupRootValue);
     case "task-get-indexed":
       return value.entry === null || taskEntryValue(value.entry);
     case "task-list-entries":

--- a/packages/niceeval/src/sandbox/docker-task-build-cache.test.ts
+++ b/packages/niceeval/src/sandbox/docker-task-build-cache.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { inventoryOwnerCounts, taskBuildInventoryState } from "./docker-task-build-cache.ts";
+
+describe("Docker cache inventory ownership projection", () => {
+  it("keeps crashed owner claims protected without reporting them active", () => {
+    const counts = inventoryOwnerCounts(
+      [{ holder: "live" }, { holder: "crashed" }],
+      ({ holder }) => holder === "live",
+    );
+
+    expect(counts).toEqual({ total: 2, live: 1, unverified: 1 });
+    expect(taskBuildInventoryState("sha256:image", "sha256:image", counts.live, counts.unverified))
+      .toBe("unverified");
+  });
+
+  it("reports active only from a verified image and verified-live lease", () => {
+    expect(taskBuildInventoryState("sha256:image", "sha256:image", 1, 0)).toBe("active-leased");
+    expect(taskBuildInventoryState("sha256:image", "sha256:image", 0, 0)).toBe("cold-reusable");
+    expect(taskBuildInventoryState(undefined, "sha256:image", 1, 0)).toBe("unverified");
+  });
+});

--- a/packages/niceeval/src/sandbox/docker-task-build-cache.test.ts
+++ b/packages/niceeval/src/sandbox/docker-task-build-cache.test.ts
@@ -1,3 +1,4 @@
+// cases: docs/engineering/testing/unit/sandbox.md
 import { describe, expect, it } from "vitest";
 import { inventoryOwnerCounts, taskBuildInventoryState } from "./docker-task-build-cache.ts";
 

--- a/packages/niceeval/src/sandbox/docker-task-build-cache.ts
+++ b/packages/niceeval/src/sandbox/docker-task-build-cache.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { constants as fsConstants, readFileSync } from "node:fs";
 import { access } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { Effect } from "effect";
@@ -120,8 +120,26 @@ function domainIdFor(ownerId: string, daemonId: string, storageDriver: string, s
     .digest("hex").slice(0, 24);
 }
 
-function inventoryState(actual: string | undefined, expected: string, leases: number): TaskBuildInventoryEntry["state"] {
-  return actual !== expected ? "unverified" : leases > 0 ? "active-leased" : "cold-reusable";
+/** @internal Pure projection used to keep read-only inventory from treating stale owners as active. */
+export function taskBuildInventoryState(
+  actual: string | undefined,
+  expected: string,
+  liveLeases: number,
+  unverifiedOwners: number,
+): TaskBuildInventoryEntry["state"] {
+  return actual !== expected || unverifiedOwners > 0
+    ? "unverified"
+    : liveLeases > 0 ? "active-leased" : "cold-reusable";
+}
+
+/** @internal Counts retain every protection claim while separating verified-live owners from unverifiable ones. */
+export function inventoryOwnerCounts<A>(owners: readonly A[], isLive: (owner: A) => boolean): {
+  readonly total: number;
+  readonly live: number;
+  readonly unverified: number;
+} {
+  const live = owners.filter(isLive).length;
+  return { total: owners.length, live, unverified: owners.length - live };
 }
 
 function passesGcAgePolicy(row: DockerTaskBuildEntryRow, now: number): boolean {
@@ -166,7 +184,7 @@ function dockerConfirmedImageAbsent(cause: unknown): boolean {
     cause instanceof Error ? cause.message : undefined,
   ].filter((value): value is string | Buffer => typeof value === "string" || Buffer.isBuffer(value))
     .map((value) => value.toString()).join("\n");
-  return /no such (?:image|object)|image .* not found/iu.test(detail);
+  return /no such (?:image|object|container)|(?:image|container) .* not found/iu.test(detail);
 }
 
 async function imageId(tag: string, dockerSocketPath?: string): Promise<string | undefined> {
@@ -196,6 +214,26 @@ function processIdentityIsLive(pid: number, bootId: string, processStart: string
     return actual.bootId === bootId && actual.processStart === processStart;
   } catch {
     return false;
+  }
+}
+
+function holderIsVerifiablyLive(holder: {
+  readonly holderPid: number;
+  readonly holderBootId: string;
+  readonly holderProcessStart: string;
+  readonly holderHostId?: string;
+}): boolean {
+  return (holder.holderHostId === undefined || holder.holderHostId === "local" || holder.holderHostId === hostname()) &&
+    processIdentityIsLive(holder.holderPid, holder.holderBootId, holder.holderProcessStart);
+}
+
+async function containerIsVerifiablyLive(containerId: string, dockerSocketPath?: string): Promise<boolean> {
+  try {
+    await docker(["container", "inspect", "--format", "{{.Id}}", containerId], dockerSocketPath);
+    return true;
+  } catch (cause) {
+    if (dockerConfirmedImageAbsent(cause)) return false;
+    throw cause;
   }
 }
 
@@ -537,22 +575,45 @@ export async function inventoryTaskBuildDomain(dockerSocketPath?: string): Promi
   const listed = await dockerCacheRepository.request({ repository: "docker-cache", operation: "list-inventory", domainId: domain.domainId });
   const entries: DockerCacheInventoryEntry[] = [];
   for (const row of listed.taskEntries) {
-    const leases = listed.taskLeases.filter((lease) => lease.buildKey === row.buildKey).length;
-    const roots = listed.taskRoots.filter((root) => root.buildKey === row.buildKey).length;
+    const leases = listed.taskLeases.filter((lease) => lease.buildKey === row.buildKey);
+    const roots = listed.taskRoots.filter((root) => root.buildKey === row.buildKey);
+    const leaseCounts = inventoryOwnerCounts(leases, holderIsVerifiablyLive);
+    const rootCounts = inventoryOwnerCounts(roots, holderIsVerifiablyLive);
     const actual = await imageId(row.tag, dockerSocketPath);
     entries.push({
       kind: "task-build", identity: { buildKey: row.buildKey, tag: row.tag, imageId: row.imageId },
-      leaseCount: leases, rootCount: roots, createdAt: row.createdAt,
+      leaseCount: leaseCounts.total, rootCount: rootCounts.total,
+      liveLeaseCount: leaseCounts.live, unverifiedLeaseCount: leaseCounts.unverified,
+      liveRootCount: rootCounts.live, unverifiedRootCount: rootCounts.unverified,
+      createdAt: row.createdAt,
       lastSuccessfulUseAt: row.lastSuccessfulUseAt, protectedUntil: row.protectedUntil,
-      state: inventoryState(actual, row.imageId, leases),
+      state: taskBuildInventoryState(
+        actual,
+        row.imageId,
+        leaseCounts.live,
+        leaseCounts.unverified + rootCounts.unverified,
+      ),
     });
   }
   for (const row of listed.setupEntries) {
+    const leases = listed.setupLeases.filter((lease) => lease.entryId === row.entryId);
+    const roots = listed.setupRoots.filter((root) => root.entryId === row.entryId);
+    const leaseCounts = inventoryOwnerCounts(
+      leases,
+      (lease) => lease.state === "active" && holderIsVerifiablyLive(lease),
+    );
+    const liveRoots = await Promise.all(roots.map((root) => containerIsVerifiablyLive(root.sandboxId, dockerSocketPath)));
+    const rootCounts = inventoryOwnerCounts(liveRoots, Boolean);
+    const providerVerified = row.imageId === null
+      ? row.state === "reserved" || row.state === "building"
+      : await imageId(row.imageId, dockerSocketPath) === row.imageId;
     entries.push({
-      kind: "sandbox-setup-prefix", state: row.state,
+      kind: "sandbox-setup-prefix",
+      state: !providerVerified || leaseCounts.unverified > 0 || rootCounts.unverified > 0 ? "unverified" : row.state,
       identity: { entryId: row.entryId, setupPrefixKey: row.setupPrefixKey, imageId: row.imageId, baseImageId: row.baseImageId },
-      leaseCount: listed.setupLeases.filter((lease) => lease.entryId === row.entryId).length,
-      rootCount: listed.setupRoots.filter((root) => root.entryId === row.entryId).length,
+      leaseCount: leaseCounts.total, rootCount: rootCounts.total,
+      liveLeaseCount: leaseCounts.live, unverifiedLeaseCount: leaseCounts.unverified,
+      liveRootCount: rootCounts.live, unverifiedRootCount: rootCounts.unverified,
       createdAt: row.createdAt, lastSuccessfulUseAt: row.lastSuccessfulUseAt, protectedUntil: row.protectedUntil,
     });
   }

--- a/packages/niceeval/src/sandbox/docker-task-build-cache.ts
+++ b/packages/niceeval/src/sandbox/docker-task-build-cache.ts
@@ -8,6 +8,8 @@ import { promisify } from "node:util";
 import { Effect } from "effect";
 import type {
   DockerCapacityObservation as ProviderCapacityObservation,
+  DockerCacheDomainInventory,
+  DockerCacheInventoryEntry,
   DockerCacheDomainDescriptor as CacheDomainDescriptor,
 } from "../docker/cache-administration.ts";
 import {
@@ -57,23 +59,8 @@ async function assertNoLegacyDockerCache(): Promise<void> {
   }
 }
 
-export interface TaskBuildInventoryEntry {
-  readonly buildKey: string;
-  readonly tag: string;
-  readonly imageId: string;
-  readonly createdAt: string;
-  readonly lastSuccessfulUseAt: string | null;
-  readonly protectedUntil: string;
-  readonly state: "active-leased" | "cold-reusable" | "unverified";
-}
-
-export interface TaskBuildDomainInventory {
-  readonly domainId: string;
-  readonly providerFamily: "docker";
-  readonly backendKind: "docker-images";
-  readonly state: "verified-managed";
-  readonly entries: readonly TaskBuildInventoryEntry[];
-}
+export type TaskBuildInventoryEntry = Extract<DockerCacheInventoryEntry, { readonly kind: "task-build" }>;
+export type TaskBuildDomainInventory = DockerCacheDomainInventory;
 
 export interface TaskBuildCacheService {
   lookup(buildKey: string, tag: string, manifestDigest: string, dockerSocketPath?: string): Promise<boolean>;
@@ -547,15 +534,26 @@ export function makeTaskBuildCacheService(): TaskBuildCacheService {
 
 export async function inventoryTaskBuildDomain(dockerSocketPath?: string): Promise<TaskBuildDomainInventory> {
   const domain = await openDomain(dockerSocketPath);
-  const listed = await dockerCacheRepository.request({ repository: "docker-cache", operation: "task-list-entries", domainId: domain.domainId });
-  const entries: TaskBuildInventoryEntry[] = [];
-  for (const row of listed.entries) {
-    const leases = await pruneTaskOwners(domain.domainId, row.buildKey);
+  const listed = await dockerCacheRepository.request({ repository: "docker-cache", operation: "list-inventory", domainId: domain.domainId });
+  const entries: DockerCacheInventoryEntry[] = [];
+  for (const row of listed.taskEntries) {
+    const leases = listed.taskLeases.filter((lease) => lease.buildKey === row.buildKey).length;
+    const roots = listed.taskRoots.filter((root) => root.buildKey === row.buildKey).length;
     const actual = await imageId(row.tag, dockerSocketPath);
     entries.push({
-      buildKey: row.buildKey, tag: row.tag, imageId: row.imageId, createdAt: row.createdAt,
+      kind: "task-build", identity: { buildKey: row.buildKey, tag: row.tag, imageId: row.imageId },
+      leaseCount: leases, rootCount: roots, createdAt: row.createdAt,
       lastSuccessfulUseAt: row.lastSuccessfulUseAt, protectedUntil: row.protectedUntil,
       state: inventoryState(actual, row.imageId, leases),
+    });
+  }
+  for (const row of listed.setupEntries) {
+    entries.push({
+      kind: "sandbox-setup-prefix", state: row.state,
+      identity: { entryId: row.entryId, setupPrefixKey: row.setupPrefixKey, imageId: row.imageId, baseImageId: row.baseImageId },
+      leaseCount: listed.setupLeases.filter((lease) => lease.entryId === row.entryId).length,
+      rootCount: listed.setupRoots.filter((root) => root.entryId === row.entryId).length,
+      createdAt: row.createdAt, lastSuccessfulUseAt: row.lastSuccessfulUseAt, protectedUntil: row.protectedUntil,
     });
   }
   return { domainId: domain.domainId, providerFamily: "docker", backendKind: "docker-images", state: "verified-managed", entries };

--- a/packages/testkit/README.md
+++ b/packages/testkit/README.md
@@ -6,13 +6,14 @@ NiceEval 场景 Repo 共用的机械测试设施。它只负责进程收据、�
 `createE2EContext()` 把调用方提供的具名命令前缀绑定到每个 case 的私有项目副本，
 回收该 case 启动的进程，然后暂存调用方声明的路径。产品 argv 和 expected 仍留在测试正文。
 
-`ProcessReceipt.expReceipt()` 严格读取 `niceeval exp --json` 的 `start → 中间事件 → receipt`
-边界，并返回最后唯一一条 `InvocationReceipt`。它不折叠 Verdict 或 Attempt，也不替测试决定 expected；
+`ProcessReceipt.expTerminal()` 通过安装候选 `niceeval/experiment/host` 的公开 decoder 严格读取
+`niceeval exp --json` 的 terminal receipt + invocation summary envelope；`expReceipt()` 返回其中轻量
+`InvocationReceipt`。它们不折叠 Verdict 或 Attempt，也不替测试决定 expected；
 这些业务事实必须从中间 `eval` 事件或 receipt 的 Record Runs 读取。
 
 `ProcessReceipt.expEvalEvents()` 严格解码公开的 Eval 结论事件。
 `ProcessReceipt.expErrorEvents()` 通过完整 `ExpEventSchema` 的 `error` 分支严格解码公开执行错误。
-`ProcessReceipt.expEvents()` 公开严格解码完整 `ExpEvent` 联合；两个筛选 API 都复用它，E2E 无需直接调用
+`ProcessReceipt.expEvents()` 公开严格解码 terminal envelope 之前的完整 progress `ExpEvent` 联合；两个筛选 API 都复用它，E2E 无需直接调用
 `ndjson<ExpEvent>()`。NiceEval 当前未从 package exports 导出 `ExpEvent` 类型或运行时 Schema，因此 Testkit
 仍拥有机器流的严格运行时 Schema，并保持与产品事件词表逐字段一致。
 `assertExpEvalOutcomes(actual, expected)` 把这些事件与测试文件显式提供的身份、Verdict 和 Attempt 字面量作精确比较。

--- a/packages/testkit/src/exp-protocol.ts
+++ b/packages/testkit/src/exp-protocol.ts
@@ -1,0 +1,6 @@
+export {
+  decodeExpTerminalEvent,
+  type ExpInvocationReceipt as InvocationReceipt,
+  type ExpTerminalEvent,
+  type ExpTerminalSummary,
+} from "niceeval/experiment/host";

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./process.js";
+export * from "./exp-protocol.js";
 export * from "./query-protocol.js";
 export * from "./inspection-request.js";
 export * from "./run-protocol.js";

--- a/packages/testkit/src/process.ts
+++ b/packages/testkit/src/process.ts
@@ -18,6 +18,11 @@ import {
   type RunGetDocument,
   type RunListDocument,
 } from "./run-protocol.js";
+import {
+  decodeExpTerminalEvent,
+  type ExpTerminalEvent,
+  type InvocationReceipt,
+} from "./exp-protocol.js";
 
 export type Argv = readonly [string, ...string[]];
 
@@ -32,31 +37,11 @@ export interface DiagnosticTruncation {
   stderr: boolean;
 }
 
-/** The invocation-level hand-off emitted by `niceeval exp --json`. */
 const NonNegativeIntegerSchema = Schema.Number.pipe(
   Schema.check(Schema.makeFilter(
     (value) => Number.isInteger(value) && value >= 0,
   )),
 );
-
-export const InvocationReceiptSchema = Schema.Struct({
-  invocationId: Schema.String,
-  createdRunIds: Schema.Array(Schema.String),
-  publicationCutoff: Schema.String,
-  startedAt: Schema.String,
-  completedAt: Schema.optional(Schema.String),
-  completion: Schema.Literals(["completed", "interrupted", "failed"]),
-});
-
-export type InvocationReceipt = Schema.Schema.Type<typeof InvocationReceiptSchema>;
-
-/** The sole terminal envelope in a `niceeval exp --json` stream. */
-export const ExpReceiptEventSchema = Schema.Struct({
-  type: Schema.Literal("receipt"),
-  receipt: InvocationReceiptSchema,
-});
-
-export type ExpReceiptEvent = Schema.Schema.Type<typeof ExpReceiptEventSchema>;
 
 /** The stream identity line emitted first by `niceeval exp --json`. */
 export const ExpStartEventSchema = Schema.Struct({
@@ -137,7 +122,7 @@ export const ExpEventSchema = Schema.Union([
   ExpNoticeEventSchema, ExpWarningEventSchema, ExpBudgetExhaustedEventSchema,
   ExpReporterErrorEventSchema, ExpInterruptedEventSchema,
   ExpJudgePrecheckEventSchema, ExpExperimentHookEventSchema,
-  ExpLockWaitEventSchema, ExpReceiptEventSchema,
+  ExpLockWaitEventSchema,
 ]);
 export type ExpEvent = Schema.Schema.Type<typeof ExpEventSchema>;
 
@@ -258,6 +243,11 @@ export class ProcessReceipt {
    * InvocationReceipt. It does not infer any Eval outcome from the stream.
    */
   expReceipt(): InvocationReceipt {
+    return this.expTerminal().receipt;
+  }
+
+  /** Strictly decode the sole terminal receipt and invocation-summary envelope. */
+  expTerminal(): ExpTerminalEvent {
     const events = this.ndjson<unknown>();
     const first = events[0];
     if (!isExpStartEvent(first)) {
@@ -279,12 +269,14 @@ export class ProcessReceipt {
     }
 
     const terminal = events.at(-1);
-    if (!isExpReceiptEvent(terminal)) {
+    try {
+      return decodeExpTerminalEvent(terminal);
+    } catch (cause) {
       throw new Error(
-        `expReceipt(): stdout does not end with a valid InvocationReceipt\n\n${this.diagnostic()}`,
+        `expTerminal(): stdout does not end with a valid terminal receipt envelope: ${reasonOf(cause)}\n\n${this.diagnostic()}`,
+        { cause },
       );
     }
-    return terminal.receipt;
   }
 
   /** Strictly decode the public Eval conclusion events from `niceeval exp --json`. */
@@ -304,8 +296,9 @@ export class ProcessReceipt {
   /** Strictly decode every public event in `niceeval exp --json`. */
   expEvents(): ExpEvent[] {
     const events = this.ndjson<unknown>();
+    this.expTerminal();
     const decoded: ExpEvent[] = [];
-    for (const event of events) {
+    for (const event of events.slice(0, -1)) {
       const result = decodeSchema(ExpEventSchema, event);
       if (Result.isFailure(result)) {
         throw new Error(
@@ -426,10 +419,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function isReceiptEvent(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value) &&
     (value as { type?: unknown }).type === "receipt";
-}
-
-function isExpReceiptEvent(value: unknown): value is ExpReceiptEvent {
-  return Result.isSuccess(Schema.decodeUnknownResult(ExpReceiptEventSchema)(value));
 }
 
 function truncateForDisplay(text: string, stream: "stdout" | "stderr"): string {


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 7c23d9957a9e3433dc82db65a18099b60823e133
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: dd341a8e4be6882c56a0924efbcbb04004c14a29
-->

## Problem

- User goal: 在运行实验前后看清 Sandbox 准备前缀如何复用，并能管理 Docker 中由 NiceEval 拥有的缓存。
- Current limitation: debug 只能逐个 Eval 查看且没有准备前缀汇总；运行结束不报告真实命中；Docker inventory 无法归属 setup-prefix；失败的 Attempt 还可能打印无法查询的 locator。
- Required capability: 让批量 planning、运行时结算、Docker-owned inventory 和 Attempt publication 共享可靠的公开投影，同时保持 GC 与轻量 receipt 的既有边界。
- User outcome: 用户可在花费前检查整批 prefix 计划、运行后核对 hit/prepared/failed、查看安全的 Docker 归属，并只收到真正可查询的 Attempt locator。

## Use cases

### Changed

#### Case: 共享分支准备

##### Starting state

```text
Docker Sandbox 已发布至少一个由多个 Eval 消费的 setup-prefix artifact。
```

##### Action

```sh
niceeval docker cache inventory --json
```

##### Result

```text
同一 verified-managed Docker images Domain 把 artifact 显示为 sandbox-setup-prefix entry，并给出安全 identity、state、lease/root 与时间字段；GC 不把它列为候选。
```

用户可以确认准备前缀确实归 NiceEval 管理，而不会因此扩大现有 task-build GC 的删除范围。 [Canonical Use Case](docs/feature/sandbox/use-case/起点与准备/共享分支准备.md).

#### Case: 预览并收窄实验

##### Starting state

```text
一个 Experiment 选择了多个 Eval，并为它们声明了可复用的 Sandbox 准备步骤。
```

##### Action

```sh
niceeval debug compare --json
```

##### Result

```text
输出 experimentId、evalIds、按 prefix identity 去重的 setupPrefixPlan，以及 lookup: "not-probed"；不创建 Sandbox 或探测库存。
```

用户能在启动付费 Attempt 前一次检查整批准备计划；运行完成后再从终态 summary 核对真实结算。 [Canonical Use Case](docs/feature/experiments/use-case/选择评测/预览并收窄.md).

## CLI

### Added

#### Case: 汇总真实 setup-prefix 结算

##### Before

```sh
niceeval exp compare
```

```text
COMPLETE\n2 attempts completed
```

##### After

```sh
niceeval exp compare
```

```text
COMPLETE\n2 attempts completed\nSetup prefixes: 3 hit · 1 prepared · 0 failed (4 total)
```

##### User impact

结束页与 JSON terminal summary 按唯一 prefix node 汇总 hit、prepared、failed；它不与结果沿用或物理 Sandbox 复用混算。

### Changed

#### Case: 批量查看 setup-prefix 计划

##### Before

```sh
niceeval debug compare --json
```

```text
Usage error: an Eval selector is required
```

##### After

```sh
niceeval debug compare --json
```

```text
{"experimentId":"compare","evalIds":["toggl-cli/01-entry-stats","toggl-cli/02-project-list"],"setupPrefixPlan":{"lookup":"not-probed","nodes":[...]},"commandPlan":{...}}
```

##### User impact

省略 Eval selector 即可规划 Experiment 选中的全部 Eval。JSON 是当前 CLI 的即时调试对象，不声明 format、schemaVersion 或跨版本解码协议。

#### Case: 识别 Docker-owned setup-prefix

##### Before

```sh
niceeval docker cache inventory --json
```

```text
{"domains":[{"entryKinds":{"taskBuild":1}}],"providerObservations":[{"state":"unverified","reason":"shared-builder-unattributed"}]}
```

##### After

```sh
niceeval docker cache inventory --json
```

```text
{"domains":[{"entryKinds":{"taskBuild":1,"sandboxSetupPrefix":3}}],"entries":[{"kind":"sandbox-setup-prefix","state":"indexed","identity":{"entryId":"...","setupPrefixKey":"...","imageId":"sha256:...","baseImageId":"sha256:..."}}]}
```

##### User impact

inventory 能可靠展示 NiceEval registry 已登记的准备前缀与活跃归属；共享 BuildKit 未验证容量仍单独展示，GC 仍只处理 task-build。

## Observable behavior and data contracts

### Changed

#### Case: Attempt publication 失败不暴露 locator

##### Before

```sh
niceeval exp completion-persistence-failure --rerun all --json
```

```text
{"type":"eval","status":"errored","locator":"@1..."}\nAttempt @1... was not found
```

##### After

```sh
niceeval exp completion-persistence-failure --rerun all --json
```

```text
{"type":"eval","status":"errored","error":"Attempt persistence/publication failed"}\n(no locator field)
```

##### User impact

只有成功发布、可通过 query/show 检查的 Attempt 才获得公开 locator；持久化失败保留明确诊断。

## Tests

### `e2e/cli/test/cache-inventory.test.ts`

#### `e2e/cli/test/cache-inventory.test.ts#necase_WT23YHZHKQ9PYBTC`

安装后的 Docker cache CLI 保持 managed image domain 与未验证 BuildKit observation 的归属边界。 It exercises niceeval docker cache inventory --json and asserts 空 domain 按 taskBuild 与 sandboxSetupPrefix 分别计数，共享 builder 只报告 unverified 容量，GC 不假定归属。. Deleting this case would allow 同时覆盖 human 输出、domain detail、空 GC plan/apply、legacy state 拒绝与无副作用。. The final contract is [docs/feature/sandbox/cli.md](docs/feature/sandbox/cli.md).

```ts
// … omitted: file=e2e/cli/test/cache-inventory.test.ts; before=    expect(result.stderr).toBe("");; after=    const document = JSON.parse(result.stdout) as {; reason=只展开本 PR 改变的 domain kind 计数与 BuildKit 归属断言；同一 case 的命令发现、GC 和 legacy state 矩阵未改变。
    const document = JSON.parse(result.stdout) as {
      format: string;
      domains: unknown[];
      providerObservations: Array<Record<string, unknown>>;
    };
    expect(document.format).toBe("niceeval.cache-inventory");
    expect(document.domains).toEqual([{
      domainId: expect.any(String),
      providerFamily: "docker",
      backendKind: "docker-images",
      state: "verified-managed",
      entryCount: 0,
      entryKinds: { taskBuild: 0, sandboxSetupPrefix: 0 },
    }]);
    expect(document.providerObservations).toEqual([{
      scope: "provider",
      providerFamily: "docker",
      backendKind: "buildkit",
      state: "unverified",
      observedAt: expect.any(String),
      totalBytes: 40_300_000_000,
      reclaimableEstimateBytes: 21_500_000_000,
      reason: "shared-builder-unattributed",
    }]);
    expect(result.stdout).not.toContain("evictable");
    expect(result.stdout).not.toContain("planId");
// … omitted: file=e2e/cli/test/cache-inventory.test.ts; before=    expect(result.stdout).not.toContain("planId");; after=    const human = await niceeval.run(["--", "docker", "cache", "inventory"], {; reason=只展开本 PR 改变的 domain kind 计数与 BuildKit 归属断言；同一 case 的命令发现、GC 和 legacy state 矩阵未改变。
```

### `e2e/cli/test/sandbox-action-debug.test.ts`

#### `e2e/cli/test/sandbox-action-debug.test.ts#necase_NVHTZ20RVFHTJWRJ`

安装后的 debug 能对单个 Eval 和整个 Experiment 输出无副作用的 command/setup-prefix plan。 It exercises niceeval debug sandbox-action-debug --json and asserts 批量结果包含两个具体 evalId、prefix identity 去重、真实 consumer，不含星号占位，也不声明 format/schemaVersion。. Deleting this case would allow 同时覆盖单 pair、敏感值脱敏、opaque barrier、无效依赖与不产生副作用。. The final contract is [docs/feature/experiments/cli.md#debug](docs/feature/experiments/cli.md#debug).

```ts
// … omitted: file=e2e/cli/test/sandbox-action-debug.test.ts; before=  "Persistent setup-prefix cache is unsupported for Docker Profile sandboxes and for read-only rootfs or tmpfs surfaces.";; after=interface DebugPlanDocument {; reason=从公开 debug JSON 类型开始展开至 case 的无副作用终态，覆盖本文件全部 changed final lines。
interface DebugPlanDocument {
  readonly experimentId: string;
  readonly evalId?: string;
  readonly evalIds: readonly string[];
  readonly setupPrefixPlan: {
    readonly lookup: "not-probed";
    readonly nodes: readonly (JsonRecord & {
      readonly prefixIdentity: string;
      readonly consumers: readonly { readonly experimentId: string; readonly evalId: string }[];
    })[];
  };
  readonly commandPlan: unknown;
}

function isRecord(value: unknown): value is JsonRecord {
  return typeof value === "object" && value !== null && !Array.isArray(value);
}

function recordsInPlan(value: unknown, records: JsonRecord[] = []): JsonRecord[] {
  if (Array.isArray(value)) {
    for (const item of value) recordsInPlan(item, records);
    return records;
  }
  if (!isRecord(value)) return records;
  records.push(value);
  for (const item of Object.values(value)) recordsInPlan(item, records);
  return records;
}

function actionProjection(node: JsonRecord): JsonRecord | undefined {
  return isRecord(node.action) ? node.action : undefined;
}

function actionId(node: JsonRecord): string | undefined {
  const action = actionProjection(node);
  if (typeof action?.id === "string") return action.id;
  return typeof node.actionId === "string" ? node.actionId : undefined;
}

function actionNodes(commandPlan: unknown): JsonRecord[] {
  return recordsInPlan(commandPlan).filter((node) => actionId(node) !== undefined);
}

function requireAction(nodes: readonly JsonRecord[], id: string): JsonRecord {
  const matches = nodes.filter((node) => actionId(node) === id);
  expect(matches, `action ${JSON.stringify(id)} must occur exactly once in the selected plan`).toHaveLength(1);
  return matches[0]!;
}

function requireRecord(value: unknown, label: string): JsonRecord {
  expect(isRecord(value), `${label} must be a structured object`).toBe(true);
  return value as JsonRecord;
}

function requireArray(value: unknown, label: string): readonly unknown[] {
  expect(Array.isArray(value), `${label} must be an array`).toBe(true);
  return value as readonly unknown[];
}

function valuesWithKeyPart(value: unknown, part: string, values: unknown[] = []): unknown[] {
  if (Array.isArray(value)) {
    for (const item of value) valuesWithKeyPart(item, part, values);
    return values;
  }
  if (!isRecord(value)) return values;
  for (const [key, item] of Object.entries(value)) {
    if (key.toLowerCase().includes(part.toLowerCase())) values.push(item);
    valuesWithKeyPart(item, part, values);
  }
  return values;
}

function expectOwner(node: JsonRecord, kind: string, id: string): void {
  expect(node.owner).toEqual({ kind, id });
  const declarationOrder = requireRecord(node.declarationOrder, `${id} declarationOrder`);
  expect(declarationOrder.owner).toEqual({ kind, id });
  expect(declarationOrder.ordinal).toEqual(expect.any(Number));
}

function expectPlannedCache(node: JsonRecord, id: string): JsonRecord {
  const cache = requireRecord(node.cache, `${id} cache`);
  expect(cache.lookup).toBe("not-probed");
  expect(cache.capability).toBe("unsupported");
  expect(cache.capabilityReason).toBe(EPHEMERAL_SETUP_PREFIX_REASON);
  expect(cache.runtime).toEqual({ status: "pending", finalKey: "not-probed" });
  return cache;
}

function expectScheduledAction(node: JsonRecord, id: string, frequency: number): void {
  const occurrence = requireRecord(node.occurrence, `${id} occurrence`);
  expect(occurrence.kind).toBe("attempt");
  const executionOrder = requireRecord(node.executionOrder, `${id} executionOrder`);
  expect(executionOrder.topologicalOrdinal).toEqual(expect.any(Number));
  expect(executionOrder.occurrencePath).toEqual(expect.any(Array));
  expect(node.changeFrequency).toEqual(expect.objectContaining({
    value: frequency,
    source: "explicit",
  }));
  expect(typeof node.schedulingReason).toBe("string");
  expectPlannedCache(node, id);
}

test("debug 交付统一且无副作用的 Sandbox action 计划 [necase_NVHTZ20RVFHTJWRJ]", async () => {
  await cliE2E.case("sandbox-action-debug", async ({ commands: { niceeval }, paths }) => {
    const sideEffects = join(paths.projectRoot, "sandbox-action-debug-side-effects.ndjson");
    const receipt = await niceeval.run([
      "debug",
      "sandbox-action-debug",
      "sandbox-action-debug/plan",
      "--json",
    ]);

    expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
    expect(receipt.stderr).toBe("");
    const document = receipt.json<DebugPlanDocument>();
    expect(document).toEqual(expect.objectContaining({
      experimentId: "sandbox-action-debug",
      evalId: "sandbox-action-debug/plan",
      evalIds: ["sandbox-action-debug/plan"],
    }));
    expect(document).not.toHaveProperty("format");
    expect(document).not.toHaveProperty("schemaVersion");
    expect(document.setupPrefixPlan.lookup).toBe("not-probed");
    expect(document.setupPrefixPlan.nodes.every((node) => node.lookup === "not-probed")).toBe(true);

    const nodes = actionNodes(document.commandPlan);
    const byId = new Map(nodes.map((node) => [actionId(node)!, node]));
    expect([...byId.keys()]).toEqual(expect.arrayContaining([
      "frequency-low",
      "frequency-high",
      "dependency-root",
      "dag-fast-dependent",
      "fingerprint-prototype-alpha",
      "fingerprint-prototype-beta",
      "fingerprint-constructor-beta",
      "builtin-fingerprint-alpha",
      "builtin-fingerprint-beta",
      "tie-experiment-first",
      "tie-experiment-second",
      "tie-eval-group",
      "tie-eval",
      "tie-agent",
      "agent-frequency-first",
      "sensitive-command",
      "opaque-barrier",
      "opaque-suffix",
    ]));

    expectOwner(requireAction(nodes, "tie-experiment-first"), "experiment", "sandbox-action-debug");
    expectOwner(requireAction(nodes, "tie-eval-group"), "eval-group", "sandbox-action-debug");
    expectOwner(requireAction(nodes, "tie-eval"), "eval", "sandbox-action-debug/plan");
    expectOwner(requireAction(nodes, "tie-agent"), "agent", "cli-sandbox-action-debug");

    for (const [id, frequency] of [
      ["frequency-low", 10],
      ["frequency-high", 40],
      ["dependency-root", 50],
      ["dag-fast-dependent", 1],
      ["fingerprint-prototype-alpha", 20],
      ["fingerprint-prototype-beta", 20],
      ["fingerprint-constructor-beta", 20],
      ["builtin-fingerprint-alpha", 20],
      ["builtin-fingerprint-beta", 20],
      ["tie-experiment-first", 100],
      ["tie-experiment-second", 100],
      ["tie-eval-group", 100],
      ["tie-eval", 100],
      ["tie-agent", 100],
      ["agent-frequency-first", 5],
      ["opaque-suffix", 300],
    ] as const) {
      expectScheduledAction(requireAction(nodes, id), id, frequency);
    }

    const dependent = requireAction(nodes, "dag-fast-dependent");
    const dependencies = requireArray(dependent.dependencies, "dag-fast-dependent dependencies");
    expect(dependencies).toHaveLength(1);
    expect(JSON.stringify(dependencies[0])).toContain("dependency-root");
    expect(dependencies[0]).toEqual(expect.objectContaining({ source: "explicit" }));

    const orderedIds = nodes.map((node) => actionId(node)!);
    const index = (id: string): number => orderedIds.indexOf(id);
    expect(index("frequency-low")).toBeLessThan(index("frequency-high"));
    expect(index("agent-frequency-first")).toBeLessThan(index("frequency-low"));
    expect(index("dependency-root")).toBeLessThan(index("dag-fast-dependent"));
    expect([
      index("tie-experiment-first"),
      index("tie-experiment-second"),
      index("tie-eval-group"),
      index("tie-eval"),
      index("tie-agent"),
    ]).toEqual([...[
      index("tie-experiment-first"),
      index("tie-experiment-second"),
      index("tie-eval-group"),
      index("tie-eval"),
      index("tie-agent"),
    ]].sort((left, right) => left - right));

    const exact = requireAction(nodes, "tie-experiment-first");
    expect(exact.truth).toBe("exact");
    const exactAction = requireRecord(exact.action, "tie-experiment-first action");
    expect(exactAction.family).toBe("@niceeval/e2e-cli/sandbox-action-debug");
    const steps = requireArray(exactAction.steps, "tie-experiment-first steps");
    expect(steps).toHaveLength(2);
    expect(steps[0]).toEqual({
      kind: "exec",
      executable: "printf",
      args: ["%s", "tie-experiment-first"],
    });
    expect(steps[1]).toEqual(expect.objectContaining({
      kind: "putText",
      path: ".debug-plan/tie-experiment-first.txt",
      digest: expect.stringMatching(/^sha256:/),
      bytes: "tie-experiment-first".length,
    }));
    expect(valuesWithKeyPart(exactAction, "automatic")).not.toEqual([]);
    const supplemental = valuesWithKeyPart(exactAction, "supplemental");
    expect(supplemental).not.toEqual([]);
    expect(supplemental.every((value) => value !== null && value !== "none")).toBe(true);

    const prototypeAlpha = requireRecord(
      requireAction(nodes, "fingerprint-prototype-alpha").action,
      "fingerprint-prototype-alpha action",
    );
    const prototypeBeta = requireRecord(
      requireAction(nodes, "fingerprint-prototype-beta").action,
      "fingerprint-prototype-beta action",
    );
    const constructorBeta = requireRecord(
      requireAction(nodes, "fingerprint-constructor-beta").action,
      "fingerprint-constructor-beta action",
    );
    const alphaFingerprint = requireRecord(prototypeAlpha.fingerprint, "prototype alpha fingerprint");
    const prototypeBetaFingerprint = requireRecord(
      prototypeBeta.fingerprint,
      "prototype beta fingerprint",
    );
    const constructorBetaFingerprint = requireRecord(
      constructorBeta.fingerprint,
      "constructor beta fingerprint",
    );
    expect([
      alphaFingerprint.automatic,
      prototypeBetaFingerprint.automatic,
      constructorBetaFingerprint.automatic,
    ]).toEqual([
      alphaFingerprint.automatic,
      alphaFingerprint.automatic,
      alphaFingerprint.automatic,
    ]);
    expect(new Set([
      alphaFingerprint.supplemental,
      prototypeBetaFingerprint.supplemental,
      constructorBetaFingerprint.supplemental,
    ]).size).toBe(3);
    expect(new Set([
      alphaFingerprint.combined,
      prototypeBetaFingerprint.combined,
      constructorBetaFingerprint.combined,
    ]).size).toBe(3);

    const builtinAlpha = requireRecord(
      requireRecord(requireAction(nodes, "builtin-fingerprint-alpha").action, "builtin alpha action").fingerprint,
      "builtin alpha fingerprint",
    );
    const builtinBeta = requireRecord(
      requireRecord(requireAction(nodes, "builtin-fingerprint-beta").action, "builtin beta action").fingerprint,
      "builtin beta fingerprint",
    );
    expect(builtinAlpha.automatic).toEqual(expect.stringMatching(/^sha256:[0-9a-f]{64}$/u));
    expect(builtinBeta.automatic).toBe(builtinAlpha.automatic);
    expect(builtinBeta.supplemental).not.toBe(builtinAlpha.supplemental);
    expect(builtinBeta.combined).not.toBe(builtinAlpha.combined);

    const sensitive = requireRecord(requireAction(nodes, "sensitive-command").action, "sensitive-command action");
    expect(sensitive.family).toBe("niceeval.sandbox.command");
    const sensitiveInput = requireRecord(sensitive.input, "sensitive-command input");
    expect(sensitiveInput.envKeysJson).toBe(JSON.stringify([PRIVATE_ENV_KEY]));
    expect(sensitiveInput.envDigest).toEqual(expect.stringMatching(/^sha256:[0-9a-f]{64}$/u));
    expect(sensitiveInput.stdinDigest).toEqual(expect.stringMatching(/^sha256:[0-9a-f]{64}$/u));
    expect(sensitiveInput.stdinBytes).toBe(Buffer.byteLength(PRIVATE_STDIN));
    const sensitiveSteps = requireArray(sensitive.steps, "sensitive-command steps");
    expect(sensitiveSteps).toEqual([
      expect.objectContaining({
        kind: "exec",
        envKeys: [PRIVATE_ENV_KEY],
        stdinDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
        stdinBytes: Buffer.byteLength(PRIVATE_STDIN),
      }),
    ]);
    const serializedPlan = JSON.stringify(document);
    expect(serializedPlan).toContain(PRIVATE_ENV_KEY);
    expect(serializedPlan).not.toContain(PRIVATE_ENV_VALUE);
    expect(serializedPlan).not.toContain(PRIVATE_STDIN.trim());

    const barrier = requireAction(nodes, "opaque-barrier");
    expect(barrier.truth).toBe("opaque");
    expect(index("opaque-barrier")).toBeLessThan(index("opaque-suffix"));
    const suffixCache = expectPlannedCache(requireAction(nodes, "opaque-suffix"), "opaque-suffix");
    expect(JSON.stringify(suffixCache.eligibility)).toContain("opaque-ancestor");

    const ensureNodes = recordsInPlan(document.commandPlan).filter((node) => node.phase === "agent.ensure");
    const ensureParents = ensureNodes.filter((node) => node.truth === "conditional");
    expect(ensureParents).toHaveLength(1);
    expect(ensureParents[0]).toEqual(expect.objectContaining({
      truth: "conditional",
      owner: { kind: "agent", id: "cli-sandbox-action-debug" },
    }));
    expect(actionId(ensureParents[0]!)).toBeUndefined();
    const ensureChildren = requireArray(ensureParents[0]!.children, "agent.ensure children")
      .map((child, index) => requireRecord(child, `agent.ensure child ${index}`));
    expect(ensureChildren).toHaveLength(2);
    expect(ensureChildren[0]).toEqual(expect.objectContaining({
      phase: "agent.ensure",
      truth: "opaque",
      label: "probe #0",
      owner: { kind: "agent", id: "cli-sandbox-action-debug" },
    }));
    expect(ensureChildren[1]).toEqual(expect.objectContaining({
      phase: "agent.ensure",
      truth: "known-no-command",
      label: "install #0",
      owner: { kind: "agent", id: "cli-sandbox-action-debug" },
      condition: expect.objectContaining({ code: "probe-miss" }),
    }));
    expect(ensureNodes).toHaveLength(1 + ensureChildren.length);
    expect(nodes.some((node) => actionId(node) === "debug-agent-probe")).toBe(false);

    const human = await niceeval.run([
      "debug",
      "sandbox-action-debug",
      "sandbox-action-debug/plan",
    ]);
    expect(human.exitCode, human.diagnostic()).toBe(0);
    expect(human.stderr).toBe("");
    expect(human.stdout).toContain("COMMAND PLAN");
    expect(human.stdout).toContain("agent.ensure");
    expect(human.stdout).toContain("action: frequency-low");
    expect(human.stdout).toContain("change frequency: 10 · explicit · rare");
    expect(human.stdout).toContain("action: dag-fast-dependent");
    expect(human.stdout).toContain("change frequency: 1 · explicit");
    expect(human.stdout).toContain("execution order: #");
    expect(human.stdout).toContain("cache: not-probed · unsupported · runtime pending · final key not-probed");
    expect(human.stdout.replace(/\s+/gu, "")).toContain(
      `cache unsupported reason: ${EPHEMERAL_SETUP_PREFIX_REASON}`.replace(/\s+/gu, ""),
    );
    expect(human.stdout).not.toContain(" · eligible");
    expect(human.stdout).not.toContain(" · ineligible:");
    expect(human.stdout.indexOf("action: frequency-low"))
      .toBeLessThan(human.stdout.indexOf("action: frequency-high"));
    expect(human.stdout.indexOf("action: agent-frequency-first"))
      .toBeLessThan(human.stdout.indexOf("action: frequency-low"));
    expect(human.stdout.indexOf("action: dependency-root"))
      .toBeLessThan(human.stdout.indexOf("action: dag-fast-dependent"));
    expect([
      human.stdout.indexOf("action: tie-experiment-first"),
      human.stdout.indexOf("action: tie-experiment-second"),
      human.stdout.indexOf("action: tie-eval-group"),
      human.stdout.indexOf("action: tie-eval"),
      human.stdout.indexOf("action: tie-agent"),
    ]).toEqual([...[
      human.stdout.indexOf("action: tie-experiment-first"),
      human.stdout.indexOf("action: tie-experiment-second"),
      human.stdout.indexOf("action: tie-eval-group"),
      human.stdout.indexOf("action: tie-eval"),
      human.stdout.indexOf("action: tie-agent"),
    ]].sort((left, right) => left - right));
    expect(human.stdout).toContain("step #0: argv");
    expect(human.stdout).toContain("step #1: putText");
    expect(human.stdout).toContain(`environment keys: [${JSON.stringify(PRIVATE_ENV_KEY)}`);
    expect(human.stdout).toContain("stdin: sha256:");
    expect(human.stdout).not.toContain(PRIVATE_ENV_VALUE);
    expect(human.stdout).not.toContain(PRIVATE_STDIN.trim());

    await copyFile(
      join(paths.projectRoot, "fixtures", "sandbox-action-debug-invalid.ts"),
      join(paths.projectRoot, "experiments", "sandbox-action-debug-invalid.ts"),
    );
    const invalid = await niceeval.run([
      "debug",
      "sandbox-action-debug-invalid",
      "sandbox-action-debug/plan",
      "--json",
    ]);
    expect(invalid.exitCode, invalid.diagnostic()).not.toBe(0);
    expect(invalid.stdout).toBe("");
    expect(invalid.stderr).toContain("sandbox.before-planning-failed");
    expect(invalid.stderr).toContain("dependency-cycle");
    expect(invalid.stderr).toContain("invalid-cycle-a");
    expect(invalid.stderr).toContain("invalid-cycle-b");
    expect(invalid.stderr).not.toContain("defect");

    const wholeExperiment = await niceeval.run(["debug", "sandbox-action-debug", "--json"]);
    expect(wholeExperiment.exitCode, wholeExperiment.diagnostic()).toBe(0);
    const wholeDocument = wholeExperiment.json<DebugPlanDocument>();
    expect(wholeDocument).toEqual(expect.objectContaining({
      experimentId: "sandbox-action-debug",
      evalIds: ["sandbox-action-debug/plan", "sandbox-action-debug/secondary"],
      setupPrefixPlan: expect.objectContaining({ lookup: "not-probed" }),
    }));
    expect(wholeDocument).not.toHaveProperty("evalId");
    expect(new Set(wholeDocument.setupPrefixPlan.nodes.map((node) => node.prefixIdentity)).size)
      .toBe(wholeDocument.setupPrefixPlan.nodes.length);
    const consumerEvalIds = new Set(wholeDocument.setupPrefixPlan.nodes.flatMap((node) =>
      node.consumers.map((consumer) => consumer.evalId)));
    expect(consumerEvalIds).toEqual(new Set([
      "sandbox-action-debug/plan",
      "sandbox-action-debug/secondary",
    ]));
    expect(consumerEvalIds).not.toContain("*");

    await expect(access(sideEffects)).rejects.toMatchObject({ code: "ENOENT" });
// … omitted: file=e2e/cli/test/sandbox-action-debug.test.ts; before=    await expect(access(sideEffects)).rejects.toMatchObject({ code: "ENOENT" });; after=  });; reason=从公开 debug JSON 类型开始展开至 case 的无副作用终态，覆盖本文件全部 changed final lines。
```

### `e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts`

#### `e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts#necase_Q373EF5FD0JC84RE`

真实 Docker setup-prefix 在 cold build、完整命中和部分重建后提供一致的 inventory 与 Invocation 终态汇总。 It exercises niceeval exp setup-prefix-cache --rerun all --json and asserts terminal summary 按唯一 node 满足 total = hit + prepared + failed；inventory 展示安全的 sandbox-setup-prefix identity，GC candidates 仍为空。. Deleting this case would allow 同时验证轻量 InvocationReceipt 不携带 summary、human 汇总一致、lease/root 活性字段与私有字段不泄露。. The final contract is [docs/feature/sandbox/architecture.md#准备前缀的身份与验证边界](docs/feature/sandbox/architecture.md#准备前缀的身份与验证边界).

```ts
// … omitted: file=e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts; before=    readonly argv?: readonly string[];; after=type SetupPrefixSummary = ReturnType<ProcessReceipt["expTerminal"]>["summary"]["setupPrefixes"];; reason=展开本 PR 为既有 Docker Journey 增加的公开 terminal decoder、inventory helper、轻量 receipt、命中结算与 human summary 全部 changed final lines；后续取消与并发矩阵未改变。
type SetupPrefixSummary = ReturnType<ProcessReceipt["expTerminal"]>["summary"]["setupPrefixes"];

function setupPrefixSummary(receipt: ProcessReceipt): SetupPrefixSummary {
  const setup = receipt.expTerminal().summary.setupPrefixes;
  expect(setup.total, receipt.diagnostic()).toBe(setup.hit + setup.prepared + setup.failed);
  return setup;
}

function humanSetupPrefixLine(summary: SetupPrefixSummary): string {
  return `Setup prefixes: ${summary.hit} hit · ${summary.prepared} prepared · ${summary.failed} failed (${summary.total} total)`;
}

const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
const docker = command(["docker"]);
const binary = resolve("node_modules/.bin/niceeval");
const projectCopy = {
  from: process.cwd(),
  prefix: "niceeval-e2e-setup-prefix-project-",
  omitTopLevel: [".niceeval", "node_modules", "test"],
  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
} as const;

function decodeEvidence(trace: QuerySuccessDocumentFor<"attempt.trace">["trace"]): SetupPrefixEvidence {
  const messages = trace.conversation.items.flatMap((item) => item.kind === "message" ? [item] : []);
  const evidenceMessages = messages.filter((item) => item.text.includes("setup-prefix-evidence:"));
  expect(evidenceMessages, "public Inspection trace must expose exactly one Agent evidence message").toHaveLength(1);
  expect(evidenceMessages[0]!.textTruncated, "public Agent evidence must fit the stable trace projection").toBe(false);
  const encoded = new Set(
    [...evidenceMessages[0]!.text.matchAll(/setup-prefix-evidence:([A-Za-z0-9_-]+)/gu)].map((match) => match[1]!),
  );
  expect(encoded.size, "public Inspection trace must expose exactly one Agent evidence payload").toBe(1);
  const value = JSON.parse(Buffer.from([...encoded][0]!, "base64url").toString("utf8")) as Partial<SetupPrefixEvidence>;
  for (const key of [
    "baseVersion",
    "runtimeMode",
    "canonicalToken",
    "buildToken",
    "fixtureToken",
    "middleToken",
    "middleVersion",
    "envToken",
    "publicEnv",
    "fixture",
    "demand",
    "sandboxId",
  ] as const) {
    expect(value[key], `${key} must be a non-empty public evidence string`).toEqual(expect.any(String));
    expect(value[key]!.length, `${key} must be non-empty`).toBeGreaterThan(0);
  }
  return value as SetupPrefixEvidence;
}

async function waitForSandboxGone(sandboxId: string, cwd: string): Promise<void> {
  await pollUntil(
    async () => {
      const inspected = await docker.run(["inspect", sandboxId], { cwd });
      return inspected.exitCode !== 0 ? true : undefined;
    },
    { timeoutMs: 15_000, intervalMs: 100, label: `private SetupPrefix clone ${sandboxId} to be removed` },
  );
}

async function containersForInvocation(pid: number, cwd: string): Promise<readonly string[]> {
  const result = await docker.run([
    "ps", "-a", "--filter", `label=niceeval.pid=${pid}`, "--format", "{{.ID}}",
  ], { cwd });
  expect(result.exitCode, result.diagnostic()).toBe(0);
  return result.stdout.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
}

type SetupPrefixResumeLayer = 1 | 2 | 3;

const layerTokenPaths = [
  ".setup-prefix/fixture-token",
  ".setup-prefix/middle-token",
  ".setup-prefix/env-token",
] as const;

async function waitForResumeGate(
  pid: number,
  root: string,
  afterLayer: SetupPrefixResumeLayer,
): Promise<string> {
  const gate = `.setup-prefix/resume-after-${afterLayer}`;
  return pollUntil(
    async () => {
      for (const id of await containersForInvocation(pid, root)) {
        const reached = await docker.run([
          "exec",
          id,
          "sh",
          "-lc",
          `test -f ${gate}/entered && test -p ${gate}/release.fifo`,
        ], { cwd: root });
        if (reached.exitCode === 0) return id;
      }
      return undefined;
    },
    { timeoutMs: 180_000, intervalMs: 25, label: `Docker setup-prefix gate after layer ${afterLayer}` },
  );
}

async function readPublishedLayerTokens(
  containerId: string,
  root: string,
  completedLayers: SetupPrefixResumeLayer,
): Promise<readonly string[]> {
  const paths = layerTokenPaths.slice(0, completedLayers);
  const result = await docker.run([
    "exec",
    containerId,
    "sh",
    "-lc",
    paths.map((path) => `cat ${path}; printf '\\n'`).join("; "),
  ], { cwd: root });
  expect(result.exitCode, result.diagnostic()).toBe(0);
  const tokens = result.stdout.trim().split(/\r?\n/u);
  expect(tokens, result.diagnostic()).toHaveLength(completedLayers);
  for (const token of tokens) expect(token).toMatch(/^[0-9a-f-]{36}$/u);
  return tokens;
}

async function releaseResumeGate(
  containerId: string,
  root: string,
  afterLayer: SetupPrefixResumeLayer,
): Promise<void> {
  const gate = `.setup-prefix/resume-after-${afterLayer}`;
  const released = await docker.run([
    "exec",
    containerId,
    "sh",
    "-lc",
    `printf 'release\\n' > ${gate}/release.fifo`,
  ], { cwd: root, timeoutMs: 15_000 });
  expect(released.exitCode, released.diagnostic()).toBe(0);
}

function evidenceLayerTokens(evidence: SetupPrefixEvidence): readonly string[] {
  return [evidence.fixtureToken, evidence.middleToken, evidence.envToken];
}

async function readIncusJournal(path: string): Promise<readonly IncusJournalRecord[]> {
  try {
    return (await readFile(path, "utf8")).trim().split("\n").filter(Boolean)
      .map((line) => JSON.parse(line) as IncusJournalRecord);
  } catch (cause) {
    if (typeof cause === "object" && cause !== null && Reflect.get(cause, "code") === "ENOENT") return [];
    throw cause;
  }
}

function incusExecCount(records: readonly IncusJournalRecord[], marker: string): number {
  return records.filter((record) => record.event === "exec" && record.detail.argv?.join(" ").includes(marker)).length;
}

interface InvokeOptions {
  readonly image?: string;
  readonly baseVersion?: string;
  readonly mode?:
    | "default"
    | "dynamic-tools"
    | "external-tmpfs"
    | "contention"
    | "capture-cancellation"
    | "layer-resume"
    | "canonical-json";
  readonly canonicalVariant?: "alpha" | "beta";
  readonly middleVersion?: "alpha" | "beta";
  readonly cancelAfter?: SetupPrefixResumeLayer;
  readonly niceevalHome?: string;
}

function invocationEnvironment(
  root: string,
  publicEnv: "PUBLIC_MODE=alpha\n" | "PUBLIC_MODE=beta\n",
  options: InvokeOptions,
): NodeJS.ProcessEnv {
  const mode = options.mode ?? "default";
  return {
    NICEEVAL_E2E_SETUP_PREFIX_PUBLIC_ENV: publicEnv,
    NICEEVAL_E2E_SETUP_PREFIX_MODE: mode,
    ...(options.image === undefined ? {} : { NICEEVAL_E2E_SETUP_PREFIX_IMAGE: options.image }),
    ...(options.canonicalVariant === undefined
      ? {}
      : { NICEEVAL_E2E_SETUP_PREFIX_CANONICAL_VARIANT: options.canonicalVariant }),
    ...(options.middleVersion === undefined
      ? {}
      : { NICEEVAL_E2E_SETUP_PREFIX_MIDDLE_VERSION: options.middleVersion }),
    ...(options.cancelAfter === undefined
      ? {}
      : { NICEEVAL_E2E_SETUP_PREFIX_CANCEL_AFTER: String(options.cancelAfter) }),
    NICEEVAL_HOME: options.niceevalHome ?? join(root, ".niceeval-user"),
  };
}

async function invoke(
  root: string,
  demand: "v1" | "v2",
  publicEnv: "PUBLIC_MODE=alpha\n" | "PUBLIC_MODE=beta\n",
  options: InvokeOptions = {},
): Promise<SetupPrefixEvidence> {
  return (await invokeDetailed(root, demand, publicEnv, options)).evidence;
}

async function invokeDetailed(
  root: string,
  demand: "v1" | "v2",
  publicEnv: "PUBLIC_MODE=alpha\n" | "PUBLIC_MODE=beta\n",
  options: InvokeOptions = {},
): Promise<{
  readonly evidence: SetupPrefixEvidence;
  readonly diagnostic: string;
  readonly setupPrefixes: SetupPrefixSummary;
}> {
  const invocationEnv = invocationEnvironment(root, publicEnv, options);
  const run = await niceeval.run(["exp", "setup-prefix-cache", "--rerun", "all", "--json"], {
    cwd: root,
    env: invocationEnv,
    timeoutMs: 360_000,
  });
  return inspectCompletedInvocation(root, demand, publicEnv, options, invocationEnv, run);
}

async function assertSetupPrefixInventory(root: string, niceevalHome: string): Promise<void> {
  const env = { NICEEVAL_HOME: niceevalHome };
  const inventory = await niceeval.run(["docker", "cache", "inventory", "--json"], { cwd: root, env });
  expect(inventory.exitCode, inventory.diagnostic()).toBe(0);
  const document = JSON.parse(inventory.stdout) as {
    readonly domains: readonly { readonly domainId: string; readonly entryKinds: { readonly sandboxSetupPrefix: number } }[];
  };
  const domain = only(document.domains, (candidate) => candidate.entryKinds.sandboxSetupPrefix > 0, inventory.diagnostic());
  const detail = await niceeval.run([
    "docker", "cache", "inventory", "--domain", domain.domainId, "--json",
  ], { cwd: root, env });
  expect(detail.exitCode, detail.diagnostic()).toBe(0);
  const entries = (JSON.parse(detail.stdout) as { readonly entries: readonly Record<string, unknown>[] }).entries
    .filter((entry) => entry.kind === "sandbox-setup-prefix");
  expect(entries.length, detail.diagnostic()).toBeGreaterThan(0);
  for (const entry of entries) {
    expect(entry).toMatchObject({
      kind: "sandbox-setup-prefix",
      state: "indexed",
      identity: {
        entryId: expect.any(String),
        setupPrefixKey: expect.stringMatching(/^prefix:[a-f0-9]{64}$/u),
        imageId: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
        baseImageId: expect.stringMatching(/^sha256:[a-f0-9]{64}$/u),
      },
      leaseCount: 0,
      rootCount: 0,
      liveLeaseCount: 0,
      unverifiedLeaseCount: 0,
      liveRootCount: 0,
      unverifiedRootCount: 0,
    });
    expect(Object.keys(entry).sort()).toEqual([
      "createdAt", "identity", "kind", "lastSuccessfulUseAt", "leaseCount", "liveLeaseCount",
      "liveRootCount", "protectedUntil", "rootCount", "state", "unverifiedLeaseCount", "unverifiedRootCount",
    ]);
  }
  expect(detail.stdout).not.toMatch(/declaration|holder|operationId|manifestDigest/iu);

  const human = await niceeval.run(["docker", "cache", "inventory", "--domain", domain.domainId], { cwd: root, env });
  expect(human.exitCode, human.diagnostic()).toBe(0);
  expect(human.stdout).toContain("sandbox-setup-prefix · indexed");
  expect(human.stdout).toContain("0 leases (0 live, 0 unverified) · 0 roots (0 live, 0 unverified)");
  expect(human.stdout).not.toMatch(/declaration|holder|operationId|manifestDigest/iu);

  const preview = await niceeval.run([
    "docker", "cache", "gc", "--domain", domain.domainId, "--json",
  ], { cwd: root, env });
  expect(preview.exitCode, preview.diagnostic()).toBe(0);
  const plan = (JSON.parse(preview.stdout) as { readonly plan: { readonly planId: string; readonly candidates: readonly unknown[] } }).plan;
  expect(plan.candidates).toEqual([]);
  const apply = await niceeval.run([
    "docker", "cache", "gc", "--domain", domain.domainId, "--apply", plan.planId, "--json",
  ], { cwd: root, env });
  expect(apply.exitCode, apply.diagnostic()).toBe(0);
  expect(JSON.parse(apply.stdout)).toMatchObject({ format: "niceeval.cache-gc-outcome", outcomes: [] });
}

async function inspectCompletedInvocation(
  root: string,
  demand: "v1" | "v2",
  publicEnv: "PUBLIC_MODE=alpha\n" | "PUBLIC_MODE=beta\n",
  options: InvokeOptions,
  invocationEnv: NodeJS.ProcessEnv,
  run: ProcessReceipt,
): Promise<{
  readonly evidence: SetupPrefixEvidence;
  readonly diagnostic: string;
  readonly setupPrefixes: SetupPrefixSummary;
}> {
  const mode = options.mode ?? "default";
  expect(run.exitCode, run.diagnostic()).toBe(0);
  expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
  expect(run.expReceipt(), "InvocationReceipt must remain a lightweight hand-off")
    .not.toHaveProperty("setupPrefixes");
  const setupPrefixes = setupPrefixSummary(run);
  const evaluation = only(
    run.expEvalEvents(),
    (event) => event.evalId === "setup-prefix-cache",
    run.diagnostic(),
  );
  expect(evaluation, run.diagnostic()).toMatchObject({
    experimentId: "setup-prefix-cache",
    verdict: "passed",
    attempts: 1,
    passed: 1,
  });

  const inspected = await inspectAttempt(
    niceeval, root, evaluation.locator, "attempt.trace", { cwd: root, env: invocationEnv },
  );
  expect(inspected.receipt.exitCode, inspected.receipt.diagnostic()).toBe(0);
  const traceDocument = inspected.receipt.attemptTrace();
  expect(traceDocument).toMatchObject({
    protocol: "niceeval.query/v1",
    operation: "attempt.trace",
  });
  const evidence = decodeEvidence(traceDocument.trace);
  expect(evidence).toMatchObject({
    demand,
    publicEnv,
    fixture: "stable setup-prefix fixture\n",
    baseVersion: options.baseVersion ?? "default",
    runtimeMode: mode,
    canonicalToken: mode === "canonical-json" ? expect.any(String) : "not-requested",
    middleVersion: options.middleVersion ?? "alpha",
  });
  await waitForSandboxGone(evidence.sandboxId, root);
  return { evidence, diagnostic: run.diagnostic(), setupPrefixes };
}

async function interruptAfterPublishedLayer(
  root: string,
  afterLayer: SetupPrefixResumeLayer,
  options: InvokeOptions,
): Promise<{ readonly tokens: readonly string[]; readonly diagnostic: string }> {
  const invocationEnv = invocationEnvironment(root, "PUBLIC_MODE=alpha\n", options);
  const interrupted = await withProcess(
    [binary, "exp", "setup-prefix-cache", "--rerun", "all", "--json"],
    {
      cwd: root,
      env: invocationEnv,
      processGroup: true,
      timeoutMs: 360_000,
      graceMs: 10_000,
    },
    async (controlled) => {
      const pid = controlled.pid;
      expect(pid, "NiceEval invocation must expose its provider ownership pid").toEqual(expect.any(Number));
      const containerId = await waitForResumeGate(pid!, root, afterLayer);
      const tokens = await readPublishedLayerTokens(containerId, root, afterLayer);
      expect(controlled.signal("SIGINT")).toBe(true);
      const receipt = await controlled.done;
      expect(receipt.exitCode, receipt.diagnostic()).toBe(130);
      expect(receipt.expReceipt(), receipt.diagnostic()).toMatchObject({ completion: "interrupted" });
      return { pid: pid!, tokens, diagnostic: receipt.diagnostic() };
    },
  );
  await pollUntil(
    async () => (await containersForInvocation(interrupted.pid, root)).length === 0 ? true : undefined,
    { timeoutMs: 15_000, intervalMs: 100, label: `cancelled layer-${afterLayer} staging cleanup` },
  );
  return { tokens: interrupted.tokens, diagnostic: interrupted.diagnostic };
}

async function retryAndReleaseLayerGate(
  root: string,
  afterLayer: SetupPrefixResumeLayer,
  options: InvokeOptions,
): Promise<{ readonly evidence: SetupPrefixEvidence; readonly diagnostic: string }> {
  const invocationEnv = invocationEnvironment(root, "PUBLIC_MODE=alpha\n", options);
  const receipt = await withProcess(
    [binary, "exp", "setup-prefix-cache", "--rerun", "all", "--json"],
    {
      cwd: root,
      env: invocationEnv,
      processGroup: true,
      timeoutMs: 360_000,
      graceMs: 10_000,
    },
    async (controlled) => {
      const pid = controlled.pid;
      expect(pid, "NiceEval retry must expose its provider ownership pid").toEqual(expect.any(Number));
      const containerId = await waitForResumeGate(pid!, root, afterLayer);
      await releaseResumeGate(containerId, root, afterLayer);
      return controlled.done;
    },
  );
  return inspectCompletedInvocation(
    root,
    "v1",
    "PUBLIC_MODE=alpha\n",
    options,
    invocationEnv,
    receipt,
  );
}

// Every case owns a private project copy, NiceEval home, image identity, and
// process-labelled containers. Keep the real Docker coverage while allowing
// Vitest to overlap these otherwise independent provider journeys.
test.concurrent("独立 Invocation 只重新执行变化的 Sandbox setup 后缀，并为每个 Attempt 提供私有 writable clone [necase_Q373EF5FD0JC84RE]", async () => {
  await withTempDir("niceeval-e2e-setup-prefix-owner-home-", async (niceevalHome) =>
    withProjectCopy(projectCopy, async ({ root }) => {
      // A unique context byte makes the first invocation a true cold BuildKey even
      // when a reliability repetition reuses the same host Docker daemon.
      await writeFile(
        join(root, "fixtures/setup-prefix/image/build-seed.txt"),
        `${randomUUID()}\n`,
        "utf8",
      );

      const coldRun = await invokeDetailed(root, "v1", "PUBLIC_MODE=alpha\n", { niceevalHome });
      const cold = coldRun.evidence;
      await assertSetupPrefixInventory(root, niceevalHome);

      const evalPath = join(root, "evals/setup-prefix-cache.eval.ts");
      const originalEval = await readFile(evalPath, "utf8");
      const changedEval = originalEval.replace('const DEMAND = "v1";', 'const DEMAND = "v2";');
      expect(changedEval, "the private project copy must change the Eval result demand").not.toBe(originalEval);
      await writeFile(evalPath, changedEval, "utf8");

      const changedDemandRun = await invokeDetailed(root, "v2", "PUBLIC_MODE=alpha\n", { niceevalHome });
      const changedDemand = changedDemandRun.evidence;
      expect(changedDemandRun.setupPrefixes.hit).toBe(changedDemandRun.setupPrefixes.total);
      expect(changedDemandRun.setupPrefixes.prepared).toBe(0);
      expect(changedDemandRun.setupPrefixes.failed).toBe(0);
      const demandDiagnostic = `${coldRun.diagnostic}\n${changedDemandRun.diagnostic}`;
      expect(changedDemand.buildToken, demandDiagnostic).toBe(cold.buildToken);
      expect(changedDemand.fixtureToken, demandDiagnostic).toBe(cold.fixtureToken);
      expect(changedDemand.middleToken, demandDiagnostic).toBe(cold.middleToken);
      expect(changedDemand.envToken, demandDiagnostic).toBe(cold.envToken);

      const changedMiddle = await invokeDetailed(root, "v2", "PUBLIC_MODE=alpha\n", {
        middleVersion: "beta",
        niceevalHome,
      });
      expect(changedMiddle.setupPrefixes.hit).toBe(0);
      expect(changedMiddle.setupPrefixes.prepared).toBe(changedMiddle.setupPrefixes.total);
      expect(changedMiddle.setupPrefixes.failed).toBe(0);
      expect(changedMiddle.evidence.buildToken).toBe(cold.buildToken);
      expect(changedMiddle.evidence.fixtureToken).toBe(cold.fixtureToken);
      expect(changedMiddle.evidence.middleToken).not.toBe(changedDemand.middleToken);
      expect(changedMiddle.evidence.envToken).not.toBe(changedDemand.envToken);

      const changedEnv = await invokeDetailed(root, "v2", "PUBLIC_MODE=beta\n", {
        middleVersion: "beta",
        niceevalHome,
      });
      expect(changedEnv.evidence.buildToken).toBe(cold.buildToken);
      expect(changedEnv.evidence.fixtureToken).toBe(cold.fixtureToken);
      expect(changedEnv.evidence.middleToken).toBe(changedMiddle.evidence.middleToken);
      expect(changedEnv.evidence.envToken).not.toBe(changedMiddle.evidence.envToken);

      const human = await niceeval.run(["exp", "setup-prefix-cache", "--rerun", "all"], {
        cwd: root,
        env: invocationEnvironment(root, "PUBLIC_MODE=beta\n", {
          middleVersion: "beta",
          niceevalHome,
        }),
        timeoutMs: 360_000,
      });
      expect(human.exitCode, human.diagnostic()).toBe(0);
      expect(human.stdout).toContain(humanSetupPrefixLine(changedDemandRun.setupPrefixes));

      expect(new Set([
        cold.sandboxId,
        changedDemand.sandboxId,
        changedMiddle.evidence.sandboxId,
        changedEnv.evidence.sandboxId,
      ]).size).toBe(4);
// … omitted: file=e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts; before=      ]).size).toBe(4);; after=    }),; reason=展开本 PR 为既有 Docker Journey 增加的公开 terminal decoder、inventory helper、轻量 receipt、命中结算与 human summary 全部 changed final lines；后续取消与并发矩阵未改变。
```

### `e2e/runner/test/timing.test.ts`

#### `e2e/runner/test/timing.test.ts#necase_EP0HS2HD783EN64J`

Attempt reservation 后若最终持久化失败，公开终态不会把 provisional locator 当作可检查事实。 It exercises niceeval exp completion-persistence-failure --rerun all --json and asserts 命令失败并给出 persistence/publication diagnostic，stdout/stderr 不出现 @Attempt locator。. Deleting this case would allow 测试通过真实项目 Record staging 文件触发完成写入失败，并用公开 query 证明任何泄漏 locator 都不可查询。. The final contract is [docs/feature/experiments/README.md](docs/feature/experiments/README.md). It also prevents the regression recorded in [memory/unpublished-attempt-locator.md](memory/unpublished-attempt-locator.md).

```ts
// rerun: pnpm e2e test --repo runner -- --run test/timing.test.ts
import {
  assertExpEvalOutcomes,
  exactEval,
  only,
} from "@niceeval/testkit";
import { readFile } from "node:fs/promises";
import { join } from "node:path";
import { expect, test } from "vitest";
import { runnerE2E, writeInspectionRequest } from "./context.ts";

const EXPECTED = [
  { experimentId: "timing", evalId: "timing/basic", verdict: "passed", attempts: 1, passed: 1 },
] as const;

async function receiptLines(root: string, name: string): Promise<string[]> {
  return (await readFile(join(root, name), "utf8"))
    .split("\n")
    .filter((line) => line !== "");
}

test("通用 Runner 公开 Agent setup、send、teardown 的完成与失败关系 [necase_21VCRD4WKW8K1E66]", async () => {
  await runnerE2E.case(
    "generic-timing",
    {
      artifacts: [
        { source: ".niceeval", target: ".niceeval", optional: true },
        { source: "timing-setup-failure.ndjson", target: "timing-setup-failure.ndjson" },
        { source: "timing-no-setup.ndjson", target: "timing-no-setup.ndjson" },
        {
          source: "timing-setup-teardown-failure.ndjson",
          target: "timing-setup-teardown-failure.ndjson",
        },
        {
          source: "timing-send-teardown-failure.ndjson",
          target: "timing-send-teardown-failure.ndjson",
        },
      ],
    },
    async ({ commands: { niceeval }, paths }) => {
      const run = await niceeval.run(["exp", "timing", "--rerun", "all", "--json"]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      const receipt = run.expReceipt();
      expect(receipt.completion, run.diagnostic()).toBe("completed");
      const events = assertExpEvalOutcomes(run.expEvalEvents(), EXPECTED, () => run.diagnostic());
      const event = exactEval(events, EXPECTED[0], () => run.diagnostic());

      const request = await writeInspectionRequest(paths.projectRoot, "timing-attempt-timing", {
        kind: "attempt.timing", locator: event.locator,
      });
      const queried = await niceeval.run(["query", "run", "--request", request]);
      expect(queried.exitCode, queried.diagnostic()).toBe(0);
      const document = queried.attemptTiming();
      expect(document).toMatchObject({
        operation: "attempt.timing",
        issues: [],
        timing: { state: "complete" },
      });
      const intervals = document.timing.activities;
      const evalRun = only(intervals, (interval) => interval.phase === "eval.run" && interval.label === "eval.run", queried.diagnostic());
      const agentSetup = only(intervals, (interval) => interval.phase === "attempt.setup" && interval.label === "agent.setup", queried.diagnostic());
      const agentSend = only(intervals, (interval) => interval.phase === "agent.send" && interval.label === "turn1", queried.diagnostic());
      expect(evalRun).toMatchObject({ parentActivityId: null, outcome: "completed" });
      expect(agentSetup).toMatchObject({ parentActivityId: null, outcome: "completed" });
      expect(agentSend).toMatchObject({ parentActivityId: evalRun.activityId, outcome: "completed" });
      expect(agentSend.startOffsetMs).toBeGreaterThanOrEqual(evalRun.startOffsetMs);
      expect(agentSend.startOffsetMs + agentSend.durationMs).toBeLessThanOrEqual(
        evalRun.startOffsetMs + evalRun.durationMs,
      );

      const setupFailure = await niceeval.run([
        "exp", "timing-setup-failure", "--rerun", "all", "--json",
      ]);
      expect(setupFailure.exitCode, setupFailure.diagnostic()).toBe(1);
      const setupFailureEval = only(
        setupFailure.expEvalEvents(),
        (item) => item.experimentId === "timing-setup-failure",
        setupFailure.diagnostic(),
      );
      expect(setupFailureEval).toMatchObject({ verdict: "errored", attempts: 1, passed: 0 });
      const setupFailureError = only(
        setupFailure.expErrorEvents(),
        (item) => item.event === "error" && item.experimentId === "timing-setup-failure",
        setupFailure.diagnostic(),
      );
      expect(setupFailureError).toMatchObject({ phase: "agent.setup" });
      expect(setupFailureError.reason).toContain("runner lifecycle setup primary failure");
      expect(await receiptLines(paths.projectRoot, "timing-setup-failure.ndjson")).toEqual([
        "setup",
        "teardown",
      ]);

      const noSetup = await niceeval.run([
        "exp", "timing-no-setup", "--rerun", "all", "--json",
      ]);
      expect(noSetup.exitCode, noSetup.diagnostic()).toBe(0);
      expect(noSetup.expEvalEvents()).toContainEqual(expect.objectContaining({
        experimentId: "timing-no-setup",
        verdict: "passed",
        attempts: 1,
        passed: 1,
      }));
      expect(await receiptLines(paths.projectRoot, "timing-no-setup.ndjson")).toEqual([
        "send",
        "teardown",
      ]);

      for (const failure of [
        {
          experimentId: "timing-setup-teardown-failure",
          receipt: "timing-setup-teardown-failure.ndjson",
          primaryPhase: "agent.setup",
          primary: "runner lifecycle setup retained failure",
          events: ["setup", "teardown"],
        },
        {
          experimentId: "timing-send-teardown-failure",
          receipt: "timing-send-teardown-failure.ndjson",
          primaryPhase: "eval.run",
          primary: "runner lifecycle send retained failure",
          events: ["send", "teardown"],
        },
      ] as const) {
        const result = await niceeval.run([
          "exp", failure.experimentId, "--rerun", "all", "--json",
        ]);
        expect(result.exitCode, result.diagnostic()).toBe(1);
        const evalEvent = only(
          result.expEvalEvents(),
          (item) => item.experimentId === failure.experimentId,
          result.diagnostic(),
        );
        expect(evalEvent).toMatchObject({ verdict: "errored", attempts: 1, passed: 0 });
        const primaryError = only(
          result.expErrorEvents(),
          (item) => item.event === "error" && item.experimentId === failure.experimentId,
          result.diagnostic(),
        );
        expect(primaryError.phase).toBe(failure.primaryPhase);
        expect(primaryError.reason).toContain(failure.primary);
        expect(primaryError.reason).not.toContain("runner lifecycle teardown secondary failure");
        expect(await receiptLines(paths.projectRoot, failure.receipt)).toEqual(failure.events);

        const traceRequest = await writeInspectionRequest(
          paths.projectRoot,
          `${failure.experimentId}-trace`,
          { kind: "attempt.trace", locator: evalEvent.locator },
        );
        const trace = await niceeval.run(["query", "run", "--request", traceRequest]);
        expect(trace.exitCode, trace.diagnostic()).toBe(0);
        const traceDocument = trace.attemptTrace();
        expect(traceDocument).toMatchObject({ operation: "attempt.trace", issues: [] });
        const teardownDiagnostic = only(
          traceDocument.trace.diagnostics.items,
          (item) => item.phase === "attempt.teardown",
          trace.diagnostic(),
        );
        expect(teardownDiagnostic.summary).toContain("runner lifecycle teardown secondary failure");
      }
    },
  );
});

test("Attempt 完成无法持久化时终态不提供不可检查的 locator [necase_EP0HS2HD783EN64J]", async () => {
  await runnerE2E.case(
    "completion-persistence-failure",
    { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
    async ({ commands: { niceeval }, paths }) => {
      const run = await niceeval.run([
        "exp", "completion-persistence-failure", "--rerun", "all", "--json",
      ]);
      expect(run.exitCode, run.diagnostic()).toBe(1);

      const terminalOutput = `${run.stdout}\n${run.stderr}`;
      const leakedLocator = terminalOutput.match(/@1[0-9A-HJKMNP-TV-Z]{12}/)?.[0];
      if (leakedLocator !== undefined) {
        const request = await writeInspectionRequest(
          paths.projectRoot,
          "unpublished-attempt-trace",
          { kind: "attempt.trace", locator: leakedLocator },
        );
        const queried = await niceeval.run(["query", "run", "--request", request]);
        expect(queried.exitCode, queried.diagnostic()).not.toBe(0);
        expect(`${queried.stdout}\n${queried.stderr}`).toMatch(/not found|not-found/i);
      }

      expect(leakedLocator, run.diagnostic()).toBeUndefined();
      expect(terminalOutput).toMatch(/publication|persistence/i);
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790683676&installation_model_id=431746&pr_number=194&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F194&signature=38a7032b363dd2d5bf7382a5844344454659d023755b7e82d63b1e82a0c14839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
