### PR TITLE
fix(inspection): 展示每个 Attempt 的独立 Verdict

### DIFF
--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -240,6 +240,7 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
 
   Attempt 明细先以 `Eval <id>` 缩进分组，不在每个 Attempt 行重复 Eval ID。同一 Eval 的多个 Attempt 各占一行，
   显示 `Attempt`、`Verdict`、`Duration` 与适用时的 `Score`。Verdict 为 `passed`、`failed`、`errored` 或 `skipped`。
+  Duration 按大小使用 `ms`、`s`、`min` 或 `h`，最多保留两位小数。
   membership action 与 origin/reference relation
   仍由具名 operation 保留，可在 Run/Attempt 下钻中查看。
 
@@ -311,40 +312,40 @@ Attempts · harness
   Eval terminal-install
   Attempt         Verdict  Duration  Score
   --------------  -------  --------  -----
-  @1M9Y03P6DXYQ   passed   18342 ms  16
+  @1M9Y03P6DXYQ   passed   18.34 s   16
 
   Eval terminal-init
   Attempt         Verdict  Duration  Score
   --------------  -------  --------  -----
-  @1MYD6J9PK5GA   passed   20117 ms  14
+  @1MYD6J9PK5GA   passed   20.12 s   14
 
   Eval terminal-run
   Attempt         Verdict  Duration  Score
   --------------  -------  --------  -----
-  @19YRYDKT4JMB   passed   3214 ms   2
+  @19YRYDKT4JMB   passed   3.21 s    2
 
   Experiment harness/v0.12.0
   Eval terminal-install
   Attempt         Verdict  Duration  Score
   --------------  -------  --------  -----
-  @19VNWKYFC0FC   passed   17803 ms  16
+  @19VNWKYFC0FC   passed   17.8 s    16
 
   Eval terminal-init
   Attempt         Verdict  Duration  Score
   --------------  -------  --------  -----
-  @1VNQTXJ03XJD   failed   21442 ms  14
+  @1VNQTXJ03XJD   failed   21.44 s   14
 
 Attempts · install
   Experiment install/canary
   Eval db-gateway
   Attempt         Verdict  Duration  Score
   --------------  -------  --------  -----
-  @1SY1PRPXSBFN   passed   8440 ms   5
+  @1SY1PRPXSBFN   passed   8.44 s    5
 
   Eval gpt-provider
   Attempt         Verdict  Duration  Score
   --------------  -------  --------  -----
-  @1QD6PEMZY39P   errored  2091 ms   5
+  @1QD6PEMZY39P   errored  2.09 s    5
 ```
 
 没有 `/` 的 Experiment 仍以完整 ID 显示在未分组 summary 与 `Attempts` 小节。Eval 相对标签只有在其首段与

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -238,8 +238,9 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
   Experiment ID 含 `/` 时，首段形成显示分组，组内 Experiment 与同前缀 Eval 使用相对标签。
   每个 Experiment 小节仍显示一次完整 ID，每个可下钻 Attempt 显示完整稳定 locator。
 
-  Attempt 表只保留 `Eval`、`Attempt`、`Verdict` 与适用时的 `Score`。同一 Eval 的多个 Attempt 各占一行，
-  分别显示 `passed`、`failed`、`errored` 或 `skipped`。membership action 与 origin/reference relation
+  Attempt 明细先以 `Eval <id>` 缩进分组，不在每个 Attempt 行重复 Eval ID。同一 Eval 的多个 Attempt 各占一行，
+  显示 `Attempt`、`Verdict`、`Duration` 与适用时的 `Score`。Verdict 为 `passed`、`failed`、`errored` 或 `skipped`。
+  membership action 与 origin/reference relation
   仍由具名 operation 保留，可在 Run/Attempt 下钻中查看。
 
   这个无 selector Overview 对项目 canonical Record 中的已发布 Run/Attempt facts 进行聚合：它按
@@ -307,24 +308,43 @@ Experiments
 
 Attempts · harness
   Experiment harness/canary
-  Eval              Attempt         Verdict  Score
-  ----------------  --------------  -------  -----
-  terminal-install  @1M9Y03P6DXYQ   passed   16
-  terminal-init     @1MYD6J9PK5GA   passed   14
-  terminal-run      @19YRYDKT4JMB   passed   2
+  Eval terminal-install
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @1M9Y03P6DXYQ   passed   18342 ms  16
+
+  Eval terminal-init
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @1MYD6J9PK5GA   passed   20117 ms  14
+
+  Eval terminal-run
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @19YRYDKT4JMB   passed   3214 ms   2
 
   Experiment harness/v0.12.0
-  Eval              Attempt         Verdict  Score
-  ----------------  --------------  -------  -----
-  terminal-install  @19VNWKYFC0FC   passed   16
-  terminal-init     @1VNQTXJ03XJD   failed   14
+  Eval terminal-install
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @19VNWKYFC0FC   passed   17803 ms  16
+
+  Eval terminal-init
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @1VNQTXJ03XJD   failed   21442 ms  14
 
 Attempts · install
   Experiment install/canary
-  Eval          Attempt         Verdict  Score
-  ------------  --------------  -------  -----
-  db-gateway    @1SY1PRPXSBFN   passed   5
-  gpt-provider  @1QD6PEMZY39P   errored  5
+  Eval db-gateway
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @1SY1PRPXSBFN   passed   8440 ms   5
+
+  Eval gpt-provider
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @1QD6PEMZY39P   errored  2091 ms   5
 ```
 
 没有 `/` 的 Experiment 仍以完整 ID 显示在未分组 summary 与 `Attempts` 小节。Eval 相对标签只有在其首段与

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -232,11 +232,15 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
 
 ### 固定投影
 
-- 无 selector 时调用 `overview.get`，格式化 totals、Experiment summaries 以及
-  Experiment → Eval → Attempt table。Experiment ID 含 `/` 时，首段形成显示分组，组内 Experiment 与同前缀
-  Eval 使用相对标签；每个 Experiment 小节仍显示一次完整 ID，每个可下钻 Attempt 显示完整稳定 locator。
-  Attempt 表只保留 `Eval`、`Attempt` 与 `Score`，不显示 membership action 或 origin/reference relation。这些 provenance
-  仍由具名 operation 保留并可在 Run/Attempt 下钻中查看。
+- 无 selector 时调用 `overview.get`，格式化 totals、Experiment summaries 与
+  Experiment → Eval → Attempt table。
+
+  Experiment ID 含 `/` 时，首段形成显示分组，组内 Experiment 与同前缀 Eval 使用相对标签。
+  每个 Experiment 小节仍显示一次完整 ID，每个可下钻 Attempt 显示完整稳定 locator。
+
+  Attempt 表只保留 `Eval`、`Attempt`、`Verdict` 与适用时的 `Score`。同一 Eval 的多个 Attempt 各占一行，
+  分别显示 `passed`、`failed`、`errored` 或 `skipped`。membership action 与 origin/reference relation
+  仍由具名 operation 保留，可在 Run/Attempt 下钻中查看。
 
   这个无 selector Overview 对项目 canonical Record 中的已发布 Run/Attempt facts 进行聚合：它按
   `experimentId + evalId + attemptOrdinal` 选择每个逻辑 slot 的最新 occurrence。当前工作树、当前安装的候选
