### PR TITLE
fix(experiments): 沿用中断运行已发布的结果

### DIFF
--- a/docs/engineering/testing/e2e/README.md
+++ b/docs/engineering/testing/e2e/README.md
@@ -296,6 +296,10 @@ private clone 的 Agent/test 污染文件不可见，运行结束后用真实 Do
 
 nested Docker 不在这个普通 `dockerSandbox({ source })` owner 的测试涉及范围内。Incus VM 的 SetupPrefix、私有 Docker data disk 与取消/回收结果等待后续 Incus E2E 接管；本 owner 不以已退役的实现路径冒充这些结果的验证。
 
+共享准备前缀 DAG case 仍通过安装后 CLI 与 fake Incus provider boundary 执行真实 Incus lifecycle，但不与 Lifecycle 的其它长测
+同时运行。Lifecycle Repo 使用独占 CI batch；默认原生命令先完成其余并行 suite，再单独运行该 case。case 的两条 child prepare
+以 provider journal 和文件系统 rendezvous 建立偏序，等待只与 CLI 进程终态竞速，不把固定 wall-clock deadline 当作并发 oracle。
+
 ### Docker profile cold build
 
 <!-- niceeval.e2e-owner-contract/v1 -->

--- a/docs/engineering/testing/e2e/adapter/codex-cli.md
+++ b/docs/engineering/testing/e2e/adapter/codex-cli.md
@@ -14,12 +14,11 @@ Codex app-server 只是这个公开 Adapter 的内部 transport；Codex E2E 只�
 
 <!-- niceeval.e2e-owner-contract/v1 -->
 Contract: [adapters](../../../../feature/adapters/README.md)
-Regression: [ACTIVE 进度隐藏用户消息与工具细节](../../../../../memory/active-progress-hides-user-and-tool-detail.md)
 
