### PR TITLE
fix(inspection): 聚焦 Show 默认错误明细

### DIFF
--- a/apps/docs-site/zh/reference/cli.mdx
+++ b/apps/docs-site/zh/reference/cli.mdx
@@ -116,7 +116,7 @@ niceeval view [--run <run-id>...] [--no-open] [--port <port>] [--json]
 | `--help` | `niceeval query` | boolean | 打印该命令的帮助。 |
 | `--run` | `niceeval show` | string[] | 显示一个已封口的 Run；可重复传入。 |
 | `--experiment` | `niceeval show` | string[] | 显示一个精确的 Experiment；可重复传入。 |
-| `--all` | `niceeval show` | boolean | 显示紧凑结果视图中隐藏的 passed Attempt。 |
+| `--all` | `niceeval show` | boolean | 显示紧凑 Results 视图中隐藏的 Attempt。 |
 | `--source` | `niceeval show` | boolean | 显示一个 Attempt 已捕获的 source facts。 |
 | `--execution` | `niceeval show` | boolean | 显示一个 Attempt 的有界 execution outline。 |
 | `--timing` | `niceeval show` | boolean | 显示一个 Attempt 已捕获的 timing activities。 |

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -213,7 +213,6 @@ niceeval show
 niceeval show --all
 niceeval show --run <run-id>...
 niceeval show --experiment <experiment-id>...
-niceeval show --experiment <experiment-id>... --all
 niceeval show @<locator>
 niceeval show @<locator> --source
 niceeval show @<locator> --execution [--expand <stable-id>]
@@ -240,8 +239,9 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
   Experiment ID 含 `/` 时，首段形成显示分组，组内 Experiment 与同前缀 Eval 使用相对标签。
   每个 Experiment 小节仍显示一次完整 ID，每个可下钻 Attempt 显示完整稳定 locator。
 
-  默认 Attempt 明细只展开需要关注的 `failed`、`errored`、`skipped`、pending 与 absent 项，隐藏 `passed` 项；
-  每个 Experiment 都显示隐藏数量及可复制的 `See more: niceeval show --experiment <id> --all` 命令。
+  默认 Attempt 明细隐藏 `passed` 与 `failed` 项；每个 Experiment 最多展开 5 个 `errored` 项，超出的部分也折叠。
+  `skipped`、pending 与 absent 项始终可见。每个 Experiment 显示各 Verdict 的隐藏数量及可复制的
+  `See more: niceeval show --experiment <id>` 命令。
   `--all` 展开全部 Attempt。展开后的明细先以 `Eval <id>` 缩进分组，不在每个 Attempt 行重复 Eval ID；
   同一 Eval 的多个 Attempt 各占一行，显示 `Attempt`、`Verdict`、`Duration` 与适用时的 `Score`。
 
@@ -256,8 +256,7 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
   或它们的 execution identity 变化不会把已封口结果从 Overview 移除，也不会把存在的 Record 显示为
   `Observed 0/0`。Overview 表达 Record 已发布的最新结果，不声称它们可为当前 target 复用；复用资格仍由
   Experiment planning 和 `accept` 的 identity 规则裁决。
-- 一个或多个 `--experiment` 逐个调用 exact `experiment.get`，格式化指定 Experiment 的 aggregate、Eval cells 和 Attempt locators；
-  默认沿用上述紧凑明细，`--all` 展开全部 Attempt。
+- 一个或多个 `--experiment` 逐个调用 exact `experiment.get`，完整格式化指定 Experiment 的 aggregate、Eval cells 和 Attempt locators。
   CLI 不得调用 `overview.get` 后按 `experimentId` 过滤。
 - 一个或多个 `--run` 逐个调用 exact `run.overview`，并且只消费这一份闭合 result。
   它显示指定 Run 的 identity、时间、denominator、Member/Attempt locators、Verdict、score、coverage、usage 与 limitations。
@@ -281,7 +280,7 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
 
 `--source`、`--execution`、`--timing`、`--usage` 与 `--diff` 都要求一个 Attempt locator，且五者互斥。
 `--expand` 只能与 `--execution` 同用。
-`--all` 只适用于无 selector 的 Results 或 `--experiment`，不能与 `--run`、Attempt locator 或 Attempt detail flag 同用。
+`--all` 只适用于无 selector 的 Results，不能与 `--experiment`、`--run`、Attempt locator 或 Attempt detail flag 同用。
 
 ### 默认 Results 示例
 
@@ -299,9 +298,9 @@ $ niceeval show
 NiceEval results
   Totals
 
-  Observed   5/5
-  Verdicts   5 passed
-  Pass rate  100%
+  Observed   7/7
+  Verdicts   5 passed; 1 failed; 1 errored; 0 skipped
+  Pass rate  71.43%
   Score      74
 
 Experiments
@@ -319,16 +318,11 @@ Experiments
 Attempts · harness
   Experiment harness/canary
   3 passed Attempts hidden
-  See more  niceeval show --experiment harness/canary --all
+  See more  niceeval show --experiment harness/canary
 
   Experiment harness/v0.12.0
