### PR TITLE
fix(inspection): 让大型 Record 的 show 总览保持可用

### DIFF
--- a/e2e/inspection/evals/overview-scale.eval.ts
+++ b/e2e/inspection/evals/overview-scale.eval.ts
@@ -1,0 +1,15 @@
+import { defineScoreEval } from "niceeval";
+import { equals } from "niceeval/expect";
+
+export default defineScoreEval({
+  description: "overview-scale: generate a benchmark-sized set of closed Assertion evidence",
+  async test(t) {
+    await t.send("produce deterministic inspection evidence");
+    await t.group(`overview-scale-${"evidence".repeat(28)}`, async () => {
+      for (let index = 0; index < 80; index += 1) {
+        t.check(`overview-scale-${index}`, equals(`overview-scale-${index}`))
+          .label(`Overview scale assertion ${index}`);
+      }
+    });
+  },
+});

--- a/e2e/inspection/experiments/harness/scale.ts
+++ b/e2e/inspection/experiments/harness/scale.ts
@@ -1,0 +1,11 @@
+import { defineExperiment } from "niceeval";
+import { deterministicAgent, deterministicSandbox } from "../../agents/deterministic.ts";
+
+export default defineExperiment({
+  description: "harness/scale: keep the complete terminal Overview readable at benchmark scale",
+  agent: deterministicAgent(),
+  sandbox: deterministicSandbox,
+  model: "inspection-fixture-v1",
+  evals: ["overview-scale"],
+  attempts: 10,
+});

--- a/e2e/inspection/test/show-cli.test.ts
+++ b/e2e/inspection/test/show-cli.test.ts
@@ -58,6 +58,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
     async ({ commands: { niceeval }, paths }) => {
       const mainExperimentId = "harness/canary";
       const alternateExperimentId = "harness/alternate";
+      const scaleExperimentId = "harness/scale";
       const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
       expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
       expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
@@ -88,6 +89,44 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
         ? alternateAttempt.locator
         : `@${alternateAttempt.locator}`;
 
+      const scaleProduced = await niceeval.run([
+        "exp",
+        scaleExperimentId,
+        "--rerun",
+        "all",
+        "--json",
+      ]);
+      expect(scaleProduced.exitCode, scaleProduced.diagnostic()).toBe(0);
+      expect(scaleProduced.expReceipt(), scaleProduced.diagnostic()).toMatchObject({
+        completion: "completed",
+      });
+      expect(scaleProduced.expEvalEvents(), scaleProduced.diagnostic()).toEqual([
+        expect.objectContaining({
+          evalId: "overview-scale",
+          attempts: 10,
+          passed: 10,
+          verdict: "passed",
+        }),
+      ]);
+
+      const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
+      writeFileSync(
+        overviewRequestPath,
+        JSON.stringify({
+          protocol: "niceeval.query/v1",
+          operation: { kind: "overview.get" },
+        }),
+        "utf8",
+      );
+      const machineOverview = await niceeval.run([
+        "query",
+        "run",
+        "--request",
+        overviewRequestPath,
+      ]);
+      expect(machineOverview.exitCode, machineOverview.diagnostic()).toBe(0);
+      expect(Buffer.byteLength(machineOverview.stdout, "utf8")).toBeGreaterThan(512 * 1024);
+
       const overview = await niceeval.run(["show"]);
       expect(overview.exitCode, overview.diagnostic()).toBe(0);
       expectHumanText(overview.stdout);
@@ -103,6 +142,8 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       ]);
       expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
       expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