@@ -271,7 +275,12 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
 ### 默认 Results 示例
 
 human renderer 将 pass rate 显示为百分比。`available` 是健康 metric 的默认状态，不附加在数值后；
-`partial`、`unavailable`、`empty`、`unsupported` 与 `failed` 仍须明确显示。Experiment summary 按路径首段分组，
+`partial`、`unavailable`、`empty`、`unsupported` 与 `failed` 仍须明确显示。
+
+Score 在纯 pass 制投影中是不适用的指标，
+human renderer 不输出 `Score unsupported` 占位：Totals 及某张表的全部成员均为 pass 制时，分别省略 Score 行或整列。
+只要该投影范围内存在 score 制成员，Score 行或列仍须显示，并为其它不可用、部分或失败的 score 保留具名状态。
+machine result 始终保留 typed `unsupported`。Experiment summary 按路径首段分组，
 Attempt 明细再按完整 Experiment 分表，使 80 列终端可以在同一行保留完整 locator：
 
 ```text
@@ -298,24 +307,24 @@ Experiments
 
 Attempts · harness
   Experiment harness/canary
-  Eval              Attempt         Score
-  ----------------  --------------  -----
-  terminal-install  @1M9Y03P6DXYQ   16
-  terminal-init     @1MYD6J9PK5GA   14
-  terminal-run      @19YRYDKT4JMB   2
+  Eval              Attempt         Verdict  Score
+  ----------------  --------------  -------  -----
+  terminal-install  @1M9Y03P6DXYQ   passed   16
+  terminal-init     @1MYD6J9PK5GA   passed   14
+  terminal-run      @19YRYDKT4JMB   passed   2
 
   Experiment harness/v0.12.0
-  Eval              Attempt         Score
-  ----------------  --------------  -----
-  terminal-install  @19VNWKYFC0FC   16
-  terminal-init     @1VNQTXJ03XJD   14
+  Eval              Attempt         Verdict  Score
+  ----------------  --------------  -------  -----
+  terminal-install  @19VNWKYFC0FC   passed   16
+  terminal-init     @1VNQTXJ03XJD   failed   14
 
 Attempts · install
   Experiment install/canary
-  Eval          Attempt         Score
-  ------------  --------------  -----
-  db-gateway    @1SY1PRPXSBFN   5
-  gpt-provider  @1QD6PEMZY39P   5
+  Eval          Attempt         Verdict  Score
+  ------------  --------------  -------  -----
+  db-gateway    @1SY1PRPXSBFN   passed   5
+  gpt-provider  @1QD6PEMZY39P   errored  5
 ```
 
 没有 `/` 的 Experiment 仍以完整 ID 显示在未分组 summary 与 `Attempts` 小节。Eval 相对标签只有在其首段与

--- a/docs/feature/inspection/use-case/比较质量与成本.md
+++ b/docs/feature/inspection/use-case/比较质量与成本.md
@@ -34,15 +34,17 @@ Experiments
 
 Attempts · compare
   Experiment compare/bub
-  Eval               Attempt        Verdict
-  -----------------  -------------  -------
-  downshift/pr-1414  @ATTEMPT-BUB-1  passed
-  downshift/pr-1414  @ATTEMPT-BUB-2  failed
-  downshift/pr-1414  @ATTEMPT-BUB-3  errored
+  Eval downshift/pr-1414
+  Attempt         Verdict  Duration
+  --------------  -------  --------
+  @ATTEMPT-BUB-1  passed   18342 ms
+  @ATTEMPT-BUB-2  failed   20117 ms
+  @ATTEMPT-BUB-3  errored  2091 ms
 ```
 
-Attempt 表保留 Experiment → Eval → Attempt 的一对多关系：同一 Eval 的每个 Attempt 各占一行，
-并显示各自的 Verdict。machine `overview.get` 仍保留 score metric 的 typed `unsupported`；
+Attempt 表用缩进保留 Experiment → Eval → Attempt 的一对多关系：Eval ID 只显示一次，
+同一 Eval 的每个 Attempt 各占一行，并显示各自的 Verdict 与 Duration。
+machine `overview.get` 仍保留 score metric 的 typed `unsupported`；
 省略 Score 只是人读布局，不改变事实。
 
 ## 查看 score 制 Results 并收窄到 Experiment

--- a/docs/feature/inspection/use-case/比较质量与成本.md
+++ b/docs/feature/inspection/use-case/比较质量与成本.md
@@ -11,7 +11,41 @@ relations: {}
 命令行为与稳定布局规则单源始终在 [Inspection CLI](../cli.md) 与
 [Inspection 架构](../architecture.md)。
 
-## 查看默认 Results 并收窄到 Experiment
+## 查看 pass 制 Results
+
+纯 pass 制评测的质量读数就是 Verdicts 与 Pass rate。Score 对它不适用，human renderer 不显示
+`unsupported` 占位行或列：
+
+```text
+$ niceeval show
+NiceEval results
+  Totals
+
+  Observed   180/180
+  Verdicts   158 passed; 17 failed; 5 errored; 0 skipped
+  Pass rate  87.78%
+
+Experiments
+  compare
+  Experiment     Observed  Agent  Model         Pass rate
+  -------------  --------  -----  ------------  ---------
+  bub            36/36     bub    gpt-5.6-luna  88.89%
+  codex          36/36     codex  gpt-5.6-luna  83.33%
+
+Attempts · compare
+  Experiment compare/bub
+  Eval               Attempt        Verdict
+  -----------------  -------------  -------
+  downshift/pr-1414  @ATTEMPT-BUB-1  passed
+  downshift/pr-1414  @ATTEMPT-BUB-2  failed
+  downshift/pr-1414  @ATTEMPT-BUB-3  errored
+```
+
+Attempt 表保留 Experiment → Eval → Attempt 的一对多关系：同一 Eval 的每个 Attempt 各占一行，
+并显示各自的 Verdict。machine `overview.get` 仍保留 score metric 的 typed `unsupported`；
+省略 Score 只是人读布局，不改变事实。
+
+## 查看 score 制 Results 并收窄到 Experiment
 
 下面的 locator、Run 与 Experiment ID 都是文档专用的 adopted target 示例，不是用户运行的实际值。
 
@@ -99,7 +133,8 @@ Overview 可见不等于当前 target 可复用。Experiment planning 仍以 exe
 }
 ```
 
-`overview.get` 的 cell 已经关闭 Experiment × Eval cost、pass rate、score 与 denominator。用户从异常 cell 的
+`overview.get` 的 cell 已经关闭 Experiment × Eval cost、pass rate、score 与 denominator。human renderer 按当前
+投影的 evaluation kind 选择可用的质量列，不会把 pass rate 和 score 混成一个读数。用户从异常 cell 的
 Attempt locator 进入 `attempt.get` 或 `attempt.trace`；machine consumer 不需要枚举 Run 后自己拼 board。
 需要证明两组 Run 是否可比时，再使用 `runs.compare`：
 

--- a/docs/feature/inspection/use-case/比较质量与成本.md
+++ b/docs/feature/inspection/use-case/比较质量与成本.md
@@ -37,9 +37,9 @@ Attempts · compare
   Eval downshift/pr-1414
   Attempt         Verdict  Duration
   --------------  -------  --------
