### PR TITLE
fix(runner): 释放已完成 Eval Group 的沙箱容量

### DIFF
--- a/docs/feature/eval-groups/architecture.md
+++ b/docs/feature/eval-groups/architecture.md
@@ -28,10 +28,20 @@ Group 是物理 resource lane，也是 Group Plugin 的显式声明位置。Grou
 不把整个 Experiment 降成串行。每个 Group 使用独立复用池；普通 `sandboxReuse` 的共享池
 不与 Group pool 合并。
 
+波次公平只决定多个**当前可派发** lane 同时竞争许可时的先后，必须保持 work-conserving：只要全局与
+Experiment 并发位空闲，并且某条 lane 能复用已经取得的 Sandbox，Runner 就继续派发该 lane。
+首波准入条件不得要求所有 lane 先取得 Provider reservation、创建物理 Sandbox 或完成首槽位，才允许任一
+lane 派发后继；等待 `provider-capacity` 的 lane 也不得占住 Experiment 并发位。否则 Group 数量大于
+Provider 物理容量时，首波会保留全部容量、后继又被首波准入条件阻塞，形成循环等待。
+
+尚未取得 Provider reservation 并启动 Sandbox 的 lane 不因暂时缺少 capacity 永久失去公平机会。已有实例释放或容量增加后，
+admission 重新把它纳入候选；这种 eventual fairness 不能以暂停已有复用 lane、制造全局空闲为代价。
+
 ## 不变量
 
 - 一条 Eval 最多属于一个 Group。
 - 同一 Group 同时最多有一条 Attempt 持有 lease。
 - Group lane 的执行顺序只来自规范化 Eval ID，不来自作者数组位置。
 - Group pool key 包含物理 Provider plan、Agent install plan、Experiment 与 Group scope。
+- 调度公平不以“每条 lane 都已取得 reservation 并启动 Sandbox”为 barrier；Provider capacity 小于 lane 数仍必须推进。
 - 结果、锁与 carry 的主键仍是 Eval Attempt；Group 只增加 lane、pool 与调度上下文。

--- a/docs/feature/experiments/use-case/并发/快慢实验混跑.md
+++ b/docs/feature/experiments/use-case/并发/快慢实验混跑.md
@@ -9,6 +9,11 @@ relations: {}
 一批 Experiment 有的 Attempt 很慢、有的很快时，不需要手工分波或为快任务预留名额。
 Runner 按剩余波次优先派发瓶颈 Run，同时让空出的并发位继续服务其它 Run。
 
+这也适用于 Eval Group 数量超过 Provider 物理容量的批次。等待 `provider-capacity` 的新 Group 保持
+queued，但不能挡住已经持有可复用 Sandbox 的 Group 后继；只要并发位空闲，后者继续执行。Runner
+不会为了让每条 Group lane 的首槽位都先取得 reservation 并启动 Sandbox，而暂停能够立即复用现有实例的工作。
+因此 Provider 容量决定同时存在的物理实例数，不会把“全部 Group 各占一个实例”变成后继派发的前置条件。
+
 每个 Experiment 只有在本 Invocation 需要串行累积，或需要限制自己的服务压力时才设置 `maxConcurrency`。
 多个 Invocation 共享可变状态时另行声明 `sharedState.key`。
 全局吞吐不足时调整 [`--max-concurrency`](限制全局并发.md)。

--- a/e2e/runner/agents/provider-capacity.ts
+++ b/e2e/runner/agents/provider-capacity.ts
@@ -10,6 +10,7 @@ const EDGE_EVAL = "provider-capacity-edge";
 const CANCEL_WAITER_EVAL = "provider-capacity-cancel-waiter";
 const CANCEL_BLOCKER_EVAL = "provider-capacity-cancel-blocker";
 const CAPACITY_EVAL_PREFIX = "provider-capacity-capacity/";