-  Eval terminal-init
-  Attempt         Verdict  Duration  Score
-  --------------  -------  --------  -----
-  @1VNQTXJ03XJD   failed   21.44 s   14
-
-  1 passed Attempts hidden
-  See more  niceeval show --experiment harness/v0.12.0 --all
+  1 passed; 1 failed Attempts hidden
+  See more  niceeval show --experiment harness/v0.12.0
 
 Attempts · install
   Experiment install/canary
@@ -338,7 +332,7 @@ Attempts · install
   @1QD6PEMZY39P   errored  2.09 s    5
 
   1 passed Attempts hidden
-  See more  niceeval show --experiment install/canary --all
+  See more  niceeval show --experiment install/canary
 ```
 
 没有 `/` 的 Experiment 仍以完整 ID 显示在未分组 summary 与 `Attempts` 小节。Eval 相对标签只有在其首段与
@@ -376,7 +370,7 @@ Next
   niceeval show @01JSHOWATTEMPT --diff
 ```
 
-Experiment 范围也是人读结果，不是 CLI 过滤后的 Results 残片。默认同样折叠 passed Attempt：
+Experiment selector 是下钻动作，直接显示完整明细，不再要求 `--all`：
 
 ```text
 $ niceeval show --experiment main
@@ -393,8 +387,11 @@ Experiment main
   --------------  -------  --------
   @ATTEMPT-FAIL   failed   21.44 s
 
-  2 passed Attempts hidden
-  See more  niceeval show --experiment main --all
+  Eval inspection
+  Attempt         Verdict  Duration
+  --------------  -------  --------
+  @ATTEMPT-PASS-1 passed   18.34 s
+  @ATTEMPT-PASS-2 passed   20.12 s
 ```
 
 命令读取 project operational Store 的单一 `PublicationCutoff`。无已发布事实、Run、Experiment 或 locator 未命中、required result shape 不合法与 `--expand` 未命中都以英文诊断写 stderr 并非零退出；

--- a/docs/feature/inspection/use-case/比较质量与成本.md
+++ b/docs/feature/inspection/use-case/比较质量与成本.md
@@ -37,16 +37,16 @@ Attempts · compare
   Eval downshift/pr-1414
   Attempt         Verdict  Duration
   --------------  -------  --------
-  @ATTEMPT-BUB-2  failed   20.12 s
   @ATTEMPT-BUB-3  errored  2.09 s
 
-  34 passed Attempts hidden
-  See more  niceeval show --experiment compare/bub --all
+  34 passed; 1 failed Attempts hidden
+  See more  niceeval show --experiment compare/bub
 ```
 
 Attempt 表用缩进保留 Experiment → Eval → Attempt 的一对多关系：Eval ID 只显示一次，
-同一 Eval 的每个可见 Attempt 各占一行，并显示各自的 Verdict 与 Duration。默认隐藏 passed Attempt，
-但 failed、errored、skipped、pending 与 absent 始终可见；复制 `See more` 命令可展开该 Experiment 的全部 Attempt。
+同一 Eval 的每个可见 Attempt 各占一行，并显示各自的 Verdict 与 Duration。默认隐藏 passed 与 failed Attempt，
+每个 Experiment 最多显示 5 个 errored Attempt；skipped、pending 与 absent 始终可见。
+复制 `See more` 命令即可完整展开该 Experiment。
 machine `overview.get` 仍保留 score metric 的 typed `unsupported`；
 省略 Score 只是人读布局，不改变事实。
 
@@ -79,16 +79,16 @@ Experiments
 Attempts · harness
   Experiment harness/canary
   3 passed Attempts hidden
-  See more  niceeval show --experiment harness/canary --all
+  See more  niceeval show --experiment harness/canary
 
   Experiment harness/v-next
   2 passed Attempts hidden
-  See more  niceeval show --experiment harness/v-next --all
+  See more  niceeval show --experiment harness/v-next
 
 Attempts · install
   Experiment install/canary
   1 passed Attempts hidden
-  See more  niceeval show --experiment install/canary --all
+  See more  niceeval show --experiment install/canary
 ```
 
 每个新 Experiment 标题都在上一张表结束后另起一段，标题后立即接其表头；标题后的空行会把它视觉上归到上一表，
@@ -108,12 +108,19 @@ Experiment harness/v-next
   Score      32
 
   Attempts