-  @ATTEMPT-BUB-1  passed   18342 ms
-  @ATTEMPT-BUB-2  failed   20117 ms
-  @ATTEMPT-BUB-3  errored  2091 ms
+  @ATTEMPT-BUB-1  passed   18.34 s
+  @ATTEMPT-BUB-2  failed   20.12 s
+  @ATTEMPT-BUB-3  errored  2.09 s
 ```
 
 Attempt 表用缩进保留 Experiment → Eval → Attempt 的一对多关系：Eval ID 只显示一次，

--- a/e2e/inspection/test/show-cli.test.ts
+++ b/e2e/inspection/test/show-cli.test.ts
@@ -109,6 +109,15 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
         }),
       ]);
 
+      const passOnlyExperiment = await niceeval.run(["show", "--experiment", scaleExperimentId]);
+      expect(passOnlyExperiment.exitCode, passOnlyExperiment.diagnostic()).toBe(0);
+      expectHumanText(passOnlyExperiment.stdout);
+      expect(passOnlyExperiment.stdout).toContain("Pass rate");
+      expect(passOnlyExperiment.stdout).toMatch(/Eval\s+Attempt\s+Verdict/u);
+      expect(passOnlyExperiment.stdout.match(/^\s*overview-scale\s+@\S+\s+passed\s*$/gmu)).toHaveLength(10);
+      expect(passOnlyExperiment.stdout).not.toContain("Score");
+      expect(passOnlyExperiment.stdout).not.toContain("unsupported");
+
       const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
       writeFileSync(
         overviewRequestPath,
@@ -146,12 +155,12 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
       expect(overview.stdout).toContain(`Experiment ${mainExperimentId}\n  Eval`);
       expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}\n  Eval`);
-      expect(overview.stdout).toMatch(/Eval\s+Attempt\s+Score/u);
+      expect(overview.stdout).toMatch(/Eval\s+Attempt\s+Verdict\s+Score/u);
       expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
       expect(overview.stdout).toContain(locator);
       expect(overview.stdout).toContain(alternateLocator);
-      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${locator}\\s+37\\.11\\s*$`, "mu"));
-      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${locator}\\s+passed\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+passed\\s+37\\.11\\s*$`, "mu"));
       expect(overview.stdout).toContain("100%");
 
       const run = await niceeval.run(["show", "--run", mainRunId]);
@@ -388,10 +397,10 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(historicalOverview.stdout).toContain(locator);
       expect(historicalOverview.stdout).toContain(alternateLocator);
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*inspection\\s+${locator}\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*inspection\\s+${locator}\\s+passed\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+passed\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).not.toContain("Observed   0/0");
     },

--- a/e2e/inspection/test/show-cli.test.ts
+++ b/e2e/inspection/test/show-cli.test.ts
@@ -113,8 +113,9 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(passOnlyExperiment.exitCode, passOnlyExperiment.diagnostic()).toBe(0);
       expectHumanText(passOnlyExperiment.stdout);
       expect(passOnlyExperiment.stdout).toContain("Pass rate");
-      expect(passOnlyExperiment.stdout).toMatch(/Eval\s+Attempt\s+Verdict/u);
-      expect(passOnlyExperiment.stdout.match(/^\s*overview-scale\s+@\S+\s+passed\s*$/gmu)).toHaveLength(10);
+      expect(passOnlyExperiment.stdout).toContain("Eval overview-scale");
+      expect(passOnlyExperiment.stdout).toMatch(/Attempt\s+Verdict\s+Duration/u);
+      expect(passOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? ms\s*$/gmu)).toHaveLength(10);
       expect(passOnlyExperiment.stdout).not.toContain("Score");
       expect(passOnlyExperiment.stdout).not.toContain("unsupported");
 
@@ -153,14 +154,14 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
       expect(overview.stdout).toContain(`Experiment ${scaleExperimentId}`);
       expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
-      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}\n  Eval`);
-      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}\n  Eval`);
-      expect(overview.stdout).toMatch(/Eval\s+Attempt\s+Verdict\s+Score/u);
+      expectInOrder(overview.stdout, [`Experiment ${mainExperimentId}`, "Eval inspection", locator]);
+      expectInOrder(overview.stdout, [`Experiment ${alternateExperimentId}`, "Eval inspection", alternateLocator]);
+      expect(overview.stdout).toMatch(/Attempt\s+Verdict\s+Duration\s+Score/u);
       expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
       expect(overview.stdout).toContain(locator);
       expect(overview.stdout).toContain(alternateLocator);