+const GROUP_CAPACITY_EVAL_PREFIX = "provider-capacity-group-";
 
 function aborted(signal: AbortSignal): Error {
   return signal.reason instanceof Error
@@ -84,6 +85,8 @@ export const providerCapacityAgent = defineSandboxAgent({
         } else {
           await writeFile(join(controlRoot, "capacity-second-entered"), "");
         }
+      } else if (evalId.startsWith(GROUP_CAPACITY_EVAL_PREFIX)) {
+        await writeFile(join(controlRoot, `group-capacity-${evalId.replaceAll("/", "-")}-entered`), "");
       } else {
         throw new Error(`unexpected provider-capacity Eval: ${evalId}`);
       }

--- a/e2e/runner/evals/provider-capacity-group-alpha/01-first.eval.ts
+++ b/e2e/runner/evals/provider-capacity-group-alpha/01-first.eval.ts
@@ -1,0 +1,8 @@
+import { defineEval } from "niceeval";
+
+export default defineEval({
+  description: "first member of the reusable capacity lane",
+  async test(t) {
+    await t.send("alpha first");
+  },
+});

--- a/e2e/runner/evals/provider-capacity-group-alpha/02-after.eval.ts
+++ b/e2e/runner/evals/provider-capacity-group-alpha/02-after.eval.ts
@@ -1,0 +1,8 @@
+import { defineEval } from "niceeval";
+
+export default defineEval({
+  description: "existing reusable lane continues while another group waits for capacity",
+  async test(t) {
+    await t.send("alpha after");
+  },
+});

--- a/e2e/runner/evals/provider-capacity-group-alpha/eval-group.ts
+++ b/e2e/runner/evals/provider-capacity-group-alpha/eval-group.ts
@@ -1,0 +1,5 @@
+import { defineEvalGroup } from "niceeval";
+import first from "./01-first.eval.ts";
+import after from "./02-after.eval.ts";
+
+export default defineEvalGroup({ evals: [first, after], onUnavailable: "stop-group" });

--- a/e2e/runner/evals/provider-capacity-group-beta/01-only.eval.ts
+++ b/e2e/runner/evals/provider-capacity-group-beta/01-only.eval.ts
@@ -1,0 +1,8 @@
+import { defineEval } from "niceeval";
+
+export default defineEval({
+  description: "new group starts after the completed reusable lane releases capacity",
+  async test(t) {
+    await t.send("beta only");
+  },
+});

--- a/e2e/runner/evals/provider-capacity-group-beta/eval-group.ts
+++ b/e2e/runner/evals/provider-capacity-group-beta/eval-group.ts
@@ -1,0 +1,4 @@
+import { defineEvalGroup } from "niceeval";
+import only from "./01-only.eval.ts";
+
+export default defineEvalGroup({ evals: [only], onUnavailable: "stop-group" });

--- a/e2e/runner/experiments/provider-capacity/50-group-reuse.ts
+++ b/e2e/runner/experiments/provider-capacity/50-group-reuse.ts
@@ -1,0 +1,42 @@
+import { defineExperiment } from "niceeval";
+import { dockerSandbox } from "niceeval/sandbox";
+import { providerCapacityAgent } from "../../agents/provider-capacity.ts";
+
+const NODE_IMAGE = "node@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f";
+const MiB = 1024 ** 2;
+const profile = process.env.NICEEVAL_E2E_PROVIDER_CAPACITY_PROFILE;
+const profileImage = process.env.NICEEVAL_E2E_PROVIDER_CAPACITY_IMAGE;
+const controlRoot = process.env.NICEEVAL_E2E_PROVIDER_CAPACITY_CONTROL_ROOT;
+
+export default defineExperiment({
+  description: "completed Eval Group lanes release scarce provider capacity",
+  agent: providerCapacityAgent,
+  sandbox: dockerSandbox({
+    source: { type: "image", image: profileImage ?? NODE_IMAGE },
+    user: "node",
+    lifetimeMs: 120_000,
+    ...(profile === undefined ? {} : {
+      dockerAccess: {
+        mode: "dind" as const,
+        isolation: "raw-privileged" as const,
+        storageProfile: profile,
+      },
+    }),
+    resources: {
+      cpus: 1,
+      memoryBytes: 1024 * MiB,
+      pidsLimit: 512,
+      ...(profile === undefined ? {} : { dockerDataBytes: 512 * MiB }),
+    },
+    readiness: {
+      command: ["sh", "-lc", "node --version >/dev/null"],
+      user: "root",
+      timeoutMs: 30_000,
+      intervalMs: 100,
+    },
+  }),
+  evals: ["provider-capacity-group-alpha/", "provider-capacity-group-beta/"],
+  maxConcurrency: 2,
+  timeoutMs: 90_000,
+  ...(controlRoot === undefined ? {} : { flags: { controlRoot } }),
+});

--- a/e2e/runner/fixtures/provider-capacity/Dockerfile
+++ b/e2e/runner/fixtures/provider-capacity/Dockerfile
@@ -9,6 +9,8 @@ COPY --from=node-runtime /usr/lib64/ /usr/lib64/
 COPY --from=node-runtime /usr/bin/ldd /usr/bin/ldd
 
 RUN ln -s usr/lib64 /lib64 \
+  && addgroup -g 1000 node \
+  && adduser -D -u 1000 -G node node \
   && node --version \
   && npm --version \
   && git --version \

--- a/e2e/runner/fixtures/provider-capacity/driver.mjs
+++ b/e2e/runner/fixtures/provider-capacity/driver.mjs
@@ -811,6 +811,20 @@ async function runCapacityOneScenario(service, environment) {
   return { control, sessionShowJson: publicSession.sessionShowJson, exitCode: result.exitCode, lifecycle: service.events };
 }
 
+async function runGroupReuseScenario(service, environment) {
+  markStage("group-reuse:start");
+  service.scenario = "group-reuse";
+  service.events = { containerCreates: 0, reservationReleases: 0, reservationCancels: 0, acquiredStates: [], activeContainers: 0, maxActiveContainers: 0 };
+  const result = await runProcess([
+    "node_modules/.bin/niceeval", "exp", "provider-capacity/50-group-reuse", "--rerun", "all", "--max-concurrency", "2", "--json",
+  ], { env: environment, timeoutMs: 120_000 });
+  if (result.exitCode !== 0) throw new Error(`group reuse invocation failed: ${result.stderr || result.stdout}`);
+  const control = await waitForControlClean(service);
+  const session = await latestPublicSession(environment, "provider-capacity/50-group-reuse");
+  markStage("group-reuse:complete");
+  return { control, sessionShowJson: session.sessionShowJson, exitCode: result.exitCode, lifecycle: service.events };
+}
+
 async function main() {
   await mkdir(controlRoot, { recursive: true });
   const socketPath = join(controlRoot, "profile-control.sock");
@@ -934,11 +948,13 @@ async function main() {
     const edgeAbnormal = await runEdgeScenario(service, childEnvironment, "provisioning");
     const cancelled = await runCancelScenario(service, childEnvironment);
     const capacityOne = await runCapacityOneScenario(service, childEnvironment);
+    const groupReuse = await runGroupReuseScenario(service, childEnvironment);
     await writeFile(join(controlRoot, "matrix-observation.json"), `${JSON.stringify({
       edgeBlocked,
       edgeAbnormal,
       cancelled,
       capacityOne,
+      groupReuse,
     })}\n`, { mode: 0o666 });
     await chmod(join(controlRoot, "matrix-observation.json"), 0o666);
     markStage("matrix:complete");

--- a/e2e/runner/test/provider-capacity-queue.test.ts
+++ b/e2e/runner/test/provider-capacity-queue.test.ts
@@ -34,6 +34,12 @@ interface MatrixObservation {
     readonly exitCode: number | null;
     readonly lifecycle: { readonly containerCreates: number; readonly activeContainers: number; readonly maxActiveContainers: number };
   };
+  readonly groupReuse: {
+    readonly control: Record<string, any>;
+    readonly sessionShowJson: string;
+    readonly exitCode: number | null;
+    readonly lifecycle: { readonly containerCreates: number; readonly activeContainers: number; readonly maxActiveContainers: number };
+  };
 }
 
 interface PublicExperimentStatus {
@@ -235,6 +241,12 @@ test("等待 Docker profile 容量时保持排队且不阻塞其它 Provider [ne
           expect(matrix.capacityOne.control.reservations).toEqual([]);
           expect(matrix.capacityOne.control.used).toEqual({ containers: 0, builds: 0 });
           expect(matrix.capacityOne.exitCode).toBe(0);
+          expect(matrix.groupReuse.lifecycle).toMatchObject({ containerCreates: 2, activeContainers: 0, maxActiveContainers: 1 });
+          expect(matrix.groupReuse.control.reservations).toEqual([]);
+          expect(matrix.groupReuse.control.used).toEqual({ containers: 0, builds: 0 });
+          expect(matrix.groupReuse.exitCode).toBe(0);
+          const groupSession = JSON.parse(matrix.groupReuse.sessionShowJson) as PublicSessionShow;
+          expect(groupSession.session?.status).toBe("completed");
         } catch (error) {
           primaryError = error;
           throw error;

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/certificate.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "candidateSha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+  "greenReceipt": "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-1.json",
+      "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-2.json",
+      "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-4.json",
+      "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-6.json",
+    "singleCase": "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree/.e2e-artifacts/eval-group-capacity-takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree/.e2e-artifacts/eval-group-capacity-takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree/.e2e-artifacts/eval-group-capacity-takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree/.e2e-artifacts/eval-group-capacity-takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree/.e2e-artifacts/eval-group-capacity-takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree/.e2e-artifacts/eval-group-capacity-takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/worktree/.e2e-artifacts/eval-group-capacity-takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "f0a774f99a5908f1cb77d212dbd81ea2a28f50bcf7087e82d07f52f7b670d551"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/green.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/green.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+    "sri": "sha512-oM56ZKDGZf3cfEeoJ52KWzjPNnTMYOdH3nLzyKmrIahYzUXWAlo18KVzgpLHH8mKkdC8zXbBME402VCwL/aFVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/provider-capacity-queue.test.ts",
+      "--testNamePattern",
+      "^等待 Docker profile 容量时保持排队且不阻塞其它 Provider \\[necase_VXE9ARZNBMZ6V0JT\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-JLeWcu/runs/takeover/target-single/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2515217 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2515218 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2515264 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2515294 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "9ff5514f-a3a1-404b-8287-5b036ecf461b",
+  "receiptSha256": "6c589d57d3aa22564a1e96ad45eec39003c61af738d33308449eff1421f976ed"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/inventory.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/inventory.json
@@ -1,0 +1,310 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "runner",
+  "argv": [
+    "/nix/store/bfqsxlviikq7vlp36kasy5hhamlxlkd2-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-OoGKkp/repos/runner/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.0_@types+node@24.13.3_esbuild@0.28.1_jiti@2.7.0_tsx@4.23.9_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+  "files": [
+    "e2e/runner/test/accept-reanchor.test.ts",
+    "e2e/runner/test/carry-partial-reuse.test.ts",
+    "e2e/runner/test/fresh-sandbox-provider-stop.test.ts",
+    "e2e/runner/test/group-or-stop-dispatch.test.ts",
+    "e2e/runner/test/group-wave-gap-dispatch.test.ts",
+    "e2e/runner/test/history-dedup.test.ts",
+    "e2e/runner/test/max-concurrency-invocation-local.test.ts",
+    "e2e/runner/test/provider-capacity-queue.test.ts",
+    "e2e/runner/test/provider-lane.test.ts",
+    "e2e/runner/test/shared-state-lifecycle.test.ts",
+    "e2e/runner/test/shared-state-recovery.test.ts",
+    "e2e/runner/test/shared-state-scheduler.test.ts",
+    "e2e/runner/test/shared-state-startup-authority.test.ts",
+    "e2e/runner/test/shared-state-zombie-owner-recovery.test.ts",
+    "e2e/runner/test/timing.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/accept-reanchor.test.ts",
+      "titlePath": [
+        "审阅变更后 accept 以 reference Member 采用旧 Attempt，保留 verdict/evidence 与审计 provenance [necase_FEJ6CWPP9EWWY2F6]"
+      ],
+      "caseId": "necase_FEJ6CWPP9EWWY2F6"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/carry-partial-reuse.test.ts",
+      "titlePath": [
+        "改变一个 Eval 后只重新派发该 identity，未改变的 Eval 继续携带 [necase_Q3G99190B9YX4TW3]"
+      ],
+      "caseId": "necase_Q3G99190B9YX4TW3"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/carry-partial-reuse.test.ts",
+      "titlePath": [
+        "未声明 sharedState 保持公开 carry；声明或变更 key 作废 carry [necase_18CRTCDWKQD3YJR7]"
+      ],
+      "caseId": "necase_18CRTCDWKQD3YJR7"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/fresh-sandbox-provider-stop.test.ts",
+      "titlePath": [
+        "fresh custom Provider group.stop 失败保留 sharedState，普通输出与 Run diagnostic 不泄露 owner token [necase_9E2KVHJXB3FTA8AE]"
+      ],
+      "caseId": "necase_9E2KVHJXB3FTA8AE"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/group-or-stop-dispatch.test.ts",
+      "titlePath": [
+        "orStop 只结束当前 Eval，三个 Group lane 仍可并行派发 [necase_JRJ0FVDAN2QKHY28]"
+      ],
+      "caseId": "necase_JRJ0FVDAN2QKHY28"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/group-wave-gap-dispatch.test.ts",
+      "titlePath": [
+        "空闲 Group lane 不等待慢 lane 的下一槽位即可继续派发 [necase_6BCCEKGMA7ZY0QMG]"
+      ],
+      "caseId": "necase_6BCCEKGMA7ZY0QMG"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/history-dedup.test.ts",
+      "titlePath": [
+        "两次同时运行同一实验时，后开始的那次不重复跑已经完成的题目 [necase_ZJFWH6XRX2EZWS5J]"
+      ],
+      "caseId": "necase_ZJFWH6XRX2EZWS5J"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/history-dedup.test.ts",
+      "titlePath": [
+        "强制重跑追加 identity，carry run 不在 history 复制旧 attempt [necase_HP9NWW0YWAV48X1P]"
+      ],
+      "caseId": "necase_HP9NWW0YWAV48X1P"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/max-concurrency-invocation-local.test.ts",
+      "titlePath": [
+        "并行运行同一 Experiment 时，每次 Invocation 保有自己的并发额度 [necase_YAJ06RV7ZR47KAZD]"
+      ],
+      "caseId": "necase_YAJ06RV7ZR47KAZD"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/provider-capacity-queue.test.ts",
+      "titlePath": [
+        "等待 Docker profile 容量时保持排队且不阻塞其它 Provider [necase_VXE9ARZNBMZ6V0JT]"
+      ],
+      "caseId": "necase_VXE9ARZNBMZ6V0JT"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/provider-lane.test.ts",
+      "titlePath": [
+        "等待 sharedState 不占用同一 exclusive provider lane，无关 Experiment 仍可进入 Agent [necase_EZDHV0MV2FA9SX7X]"
+      ],
+      "caseId": "necase_EZDHV0MV2FA9SX7X"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "fresh Sandbox 的 Attempt after 失败也保留 sharedState，直到公开显式恢复 [necase_PV16QF2DMTKR229Z]"
+      ],
+      "caseId": "necase_PV16QF2DMTKR229Z"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "复用 Sandbox 的 Attempt after 失败也会保留 sharedState，直到公开显式恢复 [necase_FFVQ9YEXTRJGGVA5]"
+      ],
+      "caseId": "necase_FFVQ9YEXTRJGGVA5"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "复用 Sandbox 的每条 Attempt after 与 Experiment teardown 完成后才交出 sharedState [necase_JDW5GFSRDDAP19P8]"
+      ],
+      "caseId": "necase_JDW5GFSRDDAP19P8"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-lifecycle.test.ts",
+      "titlePath": [
+        "相同 sharedState.key 在前一 Experiment teardown 后才允许下一 Experiment 进入 setup [necase_400VHE4GK3DNPNPC]"
+      ],
+      "caseId": "necase_400VHE4GK3DNPNPC"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "SQLite recovery 原子清理 teardown 登记后才开放等待者 [necase_X1F0QN5F124T2HQH]"
+      ],
+      "caseId": "necase_X1F0QN5F124T2HQH"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "作者删除 sharedState 声明后仍可按遗留 key 执行一次公开恢复 [necase_PKDDGWJF9WG1GKMC]"
+      ],
+      "caseId": "necase_PKDDGWJF9WG1GKMC"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "作者改掉 sharedState key 后，旧 key 仍以 immutable evidence 只清理自己的 teardown 登记 [necase_A2699428EFNX2V13]"
+      ],
+      "caseId": "necase_A2699428EFNX2V13"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "实际 Experiment teardown 失败会保留 lease，等待者只能取消或走显式恢复 [necase_BXJ9903T6J56JE4K]"
+      ],
+      "caseId": "necase_BXJ9903T6J56JE4K"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "崩溃的 recovery 可由新 actor 显式续接，旧 token 不会删除新 holder [necase_7XAMTKFQJZ58EZQ5]"
+      ],
+      "caseId": "necase_7XAMTKFQJZ58EZQ5"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "显式 recovery 拒绝 JSON，并在两种帮助入口公开全部参数 [necase_8JE0MDKWV5A2SWA2]"
+      ],
+      "caseId": "necase_8JE0MDKWV5A2SWA2"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "暂停的 owner 不会因 heartbeat 年龄失权，等待者可 SIGINT 取消且恢复后才交接 [necase_933F8H9VHA6V8153]"
+      ],
+      "caseId": "necase_933F8H9VHA6V8153"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "缺少 teardown 的显式 recovery 不改变 active generation [necase_KWHHT498E861HWMH]"
+      ],
+      "caseId": "necase_KWHHT498E861HWMH"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-recovery.test.ts",
+      "titlePath": [
+        "非函数 teardown 被公开 CLI 拒绝，遗留 owner 不会被释放 [necase_8GR53E938YVF6VVW]"
+      ],
+      "caseId": "necase_8GR53E938YVF6VVW"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-scheduler.test.ts",
+      "titlePath": [
+        "同 Invocation 的同 key waiter 不占有限 worker，holder 后继 Attempt 能继续启动 [necase_3T4GYG4AH3XJMQHE]"
+      ],
+      "caseId": "necase_3T4GYG4AH3XJMQHE"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-startup-authority.test.ts",
+      "titlePath": [
+        "full-carry 的 selected Experiment 也在同 key authority 后才补遗留 teardown [necase_MZECYXY0CYDG8HFQ]"
+      ],
+      "caseId": "necase_MZECYXY0CYDG8HFQ"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-startup-authority.test.ts",
+      "titlePath": [
+        "启动期遗留 teardown 先取得同 key authority，健康等待只发无 token 的 info [necase_YJQZERNET06GJ98S]"
+      ],
+      "caseId": "necase_YJQZERNET06GJ98S"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/shared-state-zombie-owner-recovery.test.ts",
+      "titlePath": [
+        "explicit recovery accepts a terminal Linux zombie owner but still runs its compensating teardown [necase_KFXCHWB9075701RA]"
+      ],
+      "caseId": "necase_KFXCHWB9075701RA"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/timing.test.ts",
+      "titlePath": [
+        "Run 终态持久化失败时已发布 locator 仍可公开检查 [necase_EP0HS2HD783EN64J]"
+      ],
+      "caseId": "necase_EP0HS2HD783EN64J"
+    },
+    {
+      "executor": "vitest",
+      "repo": "runner",
+      "path": "e2e/runner/test/timing.test.ts",
+      "titlePath": [
+        "通用 Runner 公开 Agent setup、send、teardown 的完成与失败关系 [necase_21VCRD4WKW8K1E66]"
+      ],
+      "caseId": "necase_21VCRD4WKW8K1E66"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/red.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/red.json
@@ -1,0 +1,54 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "64a4d559796976c2b0ef1b39b68768d06c858090bee48c5606e40399f916d8ff",
+    "sri": "sha512-yPTeV5h85bSUy6VA55w+TJi0P79AeWgtRg0/kMGQJmzio3OYXPnprlbtQ3qIGqXf/Cet+Lv3qxaccvLo8TrPVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/provider-capacity-queue.test.ts",
+      "--testNamePattern",
+      "^等待 Docker profile 容量时保持排队且不阻塞其它 Provider \\[necase_VXE9ARZNBMZ6V0JT\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-jBewZE/runs/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 2370723 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "d38fa93c-4eb8-4ab4-9e80-5c7eec3e725a",
+  "receiptSha256": "b6a0492fdb62d14a5dae240e8077b4df6f0c17e8567965868a095e709eadf642"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-1.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-1.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+    "sri": "sha512-oM56ZKDGZf3cfEeoJ52KWzjPNnTMYOdH3nLzyKmrIahYzUXWAlo18KVzgpLHH8mKkdC8zXbBME402VCwL/aFVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/provider-capacity-queue.test.ts",
+      "--testNamePattern",
+      "^等待 Docker profile 容量时保持排队且不阻塞其它 Provider \\[necase_VXE9ARZNBMZ6V0JT\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-JLeWcu/runs/takeover/isolated-copy-1/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2388585 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2388586 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2388633 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2388698 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "fbfaa00f-f3a8-45a8-9e5c-47b527c9b2bf",
+  "receiptSha256": "624b07931cb78f11f1300e6f25adf4e6aada0f3430afa55f285f9809a3dd52bf"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-2.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-2.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+    "sri": "sha512-oM56ZKDGZf3cfEeoJ52KWzjPNnTMYOdH3nLzyKmrIahYzUXWAlo18KVzgpLHH8mKkdC8zXbBME402VCwL/aFVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/provider-capacity-queue.test.ts",
+      "--testNamePattern",
+      "^等待 Docker profile 容量时保持排队且不阻塞其它 Provider \\[necase_VXE9ARZNBMZ6V0JT\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-JLeWcu/runs/takeover/isolated-copy-2/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2403414 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2403415 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2403460 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2403508 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "fade8953-f204-48e1-899d-2449223be650",
+  "receiptSha256": "6258320fefe684601247a95a279449b7638eea8c791521e0060546c1058bdc51"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-3.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-3.json
@@ -1,0 +1,73 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+    "sri": "sha512-oM56ZKDGZf3cfEeoJ52KWzjPNnTMYOdH3nLzyKmrIahYzUXWAlo18KVzgpLHH8mKkdC8zXbBME402VCwL/aFVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/provider-capacity-queue.test.ts",
+      "--testNamePattern",
+      "^等待 Docker profile 容量时保持排队且不阻塞其它 Provider \\[necase_VXE9ARZNBMZ6V0JT\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-JLeWcu/runs/takeover/isolated-copy-3/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2416692 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2416693 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2416738 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2416772 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "7b7c19ea-dd82-479a-ba43-0dbf121ceaee",
+  "receiptSha256": "ae4f878312f2d3428664496738873543b61a925b1fb9fdfde0f4d097e5e6aaa4"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-4.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-4.json
@@ -1,0 +1,79 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+    "sri": "sha512-oM56ZKDGZf3cfEeoJ52KWzjPNnTMYOdH3nLzyKmrIahYzUXWAlo18KVzgpLHH8mKkdC8zXbBME402VCwL/aFVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/provider-capacity-queue.test.ts",
+      "--testNamePattern",
+      "^等待 Docker profile 容量时保持排队且不阻塞其它 Provider \\[necase_VXE9ARZNBMZ6V0JT\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-JLeWcu/runs/takeover/same-copy/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2430497 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2430498 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2430544 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2430572 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2444049 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "7a2abb34-47ad-4482-8390-68bcfbe93e27",
+  "receiptSha256": "8d42c6d8c64e6a365285e643f5f7883a77d5effd6096792f68e274f4b3743ea3"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-5.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-5.json
@@ -1,0 +1,79 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+    "sri": "sha512-oM56ZKDGZf3cfEeoJ52KWzjPNnTMYOdH3nLzyKmrIahYzUXWAlo18KVzgpLHH8mKkdC8zXbBME402VCwL/aFVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run",
+      "test/provider-capacity-queue.test.ts",
+      "--testNamePattern",
+      "^等待 Docker profile 容量时保持排队且不阻塞其它 Provider \\[necase_VXE9ARZNBMZ6V0JT\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-JLeWcu/runs/takeover/same-copy/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2430497 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2430498 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2430544 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2430572 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2444049 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "d535a78e-afa0-4adc-8d19-022a8bd124c8",
+  "receiptSha256": "6b05a9adb9d4ca374b6d46565335eb6c99fdd9dc6e1b07104d77a7768c4863d9"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-6.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/reliability-6.json
@@ -1,0 +1,70 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT",
+  "caseId": "necase_VXE9ARZNBMZ6V0JT",
+  "inventoryDigest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba",
+  "candidate": {
+    "gitSha": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "sha256": "99a0cd81325bde439a7028502df3c209daf74e89f41c45b114e305380ae8c411",
+    "sri": "sha512-oM56ZKDGZf3cfEeoJ52KWzjPNnTMYOdH3nLzyKmrIahYzUXWAlo18KVzgpLHH8mKkdC8zXbBME402VCwL/aFVA=="
+  },
+  "source": {
+    "checkout": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+    "testFileSha256": "3039a22ddd493cad49c9e85ef7aefcefd7800968ce17032b9eecf5fdc5d87e56",
+    "sidecarSha256": "2df70da393718a1147eca23751e1a09ddc3b58c0a2ee4e5d145cb49b893bc1c6"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "exec",
+      "vitest",
+      "run"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-JLeWcu/runs/takeover/repo-default-parallel/runner",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2457224 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2457225 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2457272 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2457335 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "f3c520a8-a2b6-4393-b3e5-75b238410fe5",
+  "receiptSha256": "2913a7db54e0eb7f4aef102ae875328915a5690462acf955f63225919865b0c5"
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.cases.evidence.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.cases.evidence.json
@@ -1,0 +1,25 @@
+{
+  "format": "niceeval.e2e-case-evidence-index/v1",
+  "current": {
+    "necase_VXE9ARZNBMZ6V0JT": {
+      "memory/eval-group-retained-sandbox-capacity-deadlock.md": {
+        "red": {
+          "path": "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/red.json",
+          "digest": "sha256:d23418ace76a361565357235be15ded6453f191f103f31c7541d6580e875f296"
+        },
+        "green": {
+          "path": "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/green.json",
+          "digest": "sha256:3bc52cc4d30bd574d9d532205420f9524543ccc02553dd6190117c5cdbb9bc17"
+        },
+        "certificate": {
+          "path": "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/certificate.json",
+          "digest": "sha256:84551c1fa3856119d6ff8242069bbf88a73fb612fa7ad40493cdf9a6c6d73c34"
+        },
+        "inventory": {
+          "path": "e2e/runner/test/provider-capacity-queue.test.ts.case-evidence/necase_VXE9ARZNBMZ6V0JT/memory_eval-group-retained-sandbox-capacity-deadlock.md/nered_E4EJKYQXVYVB3DW8-netake_S4P8BRJY1ZJ6FET9/inventory.json",
+          "digest": "sha256:f992bbca2eb0db4d03942cbff3a5e4ddfcfc8522c9446c7f798c9601956a7aba"
+        }
+      }
+    }
+  }
+}

--- a/e2e/runner/test/provider-capacity-queue.test.ts.cases.json
+++ b/e2e/runner/test/provider-capacity-queue.test.ts.cases.json
@@ -4,7 +4,9 @@
   "current": {
     "necase_VXE9ARZNBMZ6V0JT": {
       "owner": "docs/engineering/testing/e2e/runner.md#runner-provider-capacity-queue",
-      "regressions": [],
+      "regressions": [
+        "memory/eval-group-retained-sandbox-capacity-deadlock.md"
+      ],
       "issues": []
     }
   },
@@ -18,6 +20,15 @@
         "owner": "docs/engineering/testing/e2e/runner.md#runner-provider-capacity-queue",
         "legacySourceDigest": "sha256:1138de21b7407b1ec92ae546d485e0710a4b458f5500cf09deb14fc86a0d046e",
         "mappingDigest": "sha256:1776e203db366aebf5c5178f85fecd7ed63715a50862e49c74cdee27d16c52e6"
+      }
+    },
+    {
+      "caseId": "necase_VXE9ARZNBMZ6V0JT",
+      "atCommit": "68bc85a5b1c913d73cf45fa6447449b8dc1cb731",
+      "transactionId": "netxn_f7ef6ea685e146899534d742b1ef6934",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/eval-group-retained-sandbox-capacity-deadlock.md"
       }
     }
   ],