+      expect(overview.stdout).toContain(`Experiment ${scaleExperimentId}`);
+      expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
       expect(overview.stdout).toContain(`Experiment ${mainExperimentId}\n  Eval`);
       expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}\n  Eval`);
       expect(overview.stdout).toMatch(/Eval\s+Attempt\s+Score/u);

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/certificate.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "candidateSha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+  "greenReceipt": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-1.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-2.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-4.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-6.json",
+    "singleCase": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/artifacts/e2e/takeover-inspection-overview/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/artifacts/e2e/takeover-inspection-overview/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/artifacts/e2e/takeover-inspection-overview/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/artifacts/e2e/takeover-inspection-overview/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/artifacts/e2e/takeover-inspection-overview/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/artifacts/e2e/takeover-inspection-overview/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-reuse/artifacts/e2e/takeover-inspection-overview/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "b8b8b5c30e7f28a9acb5f0e1de1c314373b4676b934a99351273dca6a836d22d"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/green.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/green.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+    "sri": "sha512-lGW/CiCcBngx0ot6qQLHbZIeAFftUVgMKyXj0IrDsLFHaRGFSIE3e0wV9dP+mnKMioFK7y7Ab4KlmoYVgYY+kw=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-yANIMA/runs/takeover/target-single/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1919542 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1919543 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1919607 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "06928f5a-f021-4e52-895d-c8717ee8b51c",
+  "receiptSha256": "77c705da1c985aac0166efe45634338e13121bf63429d390b9cca57f1085bb1e"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/inventory.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/inventory.json
@@ -1,0 +1,45 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "inspection",
+  "argv": [
+    "/nix/store/bfqsxlviikq7vlp36kasy5hhamlxlkd2-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-Kzcx5H/repos/inspection/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+  "files": [
+    "e2e/inspection/test/inspection-query.test.ts",
+    "e2e/inspection/test/show-cli.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/inspection-query.test.ts",
+      "titlePath": [
+        "machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]"
+      ],
+      "caseId": "necase_79TQ9VGG316D8FK0"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-cli.test.ts",
+      "titlePath": [
+        "用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]"
+      ],
+      "caseId": "necase_9FHHSQTVB492P8DS"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/red.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/red.json
@@ -1,0 +1,52 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "018e14daf62256b5eee81741c57e3c486fef6f5659c24e8075e656146764fe37",
+    "sri": "sha512-9DNLX0akRW3NRpL+UO655VpGHExfhGpen9nSk3AycpNL7mx5UpAfJ64mM/qqgG46GUwbJdy3x1lZsGWF0pCJEA=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-mBrRqr/runs/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 1902248 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "5f4cca63-19f8-4cb7-bfd9-61209d8842be",
+  "receiptSha256": "eff7208b345c0a23dc39c199fd079faf94c0b2c1feb375b6b9dfc712a2ea6d13"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-1.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-1.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+    "sri": "sha512-lGW/CiCcBngx0ot6qQLHbZIeAFftUVgMKyXj0IrDsLFHaRGFSIE3e0wV9dP+mnKMioFK7y7Ab4KlmoYVgYY+kw=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-yANIMA/runs/takeover/isolated-copy-1/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1904812 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1904813 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1904860 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "3fe9048a-85ed-4a30-bf8d-14a215d6a810",
+  "receiptSha256": "6e217ac2f7d54e233064fe5291d178cb2530f03d84f91a643584aa318fe5d61a"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-2.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-2.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+    "sri": "sha512-lGW/CiCcBngx0ot6qQLHbZIeAFftUVgMKyXj0IrDsLFHaRGFSIE3e0wV9dP+mnKMioFK7y7Ab4KlmoYVgYY+kw=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-yANIMA/runs/takeover/isolated-copy-2/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1907050 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1907051 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1907079 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "33f54178-e849-4e88-8bc6-c0df53df041f",
+  "receiptSha256": "8199c555796522146efc9dd0aa9cdbe86ecadc20902d774c4e7a3581899a5f44"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-3.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-3.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+    "sri": "sha512-lGW/CiCcBngx0ot6qQLHbZIeAFftUVgMKyXj0IrDsLFHaRGFSIE3e0wV9dP+mnKMioFK7y7Ab4KlmoYVgYY+kw=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-yANIMA/runs/takeover/isolated-copy-3/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1909579 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1909580 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1909637 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "9856be21-790b-4bcf-ab48-cea0b8885882",
+  "receiptSha256": "b6c33c14c872dcfe5a9e619a1b059c6bade7f40bdf15624773450ab45d59688f"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-4.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-4.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+    "sri": "sha512-lGW/CiCcBngx0ot6qQLHbZIeAFftUVgMKyXj0IrDsLFHaRGFSIE3e0wV9dP+mnKMioFK7y7Ab4KlmoYVgYY+kw=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-yANIMA/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1911742 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1911743 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1911772 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1913927 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "c4f97a3d-7da2-4b39-bc00-321f733e8ed9",
+  "receiptSha256": "3ea1153a6d8514c7952ad44b01d0f705a37ff19397facc50e8a750abd054b0de"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-5.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-5.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+    "sri": "sha512-lGW/CiCcBngx0ot6qQLHbZIeAFftUVgMKyXj0IrDsLFHaRGFSIE3e0wV9dP+mnKMioFK7y7Ab4KlmoYVgYY+kw=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-yANIMA/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1911742 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1911743 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1911772 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1913927 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "2ce9fd99-9eac-4a3e-91fb-cc8cf9b57047",
+  "receiptSha256": "c7ea3e1564747199823bdd8ec584cdb576cb1eee2972220575073b48ad9d1cc1"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-6.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/reliability-6.json
@@ -1,0 +1,62 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d",
+  "candidate": {
+    "gitSha": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "sha256": "db137877380f95f4fdd2eab46e00287e05ceb853cc25690bc3bbe04e115cf45f",
+    "sri": "sha512-lGW/CiCcBngx0ot6qQLHbZIeAFftUVgMKyXj0IrDsLFHaRGFSIE3e0wV9dP+mnKMioFK7y7Ab4KlmoYVgYY+kw=="
+  },
+  "source": {
+    "checkout": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+    "testFileSha256": "636ddb310e69f5f915149afebe65875d1df46813c20aa3ab51bcb7c9a3858695",
+    "sidecarSha256": "f03d4fd0906f677655b94461df7f2c21d39de6ff926bd02aa39e26b7e129057c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-yANIMA/runs/takeover/repo-default-parallel/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 1915994 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 1915995 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 1916042 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "c6f71833-6b95-4b37-a40c-4c41966bc9ff",
+  "receiptSha256": "08e3543f41ab94d61ca7ce4221dd837b47ddf9f323f357666564ea0aa71f2e62"
+}

--- a/e2e/inspection/test/show-cli.test.ts.cases.evidence.json
+++ b/e2e/inspection/test/show-cli.test.ts.cases.evidence.json
@@ -19,6 +19,24 @@
           "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-overview-includes-stale-execution-identity.md/nered_JD97KAZABC4G7GCT-netake_T7KP4ABHNZN939NR/inventory.json",
           "digest": "sha256:6bd757a6f44d51008c24ea82b7a0072d78fc24d2b995df7aa1c26c08dfbb201e"
         }
+      },
+      "memory/inspection-overview-fixed-byte-limit.md": {
+        "red": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/red.json",
+          "digest": "sha256:726552754a74927625c8fa97793d528201d4c591d33183ffd0dc5f9573058e30"
+        },
+        "green": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/green.json",
+          "digest": "sha256:c2aa2ea279539c1329ed4b0f810c61869df40915ed6dba5dac4a8eaa22829411"
+        },
+        "certificate": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/certificate.json",
+          "digest": "sha256:b8061272b394fbddd0c54b40ff79ee4a71adcb34aab1eb5dd00db225b28bd214"
+        },
+        "inventory": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/inventory.json",
+          "digest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d"
+        }
       }
     }
   },

--- a/e2e/inspection/test/show-cli.test.ts.cases.json
+++ b/e2e/inspection/test/show-cli.test.ts.cases.json
@@ -5,6 +5,7 @@
     "necase_9FHHSQTVB492P8DS": {
       "owner": "docs/engineering/testing/e2e/inspection.md#show-terminal-review",
       "regressions": [
+        "memory/inspection-overview-fixed-byte-limit.md",
         "memory/show-experiment-heading-detached-from-table.md",
         "memory/show-overview-includes-stale-execution-identity.md"
       ],
@@ -40,6 +41,15 @@
       "action": "regression-added",
       "to": {
         "memory": "memory/show-overview-includes-stale-execution-identity.md"
+      }
+    },
+    {
+      "caseId": "necase_9FHHSQTVB492P8DS",
+      "atCommit": "ef80fdcbfdd6cc07d645e745cacb1845de6cddc1",
+      "transactionId": "netxn_74518afdc94e417684805cb8671a77cd",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/inspection-overview-fixed-byte-limit.md"
       }
     }
   ],

--- a/memory/inspection-overview-fixed-byte-limit.md
+++ b/memory/inspection-overview-fixed-byte-limit.md
@@ -1,0 +1,27 @@
+---
+format: niceeval.memory/v1
+id: inspection-overview-fixed-byte-limit
+title: Large published Overviews fail Inspection
+createdAt: 2026-09-01
+kind:
+  type: problem
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - nered_108H8RGQ1RGRRNKW
+      - netake_MSCB4EXBKKC1A1CH
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS"]}
+promotions: []
+---
+## Problem
+
+A project with a legitimate published result matrix can make `niceeval show` and `overview.get` fail even though exact Run inspection succeeds. MemoryBench reproduced this with 180 selected slots: the public machine Overview was about 975 KiB, while Inspection rejected every Overview larger than 512 KiB.
+
+## Root cause
+
+`selectInspectionOverview` closes the complete fixed result and then incorrectly applies the 512 KiB budget intended for bounded detail projections. Overview is the required one-shot index for all selected Experiment × Eval × ordinal slots and repeats closed refs and coverage at cell, group, Experiment, and total aggregates. A normal benchmark therefore crosses the detail-oriented limit without corrupt or incomplete Record facts.
+
+## Fix
+
+Remove the detail-projection byte limit from the complete Overview result while preserving strict decoding. Sources, trace, and other content-heavy detail projections retain their bounded output rules; Preview retains its separate transport limit. The Show E2E generates a deterministic Overview larger than 512 KiB through installed public `exp`, verifies the machine result is complete, then requires the same installed `show` entry to render it successfully.

--- a/packages/niceeval/src/inspection/overview.ts
+++ b/packages/niceeval/src/inspection/overview.ts
@@ -20,7 +20,6 @@ import {
   type LoadedInspectionRun,
   type ResolvedInspectionAttempt,
 } from "./facts.ts";
-import { INSPECTION_RESULT_BYTE_LIMIT } from "./limits.ts";
 import type { InspectionFactSource } from "./source.ts";
 import {
   projectAttemptTiming,
@@ -970,12 +969,6 @@ function closeOverview(value: InspectionOverview): InspectionOverview {
   const closed = closeInspectionJson(value);
   if (isInspectionCodecError(closed)) {
     throw closed;
-  }
-  const bytes = new TextEncoder().encode(JSON.stringify(closed)).byteLength;
-  if (bytes > INSPECTION_RESULT_BYTE_LIMIT) {
-    throw new Error(
-      `Inspection Overview exceeds its fixed ${INSPECTION_RESULT_BYTE_LIMIT}-byte limit`,
-    );
   }
   return closed as unknown as InspectionOverview;
 }


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 6184933979838d2b1e687109b509934a52dbff5d
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: d351aa6f033cf987c63f6178ffe627e327502ce2
-->

## Problem

- User goal: 在大型评测 Record 上用 niceeval show 查看完整结果总览
- Current limitation: 合法的 Overview 超过 512 KiB 时，show 与 query overview.get 都以通用 Inspection 错误退出
- Required capability: 完整 Overview 不能复用面向正文详情投影的 512 KiB 字节预算
- User outcome: MemoryBench 的 180 个 slot 可以直接通过 show 浏览，无需拆 Run 或绕过公开 CLI

## CLI

### Changed

#### Case: 大型 Record 的 Show 总览

##### Before

```sh
pnpm exec niceeval show
```

```text
show execute overview.get failed: The Inspection operation could not be completed.
exit 1
```

##### After

```sh
pnpm exec niceeval show
```

```text
NiceEval results
  Observed   180/180
  Verdicts   158 passed; 17 failed; 5 errored; 0 skipped