-  2 passed Attempts hidden
-  See more  niceeval show --experiment harness/v-next --all
+  Eval terminal-install
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @ATTEMPT-NEXT   passed   17.8 s    16
+
+  Eval terminal-init
+  Attempt         Verdict  Duration  Score
+  --------------  -------  --------  -----
+  @ATTEMPT-VNEXT  passed   20.12 s   14
 ```
 
 这组 Summary 与 Attempts 来自 `experiment.get`，不是 renderer 对默认 Results 的二次筛选或补值。
-需要逐项核查成功结果时运行上面的 `--all` 命令，展开后仍按 Eval 缩进列出 Attempt、Verdict、Duration 与适用的 Score。
+指定 Experiment 后直接完整显示，并按 Eval 缩进列出 Attempt、Verdict、Duration 与适用的 Score。
 
 默认 Results 回答“canonical Record 中每个逻辑 slot 最新发布了什么”。当 Eval 内容、Experiment 配置、
 Sandbox identity 或当前安装的候选变化时，已封口 Attempt 仍留在 Overview；因此无 selector `niceeval show` 不会仅因

--- a/e2e/inspection/test/show-cli.test.ts
+++ b/e2e/inspection/test/show-cli.test.ts
@@ -113,25 +113,12 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(passOnlyExperiment.exitCode, passOnlyExperiment.diagnostic()).toBe(0);
       expectHumanText(passOnlyExperiment.stdout);
       expect(passOnlyExperiment.stdout).toContain("Pass rate");
-      expect(passOnlyExperiment.stdout).not.toContain("Eval overview-scale");
-      expect(passOnlyExperiment.stdout).toContain("10 passed Attempts hidden");
-      expect(passOnlyExperiment.stdout).toContain(
-        `See more  niceeval show --experiment ${scaleExperimentId} --all`,
-      );
+      expect(passOnlyExperiment.stdout).toContain("Eval overview-scale");
+      expect(passOnlyExperiment.stdout).toMatch(/Attempt\s+Verdict\s+Duration/u);
+      expect(passOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? (?:ms|s|min|h)\s*$/gmu)).toHaveLength(10);
+      expect(passOnlyExperiment.stdout).not.toContain("Attempts hidden");
       expect(passOnlyExperiment.stdout).not.toContain("Score");
       expect(passOnlyExperiment.stdout).not.toContain("unsupported");
-
-      const expandedPassOnlyExperiment = await niceeval.run([
-        "show",
-        "--experiment",
-        scaleExperimentId,
-        "--all",
-      ]);
-      expect(expandedPassOnlyExperiment.exitCode, expandedPassOnlyExperiment.diagnostic()).toBe(0);
-      expect(expandedPassOnlyExperiment.stdout).toContain("Eval overview-scale");
-      expect(expandedPassOnlyExperiment.stdout).toMatch(/Attempt\s+Verdict\s+Duration/u);
-      expect(expandedPassOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? (?:ms|s|min|h)\s*$/gmu)).toHaveLength(10);
-      expect(expandedPassOnlyExperiment.stdout).not.toContain("Attempts hidden");
 
       const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
       writeFileSync(
@@ -170,7 +157,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
       expect(overview.stdout).toContain("passed Attempts hidden");
       expect(overview.stdout).toContain(
-        `See more  niceeval show --experiment ${mainExperimentId} --all`,
+        `See more  niceeval show --experiment ${mainExperimentId}`,
       );
       expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
       expect(overview.stdout).not.toContain(locator);
@@ -215,7 +202,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       ]);
       expectShowFailure(atomicRunsFailure, ["missing-run"]);
 
-      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId, "--all"]);
+      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId]);
       expect(mainExperiment.exitCode, mainExperiment.diagnostic()).toBe(0);
       expectHumanText(mainExperiment.stdout);
       expect(mainExperiment.stdout).toContain(mainExperimentId);
@@ -228,7 +215,6 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
         alternateExperimentId,
         "--experiment",
         mainExperimentId,
-        "--all",
       ]);
       expect(experiments.exitCode, experiments.diagnostic()).toBe(0);
       expectHumanText(experiments.stdout);
@@ -374,6 +360,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
         { argv: ["show", locator, "--experiment", mainExperimentId], stderr: ["--experiment"] },
         { argv: ["show", locator, "--all"], stderr: ["--all"] },
         { argv: ["show", "--run", mainRunId, "--all"], stderr: ["--all", "--run"] },
+        { argv: ["show", "--experiment", mainExperimentId, "--all"], stderr: ["--all", "--experiment"] },
         { argv: ["show", locator, "--timing", "--usage"], stderr: ["--timing", "--usage"] },
         { argv: ["show", locator, "--source", "--diff"], stderr: ["--source", "--diff"] },
         { argv: ["show", locator, "--execution", "--expand", "item_missing"], stderr: ["item_missing"] },

--- a/packages/niceeval/src/show/contribution.ts
+++ b/packages/niceeval/src/show/contribution.ts
@@ -70,7 +70,7 @@ export const SHOW_CLI_OPTIONS = Object.freeze({
   }),
   all: option({
     type: "boolean",
-    help: help("Show passed Attempts hidden by compact result views."),
+    help: help("Show Attempts hidden by the compact Results view."),
   }),
   source: option({
     type: "boolean",
@@ -104,7 +104,7 @@ const SHOW_HELP = `niceeval show — inspect results in the terminal
 Usage:
   niceeval show [--all] [--record <file>]
   niceeval show --run <run-id>... [--record <file>]
-  niceeval show --experiment <experiment-id>... [--all] [--record <file>]
+  niceeval show --experiment <experiment-id>... [--record <file>]
   niceeval show @<locator> [--record <file>]
   niceeval show @<locator> --source
   niceeval show @<locator> --execution [--expand <stable-id>]
@@ -116,7 +116,7 @@ Selectors:
   --record <file>               Read an external canonical SQLite Record.
   --run <run-id>                Show one exact sealed Run; repeatable.
   --experiment <experiment-id>  Show one exact Experiment; repeatable.
-  --all                         Show passed Attempts hidden by compact views.
+  --all                         Show Attempts hidden by compact Results.
 
 Attempt details:
   --source                      Show captured sources and Assertion sites.
@@ -224,9 +224,12 @@ function runShow(
       );
     if (runIds.length > 0 && experimentIds.length > 0)
       return yield* usage("--run and --experiment are mutually exclusive.");