-      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${locator}\\s+passed\\s+37\\.11\\s*$`, "mu"));
-      expect(overview.stdout).toMatch(new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+passed\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"));
       expect(overview.stdout).toContain("100%");
 
       const run = await niceeval.run(["show", "--run", mainRunId]);
@@ -397,10 +398,10 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(historicalOverview.stdout).toContain(locator);
       expect(historicalOverview.stdout).toContain(alternateLocator);
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*inspection\\s+${locator}\\s+passed\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*inspection\\s+${alternateLocator}\\s+passed\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).not.toContain("Observed   0/0");
     },

--- a/e2e/inspection/test/show-cli.test.ts
+++ b/e2e/inspection/test/show-cli.test.ts
@@ -115,7 +115,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(passOnlyExperiment.stdout).toContain("Pass rate");
       expect(passOnlyExperiment.stdout).toContain("Eval overview-scale");
       expect(passOnlyExperiment.stdout).toMatch(/Attempt\s+Verdict\s+Duration/u);
-      expect(passOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? ms\s*$/gmu)).toHaveLength(10);
+      expect(passOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? (?:ms|s|min|h)\s*$/gmu)).toHaveLength(10);
       expect(passOnlyExperiment.stdout).not.toContain("Score");
       expect(passOnlyExperiment.stdout).not.toContain("unsupported");
 
@@ -160,8 +160,8 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
       expect(overview.stdout).toContain(locator);
       expect(overview.stdout).toContain(alternateLocator);
-      expect(overview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"));
-      expect(overview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
+      expect(overview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
       expect(overview.stdout).toContain("100%");
 
       const run = await niceeval.run(["show", "--run", mainRunId]);
@@ -398,10 +398,10 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(historicalOverview.stdout).toContain(locator);
       expect(historicalOverview.stdout).toContain(alternateLocator);
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? ms\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).not.toContain("Observed   0/0");
     },

--- a/packages/niceeval/src/inspection/overview.ts
+++ b/packages/niceeval/src/inspection/overview.ts
@@ -99,6 +99,7 @@ export interface InspectionOverviewMember {
   readonly publication:
     | Exclude<RunSlotPublication, { readonly state: "published" }>
     | (Extract<RunSlotPublication, { readonly state: "published" }> & {
+        readonly verdict: VerdictState | null;
         readonly score: InspectionMetricValue;
         readonly costUSD: InspectionCostMetricValue;
         readonly durationMs: InspectionMetricValue;
@@ -525,6 +526,7 @@ function overviewPublication(
     attemptLocator: resolved.locator,
     originRunId: member.attempt.originRunId,
     originSlotId: resolved.attempt.slotId,
+    verdict: selected.analysis.verdict,
     score: scoreForMember(selected),
     costUSD: costForSlots([selected]),
     durationMs: metricForSlots([selected], "durationMs", "ms", "average"),

--- a/packages/niceeval/src/inspection/results.ts
+++ b/packages/niceeval/src/inspection/results.ts
@@ -138,6 +138,7 @@ const AggregateFields = {
 } as const;
 const OverviewPublishedMemberSchema = Schema.Struct({
   ...RunPublishedPublicationSchema.fields,
+  verdict: Schema.NullOr(Schema.Literals(["passed", "failed", "errored", "skipped"])),
   score: MetricSchema,
   costUSD: CostMetricSchema,
   durationMs: MetricSchema,

--- a/packages/niceeval/src/show/model.ts
+++ b/packages/niceeval/src/show/model.ts
@@ -31,6 +31,7 @@ export type ExecutionValue =
   | { readonly state: "mixed" }
   | { readonly state: "unavailable" };
 export type Aggregate = {
+  readonly evaluationKind: "pass" | "points" | "mixed";
   readonly expected: number;
   readonly observed: number;
   readonly passed: number;
@@ -65,6 +66,7 @@ export interface OverviewView {
             readonly attemptLocator: string;
             readonly originRunId: string;
             readonly originSlotId: string;
+            readonly verdict: Verdict | null;
             readonly score: Metric;
             readonly durationMs: Metric;
             readonly tokens: Metric;
@@ -195,6 +197,7 @@ export type DiffView = { readonly locator: string } & InspectionSuccessDocumentF
 
 const metric = (value: { readonly state: MetricState; readonly value: number | null }): Metric => ({ state: value.state, value: value.value });
 const aggregate = (value: InspectionOverviewResult["totals"]): Aggregate => ({
+  evaluationKind: value.evaluationKind,
   expected: value.denominator.expected,
   observed: value.denominator.observed,
   passed: value.verdict.tally.passed,

--- a/packages/niceeval/src/show/render.ts
+++ b/packages/niceeval/src/show/render.ts
@@ -67,7 +67,9 @@ const aggregateEntries = (
         : `${value.passed} passed; ${value.failed} failed; ${value.errored} errored; ${value.skipped} skipped`,
     },
     { key: "Pass rate", value: passRate(value.passRate) },
-    { key: "Score", value: metric(value.score) },
+    ...(value.evaluationKind === "pass"
+      ? []
+      : [{ key: "Score", value: metric(value.score) }]),
     { key: "Duration", value: metric(value.durationMs, (value) => `${fmt(value)} ms`) },
     { key: "Tokens", value: metric(value.tokens) },
   ],
@@ -102,34 +104,44 @@ function groupExperiments(value: OverviewView): readonly ExperimentGroup[] {
 const attemptTable = (
   cells: OverviewView["cells"],
   group: string | null,
-): TerminalPanelContentBlock & { readonly kind: "table" } => ({
-  kind: "table",
-  columns: [
-    { header: "Eval", maxWidth: 55 },
-    { header: "Attempt", maxWidth: 14 },
-    { header: "Score" },
-  ],
-  overflow: "wrap",
-  rows: cells.flatMap((cell) =>
-    cell.members.length === 0
-      ? [[
-        relativeToGroup(cell.evalId, group),
-        "not-recorded",
-        metric(cell.aggregate.score),
-      ]]
-      : cell.members.map((member) => [
-        relativeToGroup(cell.evalId, group),
-        member.publication.state === "published"
-          ? member.publication.attemptLocator
-          : member.publication.state === "absent"
-            ? `absent (${member.publication.reason})`
-            : "pending",
-        member.publication.state === "published"
-          ? metric(member.publication.score)
-          : member.publication.state,
-      ]),
-  ),
-});
+): TerminalPanelContentBlock & { readonly kind: "table" } => {
+  const showScore = cells.some(({ aggregate }) => aggregate.evaluationKind !== "pass");
+  return {
+    kind: "table",
+    columns: [
+      { header: "Eval", maxWidth: 55 },
+      { header: "Attempt", maxWidth: 14 },
+      { header: "Verdict" },
+      ...(showScore ? [{ header: "Score" }] : []),
+    ],
+    overflow: "wrap",
+    rows: cells.flatMap((cell) =>
+      cell.members.length === 0
+        ? [[
+          relativeToGroup(cell.evalId, group),
+          "not-recorded",
+          "not-recorded",
+          ...(showScore ? [metric(cell.aggregate.score)] : []),
+        ]]
+        : cell.members.map((member) => [
+          relativeToGroup(cell.evalId, group),
+          member.publication.state === "published"
+            ? member.publication.attemptLocator
+            : member.publication.state === "absent"
+              ? `absent (${member.publication.reason})`
+              : "pending",
+          member.publication.state === "published"
+            ? member.publication.verdict ?? "not-recorded"
+            : member.publication.state,
+          ...(showScore
+            ? [member.publication.state === "published"
+              ? metric(member.publication.score)
+              : member.publication.state]
+            : []),
+        ]),
+    ),
+  };
+};
 
 const stateCount = (state: string, count: number, noun: string): string =>
   `${state}; ${count} ${noun}s`;
@@ -153,30 +165,35 @@ export function renderOverview(value: OverviewView): string {
     blocks.push({
       kind: "panel",
       title: "Experiments",
-      blocks: groups.flatMap((group) => [
-        ...(group.name === null
-          ? []
-          : [{ kind: "divider" as const, title: group.name }]),
-        {
-          kind: "table",
-          columns: [
-            { header: "Experiment" },
-            { header: "Observed" },
-            { header: "Agent" },
-            { header: "Model" },
-            { header: "Pass rate" },
-            { header: "Score" },
-          ],
-          rows: group.experiments.map((experiment) => [
-            relativeToGroup(experiment.experimentId, group.name),
-            `${experiment.aggregate.observed}/${experiment.aggregate.expected}`,
-            executionValue(experiment.agent),
-            executionValue(experiment.model),
-            passRate(experiment.aggregate.passRate),
-            metric(experiment.aggregate.score),
-          ]),
-        },
-      ]),
+      blocks: groups.flatMap((group) => {
+        const showScore = group.experiments.some(({ aggregate }) =>
+          aggregate.evaluationKind !== "pass"
+        );
+        return [
+          ...(group.name === null
+            ? []
+            : [{ kind: "divider" as const, title: group.name }]),
+          {
+            kind: "table" as const,
+            columns: [
+              { header: "Experiment" },
+              { header: "Observed" },
+              { header: "Agent" },
+              { header: "Model" },
+              { header: "Pass rate" },
+              ...(showScore ? [{ header: "Score" }] : []),
+            ],
+            rows: group.experiments.map((experiment) => [
+              relativeToGroup(experiment.experimentId, group.name),
+              `${experiment.aggregate.observed}/${experiment.aggregate.expected}`,
+              executionValue(experiment.agent),
+              executionValue(experiment.model),
+              passRate(experiment.aggregate.passRate),
+              ...(showScore ? [metric(experiment.aggregate.score)] : []),
+            ]),
+          },
+        ];
+      }),
     });
   }
   if (value.cells.length > 0) {
@@ -206,6 +223,7 @@ export function renderOverview(value: OverviewView): string {
 }
 
 export function renderExperiment(value: ExperimentView): string {
+  const showScore = value.aggregate.evaluationKind !== "pass";
   return terminal([
     {
       kind: "panel",
@@ -219,7 +237,8 @@ export function renderExperiment(value: ExperimentView): string {
           columns: [
             { header: "Eval", maxWidth: 55 },
             { header: "Attempt", maxWidth: 14 },
-            { header: "Score" },
+            { header: "Verdict" },
+            ...(showScore ? [{ header: "Score" }] : []),
           ],
           overflow: "wrap",
           rows: value.cells.flatMap((cell) =>
@@ -227,7 +246,8 @@ export function renderExperiment(value: ExperimentView): string {
               ? [[
                 cell.evalId,
                 "not-recorded",
-                metric(cell.aggregate.score),
+                "not-recorded",
+                ...(showScore ? [metric(cell.aggregate.score)] : []),
               ]]
               : cell.members.map((member) => [
                 cell.evalId,
@@ -237,8 +257,13 @@ export function renderExperiment(value: ExperimentView): string {
                     ? `absent (${member.publication.reason})`
                     : "pending",
                 member.publication.state === "published"
-                  ? metric(member.publication.score)
+                  ? member.publication.verdict ?? "not-recorded"
                   : member.publication.state,
+                ...(showScore
+                  ? [member.publication.state === "published"
+                    ? metric(member.publication.score)
+                    : member.publication.state]
+                  : []),
               ]),
           ),
         },

--- a/packages/niceeval/src/show/render.ts
+++ b/packages/niceeval/src/show/render.ts
@@ -101,30 +101,34 @@ function groupExperiments(value: OverviewView): readonly ExperimentGroup[] {
   return [...groups].map(([name, experiments]) => ({ name, experiments }));
 }
 
-const attemptTable = (
+const attemptBlocks = (
   cells: OverviewView["cells"],
   group: string | null,
-): TerminalPanelContentBlock & { readonly kind: "table" } => {
-  const showScore = cells.some(({ aggregate }) => aggregate.evaluationKind !== "pass");
-  return {
-    kind: "table",
-    columns: [
-      { header: "Eval", maxWidth: 55 },
-      { header: "Attempt", maxWidth: 14 },
-      { header: "Verdict" },
-      ...(showScore ? [{ header: "Score" }] : []),
-    ],
-    overflow: "wrap",
-    rows: cells.flatMap((cell) =>
-      cell.members.length === 0
+): readonly TerminalPanelContentBlock[] => cells.flatMap((cell) => {
+  const showScore = cell.aggregate.evaluationKind !== "pass";
+  return [
+    {
+      kind: "divider" as const,
+      title: `Eval ${relativeToGroup(cell.evalId, group)}`,
+      attachNext: true,
+    },
+    {
+      kind: "table" as const,
+      columns: [
+        { header: "Attempt", maxWidth: 14 },
+        { header: "Verdict" },
+        { header: "Duration" },
+        ...(showScore ? [{ header: "Score" }] : []),
+      ],
+      overflow: "wrap" as const,
+      rows: cell.members.length === 0
         ? [[
-          relativeToGroup(cell.evalId, group),
           "not-recorded",
           "not-recorded",
+          metric(cell.aggregate.durationMs, (value) => `${fmt(value)} ms`),
           ...(showScore ? [metric(cell.aggregate.score)] : []),
         ]]
         : cell.members.map((member) => [
-          relativeToGroup(cell.evalId, group),
           member.publication.state === "published"
             ? member.publication.attemptLocator
             : member.publication.state === "absent"
@@ -133,15 +137,18 @@ const attemptTable = (
           member.publication.state === "published"
             ? member.publication.verdict ?? "not-recorded"
             : member.publication.state,
+          member.publication.state === "published"
+            ? metric(member.publication.durationMs, (value) => `${fmt(value)} ms`)
+            : member.publication.state,
           ...(showScore
             ? [member.publication.state === "published"
               ? metric(member.publication.score)
               : member.publication.state]
             : []),
         ]),
-    ),
-  };
-};
+    },
+  ];
+});
 
 const stateCount = (state: string, count: number, noun: string): string =>
   `${state}; ${count} ${noun}s`;
@@ -211,9 +218,8 @@ export function renderOverview(value: OverviewView): string {
             {
               kind: "divider" as const,
               title: `Experiment ${experiment.experimentId}`,
-              attachNext: true,
             },
-            attemptTable(experimentCells, group.name),
+            ...attemptBlocks(experimentCells, group.name),
           ];
         }),
       });
@@ -223,7 +229,6 @@ export function renderOverview(value: OverviewView): string {
 }
 
 export function renderExperiment(value: ExperimentView): string {
-  const showScore = value.aggregate.evaluationKind !== "pass";
   return terminal([
     {
       kind: "panel",
@@ -232,41 +237,7 @@ export function renderExperiment(value: ExperimentView): string {
         { kind: "divider", title: "Summary" },
         aggregateEntries(value.aggregate),
         { kind: "divider", title: "Attempts" },
-        {
-          kind: "table",
-          columns: [
-            { header: "Eval", maxWidth: 55 },
-            { header: "Attempt", maxWidth: 14 },
-            { header: "Verdict" },
-            ...(showScore ? [{ header: "Score" }] : []),
-          ],
-          overflow: "wrap",
-          rows: value.cells.flatMap((cell) =>
-            cell.members.length === 0
-              ? [[
-                cell.evalId,
-                "not-recorded",
-                "not-recorded",
-                ...(showScore ? [metric(cell.aggregate.score)] : []),
-              ]]
-              : cell.members.map((member) => [
-                cell.evalId,
-                member.publication.state === "published"
-                  ? member.publication.attemptLocator
-                  : member.publication.state === "absent"
-                    ? `absent (${member.publication.reason})`
-                    : "pending",
-                member.publication.state === "published"
-                  ? member.publication.verdict ?? "not-recorded"
-                  : member.publication.state,
-                ...(showScore
-                  ? [member.publication.state === "published"
-                    ? metric(member.publication.score)
-                    : member.publication.state]
-                  : []),
-              ]),
-          ),
-        },
+        ...attemptBlocks(value.cells, null),
       ],
     },
   ]);

--- a/packages/niceeval/src/show/render.ts
+++ b/packages/niceeval/src/show/render.ts
@@ -45,6 +45,13 @@ const metric = (
 const passRate = (value: Metric): string =>
   metric(value, (rate) => `${fmt(rate * 100)}%`);
 
+const duration = (value: Metric): string => metric(value, (milliseconds) => {
+  if (milliseconds < 1_000) return `${fmt(milliseconds)} ms`;
+  if (milliseconds < 60_000) return `${fmt(milliseconds / 1_000)} s`;
+  if (milliseconds < 3_600_000) return `${fmt(milliseconds / 60_000)} min`;
+  return `${fmt(milliseconds / 3_600_000)} h`;
+});
+
 const score = (value: ScoredValue): string =>
   value.state === "not-scored"
     ? value.state
@@ -70,7 +77,7 @@ const aggregateEntries = (
     ...(value.evaluationKind === "pass"
       ? []
       : [{ key: "Score", value: metric(value.score) }]),
-    { key: "Duration", value: metric(value.durationMs, (value) => `${fmt(value)} ms`) },
+    { key: "Duration", value: duration(value.durationMs) },
     { key: "Tokens", value: metric(value.tokens) },
   ],
 });
@@ -125,7 +132,7 @@ const attemptBlocks = (
         ? [[
           "not-recorded",
           "not-recorded",
-          metric(cell.aggregate.durationMs, (value) => `${fmt(value)} ms`),
+          duration(cell.aggregate.durationMs),
           ...(showScore ? [metric(cell.aggregate.score)] : []),
         ]]
         : cell.members.map((member) => [
@@ -138,7 +145,7 @@ const attemptBlocks = (
             ? member.publication.verdict ?? "not-recorded"
             : member.publication.state,
           member.publication.state === "published"
-            ? metric(member.publication.durationMs, (value) => `${fmt(value)} ms`)
+            ? duration(member.publication.durationMs)
             : member.publication.state,
           ...(showScore
             ? [member.publication.state === "published"


### PR DESCRIPTION
<!-- niceeval:pr-body
base: e596bc666b9e3ea0ffa4cf5f0db015968e30156d
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: 952b5397944f7eda55fc32c74a3889b5f2e4ad16
-->

## Problem

- User goal: 在终端按 Experiment → Eval → Attempt 层级紧凑审阅结果，并看到每次 Attempt 的 Verdict 与易读耗时。
- Current limitation: Attempts 表在每个 Attempt 行重复 Eval ID，浪费终端宽度和输出 token；旧输出也缺少每次 Attempt 的 Verdict，Duration 固定使用毫秒，且纯 pass 制显示不适用的 Score unsupported。
- Required capability: Inspection 的 overview/experiment member 交付每个 published Attempt 的 typed Verdict 与 durationMs；human renderer 按 Eval 分组，逐行呈现 Attempt、Verdict、自适应 Duration 与适用时的 Score。
- User outcome: 每个 Eval ID 只显示一次，其所有 Attempt 在缩进子表中各占一行；Duration 按大小显示 ms、s、min 或 h，纯 pass 制不再显示 Score。

## Use cases

### Changed

#### Case: 按层级审阅 Eval 的多个 Attempt

##### Starting state

```text
一个已完成的 Experiment，其中同一 Eval 运行了多个 Attempt。
```

##### Action

```sh
$ niceeval show --experiment harness/scale
```

##### Result

```text
NiceEval experiment
  Experiment  harness/scale
  Observed    10/10
  Verdicts    8 passed; 1 failed; 1 errored; 0 skipped
  Pass rate   80.00%