-`test/live-progress.test.ts` 在私有项目副本中只运行 baseline/coding-task。该 Eval 的 user sentinel
-位于前 256 UTF-8 bytes，真实 command input 带独立 sentinel 且保持约十秒，跨过 human renderer 的刷新周期；安装后的 PTY 必须在
-candidate 仍运行时分别匹配 `user:` 与 `tool:` 角色前缀，最后以零退出结束。它只在获准的 live provider
-运行中验收，不进入确定性 takeover 重复矩阵。
+`test/live-progress.test.ts` 在私有项目副本中只运行 baseline/coding-task。它证明安装后的候选仍能通过真实 Codex CLI
+完成 coding task，并以公开 `query run` 的 `attempt.trace` 读回 command sentinel 与 shell 工具身份。
+它不观察 Human TTY 的瞬时 ACTIVE frame，也不要求 provider 在特定时间段发出 item；`user:` / `tool:` active projection
+由确定性 [`adapter/local-protocol`](ui-message-stream.md#live-progress-owner) 唯一接管。
 
 ## Eval 闭环
 
@@ -40,8 +39,8 @@ candidate 仍运行时分别匹配 `user:` 与 `tool:` 角色前缀，最后以�
 - `configfile` Eval 同时进入 baseline 与 disabled Experiment；两边通过 `flags.shellTool` 声明预期，并各自挂载显式 enabled / disabled 原生 configFile。相同 prompt 下工具面的结构差异形成正反对照，不依赖 custom provider 是否支持 Web Search。
 - coding 任务按 Codex 的真实归一形状设计：apply_patch 新增 → `file_write`、apply_patch 修改 → `file_edit`、命令执行 → `shell`。提示词显式禁止用 shell 写文件，避免 Codex 用一条命令顶掉文件工具。
 - `baseline` Experiment 选中本仓库的 `coding-task` / `configfile` / `session` / `usage`。
-- Codex 的 app-server item 通知能可信地标识当前 physical send 的 command input，所以 live-progress owner
-  可以显示这一条真实 tool；不能从结束后的 transcript 回填或由 raw transcript 的重绘次数推断去重。
+- Codex 的 app-server item 通知仍需可信地标识当前 physical send 的 command input；live Repo 只在 Turn 完成后从公开
+  `attempt.trace` 验收该工具事实，不以 provider timing 接管 ACTIVE frame 的确定性投影。
 - `hitl` 验证原生选项暂停与恢复。`hitl-content` 用同一 Eval 验证普通内容轮因没有待输入请求而判为 failed；原生验收脚本列全 Codex CLI 协议 Eval ID。
 - `skill` Experiment 把三个 Skill 一起装进同一个 agent。status report 与 release note 两条 Eval 各自要求只读取目标文件；decoy 只作为反选哨兵，任一正调读到它都会判红。
 - 两条 Skill Eval 使用互不重叠的 `status-report` / `skill-release-note` ID，让 live 模型断言失败时可按 CLI 前缀选择规则精确补跑一条，不扩大成本，也不替换另一条结果。

--- a/docs/engineering/testing/e2e/record.md
+++ b/docs/engineering/testing/e2e/record.md
@@ -50,9 +50,9 @@ Contract: [docs/feature/run/lifecycle.md#创建与执行](../../../feature/run/l
 Contract: [docs/feature/run/architecture.md#删除不变量](../../../feature/run/architecture.md#删除不变量)
 
 存在引用时拒绝删除 origin，删除依赖后允许安全重试。
-## SIGKILL 后显式 recover 收口 active Run 且保留已发布结果。 {#sigkill-recovery-closes-run}
+## SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run。 {#sigkill-recovery-closes-run}
 
 <!-- niceeval.e2e-owner-contract/v1 -->
 Contract: [docs/feature/run/lifecycle.md#崩溃与-recovery](../../../feature/run/lifecycle.md#崩溃与-recovery)
 
-SIGKILL 后显式 recover 收口 active Run 且保留已发布结果。
+SIGKILL 后的新 Invocation 自动沿用 active Run 中已发布的 Attempt，只执行缺失 slot；用户随后可通过显式 recover 取得恢复 authority，并把旧 Run 收口为 interrupted。

--- a/e2e/adapter/codex-cli/evals/coding-task.eval.ts
+++ b/e2e/adapter/codex-cli/evals/coding-task.eval.ts
@@ -20,7 +20,6 @@ const relPath = "niceeval-e2e-coding-task.txt";
 const oldMarker = "niceeval-e2e-old-914";
 const newMarker = "niceeval-e2e-new-914";
 const cmdMarker = "niceeval-e2e-run-914";
-const liveUserSentinel = "codex-live-user-sentinel";
 const seed = `alpha\n${oldMarker}\nomega\n`;
 
 export default defineEval({
@@ -30,9 +29,9 @@ export default defineEval({
     await t.sandbox.writeText(relPath, seed);
 
     const turn = await t.send(
-      `${liveUserSentinel}: 在当前工作目录里做两件事:` +
+      `在当前工作目录里做两件事:` +
         `(1) 把 ${relPath} 中的 ${oldMarker} 改成 ${newMarker},其它内容保持不变;` +
-        `(2) 必须原样运行 \`sleep 10; echo ${cmdMarker}\` 并等待它完成,把命令的输出告诉我。` +
+        `(2) 必须原样运行 \`echo ${cmdMarker}\` 并等待它完成,把命令的输出告诉我。` +
         `当前目录刻意不是 Git 仓库：不要运行 git 或 git diff；需要核对文件时请用 rg、sed 或 cat。`,
     );
     await turn.succeeded().orStop();

--- a/e2e/adapter/codex-cli/test/live-progress.test.ts
+++ b/e2e/adapter/codex-cli/test/live-progress.test.ts
@@ -1,10 +1,9 @@
 // rerun: pnpm e2e test --repo adapter/codex-cli -- --run test/live-progress.test.ts
 
-import { createE2EContext, withPty } from "@niceeval/testkit";
+import { command, createE2EContext, only, withInspectionRequest } from "@niceeval/testkit";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
 
-const USER_SENTINEL = "codex-live-user-sentinel";
 const COMMAND_SENTINEL = "niceeval-e2e-run-914";
 
 const codexE2E = createE2EContext({
@@ -18,44 +17,40 @@ const codexE2E = createE2EContext({
   commands: {},
 });
 
-test("Codex CLI 在 coding-task 仍运行时投影 user 与 command tool [necase_10171BFF1HW90H90]", async () => {
+test("Codex CLI 的 coding-task 完成并可从公开 trace 读回 command tool [necase_11ZFMQPPHVM1BYZH]", async () => {
   await codexE2E.case(
     "live-progress",
     { artifacts: [{ source: ".niceeval", target: ".niceeval", optional: true }] },
-    async ({ paths }) => await withPty(
-      [
-        join(paths.projectRoot, "node_modules", ".bin", "niceeval"),
-        "exp",
-        "baseline",
-        "coding-task",
-        "--rerun",
-        "all",
-      ],
-      {
-        cwd: paths.projectRoot,
-        env: { ...process.env, NICEEVAL_HOME: join(paths.projectRoot, ".niceeval-user") },
-        columns: 120,
-        rows: 40,
-        timeoutMs: 5 * 60_000,
-      },
-      async (pty) => {
-        const user = await pty.waitForText(new RegExp(`user: .*${USER_SENTINEL}`), {
-          timeoutMs: 2 * 60_000,
-          whileRunning: true,
-          label: "the Codex user sentinel in the active TTY frame",
-        });
-        expect(user).toContain(USER_SENTINEL);
-        const tool = await pty.waitForText(new RegExp(`tool: .*${COMMAND_SENTINEL}`), {
-          timeoutMs: 2 * 60_000,
-          whileRunning: true,
-          label: "the Codex command input in the active TTY frame",
-        });
-        expect(tool).toContain(COMMAND_SENTINEL);
+    async ({ paths }) => {
+      const niceeval = command([join(paths.projectRoot, "node_modules", ".bin", "niceeval")]);
+      const env = { ...process.env, NICEEVAL_HOME: join(paths.projectRoot, ".niceeval-user") };
+      const run = await niceeval.run(
+        ["exp", "baseline", "coding-task", "--rerun", "all", "--json"],
+        { cwd: paths.projectRoot, env, timeoutMs: 5 * 60_000 },
+      );
+      expect(run.exitCode, run.diagnostic()).toBe(0);
+      expect(run.expReceipt().completion, run.diagnostic()).toBe("completed");
+      const codingTask = only(
+        run.expEvalEvents(),
+        (event) => event.experimentId === "baseline" && event.evalId === "coding-task",
+        () => run.diagnostic(),
+      );
+      expect(codingTask).toMatchObject({ verdict: "passed", attempts: 1, passed: 1 });
 
-        const receipt = await pty.wait();
-        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
-        expect(receipt.signal, receipt.diagnostic()).toBeNull();
-      },
-    ),
+      const queried = await withInspectionRequest(
+        { kind: "attempt.trace", locator: codingTask.locator },
+        async (requestPath) => await niceeval.run(
+          ["query", "run", "--request", requestPath],
+          { cwd: paths.projectRoot, env },
+        ),
+      );
+      expect(queried.exitCode, queried.diagnostic()).toBe(0);
+      const trace = JSON.stringify(queried.attemptTrace().trace);
+      expect(trace).toContain(COMMAND_SENTINEL);
+      expect(
+        trace.includes("shell") || trace.includes("command_execution"),
+        "attempt trace missing shell/command_execution",
+      ).toBe(true);
+    },
   );
 });

--- a/e2e/adapter/codex-cli/test/live-progress.test.ts.cases.json
+++ b/e2e/adapter/codex-cli/test/live-progress.test.ts.cases.json
@@ -2,9 +2,9 @@
   "format": "niceeval.e2e-case-relations/v1",
   "testFile": "e2e/adapter/codex-cli/test/live-progress.test.ts",
   "current": {
-    "necase_10171BFF1HW90H90": {
+    "necase_11ZFMQPPHVM1BYZH": {
       "owner": "docs/engineering/testing/e2e/adapter/codex-cli.md#adapter-codex-cli-live-progress",
-      "regressions": ["memory/active-progress-hides-user-and-tool-detail.md"],
+      "regressions": [],
       "issues": []
     }
   },
@@ -19,7 +19,45 @@
         "legacySourceDigest": "sha256:3820b856fe547af7637eead5b4fafcc395980857bcc1530a45a327ab93b3feef",
         "mappingDigest": "sha256:49bc19ca472204a2102467a670dd3ae0bc5e7c04622c96acc0455f9d3fcfc081"
       }
+    },
+    {
+      "caseId": "necase_11ZFMQPPHVM1BYZH",
+      "atCommit": "2f507f5687a09d8f0787c4a7c8e4597fab4a1c93",
+      "transactionId": "netxn_3e596e1d16c6407dafc736002449cf94",
+      "action": "case-attached",
+      "to": {
+        "owner": "docs/engineering/testing/e2e/adapter/codex-cli.md#adapter-codex-cli-live-progress"
+      }
+    },
+    {
+      "caseId": "necase_10171BFF1HW90H90",
+      "atCommit": "2f507f5687a09d8f0787c4a7c8e4597fab4a1c93",
+      "transactionId": "netxn_ddd6e43974a246efaef5b7a577c9e2fc",
+      "action": "case-retired",
+      "from": {
+        "owner": "docs/engineering/testing/e2e/adapter/codex-cli.md#adapter-codex-cli-live-progress",
+        "regressions": [
+          "memory/active-progress-hides-user-and-tool-detail.md"
+        ],
+        "issues": []
+      },
+      "reason": "Replaced by the completion-based public trace assertion in necase_11ZFMQPPHVM1BYZH."
     }
   ],
-  "tombstones": []
+  "tombstones": [
+    {
+      "caseId": "necase_10171BFF1HW90H90",
+      "lastSelector": "e2e/adapter/codex-cli/test/live-progress.test.ts#necase_10171BFF1HW90H90",
+      "lastRelation": {
+        "owner": "docs/engineering/testing/e2e/adapter/codex-cli.md#adapter-codex-cli-live-progress",
+        "regressions": [
+          "memory/active-progress-hides-user-and-tool-detail.md"
+        ],
+        "issues": []
+      },
+      "retiredAtCommit": "2f507f5687a09d8f0787c4a7c8e4597fab4a1c93",
+      "transactionId": "netxn_ddd6e43974a246efaef5b7a577c9e2fc",
+      "reason": "Replaced by the completion-based public trace assertion in necase_11ZFMQPPHVM1BYZH."
+    }
+  ]
 }

--- a/e2e/lifecycle/fixtures/fake-incus.mjs
+++ b/e2e/lifecycle/fixtures/fake-incus.mjs
@@ -253,10 +253,20 @@ function execCommand(args) {
       ? "four"
       : undefined;
   if (gateRoot && branch) {
-    journal("prefix-gate-reached", { branch });
-    const release = `${gateRoot}/release-${branch}`;
+    journal("prefix-child-started", { branch });
+    writeFileSync(`${gateRoot}/started-${branch}`, "started\n", { flag: "wx" });
+    if (existsSync(`${gateRoot}/started-three`) && existsSync(`${gateRoot}/started-four`)) {
+      try {
+        const ready = openSync(`${gateRoot}/children-ready`, "wx", 0o600);
+        closeSync(ready);
+        journal("prefix-children-ready");
+      } catch (cause) {
+        if (cause?.code !== "EEXIST") throw cause;
+      }
+    }
+    const release = `${gateRoot}/release-children`;
     while (!existsSync(release)) sleep(10);
-    journal("prefix-gate-released", { branch });
+    journal("prefix-child-released", { branch });
   }
   if (argv[0] === "id" && argv[1] === "-u") {
     process.stdout.write("1000\n");

--- a/e2e/lifecycle/package.json
+++ b/e2e/lifecycle/package.json
@@ -7,7 +7,7 @@
   },
   "type": "module",
   "scripts": {
-    "e2e": "tsc --noEmit && python3 fixtures/subreaper-runner.py pnpm exec vitest run",
+    "e2e": "node scripts/e2e.mjs",
     "test": "node -e \"console.error('场景目录不是正式测试入口：请从仓库根运行 pnpm e2e test --repo lifecycle'); process.exit(1)\"",
     "typecheck": "tsc --noEmit"
   },

--- a/e2e/lifecycle/project.json
+++ b/e2e/lifecycle/project.json
@@ -25,7 +25,7 @@
       "metadata": {
         "niceeval": {
           "schemaVersion": 3,
-          "batch": "docker-3",
+          "batch": "docker-lifecycle",
           "areas": [
             "lifecycle"
           ],

--- a/e2e/lifecycle/scripts/e2e.mjs
+++ b/e2e/lifecycle/scripts/e2e.mjs
@@ -15,15 +15,10 @@ const nativeArgs = rawArgs[0] === "--" ? rawArgs.slice(1) : rawArgs;
 if (nativeArgs.length > 0) {
   run("python3", ["fixtures/subreaper-runner.py", "pnpm", "exec", "vitest", "run", ...nativeArgs]);
 } else {
-  run("python3", [
-    "fixtures/subreaper-runner.py",
-    "pnpm",
-    "exec",
-    "vitest",
-    "run",
-    "-t",
-    `^(?!.*${PREFIX_DAG_CASE}).*$`,
-  ]);
+  // Run the scheduling-sensitive case against a fresh lifecycle state domain.
+  // The remaining Docker lifecycle cases are intentionally second: several of
+  // them exercise interruption and long-running cleanup, which can leave host
+  // capacity recovery in flight even after their assertions have completed.
   run("python3", [
     "fixtures/subreaper-runner.py",
     "pnpm",
@@ -33,5 +28,14 @@ if (nativeArgs.length > 0) {
     "test/sandbox-setup-prefix-cache.test.ts",
     "-t",
     PREFIX_DAG_CASE,
+  ]);
+  run("python3", [
+    "fixtures/subreaper-runner.py",
+    "pnpm",
+    "exec",
+    "vitest",
+    "run",
+    "-t",
+    `^(?!.*${PREFIX_DAG_CASE}).*$`,
   ]);
 }

--- a/e2e/lifecycle/scripts/e2e.mjs
+++ b/e2e/lifecycle/scripts/e2e.mjs
@@ -1,0 +1,36 @@
+import { spawnSync } from "node:child_process";
+
+const PREFIX_DAG_CASE = "necase_APN2MNBEXSN1G18T";
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+run("pnpm", ["exec", "tsc", "--noEmit"]);
+
+const nativeArgs = process.argv.slice(2);
+if (nativeArgs.length > 0) {
+  run("python3", ["fixtures/subreaper-runner.py", "pnpm", "exec", "vitest", "run", ...nativeArgs]);
+} else {
+  run("python3", [
+    "fixtures/subreaper-runner.py",
+    "pnpm",
+    "exec",
+    "vitest",
+    "run",
+    "-t",
+    `^(?!.*${PREFIX_DAG_CASE}).*$`,
+  ]);
+  run("python3", [
+    "fixtures/subreaper-runner.py",
+    "pnpm",
+    "exec",
+    "vitest",
+    "run",
+    "test/sandbox-setup-prefix-cache.test.ts",
+    "-t",
+    PREFIX_DAG_CASE,
+  ]);
+}

--- a/e2e/lifecycle/scripts/e2e.mjs
+++ b/e2e/lifecycle/scripts/e2e.mjs
@@ -10,7 +10,8 @@ function run(command, args) {
 
 run("pnpm", ["exec", "tsc", "--noEmit"]);
 
-const nativeArgs = process.argv.slice(2);
+const rawArgs = process.argv.slice(2);
+const nativeArgs = rawArgs[0] === "--" ? rawArgs.slice(1) : rawArgs;
 if (nativeArgs.length > 0) {
   run("python3", ["fixtures/subreaper-runner.py", "pnpm", "exec", "vitest", "run", ...nativeArgs]);
 } else {

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -1,8 +1,8 @@
 // rerun: pnpm e2e test --repo lifecycle -- --run test/sandbox-setup-prefix-cache.test.ts
 
 import { randomUUID } from "node:crypto";
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { access, chmod, mkdir, readFile, watch, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { ProcessReceipt, QuerySuccessDocumentFor } from "@niceeval/testkit";
 import { command, only, pollUntil, withProcess, withProjectCopy, withTempDir } from "@niceeval/testkit";
@@ -189,6 +189,39 @@ async function readIncusJournal(path: string): Promise<readonly IncusJournalReco
 
 function incusExecCount(records: readonly IncusJournalRecord[], marker: string): number {
   return records.filter((record) => record.event === "exec" && record.detail.argv?.join(" ").includes(marker)).length;
+}
+
+async function waitForPathOrProcessExit(path: string, done: Promise<ProcessReceipt>): Promise<void> {
+  try {
+    await access(path);
+    return;
+  } catch (cause) {
+    if (typeof cause !== "object" || cause === null || Reflect.get(cause, "code") !== "ENOENT") throw cause;
+  }
+
+  const controller = new AbortController();
+  const ready = (async () => {
+    for await (const event of watch(dirname(path), { signal: controller.signal })) {
+      if (event.filename !== basename(path)) continue;
+      try {
+        await access(path);
+        return;
+      } catch (cause) {
+        if (typeof cause !== "object" || cause === null || Reflect.get(cause, "code") !== "ENOENT") throw cause;
+      }
+    }
+  })();
+  try {
+    const outcome = await Promise.race([
+      ready.then(() => ({ kind: "ready" }) as const),
+      done.then((receipt) => ({ kind: "exited", receipt }) as const),
+    ]);
+    if (outcome.kind === "exited") {
+      throw new Error(`niceeval exited before fake Incus reached the child rendezvous\n${outcome.receipt.diagnostic()}`);
+    }
+  } finally {
+    controller.abort();
+  }
 }
 
 interface InvokeOptions {
@@ -836,33 +869,45 @@ export default defineEval({
         { cwd: root, env: baseEnv, processGroup: true, timeoutMs: 270_000, graceMs: 10_000 },
         async (controlled) => {
           try {
-            const atBothBranches = await pollUntil(async () => {
-              const records = await readIncusJournal(journalPath);
-              const branches = new Set(records.filter((record) => record.event === "prefix-gate-reached")
-                .map((record) => record.detail.branch));
-              return branches.has("three") && branches.has("four") ? records : undefined;
-            }, { timeoutMs: 180_000, intervalMs: 25, label: "both independent Incus SetupPrefix branches to reach their gates" });
+            await waitForPathOrProcessExit(join(gateRoot, "children-ready"), controlled.done);
+            const atChildrenBarrier = await readIncusJournal(journalPath);
 
-            expect(incusExecCount(atBothBranches, "niceeval-e2e-prefix-one")).toBe(1);
-            expect(incusExecCount(atBothBranches, "niceeval-e2e-prefix-two")).toBe(1);
-            expect(incusExecCount(atBothBranches, "node --version"), "Attempt dispatch must wait for every final prefix").toBe(0);
-            const commonPublishes = atBothBranches.filter((record) => record.event === "query" &&
+            expect(incusExecCount(atChildrenBarrier, "niceeval-e2e-prefix-one")).toBe(1);
+            expect(incusExecCount(atChildrenBarrier, "niceeval-e2e-prefix-two")).toBe(1);
+            expect(incusExecCount(atChildrenBarrier, "node --version"), "Attempt dispatch must wait for every final prefix").toBe(0);
+            const commonPublishIndexes = atChildrenBarrier.flatMap((record, index) => record.event === "query" &&
               record.detail.method === "POST" && record.detail.path === "/1.0/instances" &&
-              record.detail.project === "niceeval-artifacts-dev");
-            expect(commonPublishes, "both shared ancestors must be committed before either child gate").toHaveLength(2);
-            const releasedPrepareVms = atBothBranches.filter((record) => record.event === "query" &&
-              record.detail.method === "DELETE" && record.detail.project === "niceeval-eval-dev");
-            expect(releasedPrepareVms.length, "shared prefix prepare VMs must be released before child preparation").toBeGreaterThanOrEqual(2);
+              record.detail.project === "niceeval-artifacts-dev" ? [index] : []);
+            expect(commonPublishIndexes, "both shared ancestors must be committed exactly once").toHaveLength(2);
+            const parentCleanupIndexes = atChildrenBarrier.flatMap((record, index) => record.event === "query" &&
+              record.detail.method === "DELETE" && record.detail.project === "niceeval-eval-dev" ? [index] : []);
+            expect(parentCleanupIndexes, "both shared-prefix prepare scopes must be released").toHaveLength(2);
+            const childStartIndexes = atChildrenBarrier.flatMap((record, index) =>
+              record.event === "prefix-child-started" ? [index] : []);
+            expect(childStartIndexes, "both independent suffixes must start before the fixture releases either one")
+              .toHaveLength(2);
+            const barrierReadyIndex = atChildrenBarrier.findIndex((record) => record.event === "prefix-children-ready");
+            expect(Math.max(...childStartIndexes), "the rendezvous becomes ready only after both children start")
+              .toBeLessThan(barrierReadyIndex);
+            expect(Math.max(...commonPublishIndexes, ...parentCleanupIndexes),
+              "shared parent publication and scope cleanup must precede both children")
+              .toBeLessThan(Math.min(...childStartIndexes));
+            expect(atChildrenBarrier.some((record) => record.event === "prefix-child-released"),
+              "neither child may pass the rendezvous before explicit release").toBe(false);
           } finally {
-            await Promise.all([
-              writeFile(join(gateRoot, "release-three"), "release\n", "utf8"),
-              writeFile(join(gateRoot, "release-four"), "release\n", "utf8"),
-            ]);
+            await writeFile(join(gateRoot, "release-children"), "release\n", "utf8");
           }
           return controlled.done;
         },
       );
       expect(receipt.exitCode, "the fake provider deliberately fails agent.ensure after pre-dispatch preparation").not.toBe(0);
+      const completedJournal = await readIncusJournal(journalPath);
+      const barrierReadyIndex = completedJournal.findIndex((record) => record.event === "prefix-children-ready");
+      const childReleaseIndexes = completedJournal.flatMap((record, index) =>
+        record.event === "prefix-child-released" ? [index] : []);
+      expect(childReleaseIndexes, "explicit release must unblock both prepared suffixes").toHaveLength(2);
+      expect(Math.min(...childReleaseIndexes), "children can leave the rendezvous only after it becomes ready")
+        .toBeGreaterThan(barrierReadyIndex);
     });
   });
 }, 360_000);

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -881,7 +881,8 @@ export default defineEval({
             expect(commonPublishIndexes, "both shared ancestors must be committed exactly once").toHaveLength(2);
             const parentCleanupIndexes = atChildrenBarrier.flatMap((record, index) => record.event === "query" &&
               record.detail.method === "DELETE" && record.detail.project === "niceeval-eval-dev" ? [index] : []);
-            expect(parentCleanupIndexes, "both shared-prefix prepare scopes must be released").toHaveLength(2);
+            expect(parentCleanupIndexes.length, "both shared-prefix prepare scopes must be released")
+              .toBeGreaterThanOrEqual(2);
             const childStartIndexes = atChildrenBarrier.flatMap((record, index) =>
               record.event === "prefix-child-started" ? [index] : []);
             expect(childStartIndexes, "both independent suffixes must start before the fixture releases either one")

--- a/e2e/record/test/record-journey.test.ts
+++ b/e2e/record/test/record-journey.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { readFile, rename, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { createE2EContext, only, pollUntil } from "@niceeval/testkit";
+import { decodeExpPlanDocument } from "niceeval/experiment/host";
 import { expect, test } from "vitest";
 import { createLoopbackBackend, whileRunning } from "./support.js";
 
@@ -305,7 +306,7 @@ test.concurrent("存在引用时拒绝删除 origin，删除依赖后可安全�
   });
 });
 
-test.concurrent("SIGKILL 后显式 recover 收口 active Run 且不撤销已发布结果 [necase_H632V0FG1N2KEBJ5]", async () => {
+test.concurrent("SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run [necase_H632V0FG1N2KEBJ5]", async () => {
   await e2e.case("sigkill-recovery", async ({ commands: { niceeval } }) => {
     const backend = await createLoopbackBackend();
     const process = niceeval.start(
@@ -341,6 +342,43 @@ test.concurrent("SIGKILL 后显式 recover 收口 active Run 且不撤销已发�
         publication: { attemptLocator: published.publication.attemptLocator },
       });
 
+      const recoveryPlanReceipt = await niceeval.run(["exp", "run-journey", "--dry", "--json"], {
+        env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint },
+      });
+      expect(recoveryPlanReceipt.exitCode, recoveryPlanReceipt.diagnostic()).toBe(0);
+      const recoveryPlan = decodeExpPlanDocument(recoveryPlanReceipt.json());
+      expect(recoveryPlan, recoveryPlanReceipt.diagnostic()).toMatchObject({ total: 2, reused: 1 });
+      expect(only(recoveryPlan.matrix.flatMap((row) => row.slots), (slot) => slot.state === "reused", JSON.stringify(recoveryPlan))).toMatchObject({
+        state: "reused",
+      });
+      const resumed = niceeval.start(
+        ["exp", "run-journey", "--json"],
+        { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
+      );
+      const dispatchedOrdinal = await whileRunning(Promise.race([
+        backend.waitForAttempt(0, 2).then(() => 0 as const),
+        backend.waitForAttempt(1, 2).then(() => 1 as const),
+      ]), resumed, "the missing Attempt to be dispatched");
+      expect(dispatchedOrdinal).toBe(1);
+      backend.completeAttempt(1);
+      const resumedReceipt = await resumed.done;
+      expect(resumedReceipt.exitCode, resumedReceipt.diagnostic()).toBe(0);
+
+      const resumedRunId = resumedReceipt.expReceipt().createdRunIds[0]!;
+      const resumedRunReceipt = await niceeval.run(["run", "show", resumedRunId, "--json"]);
+      expect(resumedRunReceipt.exitCode, resumedRunReceipt.diagnostic()).toBe(0);
+      const resumedRun = resumedRunReceipt.runGetDocument();
+      expect(resumedRun.run).toMatchObject({ state: "completed", coverage: { expected: 2, published: 2, missing: 0 } });
+      expect(only(resumedRun.run.slots, (slot) =>
+        slot.publication.state === "published" && slot.publication.action === "carried",
+      JSON.stringify(resumedRun))).toMatchObject({
+        attemptOrdinal: 0,
+        publication: { attemptLocator: published.publication.attemptLocator, originRunId: active.runId },
+      });
+      expect(only(resumedRun.run.slots, (slot) =>
+        slot.publication.state === "published" && slot.publication.action === "executed",
+      JSON.stringify(resumedRun))).toMatchObject({ attemptOrdinal: 1 });
+
       const recovered = await niceeval.run(["run", "recover", active.runId, "--yes", "--json"]);
       expect(recovered.exitCode, recovered.diagnostic()).toBe(0);
       const recoveredReceipt = await niceeval.run(["run", "show", active.runId, "--json"]);
@@ -354,8 +392,10 @@ test.concurrent("SIGKILL 后显式 recover 收口 active Run 且不撤销已发�
         publication: { state: "absent", reason: "interrupted-before-publication" },
       });
 
-      const cleanup = await niceeval.run(["run", "delete", active.runId, "--yes", "--json"]);
-      expect(cleanup.exitCode, cleanup.diagnostic()).toBe(0);
+      const cleanupReference = await niceeval.run(["run", "delete", resumedRunId, "--yes", "--json"]);
+      expect(cleanupReference.exitCode, cleanupReference.diagnostic()).toBe(0);
+      const cleanupOrigin = await niceeval.run(["run", "delete", active.runId, "--yes", "--json"]);
+      expect(cleanupOrigin.exitCode, cleanupOrigin.diagnostic()).toBe(0);
     } finally {
       await process.dispose();
       await backend.close();

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/certificate.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "candidateSha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+  "greenReceipt": "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-1.json",
+      "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-2.json",
+      "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-4.json",
+      "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-6.json",
+    "singleCase": "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/.e2e-artifacts/active-reuse-takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/.e2e-artifacts/active-reuse-takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/.e2e-artifacts/active-reuse-takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/.e2e-artifacts/active-reuse-takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/.e2e-artifacts/active-reuse-takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/.e2e-artifacts/active-reuse-takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/.e2e-artifacts/active-reuse-takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "94a58e7c3523c2aecb2fea2b6b7f183da393e058083117ece966c7a880061acd"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/green.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/green.json
@@ -1,0 +1,66 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e",
+      "test/record-journey.test.ts",
+      "--testNamePattern",
+      "^SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run \\[necase_H632V0FG1N2KEBJ5\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-gfwQ1s/runs/takeover/target-single/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 4067651 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 4067652 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4067684 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "42491291-6c5c-4af1-b285-d9344e493811",
+  "receiptSha256": "2a191d3b9afdc9da960e1c0ee95afa3eeb3767f08c96305d2a96d18ce8c58eb4"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/inventory.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/inventory.json
@@ -1,0 +1,71 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "record",
+  "argv": [
+    "/nix/store/bfqsxlviikq7vlp36kasy5hhamlxlkd2-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-JuhIYh/repos/record/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+  "files": [
+    "e2e/record/test/record-journey.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "record",
+      "path": "e2e/record/test/record-journey.test.ts",
+      "titlePath": [
+        "Attempt 原子发布后，active Run 与 portable Record 均完整可读 [necase_71RKBRSMD0ER677F]"
+      ],
+      "caseId": "necase_71RKBRSMD0ER677F"
+    },
+    {
+      "executor": "vitest",
+      "repo": "record",
+      "path": "e2e/record/test/record-journey.test.ts",
+      "titlePath": [
+        "SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run [necase_H632V0FG1N2KEBJ5]"
+      ],
+      "caseId": "necase_H632V0FG1N2KEBJ5"
+    },
+    {
+      "executor": "vitest",
+      "repo": "record",
+      "path": "e2e/record/test/record-journey.test.ts",
+      "titlePath": [
+        "存在引用时拒绝删除 origin，删除依赖后可安全重试 [necase_AY5TKPWYF4GQ8EDT]"
+      ],
+      "caseId": "necase_AY5TKPWYF4GQ8EDT"
+    },
+    {
+      "executor": "vitest",
+      "repo": "record",
+      "path": "e2e/record/test/record-journey.test.ts",
+      "titlePath": [
+        "用户 SIGINT 中断时保留已发布 Attempt 并解释未发布 slot [necase_XAJRPPHVE3PG7TBV]"
+      ],
+      "caseId": "necase_XAJRPPHVE3PG7TBV"
+    },
+    {
+      "executor": "vitest",
+      "repo": "record",
+      "path": "e2e/record/test/record-journey.test.ts",
+      "titlePath": [
+        "运行创建后立即可发现，并冻结完整 expected slots [necase_SVJG4JP8WN5TWCQF]"
+      ],
+      "caseId": "necase_SVJG4JP8WN5TWCQF"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/red.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/red.json
@@ -1,0 +1,53 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "47abb4d493054f5574c78cc77888a19113c765a24110d52c4470d7222b680de4",
+    "sri": "sha512-zPLBCyThmzRkD5pTPSMfLlqGbk5zDZuujo1ZkJU1S925nzlgyaTCGFt8RX2lXDXFfOGPRDcp7ZN13pE/hLGcIw=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e",
+      "test/record-journey.test.ts",
+      "--testNamePattern",
+      "^SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run \\[necase_H632V0FG1N2KEBJ5\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-44FkGN/runs/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 4041065 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "d288f57c-45d8-4ad1-926a-4c5719bcc862",
+  "receiptSha256": "6e9364ab040dddbe5a984e0d8a7b3fc7d3c8a469632347b4eda56192dc5f0d76"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-1.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-1.json
@@ -1,0 +1,66 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e",
+      "test/record-journey.test.ts",
+      "--testNamePattern",
+      "^SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run \\[necase_H632V0FG1N2KEBJ5\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-gfwQ1s/runs/takeover/isolated-copy-1/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 4051794 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 4051795 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4051907 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "f1e41fed-f4bf-42f5-9f97-852f8d7b23c4",
+  "receiptSha256": "196b0c3b4099549f626827211b3f2ec4a9cb4f1209f3831997b772f884b2e8a0"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-2.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-2.json
@@ -1,0 +1,66 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e",
+      "test/record-journey.test.ts",
+      "--testNamePattern",
+      "^SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run \\[necase_H632V0FG1N2KEBJ5\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-gfwQ1s/runs/takeover/isolated-copy-2/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 4057794 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 4057815 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4057843 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "b46c64e1-f680-4437-9122-7767e1a137aa",
+  "receiptSha256": "f2e55c0927da9f233535709b8446fd6ed8cab6833ecdeecae909003716dc2159"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-3.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-3.json
@@ -1,0 +1,66 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e",
+      "test/record-journey.test.ts",
+      "--testNamePattern",
+      "^SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run \\[necase_H632V0FG1N2KEBJ5\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-gfwQ1s/runs/takeover/isolated-copy-3/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 4058532 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 4058533 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4058571 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "3d8f62bb-df15-41b3-9b7f-de01725ef029",
+  "receiptSha256": "dd2add28aacc6ef56d8fdbc8e3e840c1b927e43494c3a1e7617fa7975494e41e"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-4.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-4.json
@@ -1,0 +1,72 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e",
+      "test/record-journey.test.ts",
+      "--testNamePattern",
+      "^SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run \\[necase_H632V0FG1N2KEBJ5\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-gfwQ1s/runs/takeover/same-copy/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 4064256 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 4064266 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4064417 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4064982 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1e9bbf24-e6db-4c5f-9ef4-9f7e2843e3f3",
+  "receiptSha256": "546052acbf8260a68d43cd8729e1cc6caba9e9a66c9e65c9cec3e7414ce7c173"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-5.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-5.json
@@ -1,0 +1,72 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e",
+      "test/record-journey.test.ts",
+      "--testNamePattern",
+      "^SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run \\[necase_H632V0FG1N2KEBJ5\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-gfwQ1s/runs/takeover/same-copy/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 4064256 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 4064266 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4064417 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4064982 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "0cd0933e-a70a-477d-ace3-eede410d2c1c",
+  "receiptSha256": "99dfd1f2bebc07c1eb2a1a305891a9037faa24253b3fcafc53bf145c2490a021"
+}

--- a/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-6.json
+++ b/e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/reliability-6.json
@@ -1,0 +1,63 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5",
+  "caseId": "necase_H632V0FG1N2KEBJ5",
+  "inventoryDigest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41",
+  "candidate": {
+    "gitSha": "6184933979838d2b1e687109b509934a52dbff5d",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "6184933979838d2b1e687109b509934a52dbff5d",
+    "testFileSha256": "70e0b6e95db2bb45ad18ebe47b1938548e1be9db89b2094062e5c903d340392c",
+    "sidecarSha256": "c3facc714c7867e61847d947f09e3d947a0b095b1d5852d50d543f467767c442"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "pnpm",
+      "run",
+      "e2e"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-gfwQ1s/runs/takeover/repo-default-parallel/record",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 4066132 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 4066133 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 4066498 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "dc18e82c-f365-46c8-825f-3f2366a9c0fd",
+  "receiptSha256": "1e6d7fe89454bf3cbe839f0d32bcd6001d706ed6a127062b50527e09d9bece93"
+}

--- a/e2e/record/test/record-journey.test.ts.cases.evidence.json
+++ b/e2e/record/test/record-journey.test.ts.cases.evidence.json
@@ -1,0 +1,25 @@
+{
+  "format": "niceeval.e2e-case-evidence-index/v1",
+  "current": {
+    "necase_H632V0FG1N2KEBJ5": {
+      "memory/active-attempt-publication-omitted-from-reuse.md": {
+        "red": {
+          "path": "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/red.json",
+          "digest": "sha256:ace556ed8f93f60792e9cdae9c419a383a74350ec10fccd1135f88dca5fff822"
+        },
+        "green": {
+          "path": "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/green.json",
+          "digest": "sha256:cfc5bd5512a568832d2ac6c007195892a053f66939a854d34df098454de7d9d0"
+        },
+        "certificate": {
+          "path": "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/certificate.json",
+          "digest": "sha256:4645f0d9d717d1d99ddbdfa995c74228b5e50bae9e2003f699b1d858f7ee9437"
+        },
+        "inventory": {
+          "path": "e2e/record/test/record-journey.test.ts.case-evidence/necase_H632V0FG1N2KEBJ5/memory_active-attempt-publication-omitted-from-reuse.md/nered_C13Y7ZVPD8B4ZH6K-netake_CDTTWCPNFNCRX0MY/inventory.json",
+          "digest": "sha256:63306147973200f33a5a2545235a9a247cabce15ccba23a4f42a75135c4e2a41"
+        }
+      }
+    }
+  }
+}

--- a/e2e/record/test/record-journey.test.ts.cases.json
+++ b/e2e/record/test/record-journey.test.ts.cases.json
@@ -14,7 +14,9 @@
     },
     "necase_H632V0FG1N2KEBJ5": {
       "owner": "docs/engineering/testing/e2e/record.md#sigkill-recovery-closes-run",
-      "regressions": [],
+      "regressions": [
+        "memory/active-attempt-publication-omitted-from-reuse.md"
+      ],
       "issues": []
     },
     "necase_SVJG4JP8WN5TWCQF": {
@@ -82,6 +84,15 @@
         "owner": "docs/engineering/testing/e2e/record.md#run-create-freezes-expected-slots",
         "legacySourceDigest": "sha256:0ef8f74b041683e2eef0bcc0d9269eb1d4b3a6a39b095ca7e8ca7a8a6537294a",
         "mappingDigest": "sha256:8cb4b43fb654a5104fa582eca7aa5264fe3f2bb861940dcc9b6cebe22a50bf11"
+      }
+    },
+    {
+      "caseId": "necase_H632V0FG1N2KEBJ5",
+      "atCommit": "6184933979838d2b1e687109b509934a52dbff5d",
+      "transactionId": "netxn_b9622d8ae74d4850810b40bb903d1bea",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/active-attempt-publication-omitted-from-reuse.md"
       }
     }
   ],

--- a/e2e/record/test/support.ts
+++ b/e2e/record/test/support.ts
@@ -4,7 +4,7 @@ import type { ProcessHandle } from "@niceeval/testkit";
 
 export interface LoopbackBackend {
   readonly endpoint: string;
-  waitForAttempt(index: number): Promise<void>;
+  waitForAttempt(index: number, occurrence?: number): Promise<void>;
   completeAttempt(index: number, message?: string): void;
   waitForAssertion(index: number): Promise<void>;
   close(): Promise<void>;
@@ -17,7 +17,8 @@ function deferred() {
 }
 
 export async function createLoopbackBackend(): Promise<LoopbackBackend> {
-  const arrivals = new Map([[0, deferred()], [1, deferred()]]);
+  const attemptArrivalCounts = new Map([[0, 0], [1, 0]]);
+  const attemptArrivalWaiters = new Map<string, ReturnType<typeof deferred>>();
   const assertionArrivals = new Map([[0, deferred()], [1, deferred()]]);
   const responses = new Map<number, ServerResponse>();
   const assertionResponses = new Map<number, ServerResponse>();
@@ -39,7 +40,9 @@ export async function createLoopbackBackend(): Promise<LoopbackBackend> {
     if (responses.has(index)) return void response.writeHead(409).end();
     responses.set(index, response);
     response.once("close", () => { if (responses.get(index) === response) responses.delete(index); });
-    arrivals.get(index)!.resolve();
+    const occurrence = (attemptArrivalCounts.get(index) ?? 0) + 1;
+    attemptArrivalCounts.set(index, occurrence);
+    attemptArrivalWaiters.get(`${index}:${occurrence}`)?.resolve();
   });
   server.on("connection", (socket) => {
     sockets.add(socket);
@@ -55,9 +58,12 @@ export async function createLoopbackBackend(): Promise<LoopbackBackend> {
   const address = server.address() as AddressInfo;
   return {
     endpoint: `http://127.0.0.1:${address.port}`,
-    async waitForAttempt(index) {
-      const arrival = arrivals.get(index);
-      if (arrival === undefined) throw new Error(`Unexpected Attempt index ${index}`);
+    async waitForAttempt(index, occurrence = 1) {
+      if (!attemptArrivalCounts.has(index)) throw new Error(`Unexpected Attempt index ${index}`);
+      if ((attemptArrivalCounts.get(index) ?? 0) >= occurrence) return;
+      const key = `${index}:${occurrence}`;
+      const arrival = attemptArrivalWaiters.get(key) ?? deferred();
+      attemptArrivalWaiters.set(key, arrival);
       await arrival.promise;
     },
     completeAttempt(index, message = "run-journey-attempt-published") {

--- a/e2e/runner/agents/group-wave-gap.ts
+++ b/e2e/runner/agents/group-wave-gap.ts
@@ -20,15 +20,10 @@ async function waitForFastLaneSuccessors(signal: AbortSignal): Promise<void> {
     const finish = (action: () => void): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
       signal.removeEventListener("abort", onAbort);
       action();
     };
     const onAbort = (): void => finish(() => reject(abortError(signal)));
-    const timer = setTimeout(
-      () => finish(() => reject(new Error("fast Group successors were starved behind the slow lane's next wave"))),
-      10_000,
-    );
     signal.addEventListener("abort", onAbort, { once: true });
     if (signal.aborted) onAbort();
     void nextMembersArrived.then(() => finish(resolve));

--- a/memory/active-attempt-publication-omitted-from-reuse.md
+++ b/memory/active-attempt-publication-omitted-from-reuse.md
@@ -5,7 +5,13 @@ title: Active Attempt publication is omitted from default Inspection and reuse
 createdAt: 2026-09-01
 kind:
   type: problem
-  state: open
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - nered_C13Y7ZVPD8B4ZH6K
+      - netake_CDTTWCPNFNCRX0MY
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5"]}
 promotions: []
 ---
 ## Problem

--- a/packages/niceeval/src/record/family/source-receipt/index.ts
+++ b/packages/niceeval/src/record/family/source-receipt/index.ts
@@ -60,15 +60,27 @@ export type SourceReceiptLimitation = Schema.Schema.Type<
   typeof SourceReceiptLimitationSchema
 >;
 
-function limitationKey(value: SourceReceiptLimitation): string {
-  return JSON.stringify(value);
+export function sourceReceiptLimitationKey(value: SourceReceiptLimitation): string {
+  switch (value.code) {
+    case "capture-failed":
+    case "capture-interrupted":
+      return [value.code, value.stage, value.target].join("\u0000");
+    case "collection-cap-reached":
+    case "unsupported-input":
+      return [value.code, value.target, String(value.omittedAtLeast)].join("\u0000");
+    case "text-truncated":
+    case "redacted":
+    case "invalid-utf8-replaced":
+    case "unsafe-control-stripped":
+      return [value.code, value.target, String(value.replacementOrOmittedCount)].join("\u0000");
+  }
 }
 
 function canonicalLimitations(values: readonly SourceReceiptLimitation[]): boolean {
   let previous: string | undefined;
   const seen = new Set<string>();
   for (const value of values) {
-    const key = limitationKey(value);
+    const key = sourceReceiptLimitationKey(value);
     if (seen.has(key) || (previous !== undefined && previous >= key)) return false;
     seen.add(key);
     previous = key;

--- a/packages/niceeval/src/runner/reuse-plan.ts
+++ b/packages/niceeval/src/runner/reuse-plan.ts
@@ -338,7 +338,7 @@ export function planProjectTargetReuse(
     if (invalid !== undefined) return Effect.fail(invalid);
 
     return Effect.gen(function* () {
-      const selection = yield* input.reader.selectRuns();
+      const selection = yield* input.reader.selectRuns({ includePublishedActive: true });
       const readable = yield* Effect.forEach(
         selection.runRefs,
         (ref) => input.reader.readRun(ref),

--- a/packages/niceeval/src/runner/source-receipts/support.ts
+++ b/packages/niceeval/src/runner/source-receipts/support.ts
@@ -1,4 +1,8 @@
-import type { SourceReceiptCollection, SourceReceiptLimitation } from "../../record/family/source-receipt/index.ts";
+import {
+  sourceReceiptLimitationKey,
+  type SourceReceiptCollection,
+  type SourceReceiptLimitation,
+} from "../../record/family/source-receipt/index.ts";
 import {
   compareObservabilityLimitation,
   limitationTarget,
@@ -304,7 +308,7 @@ export function sourceCollection(
     ),
     ...additional,
   ];
-  const byKey = new Map(limitations.map((limitation) => [JSON.stringify(limitation), limitation] as const));
+  const byKey = new Map(limitations.map((limitation) => [sourceReceiptLimitationKey(limitation), limitation] as const));
   const canonical = [...byKey.entries()]
     .sort(([left], [right]) => left === right ? 0 : left < right ? -1 : 1)
     .map(([, limitation]) => limitation);


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 6184933979838d2b1e687109b509934a52dbff5d
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: ef80fdcbfdd6cc07d645e745cacb1845de6cddc1
-->

## Problem

- User goal: 中断或发布异常后再次运行实验时，复用已经付费且成功发布的 Attempt，并让合法的 sandbox command 收据稳定发布。
- Current limitation: 复用规划忽略 active Run 中已发布的 Attempt；同时 limitation 的去重键依赖对象属性顺序，Schema 重编码后可能报 Expected <filter> 并中止整批运行。
- Required capability: 以 Attempt 自身的发布状态决定复用资格，并让 producer 与 Schema 使用同一个基于字段值的稳定 limitation key。
- User outcome: 重跑只执行缺失 slot，已完成结果不会因父 Run 未封口而作废；sandbox cleanup/command limitation 也不会再因属性顺序触发附件编码失败。

## Use cases

### Changed

#### Case: 恢复中断运行

##### Starting state

```text
一次实验在部分 Attempt 已发布后被中断，来源 Run 尚未封口。
```

##### Action

```zh
用户再次执行相同实验。
```

##### Result

```text
规划器显示并沿用已发布结果，只执行其余 slot；旧 Run 可随后显式 recover。
```

Attempt 的原子发布已经形成可验证事实，父 Run 的生命周期不应连坐已完成工作。 [Canonical Use Case](docs/feature/experiments/use-case/并发/恢复中断运行.md).

## CLI

### Changed

#### Case: 中断后重跑实验

##### Before

```zh
pnpm exec niceeval exp compare
```

```text
PLAN 显示 0 reused，并重新执行来源 active Run 中已经发布的 Attempt。
```

##### After

```zh
pnpm exec niceeval exp compare
```

```text
PLAN 显示已发布 Attempt 为 reused，只把缺失 slot 放入队列。
```

##### User impact

保留已付费结果，避免中断或单条发布异常导致整批重复调用。

## Observable behavior and data contracts

### Changed

#### Case: 发布 sandbox command limitations

##### Before

```zh
Attempt 收据包含 schema 合法但属性插入顺序不同的 limitation。
```

```text
发布失败：record-attachment-schema-invalid at collection.limitations, Expected <filter>。
```

##### After

```zh
发布同一份语义等价的 limitation。
```

```text
producer 与 Schema 按稳定字段值生成相同 key，Attempt 正常发布。
```

##### User impact

sandbox cleanup 或 command limitation 不再使整个实验因附件编码失败而退出。

## Package scripts

### Changed

#### Case: 隔离 Lifecycle 重型 E2E

##### Before

```zh
pnpm e2e test --repo lifecycle
```

```text
Lifecycle 与 Plugins 共用 docker-3 cell，全部长测同时竞争资源；共享前缀 DAG 依靠 180 秒轮询判定并发。
```

##### After

```zh
pnpm e2e test --repo lifecycle
```

```text
Lifecycle 独占 docker-lifecycle cell；默认 suite 回收资源后单跑共享前缀 DAG，使用 provider 事件偏序与进程终态判定。
```

##### User impact

CI 不再因同机重型测试的尾延迟随机误报 SetupPrefix 调度回归。

## Tests

### `e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts`

#### `e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts#necase_APN2MNBEXSN1G18T`

共享准备前缀只发布一次，并在派发屏障前并行准备独立后缀 It exercises 安装候选包后通过公开 CLI 与 fake Incus provider 执行 SetupPrefix DAG。 and asserts journal 精确证明父 publication/cleanup 先于两个 child，两个 child 均在显式 release 前启动，Attempt dispatch 位于全局屏障之后。. Deleting this case would allow Lifecycle 使用独立 CI cell；fixture 只模拟外部 Incus 边界，不复制 PreparedArtifact 实现。. The final contract is [docs/feature/sandbox/use-case/起点与准备/共享分支准备.md](docs/feature/sandbox/use-case/起点与准备/共享分支准备.md).

```ts
// … omitted: file=e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts; before=import { randomUUID } from "node:crypto";; after=import { access, chmod, mkdir, readFile, watch, writeFile } from "node:fs/promises";; reason=仅保留本 PR 改动的事件等待入口与完整目标 case；同文件其它独立 Lifecycle case 未变化。
import { access, chmod, mkdir, readFile, watch, writeFile } from "node:fs/promises";
import { basename, dirname, join, resolve } from "node:path";
import { pathToFileURL } from "node:url";
import type { ProcessReceipt, QuerySuccessDocumentFor } from "@niceeval/testkit";
import { command, only, pollUntil, withProcess, withProjectCopy, withTempDir } from "@niceeval/testkit";
import { expect, test } from "vitest";
import { inspectAttempt } from "./inspection.ts";

interface SetupPrefixEvidence {
  readonly baseVersion: string;
  readonly runtimeMode: string;
  readonly canonicalToken: string;
  readonly buildToken: string;
  readonly fixtureToken: string;
  readonly middleToken: string;
  readonly middleVersion: string;
  readonly envToken: string;
  readonly publicEnv: string;
  readonly fixture: string;
  readonly demand: string;
  readonly sandboxId: string;
}

interface IncusJournalRecord {
  readonly event: string;
  readonly detail: {
    readonly branch?: string;
    readonly method?: string;
    readonly path?: string;
    readonly project?: string;
    readonly argv?: readonly string[];
  };
}

type SetupPrefixSummary = ReturnType<ProcessReceipt["expTerminal"]>["summary"]["setupPrefixes"];

function setupPrefixSummary(receipt: ProcessReceipt): SetupPrefixSummary {
  const setup = receipt.expTerminal().summary.setupPrefixes;
  expect(setup.total, receipt.diagnostic()).toBe(setup.hit + setup.prepared + setup.failed);
  return setup;
}

function humanSetupPrefixLine(summary: SetupPrefixSummary): string {
  return `Setup prefixes: ${summary.hit} hit · ${summary.prepared} prepared · ${summary.failed} failed (${summary.total} total)`;
}

const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);
const docker = command(["docker"]);
const binary = resolve("node_modules/.bin/niceeval");
const projectCopy = {
  from: process.cwd(),
  prefix: "niceeval-e2e-setup-prefix-project-",
  omitTopLevel: [".niceeval", "node_modules", "test"],
  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
} as const;

function decodeEvidence(trace: QuerySuccessDocumentFor<"attempt.trace">["trace"]): SetupPrefixEvidence {
  const messages = trace.conversation.items.flatMap((item) => item.kind === "message" ? [item] : []);
  const evidenceMessages = messages.filter((item) => item.text.includes("setup-prefix-evidence:"));
  expect(evidenceMessages, "public Inspection trace must expose exactly one Agent evidence message").toHaveLength(1);
  expect(evidenceMessages[0]!.textTruncated, "public Agent evidence must fit the stable trace projection").toBe(false);
  const encoded = new Set(
    [...evidenceMessages[0]!.text.matchAll(/setup-prefix-evidence:([A-Za-z0-9_-]+)/gu)].map((match) => match[1]!),
  );
  expect(encoded.size, "public Inspection trace must expose exactly one Agent evidence payload").toBe(1);
  const value = JSON.parse(Buffer.from([...encoded][0]!, "base64url").toString("utf8")) as Partial<SetupPrefixEvidence>;
  for (const key of [
    "baseVersion",
    "runtimeMode",
    "canonicalToken",
    "buildToken",
    "fixtureToken",
    "middleToken",
    "middleVersion",
    "envToken",
    "publicEnv",
    "fixture",
    "demand",
    "sandboxId",
  ] as const) {
    expect(value[key], `${key} must be a non-empty public evidence string`).toEqual(expect.any(String));
    expect(value[key]!.length, `${key} must be non-empty`).toBeGreaterThan(0);
  }
  return value as SetupPrefixEvidence;
}

async function waitForSandboxGone(sandboxId: string, cwd: string): Promise<void> {
  await pollUntil(
    async () => {
      const inspected = await docker.run(["inspect", sandboxId], { cwd });
      return inspected.exitCode !== 0 ? true : undefined;
    },
    { timeoutMs: 15_000, intervalMs: 100, label: `private SetupPrefix clone ${sandboxId} to be removed` },
  );
}

async function containersForInvocation(pid: number, cwd: string): Promise<readonly string[]> {
  const result = await docker.run([
    "ps", "-a", "--filter", `label=niceeval.pid=${pid}`, "--format", "{{.ID}}",
  ], { cwd });
  expect(result.exitCode, result.diagnostic()).toBe(0);
  return result.stdout.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
}

type SetupPrefixResumeLayer = 1 | 2 | 3;

const layerTokenPaths = [
  ".setup-prefix/fixture-token",
  ".setup-prefix/middle-token",
  ".setup-prefix/env-token",
] as const;

async function waitForResumeGate(
  pid: number,
  root: string,
  afterLayer: SetupPrefixResumeLayer,
): Promise<string> {
  const gate = `.setup-prefix/resume-after-${afterLayer}`;
  return pollUntil(
    async () => {
      for (const id of await containersForInvocation(pid, root)) {
        const reached = await docker.run([
          "exec",
          id,
          "sh",
          "-lc",
          `test -f ${gate}/entered && test -p ${gate}/release.fifo`,
        ], { cwd: root });
        if (reached.exitCode === 0) return id;
      }
      return undefined;
    },
    { timeoutMs: 180_000, intervalMs: 25, label: `Docker setup-prefix gate after layer ${afterLayer}` },
  );
}

async function readPublishedLayerTokens(
  containerId: string,
  root: string,
  completedLayers: SetupPrefixResumeLayer,
): Promise<readonly string[]> {
  const paths = layerTokenPaths.slice(0, completedLayers);
  const result = await docker.run([
    "exec",
    containerId,
    "sh",
    "-lc",
    paths.map((path) => `cat ${path}; printf '\\n'`).join("; "),
  ], { cwd: root });
  expect(result.exitCode, result.diagnostic()).toBe(0);
  const tokens = result.stdout.trim().split(/\r?\n/u);
  expect(tokens, result.diagnostic()).toHaveLength(completedLayers);
  for (const token of tokens) expect(token).toMatch(/^[0-9a-f-]{36}$/u);
  return tokens;
}

async function releaseResumeGate(
  containerId: string,
  root: string,
  afterLayer: SetupPrefixResumeLayer,
): Promise<void> {
  const gate = `.setup-prefix/resume-after-${afterLayer}`;
  const released = await docker.run([
    "exec",
    containerId,
    "sh",
    "-lc",
    `printf 'release\\n' > ${gate}/release.fifo`,
  ], { cwd: root, timeoutMs: 15_000 });
  expect(released.exitCode, released.diagnostic()).toBe(0);
}

function evidenceLayerTokens(evidence: SetupPrefixEvidence): readonly string[] {
  return [evidence.fixtureToken, evidence.middleToken, evidence.envToken];
}

async function readIncusJournal(path: string): Promise<readonly IncusJournalRecord[]> {
  try {
    return (await readFile(path, "utf8")).trim().split("\n").filter(Boolean)
      .map((line) => JSON.parse(line) as IncusJournalRecord);
  } catch (cause) {
    if (typeof cause === "object" && cause !== null && Reflect.get(cause, "code") === "ENOENT") return [];
    throw cause;
  }
}

function incusExecCount(records: readonly IncusJournalRecord[], marker: string): number {
  return records.filter((record) => record.event === "exec" && record.detail.argv?.join(" ").includes(marker)).length;
}

async function waitForPathOrProcessExit(path: string, done: Promise<ProcessReceipt>): Promise<void> {
  try {
    await access(path);
    return;
  } catch (cause) {
    if (typeof cause !== "object" || cause === null || Reflect.get(cause, "code") !== "ENOENT") throw cause;
  }

  const controller = new AbortController();
  const ready = (async () => {
    for await (const event of watch(dirname(path), { signal: controller.signal })) {
      if (event.filename !== basename(path)) continue;
      try {
        await access(path);
        return;
      } catch (cause) {
        if (typeof cause !== "object" || cause === null || Reflect.get(cause, "code") !== "ENOENT") throw cause;
      }
    }
  })();
  try {
    const outcome = await Promise.race([
      ready.then(() => ({ kind: "ready" }) as const),
      done.then((receipt) => ({ kind: "exited", receipt }) as const),
    ]);
    if (outcome.kind === "exited") {
      throw new Error(`niceeval exited before fake Incus reached the child rendezvous\n${outcome.receipt.diagnostic()}`);
    }
  } finally {
    controller.abort();
  }
}

interface InvokeOptions {
// … omitted: file=e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts; before=interface InvokeOptions {; after=test.concurrent("共享准备前缀只发布一次，并在全局派发屏障前并行准备独立后缀 [necase_APN2MNBEXSN1G18T]", async () => {; reason=仅保留本 PR 改动的事件等待入口与完整目标 case；同文件其它独立 Lifecycle case 未变化。
test.concurrent("共享准备前缀只发布一次，并在全局派发屏障前并行准备独立后缀 [necase_APN2MNBEXSN1G18T]", async () => {
  await withProjectCopy(projectCopy, async ({ root }) => {
    await withTempDir("niceeval-e2e-incus-prefix-dag-", async (runtimeRoot) => {
      const binDir = join(runtimeRoot, "bin");
      const descriptor = join(runtimeRoot, "incus-provider.json");
      const state = join(runtimeRoot, "incus-state.json");
      const journalPath = join(runtimeRoot, "incus-journal.ndjson");
      const gateRoot = join(runtimeRoot, "gates");
      const fakeIncus = resolve("fixtures/fake-incus.mjs");
      const digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
      await mkdir(binDir, { recursive: true });
      await mkdir(gateRoot, { recursive: true });
      const wrapper = join(binDir, "incus");
      await writeFile(wrapper, `#!/usr/bin/env node\nawait import(${JSON.stringify(pathToFileURL(fakeIncus).href)});\n`, "utf8");
      await chmod(wrapper, 0o755);
      await writeFile(descriptor, `${JSON.stringify({
        schemaVersion: "niceeval.incus-provider/v2",
        domains: [{
          name: "development",
          status: "configured",
          executionDomainId: "e2e-incus-prefix-dag",
          project: "niceeval-eval-dev",
          storagePool: "niceeval-sandbox-dev",
          network: "niceeval-dev",
          storage: "development-dir",
          quota: "unattested",
          maxInstances: 8,
          artifactProject: "niceeval-artifacts-dev",
          artifactMaxInstances: 8,
          dockerDataBytes: 1024 ** 3,
          workdir: "/home/sandbox/workspace",
          user: "node",
          hostGateway: "10.0.0.1",
          trustedBaseImages: [`niceeval/docker-execution-v1@sha256:${digest}`],
        }],
      })}\n`, "utf8");
      await writeFile(join(root, "experiments/incus-prefix-dag.ts"), `
import { defineExperiment } from "niceeval";
import { actionRef, incusSandbox, shell } from "niceeval/sandbox";
import { quickAgent } from "../agents/deterministic.ts";
const sandbox = incusSandbox({
  image: "niceeval/docker-execution-v1@sha256:${digest}",
  project: "niceeval-eval-dev",
  storagePool: "niceeval-sandbox-dev",
  acceptDevelopmentDomain: true,
  resources: { dockerDataBytes: ${1024 ** 3} },
}).before(shell({ id: "prefix-one", command: "true # niceeval-e2e-prefix-one", changeFrequency: 10 }))
  .before(shell({ id: "prefix-two", command: "true # niceeval-e2e-prefix-two", changeFrequency: 20, dependsOn: [actionRef("prefix-one")] }));
export default defineExperiment({
  agent: quickAgent,
  sandbox,
  evals: ["prefix-branch-three", "prefix-branch-four"],
  attempts: 1,
});
`, "utf8");
      await writeFile(join(root, "evals/prefix-branch-three.eval.ts"), `
import { defineEval } from "niceeval";
import { actionRef, sandboxLayer, shell } from "niceeval/sandbox";
export default defineEval({
  sandbox: sandboxLayer().before(shell({ id: "prefix-three", command: "true # niceeval-e2e-prefix-branch-three", changeFrequency: 30, dependsOn: [actionRef("prefix-two")] })),
  async test(t) { await (await t.send("three")).succeeded().orStop(); },
});
`, "utf8");
      await writeFile(join(root, "evals/prefix-branch-four.eval.ts"), `
import { defineEval } from "niceeval";
import { actionRef, sandboxLayer, shell } from "niceeval/sandbox";
export default defineEval({
  sandbox: sandboxLayer().before(shell({ id: "prefix-four", command: "true # niceeval-e2e-prefix-branch-four", changeFrequency: 40, dependsOn: [actionRef("prefix-two")] })),
  async test(t) { await (await t.send("four")).succeeded().orStop(); },
});
`, "utf8");

      const baseEnv: NodeJS.ProcessEnv = {
        ...process.env,
        PATH: `${binDir}:${process.env.PATH ?? ""}`,
        NICEEVAL_HOME: join(runtimeRoot, "user"),
        XDG_STATE_HOME: join(runtimeRoot, "xdg-state"),
        NICEEVAL_INCUS_DESCRIPTOR: descriptor,
        NICEEVAL_E2E_FAKE_INCUS_STATE: state,
        NICEEVAL_E2E_FAKE_INCUS_JOURNAL: journalPath,
        NICEEVAL_E2E_FAKE_INCUS_GATE_ROOT: gateRoot,
      };
      const receipt = await withProcess(
        [binary, "exp", "incus-prefix-dag", "--rerun", "all", "--max-concurrency", "2", "--json"],
        { cwd: root, env: baseEnv, processGroup: true, timeoutMs: 270_000, graceMs: 10_000 },
        async (controlled) => {
          try {
            await waitForPathOrProcessExit(join(gateRoot, "children-ready"), controlled.done);
            const atChildrenBarrier = await readIncusJournal(journalPath);

            expect(incusExecCount(atChildrenBarrier, "niceeval-e2e-prefix-one")).toBe(1);
            expect(incusExecCount(atChildrenBarrier, "niceeval-e2e-prefix-two")).toBe(1);
            expect(incusExecCount(atChildrenBarrier, "node --version"), "Attempt dispatch must wait for every final prefix").toBe(0);
            const commonPublishIndexes = atChildrenBarrier.flatMap((record, index) => record.event === "query" &&
              record.detail.method === "POST" && record.detail.path === "/1.0/instances" &&
              record.detail.project === "niceeval-artifacts-dev" ? [index] : []);
            expect(commonPublishIndexes, "both shared ancestors must be committed exactly once").toHaveLength(2);
            const parentCleanupIndexes = atChildrenBarrier.flatMap((record, index) => record.event === "query" &&
              record.detail.method === "DELETE" && record.detail.project === "niceeval-eval-dev" ? [index] : []);
            expect(parentCleanupIndexes.length, "both shared-prefix prepare scopes must be released")
              .toBeGreaterThanOrEqual(2);
            const childStartIndexes = atChildrenBarrier.flatMap((record, index) =>
              record.event === "prefix-child-started" ? [index] : []);
            expect(childStartIndexes, "both independent suffixes must start before the fixture releases either one")
              .toHaveLength(2);
            const barrierReadyIndex = atChildrenBarrier.findIndex((record) => record.event === "prefix-children-ready");
            expect(Math.max(...childStartIndexes), "the rendezvous becomes ready only after both children start")
              .toBeLessThan(barrierReadyIndex);
            expect(Math.max(...commonPublishIndexes, ...parentCleanupIndexes),
              "shared parent publication and scope cleanup must precede both children")
              .toBeLessThan(Math.min(...childStartIndexes));
            expect(atChildrenBarrier.some((record) => record.event === "prefix-child-released"),
              "neither child may pass the rendezvous before explicit release").toBe(false);
          } finally {
            await writeFile(join(gateRoot, "release-children"), "release\n", "utf8");
          }
          return controlled.done;
        },
      );
      expect(receipt.exitCode, "the fake provider deliberately fails agent.ensure after pre-dispatch preparation").not.toBe(0);
      const completedJournal = await readIncusJournal(journalPath);
      const barrierReadyIndex = completedJournal.findIndex((record) => record.event === "prefix-children-ready");
      const childReleaseIndexes = completedJournal.flatMap((record, index) =>
        record.event === "prefix-child-released" ? [index] : []);
      expect(childReleaseIndexes, "explicit release must unblock both prepared suffixes").toHaveLength(2);
      expect(Math.min(...childReleaseIndexes), "children can leave the rendezvous only after it becomes ready")
        .toBeGreaterThan(barrierReadyIndex);
    });
  });
}, 360_000);
```

### `e2e/record/test/record-journey.test.ts`

#### `e2e/record/test/record-journey.test.ts#necase_H632V0FG1N2KEBJ5`

SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run It exercises 安装候选包后通过公开 CLI run、dry-run、show、recover 与 delete 完成全流程。 and asserts dry plan reused=1；恢复运行只派发 ordinal 1；新 Run 同时包含 carried 与 executed member；旧 Run 可 recover 为 interrupted。. Deleting this case would allow 无源码调用、无私有 Record 读取、无核心实现 mock。. The final contract is [docs/feature/run/lifecycle.md#崩溃与-recovery](docs/feature/run/lifecycle.md#崩溃与-recovery). It also prevents the regression recorded in [memory/active-attempt-publication-omitted-from-reuse.md](memory/active-attempt-publication-omitted-from-reuse.md).

```ts

import { randomUUID } from "node:crypto";
import { readFile, rename, writeFile } from "node:fs/promises";
import { join, resolve } from "node:path";
import { createE2EContext, only, pollUntil } from "@niceeval/testkit";
import { decodeExpPlanDocument } from "niceeval/experiment/host";
import { expect, test } from "vitest";
import { createLoopbackBackend, whileRunning } from "./support.js";

const e2e = createE2EContext({
  repoId: "record",
  project: {
    from: process.cwd(),
    prefix: "niceeval-e2e-run-",
    omitTopLevel: [".e2e-artifacts", ".niceeval", "node_modules", "test"],
    links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
  },
  commands: { niceeval: [join(process.cwd(), "node_modules", ".bin", "niceeval")] },
});

test.concurrent("运行创建后立即可发现，并冻结完整 expected slots [necase_SVJG4JP8WN5TWCQF]", async () => {
  await e2e.case("run-create-discovery", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) =>
          run.state === "active" && run.coverage.expected === 2 && run.coverage.published === 0
        );
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the created Run to be listed" }), process, "the created Run became visible");
      expect(active).toMatchObject({
        experimentId: "run-journey",
        state: "active",
        coverage: { expected: 2, published: 0, missing: 2 },
      });
      expect(active.runId).toMatch(/^[0-9a-f-]{36}$/u);
      expect(active.invocationId).toEqual(expect.any(String));

      const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
      const shown = receipt.runGetDocument();
      expect(shown.run).toMatchObject({
        runId: active.runId,
        state: "active",
        coverage: { expected: 2, published: 0, missing: 2 },
      });
      expect(shown.run.slots).toHaveLength(2);
      expect(shown.run.slots).toEqual(expect.arrayContaining([
        expect.objectContaining({ evalId: "run-journey", attemptOrdinal: 0, publication: { state: "pending" } }),
        expect.objectContaining({ evalId: "run-journey", attemptOrdinal: 1, publication: { state: "pending" } }),
      ]));
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("Attempt 原子发布后，active Run 与 portable Record 均完整可读 [necase_71RKBRSMD0ER677F]", async () => {
  await e2e.case("attempt-readable-while-active", async ({ paths, commands: { niceeval } }) => {
    const unpublishedCanary = `niceeval-unpublished-attempt-canary-${randomUUID()}`;
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      {
        env: {
          NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint,
        },
        timeoutMs: 90_000,
      },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the active Run to be listed" }), process, "the active Run became visible");
      const beforePublicationReceipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(beforePublicationReceipt.exitCode, beforePublicationReceipt.diagnostic()).toBe(0);
      const beforePublication = beforePublicationReceipt.runGetDocument();
      expect(beforePublication.run).toMatchObject({
        state: "active",
        coverage: { expected: 2, published: 0, missing: 2 },
      });
      expect(beforePublication.run.slots).toEqual(expect.arrayContaining([
        expect.objectContaining({ attemptOrdinal: 0, publication: { state: "pending" } }),
        expect.objectContaining({ attemptOrdinal: 1, publication: { state: "pending" } }),
      ]));

      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const shown = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the first Attempt publication" }), process, "the first Attempt publication became visible");
      expect(shown.run).toMatchObject({ state: "active", coverage: { expected: 2, published: 1, missing: 1 } });
      const published = only(shown.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(shown));
      expect(published).toMatchObject({
        evalId: "run-journey",
        attemptOrdinal: 0,
        publication: {
          state: "published",
          action: "executed",
          attemptLocator: expect.stringMatching(/^@1[0-9A-HJKMNP-TV-Z]{12}$/u),
          originRunId: active.runId,
          originSlotId: published.slotId,
        },
      });
      expect(only(shown.run.slots, (slot) => slot.publication.state === "pending", JSON.stringify(shown))).toMatchObject({
        attemptOrdinal: 1,
        publication: { state: "pending" },
      });
      if (published.publication.state !== "published") throw new Error("Expected a published slot");

      const request = join(paths.projectRoot, "published-attempt.query.json");
      await writeFile(request, `${JSON.stringify({
        protocol: "niceeval.query/v1",
        operation: { kind: "attempt.get", locator: published.publication.attemptLocator },
      })}\n`, "utf8");
      const attemptReceipt = await niceeval.run(["query", "run", "--request", request]);
      expect(attemptReceipt.exitCode, attemptReceipt.diagnostic()).toBe(0);
      expect(attemptReceipt.attempt()).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "attempt.get",
        issues: [],
        attempt: {
          locator: published.publication.attemptLocator,
          core: { outcome: "completed" },
        },
      });

      const humanAttempt = await niceeval.run(["show", published.publication.attemptLocator]);
      expect(humanAttempt.exitCode, humanAttempt.diagnostic()).toBe(0);
      expect(humanAttempt.stdout, humanAttempt.diagnostic()).toContain(published.publication.attemptLocator);
      expect(humanAttempt.stdout, humanAttempt.diagnostic()).toContain("completed");

      const humanOverview = await niceeval.run(["show"]);
      expect(humanOverview.exitCode, humanOverview.diagnostic()).toBe(0);
      expect(humanOverview.stdout, humanOverview.diagnostic()).toContain(published.publication.attemptLocator);
      expect(humanOverview.stdout, humanOverview.diagnostic()).toContain("1/2");

      backend.completeAttempt(1, `run-journey-attempt-published ${unpublishedCanary}`);
      await whileRunning(backend.waitForAssertion(1), process, "the second Attempt recorded its unpublished assertion");

      expect(process.signal("SIGINT")).toBe(true);
      const interruptedReceipt = await process.done;
      expect(interruptedReceipt.exitCode, interruptedReceipt.diagnostic()).toBe(130);
      expect(interruptedReceipt.expReceipt(), interruptedReceipt.diagnostic()).toMatchObject({
        completion: "interrupted",
        createdRunIds: [active.runId],
      });

      const canonicalRecord = join(paths.projectRoot, ".niceeval", "record.sqlite");
      const canonicalBytes = await readFile(canonicalRecord);
      expect(canonicalBytes.includes(Buffer.from(unpublishedCanary, "utf8"))).toBe(false);

      const externalRecord = join(paths.projectRoot, "finished-record.sqlite");
      await rename(canonicalRecord, externalRecord);
      const externalAttemptReceipt = await niceeval.run([
        "query",
        "run",
        "--record",
        externalRecord,
        "--request",
        request,
      ]);
      expect(externalAttemptReceipt.exitCode, externalAttemptReceipt.diagnostic()).toBe(0);
      expect(externalAttemptReceipt.attempt()).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "attempt.get",
        issues: [],
        attempt: {
          locator: published.publication.attemptLocator,
          core: { outcome: "completed" },
        },
      });
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("用户 SIGINT 中断时保留已发布 Attempt 并解释未发布 slot [necase_XAJRPPHVE3PG7TBV]", async () => {
  await e2e.case("sigint-preserves-publication", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the active Run to be listed" }), process, "the active Run became visible");
      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const before = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the first Attempt publication" }), process, "the first Attempt publication became visible");
      const published = only(before.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(before));
      if (published.publication.state !== "published") throw new Error("Expected a published slot");

      expect(process.signal("SIGINT")).toBe(true);
      const interruptedReceipt = await process.done;
      expect(interruptedReceipt.exitCode, interruptedReceipt.diagnostic()).toBe(130);
      expect(interruptedReceipt.expReceipt(), interruptedReceipt.diagnostic()).toMatchObject({
        completion: "interrupted",
        createdRunIds: [active.runId],
      });
      const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
      const interrupted = receipt.runGetDocument();
      expect(interrupted.run).toMatchObject({ state: "interrupted", coverage: { expected: 2, published: 1, missing: 1 } });
      expect(only(interrupted.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(interrupted))).toMatchObject({
        publication: { attemptId: published.publication.attemptId, attemptLocator: published.publication.attemptLocator },
      });
      expect(only(interrupted.run.slots, (slot) => slot.publication.state === "absent", JSON.stringify(interrupted))).toMatchObject({
        attemptOrdinal: 1,
        publication: { state: "absent", reason: "interrupted-before-publication" },
      });
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("存在引用时拒绝删除 origin，删除依赖后可安全重试 [necase_AY5TKPWYF4GQ8EDT]", async () => {
  await e2e.case("reference-safe-delete", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const origin = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the origin Run to be listed" }), process, "the origin Run became visible");
      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const originShown = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", origin.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the origin Attempt publication" }), process, "the origin Attempt publication became visible");
      const published = only(originShown.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(originShown));
      if (published.publication.state !== "published") throw new Error("Expected a published slot");
      expect(process.signal("SIGINT")).toBe(true);
      const interrupted = await process.done;
      expect(interrupted.exitCode, interrupted.diagnostic()).toBe(130);

      const beforeReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(beforeReceipt.exitCode, beforeReceipt.diagnostic()).toBe(0);
      const known = new Set(beforeReceipt.runListDocument().runs.map((run) => run.runId));
      const accepted = await niceeval.run(["accept", published.publication.attemptLocator]);
      expect(accepted.exitCode, accepted.diagnostic()).toBe(0);
      const afterReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(afterReceipt.exitCode, afterReceipt.diagnostic()).toBe(0);
      const dependency = only(afterReceipt.runListDocument().runs, (run) => !known.has(run.runId), afterReceipt.diagnostic());
      expect(dependency).toMatchObject({ state: "completed", coverage: { expected: 1, published: 1, missing: 0 } });
      const dependencyReceipt = await niceeval.run(["run", "show", dependency.runId, "--json"]);
      expect(dependencyReceipt.exitCode, dependencyReceipt.diagnostic()).toBe(0);
      expect(only(dependencyReceipt.runGetDocument().run.slots, (slot) => slot.publication.state === "published", dependencyReceipt.diagnostic())).toMatchObject({
        publication: { state: "published", action: "accepted", attemptId: published.publication.attemptId, originRunId: origin.runId },
      });

      const refused = await niceeval.run(["run", "delete", origin.runId, "--yes", "--json"]);
      expect(refused.exitCode, refused.diagnostic()).not.toBe(0);
      expect(`${refused.stdout}\n${refused.stderr}`).toContain("run-referenced");
      expect(`${refused.stdout}\n${refused.stderr}`).toContain(dependency.runId);
      expect(`${refused.stdout}\n${refused.stderr}`).toContain(published.publication.attemptLocator);
      const retainedReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(retainedReceipt.exitCode, retainedReceipt.diagnostic()).toBe(0);
      expect(retainedReceipt.runListDocument().runs.map((run) => run.runId)).toContain(origin.runId);

      const deleteDependency = await niceeval.run(["run", "delete", dependency.runId, "--yes", "--json"]);
      expect(deleteDependency.exitCode, deleteDependency.diagnostic()).toBe(0);
      const deleteOrigin = await niceeval.run(["run", "delete", origin.runId, "--yes", "--json"]);
      expect(deleteOrigin.exitCode, deleteOrigin.diagnostic()).toBe(0);
      const finalReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(finalReceipt.exitCode, finalReceipt.diagnostic()).toBe(0);
      expect(finalReceipt.runListDocument().runs.map((run) => run.runId)).not.toContain(origin.runId);
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run [necase_H632V0FG1N2KEBJ5]", async () => {
  await e2e.case("sigkill-recovery", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the active Run to be listed" }), process, "the active Run became visible");
      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const beforeKill = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the first Attempt publication" }), process, "the first Attempt publication became visible");
      const published = only(beforeKill.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(beforeKill));
      if (published.publication.state !== "published") throw new Error("Expected a published slot");

      expect(process.signal("SIGKILL")).toBe(true);
      const killed = await process.done;
      expect(killed.signal, killed.diagnostic()).toBe("SIGKILL");
      const activeReceipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(activeReceipt.exitCode, activeReceipt.diagnostic()).toBe(0);
      const stillActive = activeReceipt.runGetDocument();
      expect(stillActive.run).toMatchObject({ state: "active", coverage: { expected: 2, published: 1, missing: 1 } });
      expect(only(stillActive.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(stillActive))).toMatchObject({
        publication: { attemptLocator: published.publication.attemptLocator },
      });

      const recoveryPlanReceipt = await niceeval.run(["exp", "run-journey", "--dry", "--json"], {
        env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint },
      });
      expect(recoveryPlanReceipt.exitCode, recoveryPlanReceipt.diagnostic()).toBe(0);
      const recoveryPlan = decodeExpPlanDocument(recoveryPlanReceipt.json());
      expect(recoveryPlan, recoveryPlanReceipt.diagnostic()).toMatchObject({ total: 2, reused: 1 });
      expect(only(recoveryPlan.matrix.flatMap((row) => row.slots), (slot) => slot.state === "reused", JSON.stringify(recoveryPlan))).toMatchObject({
        state: "reused",
      });
      const resumed = niceeval.start(
        ["exp", "run-journey", "--json"],
        { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
      );
      const dispatchedOrdinal = await whileRunning(Promise.race([
        backend.waitForAttempt(0, 2).then(() => 0 as const),
        backend.waitForAttempt(1, 2).then(() => 1 as const),
      ]), resumed, "the missing Attempt to be dispatched");
      expect(dispatchedOrdinal).toBe(1);
      backend.completeAttempt(1);
      const resumedReceipt = await resumed.done;
      expect(resumedReceipt.exitCode, resumedReceipt.diagnostic()).toBe(0);

      const resumedRunId = resumedReceipt.expReceipt().createdRunIds[0]!;
      const resumedRunReceipt = await niceeval.run(["run", "show", resumedRunId, "--json"]);
      expect(resumedRunReceipt.exitCode, resumedRunReceipt.diagnostic()).toBe(0);
      const resumedRun = resumedRunReceipt.runGetDocument();
      expect(resumedRun.run).toMatchObject({ state: "completed", coverage: { expected: 2, published: 2, missing: 0 } });
      expect(only(resumedRun.run.slots, (slot) =>
        slot.publication.state === "published" && slot.publication.action === "carried",
      JSON.stringify(resumedRun))).toMatchObject({
        attemptOrdinal: 0,
        publication: { attemptLocator: published.publication.attemptLocator, originRunId: active.runId },
      });
      expect(only(resumedRun.run.slots, (slot) =>
        slot.publication.state === "published" && slot.publication.action === "executed",
      JSON.stringify(resumedRun))).toMatchObject({ attemptOrdinal: 1 });

      const recovered = await niceeval.run(["run", "recover", active.runId, "--yes", "--json"]);
      expect(recovered.exitCode, recovered.diagnostic()).toBe(0);
      const recoveredReceipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(recoveredReceipt.exitCode, recoveredReceipt.diagnostic()).toBe(0);
      const recoveredRun = recoveredReceipt.runGetDocument();
      expect(recoveredRun.run).toMatchObject({ state: "interrupted", coverage: { expected: 2, published: 1, missing: 1 } });
      expect(only(recoveredRun.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(recoveredRun))).toMatchObject({
        publication: { attemptLocator: published.publication.attemptLocator },
      });
      expect(only(recoveredRun.run.slots, (slot) => slot.publication.state === "absent", JSON.stringify(recoveredRun))).toMatchObject({
        publication: { state: "absent", reason: "interrupted-before-publication" },
      });

      const cleanupReference = await niceeval.run(["run", "delete", resumedRunId, "--yes", "--json"]);
      expect(cleanupReference.exitCode, cleanupReference.diagnostic()).toBe(0);
      const cleanupOrigin = await niceeval.run(["run", "delete", active.runId, "--yes", "--json"]);
      expect(cleanupOrigin.exitCode, cleanupOrigin.diagnostic()).toBe(0);
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});
```

### `e2e/runner/test/group-wave-gap-dispatch.test.ts`

#### `e2e/runner/test/group-wave-gap-dispatch.test.ts#necase_6BCCEKGMA7ZY0QMG`

空闲 Group lane 不等待慢 lane 的下一槽位即可继续派发 It exercises 安装候选包后运行 niceeval exp group-wave-gap --json。 and asserts alpha 与 beta 的显式后继到达事件释放 gamma；9 个 Eval 全部通过，不用固定十秒速度阈值作为调度 oracle。. Deleting this case would allow 仍从公开 CLI 入口运行，不调用 scheduler 源码，也不复制调度算法。. The final contract is [docs/feature/experiments/use-case/并发/快慢实验混跑.md](docs/feature/experiments/use-case/并发/快慢实验混跑.md).

```ts
// rerun: pnpm e2e test --repo runner -- --run test/group-wave-gap-dispatch.test.ts
import { expect, test } from "vitest";
import { runnerE2E } from "./context.ts";

test("空闲 Group lane 不等待慢 lane 的下一槽位即可继续派发 [necase_6BCCEKGMA7ZY0QMG]", async () => {
  await runnerE2E.case("group-wave-gap-dispatch", {}, async ({ commands: { niceeval } }) => {
    const result = await niceeval.run(["exp", "group-wave-gap", "--json"], { timeoutMs: 120_000 });
    expect(result.exitCode, result.diagnostic()).toBe(0);
    const evals = result.expEvents()
      .filter((event) => event.event === "eval");
    expect(evals).toHaveLength(9);
    expect(evals.map((event) => event.verdict)).toEqual(Array(9).fill("passed"));
  });
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790828587&installation_model_id=431746&pr_number=207&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F207&signature=739c3813cd03822ee8a82a78e01ba8622d1e8f03ff565feb65aa7c032910b832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