--- a/memory/eval-group-retained-sandbox-capacity-deadlock.md
+++ b/memory/eval-group-retained-sandbox-capacity-deadlock.md
@@ -1,0 +1,30 @@
+---
+format: niceeval.memory/v1
+id: eval-group-retained-sandbox-capacity-deadlock
+title: Eval Group 保留 Sandbox 导致 provider capacity 死锁
+createdAt: 2026-08-31
+kind:
+  type: problem
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT"]}
+promotions: []
+---
+## 现象
+
+当一个 Experiment 含有多条 Eval Group lane，且物理 Sandbox provider 容量小于 Group 数量时，已完成的 Group 仍保留自己的 reusable Sandbox，尚未启动的 Group 永远等不到 provider capacity。队列仍有工作，但运行数逐步降到零。
+
+## 根因
+
+每个 Eval Group 拥有独立 `ReusableSandboxPool`，但 pool 只在整个 Experiment teardown 时停止。Experiment teardown 又要等待所有 Group Attempt 结算，因此“未启动 Group 等容量”与“已完成 Group 等 Experiment 结束才释放容量”形成循环等待。全局/Experiment permit 在 provider admission wait 时会正确释放，Docker profile 也正确执行容量约束；问题是 Runner 的 Group pool 生命周期过长。
+
+## 修复目标
+
+Group 的全部非 carry Attempt 一旦结算，就冻结并停止该 Group 的 pool，释放物理 provider capacity；停止后的 pool 继续作为 registry tombstone，禁止晚到路径重新创建。Attempt scope 清理必须先于 Group stop，Group stop 必须先于 Experiment teardown/sharedState release。Group stop 失败只形成 cleanup diagnostic 与 Experiment cleanup failure，不改写已封存 Verdict，也不阻塞其它 Group。
+
+## 回归证明
+
+正式 E2E 从公开 `niceeval exp` 入口运行两个 Eval Group、三个 Eval；受控 Docker profile 的物理容量为 1。修复前第二个 Group 永久等待；修复后只创建两个物理 Sandbox，最大同时活跃数为 1，最终活跃数与 reservation 均为 0。