Attempts
  Eval overview-scale
  Attempt     Verdict  Duration
  ----------  -------  --------
  @ATTEMPT-1  passed   18.34 s
  @ATTEMPT-2  failed   2.12 min
  @ATTEMPT-3  errored  1.09 h
```

Experiment → Eval → Attempt 的一对多关系用缩进表达：Eval ID 只显示一次，每个 Attempt 保留独立 Verdict；Duration 根据大小使用 ms、s、min 或 h，纯 pass 制不显示 Score unsupported。 [Canonical Use Case](docs/feature/inspection/use-case/比较质量与成本.md).

## CLI

### Changed

#### Case: 同一 Eval 的多个 Attempt

##### Before

```sh
$ niceeval show --experiment harness/scale
```

```text
Eval            Attempt     Score
--------------  ----------  -----------
overview-scale  @ATTEMPT-1  unsupported
overview-scale  @ATTEMPT-2  unsupported
```

##### After

```sh
$ niceeval show --experiment harness/scale
```

```text
Eval overview-scale
Attempt     Verdict  Duration
----------  -------  --------
@ATTEMPT-1  passed   18.34 s
@ATTEMPT-2  failed   2.12 min
```

##### User impact

Eval ID 不再在每个 Attempt 行重复；每个 Attempt 显示 Verdict，Duration 自动选择 ms、s、min 或 h。纯 pass 制省略 Score，points 或 mixed 投影继续显示 Score。

## Tests

### `e2e/inspection/test/show-cli.test.ts`

#### `e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS`

human show 用 Eval 父级与 Attempt 子表保留一对多关系，每行显示 Verdict 与自适应单位的 Duration，并只在适用投影显示 Score。 It exercises 安装候选包后，通过 niceeval exp 为同一 Eval 生成 10 个 pass 制 Attempt，并生成 points 结果，再从 niceeval show 的公开 CLI 入口读取。 and asserts 输出先显示一次 Eval overview-scale，再显示恰好 10 个不同 Attempt 行；每行含 passed Verdict 与 ms、s、min 或 h Duration；pass-only 子表不含 Score 或 unsupported；points 总览仍显示 Score。. Deleting this case would allow 删除该断言会让 Eval ID 在每行重复、多 Attempt 被折叠、Verdict 或 Duration 丢失，也可能破坏 Duration 单位或 Score 的按 evaluation kind 显示。. The final contract is [docs/feature/inspection/cli.md#niceeval-show](docs/feature/inspection/cli.md#niceeval-show).

```ts
// rerun: pnpm e2e test --repo inspection -- --run test/show-cli.test.ts