-    if (all && (locator !== undefined || runIds.length > 0))
+    if (
+      all &&
+      (locator !== undefined || runIds.length > 0 || experimentIds.length > 0)
+    )
       return yield* usage(
-        "--all applies only to Results or --experiment, not --run or an Attempt locator.",
+        "--all applies only to Results, not --experiment, --run, or an Attempt locator.",
       );
     const facts = yield* Effect.flatMap(
       CliInvocationFacts,
@@ -305,7 +308,6 @@ function runShow(
                 yield* project("experiment.get", () =>
                   projectExperiment(document),
                 ),
-                { all },
               ),
             );
           }

--- a/packages/niceeval/src/show/render.ts
+++ b/packages/niceeval/src/show/render.ts
@@ -112,16 +112,24 @@ const attemptBlocks = (
   cells: OverviewView["cells"],
   group: string | null,
   all: boolean,
-): readonly TerminalPanelContentBlock[] => cells.flatMap((cell) => {
-  const showScore = cell.aggregate.evaluationKind !== "pass";
-  const members = all
-    ? cell.members
-    : cell.members.filter((member) =>
-      member.publication.state !== "published" ||
-      member.publication.verdict !== "passed"
-    );
-  if (cell.members.length > 0 && members.length === 0) return [];
-  return [
+): readonly TerminalPanelContentBlock[] => {
+  let shownErrors = 0;
+  return cells.flatMap((cell) => {
+    const showScore = cell.aggregate.evaluationKind !== "pass";
+    const members = all
+      ? cell.members
+      : cell.members.filter((member) => {
+        if (member.publication.state !== "published") return true;
+        if (
+          member.publication.verdict === "passed" ||
+          member.publication.verdict === "failed"
+        ) return false;
+        if (member.publication.verdict !== "errored") return true;
+        shownErrors += 1;
+        return shownErrors <= 5;
+      });
+    if (cell.members.length > 0 && members.length === 0) return [];
+    return [
     {
       kind: "divider" as const,
       title: `Eval ${relativeToGroup(cell.evalId, group)}`,
@@ -162,17 +170,30 @@ const attemptBlocks = (
             : []),
         ]),
     },
-  ];
-});
+    ];
+  });
+};
 