--- a/packages/niceeval/src/runner/run.ts
+++ b/packages/niceeval/src/runner/run.ts
@@ -1023,6 +1023,29 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
     }
   });
 
+  interface GroupLaneLifecycleCell {
+    readonly pendingAttempts: Set<Attempt>;
+    readonly settledAttempts: Set<Attempt>;
+    readonly mutex: Semaphore.Semaphore;
+  }
+  const groupLaneLifecycles = new Map<AgentRun, Map<string, GroupLaneLifecycleCell>>();
+  for (const attempt of attempts) {
+    const group = attempt.evalDef.evalGroup;
+    if (group === undefined) continue;
+    let byGroup = groupLaneLifecycles.get(attempt.run);
+    if (byGroup === undefined) groupLaneLifecycles.set(attempt.run, (byGroup = new Map()));
+    let cell = byGroup.get(group.id);
+    if (cell === undefined) {
+      cell = {
+        pendingAttempts: new Set(),
+        settledAttempts: new Set(),
+        mutex: yield* Semaphore.make(1),
+      };
+      byGroup.set(group.id, cell);
+    }
+    cell.pendingAttempts.add(attempt);
+  }
+
   // 两级并发闸:全局(opts.maxConcurrency)+ 实验级(AgentRun.maxConcurrency,可选)。两者都只
   // 属于本 Invocation；跨 Invocation 的共享外部状态由 sharedState 租约另行保护，不能把
   // `maxConcurrency` 误当成跨进程临界区。