import { only } from "@niceeval/testkit";
import { readFileSync, writeFileSync } from "node:fs";
import { join } from "node:path";
import { expect, test } from "vitest";
import { inspectionCaseArtifacts, inspectionE2E } from "./support.ts";

function expectHumanText(stdout: string): void {
  expect(stdout.trim()).not.toBe("");
  expect(() => JSON.parse(stdout)).toThrow();
}

function expectInOrder(stdout: string, values: readonly string[]): void {
  let cursor = 0;
  for (const value of values) {
    const position = stdout.indexOf(value, cursor);
    expect(
      position,
      `expected ${JSON.stringify(value)} after byte ${cursor} in:\n${stdout}`,
    ).toBeGreaterThanOrEqual(cursor);
    cursor = position + value.length;
  }
}

interface FailedShowResult {
  readonly exitCode: number;
  readonly stdout: string;
  readonly stderr: string;
  diagnostic(): string;
}

function expectShowFailure(
  result: FailedShowResult,
  stderrValues: readonly string[],
): void {
  expect(result.exitCode, result.diagnostic()).not.toBe(0);
  expect(result.stdout, result.diagnostic()).toBe("");
  expect(result.stderr.trim(), result.diagnostic()).not.toBe("");
  for (const value of stderrValues) {
    expect(result.stderr, result.diagnostic()).toContain(value);
  }
}

function stableIdentity(stdout: string, label: string): string {
  const escaped = label.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
  const identity = stdout.match(new RegExp(`^\\s*${escaped}\\s+(\\S+)\\s*$`, "mu"))?.[1];
  expect(identity, `expected ${label} in stable identity index:\n${stdout}`).toBeDefined();
  if (identity === undefined) throw new Error(`expected ${label} stable identity`);
  expect(identity).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
  return identity;
}