exit 0
```

##### User impact

大型 benchmark 的完整 Overview 不再被详情投影的 512 KiB 预算误杀；现有命令和输出形态不变。

## Tests

### `e2e/inspection/test/show-cli.test.ts`

#### `e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS`

安装后 CLI 对超过旧 512 KiB 阈值的合法 Overview 仍可完成 machine query 与人读 show It exercises pnpm e2e test --repo inspection -- --run test/show-cli.test.ts and asserts 公开 exp 生成 10-slot、每 slot 80 条 Assertion evidence 的 Record；query 输出大于 512 KiB 且 show 成功呈现 10/10. Deleting this case would allow 不读取私有 Record，不调用源码 selector，不通过提高测试 timeout 或测试 retry 过关. The final contract is [docs/feature/inspection/cli.md#niceeval-show](docs/feature/inspection/cli.md#niceeval-show). It also prevents the regression recorded in [memory/inspection-overview-fixed-byte-limit.md](memory/inspection-overview-fixed-byte-limit.md).

```ts
// … omitted: file=e2e/inspection/test/show-cli.test.ts; before=      const alternateExperimentId = "harness/alternate";; after=      const scaleExperimentId = "harness/scale";; reason=该既有 owner 同时覆盖 Run、Attempt 与其它 Show 详情；本次只实质修改大型 Overview 的公开生成和断言片段。
      const scaleExperimentId = "harness/scale";
      const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
      expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
      expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const mainRunId = only(mainProduced.expReceipt().createdRunIds, () => true, mainProduced.diagnostic());
      const attempt = only(
        mainProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        mainProduced.diagnostic(),
      );
      expect(attempt).toMatchObject({ verdict: "passed" });
      const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;

      const alternateProduced = await niceeval.run(["exp", alternateExperimentId, "--rerun", "all", "--json"]);
      expect(alternateProduced.exitCode, alternateProduced.diagnostic()).toBe(0);
      expect(alternateProduced.expReceipt(), alternateProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const alternateRunId = only(
        alternateProduced.expReceipt().createdRunIds,
        () => true,
        alternateProduced.diagnostic(),
      );
      const alternateAttempt = only(
        alternateProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        alternateProduced.diagnostic(),
      );
      expect(alternateAttempt).toMatchObject({ verdict: "passed" });
      const alternateLocator = alternateAttempt.locator.startsWith("@")
        ? alternateAttempt.locator
        : `@${alternateAttempt.locator}`;

      const scaleProduced = await niceeval.run([
        "exp",
        scaleExperimentId,
        "--rerun",
        "all",
        "--json",
      ]);
      expect(scaleProduced.exitCode, scaleProduced.diagnostic()).toBe(0);
      expect(scaleProduced.expReceipt(), scaleProduced.diagnostic()).toMatchObject({
        completion: "completed",
      });
      expect(scaleProduced.expEvalEvents(), scaleProduced.diagnostic()).toEqual([
        expect.objectContaining({
          evalId: "overview-scale",
          attempts: 10,
          passed: 10,
          verdict: "passed",
        }),
      ]);

      const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
      writeFileSync(
        overviewRequestPath,
        JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "overview.get" },
        }),
        "utf8",
      );
      const machineOverview = await niceeval.run([
        "query",
        "run",
        "--request",
        overviewRequestPath,
      ]);
      expect(machineOverview.exitCode, machineOverview.diagnostic()).toBe(0);
      expect(Buffer.byteLength(machineOverview.stdout, "utf8")).toBeGreaterThan(512 * 1024);

      const overview = await niceeval.run(["show"]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      expectHumanText(overview.stdout);
      expectInOrder(overview.stdout, ["Totals", "Experiments"]);
      expectInOrder(overview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${scaleExperimentId}`);
      expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
// … omitted: file=e2e/inspection/test/show-cli.test.ts; before=      expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);; after=      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}\n  Eval`);; reason=该既有 owner 同时覆盖 Run、Attempt 与其它 Show 详情；本次只实质修改大型 Overview 的公开生成和断言片段。
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790850090&installation_model_id=431746&pr_number=208&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F208&signature=f35351a918998619f1feb801fa496679ef0e678e9a07b24873ef9e29d5fcc127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->