@@ -1215,6 +1238,49 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
     const list = experimentDiagnostics.get(input.experimentId) ?? [];
     list.push(record);
     experimentDiagnostics.set(input.experimentId, list);
+  };
+
+  const settleGroupLaneAttempt = (attempt: Attempt): Effect.Effect<void> => {
+    const group = attempt.evalDef.evalGroup;
+    if (group === undefined) return Effect.void;
+    const cell = groupLaneLifecycles.get(attempt.run)?.get(group.id);
+    if (cell === undefined) return Effect.die(new Error(`Missing Eval Group lifecycle for ${group.id}.`));
+    return cell.mutex.withPermits(1)(Effect.gen(function* () {
+      if (cell.settledAttempts.has(attempt)) return;
+      cell.settledAttempts.add(attempt);
+      cell.pendingAttempts.delete(attempt);
+      if (cell.pendingAttempts.size > 0) return;
+
+      // A completed Group lane no longer needs to retain provider capacity.
+      // Keep the stopped pool in the Experiment registry as a tombstone and
+      // single-flight finalizer receipt; Experiment teardown joins it again.
+      const pool = existingReusePoolFor(attempt);
+      if (pool === undefined) return;
+      yield* pool.freeze();
+      const stopped = yield* Effect.exit(pool.stop());
+      if (Exit.isSuccess(stopped)) return;
+
+      const cause = Cause.squash(stopped.cause);
+      const error = cause instanceof Error ? cause : new Error(String(cause));
+      recordSandboxCleanupFailure(attempt.run, { stage: "sandbox.stop", error });
+      const experimentId = attempt.run.experimentId ?? attempt.run.agent.name;
+      const message = `Sandbox reuse cleanup failed before Experiment teardown: ${error.message}`;
+      reportDiagnostic({
+        key: `sandbox-reuse-cleanup-failed:${experimentId}`,
+        code: "sandbox-reuse-cleanup-failed",
+        severity: "warning",
+        message,
+        data: { experimentId },
+      });
+      recordExperimentDiagnostic({
+        experimentId: attempt.run.experimentId,
+        code: "sandbox-reuse-cleanup-failed",
+        level: "warning",
+        message,
+        phase: "experiment.teardown",
+        dedupeKey: `sandbox-reuse-cleanup-failed:${experimentId}`,
+      });
+    }));
   };
   /**
    * Owner tokens are an explicit inspection capability, not ordinary Runner
@@ -1435,6 +1501,7 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
             level: "warning",
             message,
             phase: "experiment.teardown",
+            dedupeKey: `sandbox-reuse-cleanup-failed:${experimentId}`,
           });
         }
 
@@ -3129,12 +3196,13 @@ export function runEvals<AttachmentError, AttachmentRequirements>(
         // 实验级 teardown / sharedState lease 结算:每个 attempt 收尾(含被 preflight 跳过、被中断的、被用例锁
         // 被 preflight 跳过、被中断的)都从身份集合移除；最后一个触发 ExperimentDef.teardown。ensuring
         // 在中断路径同样执行，重复 finalizer 也不会让状态下溢。
-        const withExpLifecycle =
-          !a.run.setup && !a.run.teardown && !a.run.sharedState
-            ? orderedPipeline
-            : orderedPipeline.pipe(
-                Effect.ensuring(settleExperimentAttempt(a).pipe(Effect.orDie)),
-              );
+        const settleOwnedLifecycles = Effect.gen(function* () {
+          yield* settleGroupLaneAttempt(a);
+          if (a.run.setup || a.run.teardown || a.run.sharedState) {
+            yield* settleExperimentAttempt(a).pipe(Effect.orDie);
+          }
+        });
+        const withExpLifecycle = orderedPipeline.pipe(Effect.ensuring(settleOwnedLifecycles));
         // 用例锁释放:这个 key 的全部 attempt(真实派发的与被 late-carry 跳过的)都 settle 后
         // 删锁,与上面的实验级 teardown 计数同一种「逐 attempt 收尾时递减,归零触发」模式,
         // 挂在最外层确保晚于实验级 teardown 计数结算(docs「用例全部 attempt 收尾(含沙箱销毁)


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 980711e7d3d99b4441fa276aab8067d724950c87
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: f790848148f78fb0378b4eef1a3e48678cb65fc2
-->

## Problem

- User goal: 在 Sandbox provider 容量小于 Eval Group 数量时，批量实验仍持续推进并最终完成。
- Current limitation: 已完成的 Eval Group 会把 reusable Sandbox 保留到整个 Experiment 结束，未启动 Group 因此永久等待 provider capacity。
- Required capability: Runner 必须在每条 Group lane 的全部 Attempt 结算后冻结并停止该 lane 的复用池，同时保持 Experiment teardown 与清理失败语义。
- User outcome: 容量为 1 的 provider 也能依次运行多个 Eval Group，不再出现 queued 仍很多但 ACTIVE 归零的死锁。

## Use cases

### Changed

#### Case: 容量受限时混跑 Eval Group

##### Starting state

```text
一个 Experiment 含两个 Eval Group、三个 Eval；Docker profile 的 maxContainers 为 1。
```

##### Action

```sh
niceeval exp provider-capacity/50-group-reuse --rerun all --max-concurrency 2 --json
```

##### Result

```text
3 个 Eval 全部 passed；只创建 2 个物理 Sandbox，max active=1，结束后 active=0。
```

已完成 Group 立即归还其物理容量；等待新 Sandbox 的 Group 不再与已完成 Group 构成循环等待。 [Canonical Use Case](docs/feature/experiments/use-case/并发/快慢实验混跑.md).

## Observable behavior and data contracts

### Changed

#### Case: Eval Group 在容量 1 的 provider 上依次推进

##### Before

```sh
niceeval exp compare --max-concurrency 10
```

```text
首批 Group 占满 provider 后，已完成 Group 仍保留 Sandbox；其余 Group 持续 queued，ACTIVE 最终降为 0。
```

##### After

```sh
niceeval exp compare --max-concurrency 10
```

```text
Group lane 完成后释放 Sandbox；等待中的 Group 取得容量继续运行，直到全部 Attempt 终态。
```

##### User impact

不需要降低 Group 数量、扩大 provider 容量或手工重启批次；现有 Experiment 配置直接恢复 work-conserving 进度。

## Tests

### `e2e/runner/test/provider-capacity-queue.test.ts`

#### `e2e/runner/test/provider-capacity-queue.test.ts#necase_VXE9ARZNBMZ6V0JT`

provider capacity 等待不会阻塞已有 reusable Group lane，完成的 Group 会及时归还容量。 It exercises 从已安装候选的公开 niceeval exp 入口运行受控 Docker profile。 and asserts 两个 Group 的 3 个 Eval 全部通过；物理 create=2、max active=1、final active=0，reservation 清空。. Deleting this case would allow 使用真实 Docker profile 与公开 Session/CLI 输出，不读取 .niceeval 私有记录，也不以核心实现 mock 代替资源生命周期。. The final contract is [docs/feature/sandbox/lifecycle.md#命令计划怎样投影这条时序](docs/feature/sandbox/lifecycle.md#命令计划怎样投影这条时序). It also prevents the regression recorded in [memory/eval-group-retained-sandbox-capacity-deadlock.md](memory/eval-group-retained-sandbox-capacity-deadlock.md).

```ts
// rerun: pnpm e2e test --repo runner -- --run test/provider-capacity-queue.test.ts
import { access, readFile, writeFile } from "node:fs/promises";
import { join } from "node:path";
import { command, pollUntil, withTempDir } from "@niceeval/testkit";
import { expect, test } from "vitest";
import { runnerE2E } from "./context.ts";

const DRIVER_IMAGE = "node@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f";
const PROFILE_EXPERIMENT = "provider-capacity/base/00-profile";
const INDEPENDENT_EXPERIMENT = "provider-capacity/base/10-independent";
const DRIVER_DEADLINE_MS = 230_000;
const OWNER_DEADLINE_MS = 235_000;
const docker = command(["docker"]);

interface PublicObservation {
  readonly sessionListJson: string;
  readonly sessionShowJson: string;
  readonly sessionShowHuman: string;
  readonly liveHuman: string;
}

interface MatrixObservation {
  readonly edgeBlocked: { readonly sessionShowJson: string; readonly control: Record<string, any>; readonly liveHuman: string };
  readonly edgeAbnormal: { readonly sessionShowJson: string; readonly control: Record<string, any>; readonly liveHuman: string };
  readonly cancelled: {
    readonly cancelControl: Record<string, any>;
    readonly cancelHuman: string;
    readonly cancelPublic: { readonly sessionShowJson: string };
    readonly reuse: { readonly sessionShowJson: string; readonly exitCode: number | null; readonly control: Record<string, any>; readonly liveHuman: string };
  };
  readonly capacityOne: {
    readonly control: Record<string, any>;
    readonly sessionShowJson: string;
    readonly exitCode: number | null;
    readonly lifecycle: { readonly containerCreates: number; readonly activeContainers: number; readonly maxActiveContainers: number };
  };
  readonly groupReuse: {
    readonly control: Record<string, any>;
    readonly sessionShowJson: string;
    readonly exitCode: number | null;
    readonly lifecycle: { readonly containerCreates: number; readonly activeContainers: number; readonly maxActiveContainers: number };
  };
}

interface PublicExperimentStatus {
  readonly experimentId?: string;
  readonly running?: number;
  readonly queued?: number;
  readonly elsewhere?: number;
  readonly [key: string]: unknown;
}

interface PublicSessionShow {
  readonly format?: string;
  readonly session?: {
    readonly status?: string;
    readonly experiments?: readonly PublicExperimentStatus[];
  };
}

async function exists(path: string): Promise<boolean> {
  try {
    await access(path);
    return true;
  } catch {
    return false;
  }
}

function recordsIn(value: unknown): Readonly<Record<string, unknown>>[] {
  if (Array.isArray(value)) return value.flatMap(recordsIn);
  if (typeof value !== "object" || value === null) return [];
  const record = value as Record<string, unknown>;
  return [record, ...Object.values(record).flatMap(recordsIn)];
}

function terminalText(value: string): string {
  return value
    .replace(/\x1B\][^\x07]*(?:\x07|\x1B\\)/gu, "")
    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/gu, "")
    .replaceAll("\r", "")
    .replaceAll("\b", "");
}

async function removeOwnedDockerObjects(label: string, cleanupErrors: unknown[]): Promise<void> {
  const kinds = [
    { list: ["ps", "--all", "--quiet", "--filter", `label=${label}`], remove: ["rm", "--force", "--volumes"] },
    { list: ["network", "ls", "--quiet", "--filter", `label=${label}`], remove: ["network", "rm"] },
    { list: ["volume", "ls", "--quiet", "--filter", `label=${label}`], remove: ["volume", "rm", "--force"] },
  ] as const;
  for (const kind of kinds) {
    const listed = await docker.run(kind.list);
    if (listed.exitCode !== 0) {
      cleanupErrors.push(new Error(listed.diagnostic()));
      continue;
    }
    const ids = listed.stdout.split("\n").map((id) => id.trim()).filter(Boolean);
    if (ids.length === 0) continue;
    const removed = await docker.run([...kind.remove, ...ids], { timeoutMs: 30_000 });
    if (removed.exitCode !== 0) cleanupErrors.push(new Error(removed.diagnostic()));
  }
}

async function restoreBindMountPermissions(
  label: string,
  projectRoot: string,
  controlRoot: string,
): Promise<void> {
  const restored = await docker.run([
    "run", "--rm", "--network", "none",
    "--label", label,
    "--mount", `type=bind,src=${projectRoot},dst=/project`,
    "--mount", `type=bind,src=${controlRoot},dst=/control-root`,
    DRIVER_IMAGE,
    "sh", "-ceu",
    'owner="$1"; shift; for target do if [ -e "$target" ]; then chown -R "$owner" "$target"; fi; done',
    "provider-capacity-permission-recovery",
    `${process.getuid!()}:${process.getgid!()}`,
    "/project/.niceeval",
    "/control-root",
  ], { timeoutMs: 30_000 });
  if (restored.exitCode !== 0) throw new Error(restored.diagnostic());
}

async function removeOwnedDockerResources(
  runId: string,
  image: string,
  projectRoot: string,
  controlRoot: string,
  restorePermissions: boolean,
): Promise<void> {
  const label = `niceeval.e2e.provider-capacity=${runId}`;
  const cleanupErrors: unknown[] = [];
  await removeOwnedDockerObjects(label, cleanupErrors);
  if (restorePermissions) {
    try {
      await restoreBindMountPermissions(label, projectRoot, controlRoot);
    } catch (error) {
      cleanupErrors.push(error);
    }
  }
  // A timed-out permission helper can outlive its Docker client. Sweep the
  // same owned label again before removing the fixture image.
  await removeOwnedDockerObjects(label, cleanupErrors);
  const removedImage = await docker.run(["image", "rm", "--force", image], { timeoutMs: 30_000 });
  if (removedImage.exitCode !== 0 && !/No such image/u.test(removedImage.diagnostic())) {
    cleanupErrors.push(new Error(removedImage.diagnostic()));
  }
  if (cleanupErrors.length > 0) {
    throw new AggregateError(cleanupErrors, "provider-capacity Docker fixture cleanup failed");
  }
}

test("等待 Docker profile 容量时保持排队且不阻塞其它 Provider [necase_VXE9ARZNBMZ6V0JT]", async () => {
  await runnerE2E.case(
    "provider-capacity-queue",
    { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
    async ({ paths, start }) => {
      await withTempDir("niceeval-runner-provider-capacity-", async (controlRoot) => {
        const runId = crypto.randomUUID();
        const image = `niceeval-e2e-provider-capacity:${runId}`;
        let observation: PublicObservation | undefined;
        let driverStarted = false;
        let primaryError: unknown;
        try {
          const built = await docker.run([
            "build",
            "--tag", image,
            join(paths.projectRoot, "fixtures/provider-capacity"),
          ], { timeoutMs: 120_000 });
          expect(built.exitCode, built.diagnostic()).toBe(0);

          const driver = start([
            "docker", "run", "--rm", "--init", "--network", "none",
            "--label", `niceeval.e2e.provider-capacity=${runId}`,
            "--mount", `type=bind,src=${paths.sourceRoot},dst=${paths.sourceRoot},readonly`,
            "--mount", `type=bind,src=${paths.projectRoot},dst=${paths.projectRoot}`,
            "--mount", `type=bind,src=${controlRoot},dst=${controlRoot}`,
            "--mount", "type=bind,src=/run/docker.sock,dst=/run/docker.sock",
            "--workdir", paths.projectRoot,
            "--env", `NICEEVAL_E2E_PROVIDER_CAPACITY_CONTROL_ROOT=${controlRoot}`,
            "--env", `NICEEVAL_E2E_PROVIDER_CAPACITY_IMAGE=${image}`,
            "--env", `NICEEVAL_E2E_PROVIDER_CAPACITY_RUN_ID=${runId}`,
            "--env", `NICEEVAL_E2E_HOST_UID=${process.getuid!()}`,
            "--env", `NICEEVAL_E2E_HOST_GID=${process.getgid!()}`,
            DRIVER_IMAGE,
            "node", "fixtures/provider-capacity/driver.mjs",
          ], { timeoutMs: DRIVER_DEADLINE_MS, graceMs: 10_000 });
          driverStarted = true;

          const ready = join(controlRoot, "observation-ready");
          await Promise.race([
            pollUntil(
              async () => await exists(ready) ? true : undefined,
              { timeoutMs: 90_000, intervalMs: 50, label: "public provider-capacity observation" },
            ),
            driver.done.then((receipt) => {
              throw new Error(`provider-capacity driver exited before observation\n${receipt.diagnostic()}`);
            }),
          ]);
          try {
            observation = JSON.parse(
              await readFile(join(controlRoot, "public-observation.json"), "utf8"),
            ) as PublicObservation;
          } finally {
            await writeFile(join(controlRoot, "release-profile-first"), "");
          }
          const driverReceipt = await driver.done;
          expect(driverReceipt.exitCode, driverReceipt.diagnostic()).toBe(0);
          const matrix = JSON.parse(
            await readFile(join(controlRoot, "matrix-observation.json"), "utf8"),
          ) as MatrixObservation;
          const assertNoCreate = (scenario: string, observation: { readonly sessionShowJson: string; readonly control: Record<string, any>; readonly liveHuman: string }) => {
            expect(observation.control.reservations, `${scenario} reservations must be released`).toEqual([]);
            expect(observation.control.used, `${scenario} provider capacity must be zero`).toEqual({ containers: 0, builds: 0 });
            expect(observation.control.events?.containerCreates, `${scenario} must not call container.create`).toBe(0);
            expect(
              (observation.control.events?.reservationReleases ?? 0) +
              (observation.control.events?.reservationCancels ?? 0),
              `${scenario} must relinquish its reservation`,
            ).toBeGreaterThanOrEqual(1);
            expect(observation.liveHuman, `${scenario} must not expose sandbox creation`).not.toMatch(/creating sandbox|sandbox\.create/u);
            expect(observation.sessionShowJson, `${scenario} public session must not expose sandbox.create`).not.toContain("sandbox.create");
          };
          assertNoCreate("immediate blocked", matrix.edgeBlocked);
          assertNoCreate("abnormal non-granted", matrix.edgeAbnormal);
          expect(matrix.edgeBlocked.control.events?.acquiredStates).toContain("blocked");
          expect(matrix.edgeBlocked.control.events?.reservationCancels).toBeGreaterThanOrEqual(1);
          expect(matrix.edgeAbnormal.control.events?.acquiredStates).toContain("provisioning");
          expect(matrix.edgeAbnormal.control.events?.reservationReleases).toBeGreaterThanOrEqual(1);
          assertNoCreate("grant/reacquire cancellation", {
            sessionShowJson: matrix.cancelled.cancelPublic.sessionShowJson,
            control: matrix.cancelled.cancelControl,
            liveHuman: matrix.cancelled.cancelHuman,
          });
          expect(matrix.cancelled.cancelControl.events?.acquiredStates).toEqual(expect.arrayContaining(["queued", "granted"]));
          expect(matrix.cancelled.reuse.control.events?.containerCreates).toBe(1);
          expect(matrix.cancelled.reuse.control.reservations).toEqual([]);
          expect(matrix.cancelled.reuse.exitCode).toBe(0);
          expect(matrix.capacityOne.lifecycle).toMatchObject({ containerCreates: 2, activeContainers: 0, maxActiveContainers: 1 });
          expect(matrix.capacityOne.control.reservations).toEqual([]);
          expect(matrix.capacityOne.control.used).toEqual({ containers: 0, builds: 0 });
          expect(matrix.capacityOne.exitCode).toBe(0);
          expect(matrix.groupReuse.lifecycle).toMatchObject({ containerCreates: 2, activeContainers: 0, maxActiveContainers: 1 });
          expect(matrix.groupReuse.control.reservations).toEqual([]);
          expect(matrix.groupReuse.control.used).toEqual({ containers: 0, builds: 0 });
          expect(matrix.groupReuse.exitCode).toBe(0);
          const groupSession = JSON.parse(matrix.groupReuse.sessionShowJson) as PublicSessionShow;
          expect(groupSession.session?.status).toBe("completed");
        } catch (error) {
          primaryError = error;
          throw error;
        } finally {
          try {
            await removeOwnedDockerResources(
              runId,
              image,
              paths.projectRoot,
              controlRoot,
              driverStarted,
            );
          } catch (cleanupError) {
            if (primaryError !== undefined) {
              throw new AggregateError(
                [primaryError, cleanupError],
                "provider-capacity owner and Docker fixture cleanup both failed",
              );
            }
            throw cleanupError;
          }
        }

        expect(observation, "driver must capture public status while the first reservation is gated").toBeDefined();
        const session = JSON.parse(observation!.sessionShowJson) as PublicSessionShow;
        expect(session).toMatchObject({ format: "niceeval.session", session: { status: "active" } });
        const experiments = session.session?.experiments ?? [];
        const profile = experiments.find((experiment) => experiment.experimentId === PROFILE_EXPERIMENT);
        expect(profile, "public Session must include the profile-bound Experiment").toBeDefined();
        expect(profile).toMatchObject({ running: 1, queued: 1 });
        const independent = experiments.find(
          (experiment) => experiment.experimentId === INDEPENDENT_EXPERIMENT,
        );
        expect(
          independent,
          "the same public Session snapshot must show the unrelated Provider Attempt completed",
        ).toMatchObject({ running: 0, queued: 0, elsewhere: 0 });

        const aggregate = experiments.reduce(
          (counts, experiment) => ({
            running: counts.running + (experiment.running ?? 0),
            queued: counts.queued + (experiment.queued ?? 0),
          }),
          { running: 0, queued: 0 },
        );
        expect(aggregate).toEqual({ running: 1, queued: 1 });

        const waiter = recordsIn(profile).find(
          (record) => record.state === "queued" && record.reason === "provider-capacity",
        );
        expect(waiter, "the queued Attempt must expose reason=provider-capacity").toBeDefined();
        expect(JSON.stringify(waiter)).not.toContain("sandbox.create");
        expect(JSON.stringify(waiter)).not.toContain("creating sandbox");

        expect(observation!.sessionShowHuman).toMatch(
          /provider-capacity\/base\/00-profile[^\n]*1 running · 1 queued/u,
        );
        const liveHuman = terminalText(observation!.liveHuman);
        const statusLine = liveHuman.split("\n").filter((line) => line.includes("total ·")).at(-1);
        expect(statusLine, liveHuman).toMatch(/3 total.*1 running.*1 queued.*1 passed/u);
        const waiterLine = liveHuman.split("\n").find((line) => line.includes("waiting for provider capacity"));
        expect(waiterLine, liveHuman).toBeDefined();
        expect(waiterLine).not.toContain("creating sandbox");
      });
    },
  );
}, OWNER_DEADLINE_MS);
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790768291&installation_model_id=431746&pr_number=205&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F205&signature=51df6b636035ed0ce2ce582aa014d90e694ef1aa6e6264c052ac711465b01765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->