test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]", async () => {
  await inspectionE2E.case(
    "show-terminal-review",
    { artifacts: inspectionCaseArtifacts() },
    async ({ commands: { niceeval }, paths }) => {
      const mainExperimentId = "harness/canary";
      const alternateExperimentId = "harness/alternate";
      const scaleExperimentId = "harness/scale";
      const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
      expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
      expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const mainRunId = only(mainProduced.expReceipt().createdRunIds, () => true, mainProduced.diagnostic());
      const attempt = only(
        mainProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        mainProduced.diagnostic(),
      );
      expect(attempt).toMatchObject({ verdict: "passed" });
      const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;

      const alternateProduced = await niceeval.run(["exp", alternateExperimentId, "--rerun", "all", "--json"]);
      expect(alternateProduced.exitCode, alternateProduced.diagnostic()).toBe(0);
      expect(alternateProduced.expReceipt(), alternateProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const alternateRunId = only(
        alternateProduced.expReceipt().createdRunIds,
        () => true,
        alternateProduced.diagnostic(),
      );
      const alternateAttempt = only(
        alternateProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        alternateProduced.diagnostic(),
      );
      expect(alternateAttempt).toMatchObject({ verdict: "passed" });
      const alternateLocator = alternateAttempt.locator.startsWith("@")
        ? alternateAttempt.locator
        : `@${alternateAttempt.locator}`;

      const scaleProduced = await niceeval.run([
        "exp",
        scaleExperimentId,
        "--rerun",
        "all",
        "--json",
      ]);
      expect(scaleProduced.exitCode, scaleProduced.diagnostic()).toBe(0);
      expect(scaleProduced.expReceipt(), scaleProduced.diagnostic()).toMatchObject({
        completion: "completed",
      });
      expect(scaleProduced.expEvalEvents(), scaleProduced.diagnostic()).toEqual([
        expect.objectContaining({
          evalId: "overview-scale",
          attempts: 10,
          passed: 10,
          verdict: "passed",
        }),
      ]);

      const passOnlyExperiment = await niceeval.run(["show", "--experiment", scaleExperimentId]);
      expect(passOnlyExperiment.exitCode, passOnlyExperiment.diagnostic()).toBe(0);
      expectHumanText(passOnlyExperiment.stdout);
      expect(passOnlyExperiment.stdout).toContain("Pass rate");
      expect(passOnlyExperiment.stdout).toContain("Eval overview-scale");
      expect(passOnlyExperiment.stdout).toMatch(/Attempt\s+Verdict\s+Duration/u);
      expect(passOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? (?:ms|s|min|h)\s*$/gmu)).toHaveLength(10);
      expect(passOnlyExperiment.stdout).not.toContain("Score");
      expect(passOnlyExperiment.stdout).not.toContain("unsupported");

      const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
      writeFileSync(
        overviewRequestPath,
        JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "overview.get" },
        }),
        "utf8",
      );
      const machineOverview = await niceeval.run([
        "query",
        "run",
        "--request",
        overviewRequestPath,
      ]);
      expect(machineOverview.exitCode, machineOverview.diagnostic()).toBe(0);
      expect(Buffer.byteLength(machineOverview.stdout, "utf8")).toBeGreaterThan(512 * 1024);

      const overview = await niceeval.run(["show"]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      expectHumanText(overview.stdout);
      expectInOrder(overview.stdout, ["Totals", "Experiments"]);
      expectInOrder(overview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${scaleExperimentId}`);
      expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
      expectInOrder(overview.stdout, [`Experiment ${mainExperimentId}`, "Eval inspection", locator]);
      expectInOrder(overview.stdout, [`Experiment ${alternateExperimentId}`, "Eval inspection", alternateLocator]);
      expect(overview.stdout).toMatch(/Attempt\s+Verdict\s+Duration\s+Score/u);
      expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
      expect(overview.stdout).toContain(locator);
      expect(overview.stdout).toContain(alternateLocator);
      expect(overview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
      expect(overview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
      expect(overview.stdout).toContain("100%");

      const run = await niceeval.run(["show", "--run", mainRunId]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      expectHumanText(run.stdout);
      expect(run.stdout).toContain(mainRunId);
      expectInOrder(run.stdout, [mainExperimentId, "inspection", locator]);

      const runs = await niceeval.run([
        "show",
        "--run",
        alternateRunId,
        "--run",
        mainRunId,
      ]);
      expect(runs.exitCode, runs.diagnostic()).toBe(0);
      expectHumanText(runs.stdout);
      expect(runs.stdout).toContain(`Run ${mainRunId}`);
      expect(runs.stdout).toContain(`Run ${alternateRunId}`);
      expect(runs.stdout).toContain(locator);
      expect(runs.stdout).toContain(alternateLocator);
      expect(runs.stdout.match(/^Run /gmu)).toHaveLength(2);

      const atomicRunsFailure = await niceeval.run([
        "show",
        "--run",
        mainRunId,
        "--run",
        "missing-run",
      ]);
      expectShowFailure(atomicRunsFailure, ["missing-run"]);

      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId]);
      expect(mainExperiment.exitCode, mainExperiment.diagnostic()).toBe(0);
      expectHumanText(mainExperiment.stdout);
      expect(mainExperiment.stdout).toContain(mainExperimentId);
      expect(mainExperiment.stdout).toContain(locator);
      expect(mainExperiment.stdout).not.toContain(alternateLocator);

      const experiments = await niceeval.run([
        "show",
        "--experiment",
        alternateExperimentId,
        "--experiment",
        mainExperimentId,
      ]);
      expect(experiments.exitCode, experiments.diagnostic()).toBe(0);
      expectHumanText(experiments.stdout);
      expect(experiments.stdout).toContain(mainExperimentId);
      expect(experiments.stdout).toContain(alternateExperimentId);
      expect(experiments.stdout).toContain(locator);
      expect(experiments.stdout).toContain(alternateLocator);

      const missingExperiment = await niceeval.run([
        "show",
        "--experiment",
        mainExperimentId,
        "--experiment",
        "does-not-exist",
      ]);
      expectShowFailure(missingExperiment, ["does-not-exist"]);

      const attemptOverview = await niceeval.run(["show", locator]);
      expect(attemptOverview.exitCode, attemptOverview.diagnostic()).toBe(0);
      expectHumanText(attemptOverview.stdout);
      expect(attemptOverview.stdout).toContain(locator);
      expectInOrder(attemptOverview.stdout, [mainExperimentId, "inspection", "Outcome", "Score", "Evidence"]);
      expect(attemptOverview.stdout).toContain("passed");
      expect(attemptOverview.stdout).toContain("Inspection tool occurrence");
      expect(attemptOverview.stdout).toContain("Compact score contribution");
      expect(attemptOverview.stdout).toContain("Mismatched Boolean contributes zero");
      expect(attemptOverview.stdout).toContain("Measurement contributes three points");
      expect(attemptOverview.stdout).toContain("Collection evidence remains bounded");
      expect(attemptOverview.stdout).toMatch(/assertions\s+(?:available|partial)\s+·\s+5 entries/u);
      expect(attemptOverview.stdout).toMatch(/coverage\s+.+/u);
      expect(attemptOverview.stdout).toMatch(/limitations\s+.+/u);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --source`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --execution`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --timing`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --usage`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --diff`);

      const source = await niceeval.run(["show", locator, "--source"]);
      expect(source.exitCode, source.diagnostic()).toBe(0);
      expectHumanText(source.stdout);
      expect(source.stdout).toContain("Captured source");
      expect(source.stdout).toContain("inspection.eval.ts");
      expect(source.stdout).toContain("Inspection tool occurrence");
      const sourceIdentity = source.stdout.match(/inspection\.eval\.ts · (\S+) · \d+ bytes/u)?.[1];
      expect(sourceIdentity, source.diagnostic()).toBeDefined();
      if (sourceIdentity === undefined) throw new Error("expected captured source identity");
      expect(source.stdout.split(sourceIdentity).length - 1).toBeGreaterThan(1);
      expect(source.stdout).toMatch(
        new RegExp(`Assertion source facts[\\s\\S]+mapped · ${sourceIdentity} · [0-9a-f]{64}`, "u"),
      );

      const execution = await niceeval.run(["show", locator, "--execution"]);
      expect(execution.exitCode, execution.diagnostic()).toBe(0);
      expectHumanText(execution.stdout);
      expect(execution.stdout).toContain(locator);
      expect(execution.stdout).toContain("Conversation · partial");
      expect(execution.stdout).toContain("Commands ·");
      expect(execution.stdout).toContain("Stable identities");
      expect(execution.stdout).toContain("inspection_fixture");
      expect(execution.stdout).toContain("inspection-tool-input");
      expect(execution.stdout).toContain("inspection-tool-result");
      const itemIdentity = stableIdentity(execution.stdout, "item");
      const toolIdentity = stableIdentity(execution.stdout, "tool occurrence");
      const commandIdentity = stableIdentity(execution.stdout, "command");
      expect(execution.stdout.split(itemIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(toolIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(commandIdentity).length - 1).toBeGreaterThan(1);

      const itemDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        itemIdentity,
      ]);
      expect(itemDetail.exitCode, itemDetail.diagnostic()).toBe(0);
      expectHumanText(itemDetail.stdout);
      expect(itemDetail.stdout).toContain(locator);
      expect(itemDetail.stdout).toContain(itemIdentity);
      expect(itemDetail.stdout).toContain("item");

      const toolDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        toolIdentity,
      ]);
      expect(toolDetail.exitCode, toolDetail.diagnostic()).toBe(0);
      expectHumanText(toolDetail.stdout);
      expect(toolDetail.stdout).toContain(locator);
      expect(toolDetail.stdout).toContain(toolIdentity);
      expect(toolDetail.stdout).toContain("inspection_fixture");
      expect(toolDetail.stdout).toContain("inspection-tool-input");
      expect(toolDetail.stdout).toContain("inspection-tool-result");

      const commandDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        commandIdentity,
      ]);
      expect(commandDetail.exitCode, commandDetail.diagnostic()).toBe(0);
      expectHumanText(commandDetail.stdout);
      expect(commandDetail.stdout).toContain(locator);
      expect(commandDetail.stdout).toContain(commandIdentity);
      expect(commandDetail.stdout).toMatch(/invocation|command/iu);
      expect(commandDetail.stdout).toMatch(/outcome|exit/iu);

      const timing = await niceeval.run(["show", locator, "--timing"]);
      expect(timing.exitCode, timing.diagnostic()).toBe(0);
      expectHumanText(timing.stdout);
      expect(timing.stdout).toContain(locator);
      expect(timing.stdout).toMatch(/timing/iu);
      expect(timing.stdout).toContain("eval.run");

      const usage = await niceeval.run(["show", locator, "--usage"]);
      expect(usage.exitCode, usage.diagnostic()).toBe(0);
      expectHumanText(usage.stdout);
      expect(usage.stdout).toContain(locator);
      expect(usage.stdout).toMatch(/usage/iu);
      expect(usage.stdout).toMatch(/input(?: tokens)?\s+10/iu);
      expect(usage.stdout).toMatch(/output(?: tokens)?\s+5/iu);
      expect(usage.stdout).toMatch(/requests?\s+1/iu);

      const diff = await niceeval.run(["show", locator, "--diff"]);
      expect(diff.exitCode, diff.diagnostic()).toBe(0);
      expectHumanText(diff.stdout);
      expect(diff.stdout).toContain(locator);
      expect(diff.stdout).toMatch(/diff/iu);
      expect(diff.stdout).toContain("complete");
      expect(diff.stdout).toContain("inspection-agent-change.txt");
      expect(diff.stdout).toContain("created");

      const usageErrors: readonly {
        readonly argv: readonly string[];
        readonly stderr: readonly string[];
      }[] = [
        { argv: ["show", locator, "--source", "--execution"], stderr: ["--source", "--execution"] },
        { argv: ["show", locator, "--expand", itemIdentity], stderr: ["--expand", "--execution"] },
        { argv: ["show", locator, "--run", mainRunId], stderr: ["--run"] },
        { argv: ["show", locator, "--experiment", mainExperimentId], stderr: ["--experiment"] },
        { argv: ["show", locator, "--timing", "--usage"], stderr: ["--timing", "--usage"] },
        { argv: ["show", locator, "--source", "--diff"], stderr: ["--source", "--diff"] },
        { argv: ["show", locator, "--execution", "--expand", "item_missing"], stderr: ["item_missing"] },
        { argv: ["show", locator, "--execution", "--expand", "t1.c1"], stderr: ["stable", "itemId"] },
        { argv: ["show", locator, "--execution", "--expand", "cmd1"], stderr: ["stable", "commandId"] },
        { argv: ["show", locator, "--json"], stderr: ["--json"] },
        { argv: ["show", locator, "--report", "standard"], stderr: ["--report"] },
        { argv: ["show", "@does-not-exist"], stderr: ["does-not-exist"] },
      ];
      for (const usageError of usageErrors) {
        expectShowFailure(
          await niceeval.run([...usageError.argv]),
          usageError.stderr,
        );
      }

      const evalPath = join(paths.projectRoot, "evals", "inspection.eval.ts");
      const evalSource = readFileSync(evalPath, "utf8");
      expect(evalSource).toContain("inspection-fixture");
      writeFileSync(
        evalPath,
        evalSource.replace("inspection-fixture", "inspection-fixture-after-review"),
        "utf8",
      );

      const changedPlan = await niceeval.run(["exp", mainExperimentId, "--dry"]);
      expect(changedPlan.exitCode, changedPlan.diagnostic()).toBe(0);
      expect(changedPlan.stdout).toContain("identity-mismatch");
      expect(changedPlan.stdout).toContain(`niceeval accept ${locator}`);

      const historicalOverview = await niceeval.run(["show"]);
      expect(historicalOverview.exitCode, historicalOverview.diagnostic()).toBe(0);
      expectHumanText(historicalOverview.stdout);
      expectInOrder(historicalOverview.stdout, ["Totals", "Experiments"]);
      expectInOrder(historicalOverview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(historicalOverview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(historicalOverview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(historicalOverview.stdout).toContain(locator);
      expect(historicalOverview.stdout).toContain(alternateLocator);
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).not.toContain("Observed   0/0");
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790916717&installation_model_id=431746&pr_number=209&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F209&signature=4779c98420c5fb6d5e93f7dfd764ae7d83af6fb5fef45204bbee4f55f44a5a54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