-const hiddenPassedAttempts = (cells: OverviewView["cells"]): number =>
-  cells.reduce(
-    (count, cell) => count + cell.members.filter((member) =>
-      member.publication.state === "published" &&
-      member.publication.verdict === "passed"
-    ).length,
-    0,
-  );
+const hiddenAttemptSummary = (cells: OverviewView["cells"]): string | null => {
+  const counts = { passed: 0, failed: 0, errored: 0 };
+  for (const cell of cells) {
+    for (const member of cell.members) {
+      if (member.publication.state !== "published") continue;
+      const verdict = member.publication.verdict;
+      if (
+        verdict === "passed" ||
+        verdict === "failed" ||
+        verdict === "errored"
+      ) counts[verdict] += 1;
+    }
+  }
+  const hidden = [
+    ...(counts.passed > 0 ? [`${counts.passed} passed`] : []),
+    ...(counts.failed > 0 ? [`${counts.failed} failed`] : []),
+    ...(counts.errored > 5 ? [`${counts.errored - 5} errored`] : []),
+  ];
+  return hidden.length === 0 ? null : `${hidden.join("; ")} Attempts hidden`;
+};
 
 const compactContinuation = (
   cells: OverviewView["cells"],
@@ -180,20 +201,20 @@ const compactContinuation = (
   all: boolean,
 ): readonly TerminalPanelContentBlock[] => {
   if (all) return [];
-  const hidden = hiddenPassedAttempts(cells);
-  return hidden === 0
+  const hidden = hiddenAttemptSummary(cells);
+  return hidden === null
     ? []
     : [
       {
         kind: "divider",
-        title: `${hidden} passed Attempts hidden`,
+        title: hidden,
         attachNext: true,
       },
       {
         kind: "keyValue",
         entries: [{
           key: "See more",
-          value: `niceeval show --experiment ${experimentId} --all`,
+          value: `niceeval show --experiment ${experimentId}`,
         }],
       },
     ];
@@ -282,11 +303,7 @@ export function renderOverview(
   return terminal(blocks);
 }
 
-export function renderExperiment(
-  value: ExperimentView,
-  options: { readonly all?: boolean } = {},
-): string {
-  const all = options.all === true;
+export function renderExperiment(value: ExperimentView): string {
   return terminal([
     {
       kind: "panel",
@@ -295,8 +312,7 @@ export function renderExperiment(
         { kind: "divider", title: "Summary" },
         aggregateEntries(value.aggregate),
         { kind: "divider", title: "Attempts" },
-        ...attemptBlocks(value.cells, null, all),
-        ...compactContinuation(value.cells, value.experimentId, all),
+        ...attemptBlocks(value.cells, null, true),
       ],
     },
   ]);

--- a/packages/repo-tools/src/docs/reference-compiler.ts
+++ b/packages/repo-tools/src/docs/reference-compiler.ts
@@ -602,7 +602,7 @@ const CHINESE_CLI_REFERENCE_SUMMARIES: Readonly<Record<string, string>> = Object
   "src/show/contribution.ts#SHOW_CLI_OPTIONS#record": "读取一个外部 canonical SQLite Record。",
   "src/show/contribution.ts#SHOW_CLI_OPTIONS#run": "显示一个已封口的 Run；可重复传入。",
   "src/show/contribution.ts#SHOW_CLI_OPTIONS#experiment": "显示一个精确的 Experiment；可重复传入。",
-  "src/show/contribution.ts#SHOW_CLI_OPTIONS#all": "显示紧凑结果视图中隐藏的 passed Attempt。",
+  "src/show/contribution.ts#SHOW_CLI_OPTIONS#all": "显示紧凑 Results 视图中隐藏的 Attempt。",
   "src/show/contribution.ts#SHOW_CLI_OPTIONS#source": "显示一个 Attempt 已捕获的 source facts。",
   "src/show/contribution.ts#SHOW_CLI_OPTIONS#execution": "显示一个 Attempt 的有界 execution outline。",
   "src/show/contribution.ts#SHOW_CLI_OPTIONS#timing": "显示一个 Attempt 已捕获的 timing activities。",


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 1b5be1df76fac275331649b444280cdf1f51f788
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: df934f8e553b39e272ddea0b1ebe7cd9f2149cdd
-->

## Problem

- User goal: 默认查看大型 Results 时只看到真正需要诊断的少量状态，并能直接下钻一个 Experiment。
- Current limitation: 默认视图仍展示全部 failed Attempt，errored 较多时也会刷屏；指定 Experiment 后还要求额外传 --all 才能看到完整明细。
- Required capability: 折叠默认 Results 中的 passed 与 failed，限制 errored 展示数量，并让 --experiment 本身成为完整下钻。
- User outcome: 默认 Overview 保持短小；See more 命令可直接复制，指定 Experiment 后立即看到全部 Attempt。

## Use cases

### Changed

#### Case: 比较质量与成本

##### Starting state

```text
Record 中包含大量 passed、failed 或 errored Attempt。
```

##### Action

```zh
用户先运行 niceeval show，再复制 See more 命令查看一个 Experiment。
```

##### Result

```text
Overview 隐藏 passed 与 failed、最多显示 5 个 errored；niceeval show --experiment <id> 完整显示该 Experiment。
```

默认视图聚焦运行异常，评测失败留在摘要统计中；显式 Experiment selector 直接完成下钻。 [Canonical Use Case](docs/feature/inspection/use-case/比较质量与成本.md).

## CLI

### Changed

#### Case: Results 默认明细与 Experiment 下钻

##### Before

```text
niceeval show；niceeval show --experiment <id> --all
```

```text
Overview 展示全部 failed 与 errored；指定 Experiment 需要 --all 才完整。
```

##### After

```text
niceeval show；niceeval show --experiment <id>
```

```text
Overview 隐藏 passed/failed，每个 Experiment 最多展示 5 个 errored；指定 Experiment 直接完整展示。
```

##### User impact

大型结果更短，failed 不再占用诊断区，错误风暴有上限，See more 命令也更直接。

## Tests

### `e2e/inspection/test/show-cli.test.ts`

#### `e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS`

默认 Overview 使用紧凑明细，Experiment selector 直接返回完整 Attempt 明细。 It exercises 安装候选后运行真实 niceeval show、show --all 和 show --experiment 命令。 and asserts Overview 隐藏正常结果并给出不带 --all 的 See more；Experiment 显示全部 passed Attempt；--experiment 与 --all 组合返回 usage error。. Deleting this case would allow 覆盖 10 个 passed Attempt 的规模场景、默认与完整 Overview、重复 Experiment selector 和历史结果。. The final contract is [docs/feature/inspection/cli.md#niceeval-show](docs/feature/inspection/cli.md#niceeval-show).

```ts
// rerun: pnpm e2e test --repo inspection -- --run test/show-cli.test.ts

import { only } from "@niceeval/testkit";
import { readFileSync, writeFileSync } from "node:fs";
import { join } from "node:path";
import { expect, test } from "vitest";
import { inspectionCaseArtifacts, inspectionE2E } from "./support.ts";

function expectHumanText(stdout: string): void {
  expect(stdout.trim()).not.toBe("");
  expect(() => JSON.parse(stdout)).toThrow();
}

function expectInOrder(stdout: string, values: readonly string[]): void {
  let cursor = 0;
  for (const value of values) {
    const position = stdout.indexOf(value, cursor);
    expect(
      position,
      `expected ${JSON.stringify(value)} after byte ${cursor} in:\n${stdout}`,
    ).toBeGreaterThanOrEqual(cursor);
    cursor = position + value.length;
  }
}

interface FailedShowResult {
  readonly exitCode: number;
  readonly stdout: string;
  readonly stderr: string;
  diagnostic(): string;
}

function expectShowFailure(
  result: FailedShowResult,
  stderrValues: readonly string[],
): void {
  expect(result.exitCode, result.diagnostic()).not.toBe(0);
  expect(result.stdout, result.diagnostic()).toBe("");
  expect(result.stderr.trim(), result.diagnostic()).not.toBe("");
  for (const value of stderrValues) {
    expect(result.stderr, result.diagnostic()).toContain(value);
  }
}

function stableIdentity(stdout: string, label: string): string {
  const escaped = label.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
  const identity = stdout.match(new RegExp(`^\\s*${escaped}\\s+(\\S+)\\s*$`, "mu"))?.[1];
  expect(identity, `expected ${label} in stable identity index:\n${stdout}`).toBeDefined();
  if (identity === undefined) throw new Error(`expected ${label} stable identity`);
  expect(identity).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
  return identity;
}

test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]", async () => {
  await inspectionE2E.case(
    "show-terminal-review",
    { artifacts: inspectionCaseArtifacts() },
    async ({ commands: { niceeval }, paths }) => {
      const mainExperimentId = "harness/canary";
      const alternateExperimentId = "harness/alternate";
      const scaleExperimentId = "harness/scale";
      const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
      expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
      expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const mainRunId = only(mainProduced.expReceipt().createdRunIds, () => true, mainProduced.diagnostic());
      const attempt = only(
        mainProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        mainProduced.diagnostic(),
      );
      expect(attempt).toMatchObject({ verdict: "passed" });
      const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;

      const alternateProduced = await niceeval.run(["exp", alternateExperimentId, "--rerun", "all", "--json"]);
      expect(alternateProduced.exitCode, alternateProduced.diagnostic()).toBe(0);
      expect(alternateProduced.expReceipt(), alternateProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const alternateRunId = only(
        alternateProduced.expReceipt().createdRunIds,
        () => true,
        alternateProduced.diagnostic(),
      );
      const alternateAttempt = only(
        alternateProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        alternateProduced.diagnostic(),
      );
      expect(alternateAttempt).toMatchObject({ verdict: "passed" });
      const alternateLocator = alternateAttempt.locator.startsWith("@")
        ? alternateAttempt.locator
        : `@${alternateAttempt.locator}`;

      const scaleProduced = await niceeval.run([
        "exp",
        scaleExperimentId,
        "--rerun",
        "all",
        "--json",
      ]);
      expect(scaleProduced.exitCode, scaleProduced.diagnostic()).toBe(0);
      expect(scaleProduced.expReceipt(), scaleProduced.diagnostic()).toMatchObject({
        completion: "completed",
      });
      expect(scaleProduced.expEvalEvents(), scaleProduced.diagnostic()).toEqual([
        expect.objectContaining({
          evalId: "overview-scale",
          attempts: 10,
          passed: 10,
          verdict: "passed",
        }),
      ]);

      const passOnlyExperiment = await niceeval.run(["show", "--experiment", scaleExperimentId]);
      expect(passOnlyExperiment.exitCode, passOnlyExperiment.diagnostic()).toBe(0);
      expectHumanText(passOnlyExperiment.stdout);
      expect(passOnlyExperiment.stdout).toContain("Pass rate");
      expect(passOnlyExperiment.stdout).toContain("Eval overview-scale");
      expect(passOnlyExperiment.stdout).toMatch(/Attempt\s+Verdict\s+Duration/u);
      expect(passOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? (?:ms|s|min|h)\s*$/gmu)).toHaveLength(10);
      expect(passOnlyExperiment.stdout).not.toContain("Attempts hidden");
      expect(passOnlyExperiment.stdout).not.toContain("Score");
      expect(passOnlyExperiment.stdout).not.toContain("unsupported");

      const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
      writeFileSync(
        overviewRequestPath,
        JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "overview.get" },
        }),
        "utf8",
      );
      const machineOverview = await niceeval.run([
        "query",
        "run",
        "--request",
        overviewRequestPath,
      ]);
      expect(machineOverview.exitCode, machineOverview.diagnostic()).toBe(0);
      expect(Buffer.byteLength(machineOverview.stdout, "utf8")).toBeGreaterThan(512 * 1024);

      const overview = await niceeval.run(["show"]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      expectHumanText(overview.stdout);
      expectInOrder(overview.stdout, ["Totals", "Experiments"]);
      expectInOrder(overview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${scaleExperimentId}`);
      expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
      expect(overview.stdout).toContain("passed Attempts hidden");
      expect(overview.stdout).toContain(
        `See more  niceeval show --experiment ${mainExperimentId}`,
      );
      expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
      expect(overview.stdout).not.toContain(locator);
      expect(overview.stdout).not.toContain(alternateLocator);
      expect(overview.stdout).toContain("100%");

      const expandedOverview = await niceeval.run(["show", "--all"]);
      expect(expandedOverview.exitCode, expandedOverview.diagnostic()).toBe(0);
      expectInOrder(expandedOverview.stdout, [`Experiment ${mainExperimentId}`, "Eval inspection", locator]);
      expectInOrder(expandedOverview.stdout, [`Experiment ${alternateExperimentId}`, "Eval inspection", alternateLocator]);
      expect(expandedOverview.stdout).toMatch(/Attempt\s+Verdict\s+Duration\s+Score/u);
      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));

      const run = await niceeval.run(["show", "--run", mainRunId]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      expectHumanText(run.stdout);
      expect(run.stdout).toContain(mainRunId);
      expectInOrder(run.stdout, [mainExperimentId, "inspection", locator]);

      const runs = await niceeval.run([
        "show",
        "--run",
        alternateRunId,
        "--run",
        mainRunId,
      ]);
      expect(runs.exitCode, runs.diagnostic()).toBe(0);
      expectHumanText(runs.stdout);
      expect(runs.stdout).toContain(`Run ${mainRunId}`);
      expect(runs.stdout).toContain(`Run ${alternateRunId}`);
      expect(runs.stdout).toContain(locator);
      expect(runs.stdout).toContain(alternateLocator);
      expect(runs.stdout.match(/^Run /gmu)).toHaveLength(2);

      const atomicRunsFailure = await niceeval.run([
        "show",
        "--run",
        mainRunId,
        "--run",
        "missing-run",
      ]);
      expectShowFailure(atomicRunsFailure, ["missing-run"]);

      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId]);
      expect(mainExperiment.exitCode, mainExperiment.diagnostic()).toBe(0);
      expectHumanText(mainExperiment.stdout);
      expect(mainExperiment.stdout).toContain(mainExperimentId);
      expect(mainExperiment.stdout).toContain(locator);
      expect(mainExperiment.stdout).not.toContain(alternateLocator);

      const experiments = await niceeval.run([
        "show",
        "--experiment",
        alternateExperimentId,
        "--experiment",
        mainExperimentId,
      ]);
      expect(experiments.exitCode, experiments.diagnostic()).toBe(0);
      expectHumanText(experiments.stdout);
      expect(experiments.stdout).toContain(mainExperimentId);
      expect(experiments.stdout).toContain(alternateExperimentId);
      expect(experiments.stdout).toContain(locator);
      expect(experiments.stdout).toContain(alternateLocator);

      const missingExperiment = await niceeval.run([
        "show",
        "--experiment",
        mainExperimentId,
        "--experiment",
        "does-not-exist",
      ]);
      expectShowFailure(missingExperiment, ["does-not-exist"]);

      const attemptOverview = await niceeval.run(["show", locator]);
      expect(attemptOverview.exitCode, attemptOverview.diagnostic()).toBe(0);
      expectHumanText(attemptOverview.stdout);
      expect(attemptOverview.stdout).toContain(locator);
      expectInOrder(attemptOverview.stdout, [mainExperimentId, "inspection", "Outcome", "Score", "Evidence"]);
      expect(attemptOverview.stdout).toContain("passed");
      expect(attemptOverview.stdout).toContain("Inspection tool occurrence");
      expect(attemptOverview.stdout).toContain("Compact score contribution");
      expect(attemptOverview.stdout).toContain("Mismatched Boolean contributes zero");
      expect(attemptOverview.stdout).toContain("Measurement contributes three points");
      expect(attemptOverview.stdout).toContain("Collection evidence remains bounded");
      expect(attemptOverview.stdout).toMatch(/assertions\s+(?:available|partial)\s+·\s+5 entries/u);
      expect(attemptOverview.stdout).toMatch(/coverage\s+.+/u);
      expect(attemptOverview.stdout).toMatch(/limitations\s+.+/u);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --source`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --execution`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --timing`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --usage`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --diff`);

      const source = await niceeval.run(["show", locator, "--source"]);
      expect(source.exitCode, source.diagnostic()).toBe(0);
      expectHumanText(source.stdout);
      expect(source.stdout).toContain("Captured source");
      expect(source.stdout).toContain("inspection.eval.ts");
      expect(source.stdout).toContain("Inspection tool occurrence");
      const sourceIdentity = source.stdout.match(/inspection\.eval\.ts · (\S+) · \d+ bytes/u)?.[1];
      expect(sourceIdentity, source.diagnostic()).toBeDefined();
      if (sourceIdentity === undefined) throw new Error("expected captured source identity");
      expect(source.stdout.split(sourceIdentity).length - 1).toBeGreaterThan(1);
      expect(source.stdout).toMatch(
        new RegExp(`Assertion source facts[\\s\\S]+mapped · ${sourceIdentity} · [0-9a-f]{64}`, "u"),
      );

      const execution = await niceeval.run(["show", locator, "--execution"]);
      expect(execution.exitCode, execution.diagnostic()).toBe(0);
      expectHumanText(execution.stdout);
      expect(execution.stdout).toContain(locator);
      expect(execution.stdout).toContain("Conversation · partial");
      expect(execution.stdout).toContain("Commands ·");
      expect(execution.stdout).toContain("Stable identities");
      expect(execution.stdout).toContain("inspection_fixture");
      expect(execution.stdout).toContain("inspection-tool-input");
      expect(execution.stdout).toContain("inspection-tool-result");
      const itemIdentity = stableIdentity(execution.stdout, "item");
      const toolIdentity = stableIdentity(execution.stdout, "tool occurrence");
      const commandIdentity = stableIdentity(execution.stdout, "command");
      expect(execution.stdout.split(itemIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(toolIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(commandIdentity).length - 1).toBeGreaterThan(1);

      const itemDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        itemIdentity,
      ]);
      expect(itemDetail.exitCode, itemDetail.diagnostic()).toBe(0);
      expectHumanText(itemDetail.stdout);
      expect(itemDetail.stdout).toContain(locator);
      expect(itemDetail.stdout).toContain(itemIdentity);
      expect(itemDetail.stdout).toContain("item");

      const toolDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        toolIdentity,
      ]);
      expect(toolDetail.exitCode, toolDetail.diagnostic()).toBe(0);
      expectHumanText(toolDetail.stdout);
      expect(toolDetail.stdout).toContain(locator);
      expect(toolDetail.stdout).toContain(toolIdentity);
      expect(toolDetail.stdout).toContain("inspection_fixture");
      expect(toolDetail.stdout).toContain("inspection-tool-input");
      expect(toolDetail.stdout).toContain("inspection-tool-result");

      const commandDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        commandIdentity,
      ]);
      expect(commandDetail.exitCode, commandDetail.diagnostic()).toBe(0);
      expectHumanText(commandDetail.stdout);
      expect(commandDetail.stdout).toContain(locator);
      expect(commandDetail.stdout).toContain(commandIdentity);
      expect(commandDetail.stdout).toMatch(/invocation|command/iu);
      expect(commandDetail.stdout).toMatch(/outcome|exit/iu);

      const timing = await niceeval.run(["show", locator, "--timing"]);
      expect(timing.exitCode, timing.diagnostic()).toBe(0);
      expectHumanText(timing.stdout);
      expect(timing.stdout).toContain(locator);
      expect(timing.stdout).toMatch(/timing/iu);
      expect(timing.stdout).toContain("eval.run");

      const usage = await niceeval.run(["show", locator, "--usage"]);
      expect(usage.exitCode, usage.diagnostic()).toBe(0);
      expectHumanText(usage.stdout);
      expect(usage.stdout).toContain(locator);
      expect(usage.stdout).toMatch(/usage/iu);
      expect(usage.stdout).toMatch(/input(?: tokens)?\s+10/iu);
      expect(usage.stdout).toMatch(/output(?: tokens)?\s+5/iu);
      expect(usage.stdout).toMatch(/requests?\s+1/iu);

      const diff = await niceeval.run(["show", locator, "--diff"]);
      expect(diff.exitCode, diff.diagnostic()).toBe(0);
      expectHumanText(diff.stdout);
      expect(diff.stdout).toContain(locator);
      expect(diff.stdout).toMatch(/diff/iu);
      expect(diff.stdout).toContain("complete");
      expect(diff.stdout).toContain("inspection-agent-change.txt");
      expect(diff.stdout).toContain("created");

      const usageErrors: readonly {
        readonly argv: readonly string[];
        readonly stderr: readonly string[];
      }[] = [
        { argv: ["show", locator, "--source", "--execution"], stderr: ["--source", "--execution"] },
        { argv: ["show", locator, "--expand", itemIdentity], stderr: ["--expand", "--execution"] },
        { argv: ["show", locator, "--run", mainRunId], stderr: ["--run"] },
        { argv: ["show", locator, "--experiment", mainExperimentId], stderr: ["--experiment"] },
        { argv: ["show", locator, "--all"], stderr: ["--all"] },
        { argv: ["show", "--run", mainRunId, "--all"], stderr: ["--all", "--run"] },
        { argv: ["show", "--experiment", mainExperimentId, "--all"], stderr: ["--all", "--experiment"] },
        { argv: ["show", locator, "--timing", "--usage"], stderr: ["--timing", "--usage"] },
        { argv: ["show", locator, "--source", "--diff"], stderr: ["--source", "--diff"] },
        { argv: ["show", locator, "--execution", "--expand", "item_missing"], stderr: ["item_missing"] },
        { argv: ["show", locator, "--execution", "--expand", "t1.c1"], stderr: ["stable", "itemId"] },
        { argv: ["show", locator, "--execution", "--expand", "cmd1"], stderr: ["stable", "commandId"] },
        { argv: ["show", locator, "--json"], stderr: ["--json"] },
        { argv: ["show", locator, "--report", "standard"], stderr: ["--report"] },
        { argv: ["show", "@does-not-exist"], stderr: ["does-not-exist"] },
      ];
      for (const usageError of usageErrors) {
        expectShowFailure(
          await niceeval.run([...usageError.argv]),
          usageError.stderr,
        );
      }

      const evalPath = join(paths.projectRoot, "evals", "inspection.eval.ts");
      const evalSource = readFileSync(evalPath, "utf8");
      expect(evalSource).toContain("inspection-fixture");
      writeFileSync(
        evalPath,
        evalSource.replace("inspection-fixture", "inspection-fixture-after-review"),
        "utf8",
      );

      const changedPlan = await niceeval.run(["exp", mainExperimentId, "--dry"]);
      expect(changedPlan.exitCode, changedPlan.diagnostic()).toBe(0);
      expect(changedPlan.stdout).toContain("identity-mismatch");
      expect(changedPlan.stdout).toContain(`niceeval accept ${locator}`);

      const historicalOverview = await niceeval.run(["show", "--all"]);
      expect(historicalOverview.exitCode, historicalOverview.diagnostic()).toBe(0);
      expectHumanText(historicalOverview.stdout);
      expectInOrder(historicalOverview.stdout, ["Totals", "Experiments"]);
      expectInOrder(historicalOverview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(historicalOverview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(historicalOverview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(historicalOverview.stdout).toContain(locator);
      expect(historicalOverview.stdout).toContain(alternateLocator);
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).not.toContain("Observed   0/0");
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790925687&installation_model_id=431746&pr_number=211&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F211&signature=f09ab2a6a4400b78dca3db872be60eba118d4104ec98e1d6b125b6abf13e7dab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->