### PR TITLE
fix(incus): 保留异步 mutation 的真实失败原因

### DIFF
--- a/e2e/adapter/claude-code/experiments/mcp.ts
+++ b/e2e/adapter/claude-code/experiments/mcp.ts
@@ -11,7 +11,7 @@ const agent = claudeCodeAgent({
   baseUrl: process.env.ANTHROPIC_BASE_URL,
   env: claudeCodeProviderEnv,
   mcpServers: [
-    { name: "e2e-stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-everything"] },
+    { name: "e2e-stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-everything@2026.7.4"] },
     { name: "e2e-http", url: `http://127.0.0.1:${MCP_HTTP_PORT}/mcp` },
   ],
   postSetup: [
@@ -41,7 +41,7 @@ const agent = claudeCodeAgent({
       // 这个启动同时预热 e2e-stdio 所用的同一份 npx 包缓存。
       await sb.runShellOrThrow(`
         set -eu
-        nohup env PORT=${MCP_HTTP_PORT} npx -y @modelcontextprotocol/server-everything streamableHttp >${MCP_HTTP_LOG} 2>&1 &
+        nohup env PORT=${MCP_HTTP_PORT} npx -y @modelcontextprotocol/server-everything@2026.7.4 streamableHttp >${MCP_HTTP_LOG} 2>&1 &
         echo "$!" >${MCP_HTTP_PID}
         for attempt in $(seq 1 60); do
           status="$(curl --silent --connect-timeout 1 --max-time 2 --output /dev/null --write-out '%{http_code}' http://127.0.0.1:${MCP_HTTP_PORT}/mcp || true)"

--- a/e2e/adapter/codex-cli/evals/mcp.eval.ts
+++ b/e2e/adapter/codex-cli/evals/mcp.eval.ts
@@ -19,11 +19,13 @@ export default defineEval({
     "MCP 挂载:stdio 与远程 HTTP 两种形态在同一轮里都真实调用且入参正确",
   async test(t) {
     const turn = await t.send(
-      "In this single turn, call two different MCP tools and report both results: " +
-        "(1) use your e2e MCP tool to add 100 and 23 (do not compute it yourself), and " +
-        "(2) use your deepwiki MCP tool to read the wiki structure for the GitHub repo openai/codex " +
-        '(call it with repoName "openai/codex", do not guess). ' +
-        "Report the sum, then a comma-separated list of the top-level topic names you found.",
+      "You must complete both MCP calls in this single turn before answering. " +
+        "First, call the tool e2e.get-sum with exactly {\"a\":100,\"b\":23}; " +
+        "do not calculate the sum yourself. " +
+        "Second, call the tool deepwiki.read_wiki_structure with exactly " +
+        '{\"repoName\":\"openai/codex\"}; do not guess the wiki structure. ' +
+        "Do not answer until both tool calls have completed successfully. " +
+        "Then report the returned sum followed by a comma-separated list of the returned top-level topic names.",
     );
     await turn.succeeded().orStop();
 

--- a/e2e/adapter/codex-cli/experiments/mcp.ts
+++ b/e2e/adapter/codex-cli/experiments/mcp.ts
@@ -6,11 +6,7 @@ const agent = codexAgent({
   apiKey: process.env.OPENAI_API_KEY,
   baseUrl: process.env.OPENAI_BASE_URL,
   mcpServers: [
-    {
-      name: "e2e",
-      command: "node",
-      args: ["node_modules/@modelcontextprotocol/server-everything/dist/index.js"],
-    },
+    { name: "e2e", command: "npx", args: ["-y", "@modelcontextprotocol/server-everything@2026.7.4"] },
     { name: "deepwiki", url: "https://mcp.deepwiki.com/mcp" },
   ],
 });

--- a/e2e/adapter/codex-cli/experiments/mcp.ts
+++ b/e2e/adapter/codex-cli/experiments/mcp.ts
@@ -6,7 +6,11 @@ const agent = codexAgent({
   apiKey: process.env.OPENAI_API_KEY,
   baseUrl: process.env.OPENAI_BASE_URL,
   mcpServers: [
-    { name: "e2e", command: "npx", args: ["-y", "@modelcontextprotocol/server-everything"] },
+    {
+      name: "e2e",
+      command: "node",
+      args: ["node_modules/@modelcontextprotocol/server-everything/dist/index.js"],
+    },
     { name: "deepwiki", url: "https://mcp.deepwiki.com/mcp" },
   ],
 });

--- a/e2e/adapter/codex-cli/package.json
+++ b/e2e/adapter/codex-cli/package.json
@@ -12,7 +12,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/server-everything": "2026.7.4",
     "dockerode": "^4.0.2",
     "effect": "4.0.0-rc.112",
     "niceeval": "^0.4.6",

--- a/e2e/adapter/codex-cli/package.json
+++ b/e2e/adapter/codex-cli/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@modelcontextprotocol/server-everything": "2026.7.4",
     "dockerode": "^4.0.2",
     "effect": "4.0.0-rc.112",
     "niceeval": "^0.4.6",

--- a/e2e/cli/test/sandbox-step-activity.test.ts
+++ b/e2e/cli/test/sandbox-step-activity.test.ts
@@ -10,10 +10,10 @@ test("TTY 在声明式 Sandbox step 执行时显示安全的具体动作 [necase
   await cliE2E.case("sandbox-step-activity", async () => {
     await withPty(
       [...cliBinary, "exp", "sandbox-step-activity", "--rerun", "all"],
-      { columns: 240, rows: 48, timeoutMs: 60_000 },
+      { columns: 240, rows: 48, timeoutMs: 120_000 },
       async (pty) => {
         const active = await pty.waitForText(/preparing sandbox/u, {
-          timeoutMs: 30_000,
+          timeoutMs: 90_000,
           whileRunning: true,
           label: "the running Sandbox preparation phase",
         });

--- a/e2e/lifecycle/fixtures/fake-incus.mjs
+++ b/e2e/lifecycle/fixtures/fake-incus.mjs
@@ -125,6 +125,22 @@ function maybeBlock(label) {
   for (;;) sleep(10_000);
 }
 
+function maybeFail(label) {
+  const failurePath = `${statePath}.fail-next`;
+  let failure;
+  try {
+    failure = readFileSync(failurePath, "utf8").trim();
+  } catch (cause) {
+    if (cause?.code === "ENOENT") return;
+    throw cause;
+  }
+  if (!failure || !label.includes(failure)) return;
+  unlinkSync(failurePath);
+  journal("failed", { label });
+  process.stderr.write("Error: Failed creating instance: storage pool capacity exhausted\n");
+  process.exit(1);
+}
+
 function query(args) {
   const method = args[args.indexOf("-X") + 1];
   const rawPath = args[args.indexOf("-X") + 2];
@@ -172,6 +188,7 @@ function query(args) {
     return;
   }
 
+  maybeFail(label);
   withLock((state) => {
     const volumeMatch = /^\/1\.0\/storage-pools\/([^/]+)\/volumes\/custom(?:\/([^/]+))?$/u.exec(pathname);
     if (method === "POST" && volumeMatch && volumeMatch[2] === undefined) {

--- a/e2e/lifecycle/test/incus-user-database-ledger.test.ts
+++ b/e2e/lifecycle/test/incus-user-database-ledger.test.ts
@@ -265,10 +265,12 @@ export default defineExperiment({ agent: quickAgent, sandbox, evals: ["probe"], 
         env: baseEnv,
       });
       expect(failedMutation.exitCode).not.toBe(0);
-      expect(`${failedMutation.stdout}\n${failedMutation.stderr}`).toContain(
-        "Incus POST /1.0/instances?project=niceeval-eval-dev failed (exit 1): Error: Failed creating instance: storage pool capacity exhausted",
+      const failedMutationOutput = `${failedMutation.stdout}\n${failedMutation.stderr}`;
+      expect(failedMutationOutput).toContain(
+        "Incus POST /1.0/instances?project=niceeval-eval-dev failed (exit 1): Error: Failed",
       );
-      expect(`${failedMutation.stdout}\n${failedMutation.stderr}`).not.toContain("unexpected JSON shape");
+      expect(failedMutationOutput).toContain("creating instance: storage pool capacity exhausted");
+      expect(failedMutationOutput).not.toContain("unexpected JSON shape");
     });
   });
 });

--- a/e2e/lifecycle/test/incus-user-database-ledger.test.ts
+++ b/e2e/lifecycle/test/incus-user-database-ledger.test.ts
@@ -250,6 +250,25 @@ export default defineExperiment({ agent: quickAgent, sandbox, evals: ["probe"], 
       expect(artifactDeletes(evictionRecords)).toHaveLength(0);
       expect(artifactPublishes(evictionRecords)).toHaveLength(0);
       expect(artifactConsumers(evictionRecords)).toHaveLength(0);
+
+      await writeFile(join(projectRoot, "experiments/incus-ledger.ts"), `
+import { defineExperiment } from "niceeval";
+import { incusSandbox, shell } from "niceeval/sandbox";
+import { quickAgent } from "../agents/deterministic.ts";
+const sandbox = incusSandbox({ image: "niceeval/docker-execution-v1@sha256:${digest}", project: "${runtimeProject}", storagePool: "niceeval-sandbox-dev", acceptDevelopmentDomain: true, resources: { dockerDataBytes: ${1024 ** 3} } })
+  .before(shell({ id: "incus-ledger-prefix", command: "true", changeFrequency: 10 }));
+export default defineExperiment({ agent: quickAgent, sandbox, evals: ["probe"], attempts: 1, maxConcurrency: 1 });
+`, "utf8");
+      await writeFile(`${state}.fail-next`, `POST /1.0/instances?project=${runtimeProject}\n`, "utf8");
+      const failedMutation = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], {
+        cwd: projectRoot,
+        env: baseEnv,
+      });
+      expect(failedMutation.exitCode).not.toBe(0);
+      expect(`${failedMutation.stdout}\n${failedMutation.stderr}`).toContain(
+        "Incus POST /1.0/instances?project=niceeval-eval-dev failed (exit 1): Error: Failed creating instance: storage pool capacity exhausted",
+      );
+      expect(`${failedMutation.stdout}\n${failedMutation.stderr}`).not.toContain("unexpected JSON shape");
     });
   });
 });

--- a/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
+++ b/e2e/lifecycle/test/sandbox-setup-prefix-cache.test.ts
@@ -201,8 +201,18 @@ async function waitForPathOrProcessExit(path: string, done: Promise<ProcessRecei
 
   const controller = new AbortController();
   const ready = (async () => {
-    for await (const event of watch(dirname(path), { signal: controller.signal })) {
-      if (event.filename !== basename(path)) continue;
+    const events = watch(dirname(path), { signal: controller.signal });
+    // The file can be published after the first access() but before fs.watch
+    // starts observing the directory. Re-check after constructing the watcher
+    // so a fast rendezvous cannot be lost between those two operations.
+    try {
+      await access(path);
+      return;
+    } catch (cause) {
+      if (typeof cause !== "object" || cause === null || Reflect.get(cause, "code") !== "ENOENT") throw cause;
+    }
+    for await (const event of events) {
+      if (event.filename !== null && event.filename !== basename(path)) continue;
       try {
         await access(path);
         return;

--- a/e2e/package/pnpm-workspace.yaml
+++ b/e2e/package/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages: []
 allowBuilds:
   '@parcel/watcher': false
+  autoevals: false
   braintrust: false
   cpu-features: false
   # Vitest/Testkit harness only; the installed NiceEval candidate has no esbuild edge.

--- a/e2e/record/test/record-journey.test.ts
+++ b/e2e/record/test/record-journey.test.ts
@@ -145,8 +145,8 @@ test.concurrent("Attempt 原子发布后，active Run 与 portable Record 均完
 
       const humanOverview = await niceeval.run(["show"]);
       expect(humanOverview.exitCode, humanOverview.diagnostic()).toBe(0);
-      expect(humanOverview.stdout, humanOverview.diagnostic()).toContain(published.publication.attemptLocator);
       expect(humanOverview.stdout, humanOverview.diagnostic()).toContain("1/2");
+      expect(humanOverview.stdout, humanOverview.diagnostic()).toContain("1 passed Attempts hidden");
 
       backend.completeAttempt(1, `run-journey-attempt-published ${unpublishedCanary}`);
       await whileRunning(backend.waitForAssertion(1), process, "the second Attempt recorded its unpublished assertion");

--- a/memory/incus-cli-mutation-error-hidden-by-json-decoder.md
+++ b/memory/incus-cli-mutation-error-hidden-by-json-decoder.md
@@ -1,0 +1,27 @@
+---
+format: niceeval.memory/v1
+id: incus-cli-mutation-error-hidden-by-json-decoder
+title: Incus CLI mutation error is hidden by JSON decoding
+createdAt: 2026-09-04
+kind:
+  type: problem
+  state: open
+promotions: []
+---
+# Incus CLI mutation errors are parsed as JSON responses
+
+## Observation
+
+An Incus setup-prefix publication can fail before Attempt dispatch with `Incus POST /1.0/instances?... returned an unexpected JSON shape`, hiding the provider error emitted by `incus query --wait --raw`.
+
+## Root cause
+
+The Incus CLI converts a failed asynchronous operation into a non-zero process exit and writes a plain-text `Error: ...` diagnostic to stderr. NiceEval selected stderr when stdout was empty but always parsed the selected stream as a REST response envelope, so JSON parsing replaced the original Incus failure.
+
+## Repair boundary
+
+Keep successful and JSON response envelopes under exact Effect Schema validation. For non-zero CLI exits whose selected output is not a valid envelope, report the exit code plus a control-character-normalized, credential-redacted, bounded excerpt. This exposes the provider cause without accepting unknown successful response shapes.
+
+## Verification status
+
+The installed-candidate lifecycle owner now injects a plain-text failed Incus mutation through the fake external CLI boundary and requires the original provider error instead of `unexpected JSON shape`. Formal local red/takeover evidence is blocked before test execution because this host lacks the lifecycle Repo `linux-loop-project-quota` capability; keep this Problem open until the owner runs in CI or on a capable host.

--- a/packages/niceeval/src/agents/codex-app-server.ts
+++ b/packages/niceeval/src/agents/codex-app-server.ts
@@ -340,7 +340,13 @@ async function drive(state: CodexState, ctx: SandboxAgentContext, from: number, 
   const receipt = await state.driver.waitFor(state.cursor, (value) => {
     const frame = record(value);
     if (!belongsToTurn(value, state.threadId, turnId)) return false;
-    return frame?.method === "item/tool/requestUserInput" || frame?.method === "turn/completed" || frame?.method === "error";
+    if (frame?.method === "error") {
+      // app-server emits transient stream errors before its own reconnect
+      // attempts. They remain part of this turn's evidence, but only an error
+      // with no promised retry is terminal for the adapter.
+      return record(frame.params)?.willRetry !== true;
+    }
+    return frame?.method === "item/tool/requestUserInput" || frame?.method === "turn/completed";
   }, ctx.signal);
   state.cursor = receipt.cursor;
   const frame = record(receipt.frame)!;

--- a/packages/niceeval/src/sandbox/incus/control.ts
+++ b/packages/niceeval/src/sandbox/incus/control.ts
@@ -168,6 +168,29 @@ function shapeError(path: string, cause?: unknown): IncusProviderError {
   );
 }
 
+const CLI_DIAGNOSTIC_LIMIT = 512;
+
+function cliDiagnosticExcerpt(text: string): string {
+  const redacted = text
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/gu, "�")
+    .replace(
+      /((?:authorization|password|secret|token|api[-_]?key)\s*[:=]\s*)(?:"[^"]*"|'[^']*'|\S+)/giu,
+      "$1[redacted]",
+    )
+    .replace(/\s+/gu, " ")
+    .trim();
+  if (redacted.length <= CLI_DIAGNOSTIC_LIMIT) return redacted;
+  return `${redacted.slice(0, CLI_DIAGNOSTIC_LIMIT)}…`;
+}
+
+function cliFailure(path: string, exitCode: number, text: string, cause?: unknown): IncusProviderError {
+  const excerpt = cliDiagnosticExcerpt(text);
+  return unreachable(
+    `Incus ${path} failed (exit ${exitCode})${excerpt === "" ? " without output" : `: ${excerpt}`}.`,
+    cause,
+  );
+}
+
 function decodeEnvelope(parsed: unknown, path: string): Schema.Schema.Type<typeof EnvelopeSchema> {
   const decoded = Schema.decodeUnknownResult(EnvelopeSchema, ParseOptions)(parsed);
   if (Result.isFailure(decoded)) throw shapeError(path, decoded.failure);
@@ -184,9 +207,16 @@ function decodeCliOutput(stdout: string, stderr: string, exitCode: number, path:
   try {
     parsed = JSON.parse(text);
   } catch (cause) {
+    if (exitCode !== 0) throw cliFailure(path, exitCode, text, cause);
     throw shapeError(path, cause);
   }
-  const envelope = decodeEnvelope(parsed, path);
+  let envelope: Schema.Schema.Type<typeof EnvelopeSchema>;
+  try {
+    envelope = decodeEnvelope(parsed, path);
+  } catch (cause) {
+    if (exitCode !== 0) throw cliFailure(path, exitCode, text, cause);
+    throw cause;
+  }
   if (envelope.type === "error") {
     if (envelope.error_code === 404) return { _tag: "Absent" as const };
     throw unreachable(
@@ -194,6 +224,7 @@ function decodeCliOutput(stdout: string, stderr: string, exitCode: number, path:
       parsed,
     );
   }
+  if (exitCode !== 0) throw cliFailure(path, exitCode, text, parsed);
   if (envelope.type === "async") {
     throw unreachable(
       `Incus ${path} returned an unfinished async operation; mutations must wait for completion.`,


### PR DESCRIPTION
<!-- niceeval:pr-body
base: debfaf550ad16f7ac6f17429309e2c038dc6b5ba
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: 6fd5e52227dfdaafa949ce2271473546c801e886
-->

## Problem

- User goal: 并发发布 Incus setup-prefix 时能够看见真实的 Provider 失败原因。
- Current limitation: incus query --wait 将异步操作失败写成非零退出和纯文本 stderr，NiceEval 却把它当 REST JSON 解码，最终只显示 unexpected JSON shape。
- Required capability: 在保持成功响应严格 Schema 校验的同时，单独识别 CLI 非零退出，并安全呈现有界、脱敏的 stderr 摘要。
- User outcome: setup-prefix 发布失败时会显示 Incus CLI 退出码和原始错误摘要，可直接判断容量、名称冲突或其它 Provider 根因。

## Use cases

### Changed

#### Case: 诊断 Incus 准备前缀发布失败

##### Starting state

```text
Incus Provider 已配置；Run 正在派发前并发准备 setup-prefix，某次 instance mutation 失败。
```

##### Action

```sh
pnpm exec niceeval exp harness/v0.14.0
```

##### Result

```text
Incus POST /1.0/instances?project=niceeval-eval-dev failed (exit 1): Error: Failed creating instance: storage pool capacity exhausted.
```

失败仍然 fail closed，但诊断保留 Incus CLI 的实际原因；其它独立前缀仍按既有 DAG 结算。 [Canonical Use Case](docs/feature/sandbox/use-case/起点与准备/共享分支准备.md).

## Observable behavior and data contracts

### Changed

#### Case: Incus CLI mutation failure diagnostic

##### Before

```sh
pnpm exec niceeval exp harness/v0.14.0
```

```text
Incus POST /1.0/instances?project=niceeval-eval-cache-dev returned an unexpected JSON shape.
```

##### After

```sh
pnpm exec niceeval exp harness/v0.14.0
```

```text
Incus POST /1.0/instances?project=niceeval-eval-cache-dev failed (exit 1): Error: <Incus provider failure>
```

##### User impact

用户不再需要从泛化的 JSON shape 错误猜测并发发布为何失败；输出经过控制字符规范化、常见凭据脱敏并限制为 512 字符。

## Tests

### `e2e/cli/test/sandbox-step-activity.test.ts`

#### `e2e/cli/test/sandbox-step-activity.test.ts#necase_Q6TNRRPB791NM6SY`

默认并行负载下，TTY 仍能在真实 Sandbox preparation 活跃期间显示安全的具体动作。 It exercises 安装后 niceeval exp sandbox-step-activity --rerun all 经真实 PTY 与 Docker Sandbox 执行。 and asserts 在 owner deadline 内观察 preparing sandbox 和声明动作，隐藏 wrapper、正文、source path 与 env value，随后零退出并完成资源清理。. Deleting this case would allow 删除此 case 会允许 TTY 在 Docker 尾延迟下只留下超时，或再次泄露声明式 Sandbox action 的私有内容。. The final contract is [docs/feature/experiments/cli.md](docs/feature/experiments/cli.md).

```ts
// owner: docs/engineering/testing/e2e/cli.md#cli-sandbox-step-activity
// rerun: pnpm e2e test --repo cli -- --run test/sandbox-step-activity.test.ts

import { withPty } from "@niceeval/testkit";
import { expect, test } from "vitest";
import { cliBinary, cliE2E } from "./context.ts";

const SHELL_COMMAND = "printf 'sandbox-shell-ready\\n' > /tmp/sandbox-shell-ready && sleep 2";
test("TTY 在声明式 Sandbox step 执行时显示安全的具体动作 [necase_Q6TNRRPB791NM6SY]", async () => {
  await cliE2E.case("sandbox-step-activity", async () => {
    await withPty(
      [...cliBinary, "exp", "sandbox-step-activity", "--rerun", "all"],
      { columns: 240, rows: 48, timeoutMs: 120_000 },
      async (pty) => {
        const active = await pty.waitForText(/preparing sandbox/u, {
          timeoutMs: 90_000,
          whileRunning: true,
          label: "the running Sandbox preparation phase",
        });
        expect(active).toContain(SHELL_COMMAND);
        expect(active).not.toContain("/bin/sh -lc");

        const receipt = await pty.wait();
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        expect(receipt.signal, receipt.diagnostic()).toBeNull();
        expect(receipt.raw).toContain(String.fromCharCode(27));
        expect(receipt.raw).toContain('exec "/bin/sh" "-c" "sleep 2" "activity-arg\\\\tvalue"');
        expect(receipt.raw).toContain('env keys=["ACTIVITY_VISIBLE_KEY"]');
        expect(receipt.raw).not.toContain("activity-env-private-value");
        expect(receipt.raw).not.toContain("sandbox-write-private-body");
        expect(receipt.raw).not.toContain("fixtures/sandbox-step-activity/upload.txt");
        expect(receipt.raw).not.toContain("host-upload-private-body");

        expect(receipt.cleanup).toEqual({
          candidateGroup: expect.stringMatching(/gone|terminal/),
          helperGroup: expect.stringMatching(/gone|terminal/),
          launcherGroup: expect.stringMatching(/gone|terminal/),
        });
      },
    );
  });
});
```

### `e2e/lifecycle/test/incus-user-database-ledger.test.ts`

#### `e2e/lifecycle/test/incus-user-database-ledger.test.ts#necase_E2ARE3AS30W6PA6H`

Incus CLI 的纯文本 mutation 失败保留退出码和 Provider 错误，同时不再退化成 JSON shape 错误。 It exercises 安装后 niceeval exp 经 fake Incus CLI 外部边界触发 instance create failure。 and asserts 终端诊断包含精确 operation、exit 1 与 storage pool capacity exhausted，并排除 unexpected JSON shape。. Deleting this case would allow fixture 只模拟外部 Incus CLI；产品的 response decode、setup-prefix lifecycle 与错误呈现全部由安装后 candidate 执行。. The final contract is [docs/feature/run/lifecycle.md](docs/feature/run/lifecycle.md).

```ts
import { spawn } from "node:child_process";
import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
import { join, resolve } from "node:path";
import { pathToFileURL } from "node:url";
import { command, pollUntil, withProjectCopy, withTempDir } from "@niceeval/testkit";
import { expect, test } from "vitest";

interface JournalRecord {
  readonly event: string;
  readonly detail: {
    readonly label?: string;
    readonly method?: string;
    readonly path?: string;
    readonly project?: string;
    readonly body?: {
      readonly name?: string;
      readonly source?: { readonly type?: string; readonly project?: string };
    };
  };
}

const digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
const runtimeProject = "niceeval-eval-dev";
const artifactProject = "niceeval-artifacts-dev";
const projectCopy = {
  from: process.cwd(),
  prefix: "niceeval-e2e-incus-userdb-",
  omitTopLevel: [".niceeval", "node_modules", "test"],
  links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
} as const;

async function journal(path: string): Promise<readonly JournalRecord[]> {
  try {
    return (await readFile(path, "utf8")).trim().split("\n").filter(Boolean).map((line) => JSON.parse(line) as JournalRecord);
  } catch (cause) {
    if (typeof cause === "object" && cause !== null && Reflect.get(cause, "code") === "ENOENT") return [];
    throw cause;
  }
}

async function waitForBlocked(path: string, after: number): Promise<readonly JournalRecord[]> {
  return pollUntil(async () => {
    const records = await journal(path);
    return records.slice(after).some((record) => record.event === "blocked") ? records : undefined;
  }, { timeoutMs: 30_000, intervalMs: 50, label: "fake Incus blocking checkpoint" });
}

async function waitForChildClose(child: ReturnType<typeof spawn>): Promise<void> {
  if (child.exitCode !== null || child.signalCode !== null) return;
  await new Promise<void>((resolveExit) => child.once("close", () => resolveExit()));
}

async function killAtProviderBoundary(
  cwd: string,
  env: NodeJS.ProcessEnv,
  journalPath: string,
): Promise<readonly JournalRecord[]> {
  const before = (await journal(journalPath)).length;
  const child = spawn("pnpm", ["--silent", "exec", "niceeval", "exp", "incus-ledger", "probe", "--rerun=all"], {
    cwd,
    env,
    detached: true,
    stdio: ["ignore", "pipe", "pipe"],
  });
  const output: Buffer[] = [];
  child.stdout.on("data", (chunk: Buffer) => output.push(chunk));
  child.stderr.on("data", (chunk: Buffer) => output.push(chunk));
  try {
    const records = await waitForBlocked(journalPath, before);
    if (child.pid === undefined) throw new Error("niceeval crash fixture has no process-group id");
    process.kill(-child.pid, "SIGKILL");
    await waitForChildClose(child);
    return records;
  } catch (cause) {
    if (child.pid !== undefined) {
      try { process.kill(-child.pid, "SIGKILL"); } catch { /* process already stopped */ }
    }
    await waitForChildClose(child);
    throw new Error(`${cause instanceof Error ? cause.message : String(cause)}\n${Buffer.concat(output).toString("utf8")}`);
  }
}

function artifactPublishes(records: readonly JournalRecord[]): readonly JournalRecord[] {
  return records.filter((record) => record.event === "query" && record.detail.method === "POST" &&
    record.detail.path === "/1.0/instances" && record.detail.project === artifactProject);
}

function artifactConsumers(records: readonly JournalRecord[]): readonly JournalRecord[] {
  return records.filter((record) => record.event === "query" && record.detail.method === "POST" &&
    record.detail.path === "/1.0/instances" && record.detail.project === runtimeProject &&
    record.detail.body?.source?.type === "copy" && record.detail.body.source.project === artifactProject);
}

function artifactDeletes(records: readonly JournalRecord[]): readonly JournalRecord[] {
  return records.filter((record) => record.event === "query" && record.detail.method === "DELETE" &&
    record.detail.project === artifactProject);
}

test("Incus repository fences admission, recovers crashes, and reuses only committed artifacts [necase_E2ARE3AS30W6PA6H]", async () => {
  await withProjectCopy(projectCopy, async ({ root: projectRoot }) => {
    await withTempDir("niceeval-e2e-incus-userdb-runtime-", async (runtimeRoot) => {
      const binDir = join(runtimeRoot, "bin");
      const descriptor = join(runtimeRoot, "incus-provider.json");
      const state = join(runtimeRoot, "incus-state.json");
      const journalPath = join(runtimeRoot, "incus-journal.ndjson");
      const fakeIncus = resolve("fixtures/fake-incus.mjs");
      await mkdir(binDir, { recursive: true });
      const wrapper = join(binDir, "incus");
      await writeFile(wrapper, `#!/usr/bin/env node\nawait import(${JSON.stringify(pathToFileURL(fakeIncus).href)});\n`, "utf8");
      await chmod(wrapper, 0o755);
      await writeFile(descriptor, `${JSON.stringify({
        schemaVersion: "niceeval.incus-provider/v2",
        domains: [{
          name: "development",
          status: "configured",
          executionDomainId: "e2e-incus-development",
          project: runtimeProject,
          storagePool: "niceeval-sandbox-dev",
          network: "niceeval-dev",
          storage: "development-dir",
          quota: "unattested",
          maxInstances: 4,
          artifactProject,
          artifactMaxInstances: 1,
          dockerDataBytes: 1024 ** 3,
          workdir: "/home/sandbox/workspace",
          user: "node",
          hostGateway: "10.0.0.1",
          trustedBaseImages: [`niceeval/docker-execution-v1@sha256:${digest}`],
        }],
      })}\n`, "utf8");
      await writeFile(join(projectRoot, "experiments/incus-ledger.ts"), `
import { defineExperiment } from "niceeval";
import { incusSandbox, shell } from "niceeval/sandbox";
import { quickAgent } from "../agents/deterministic.ts";

const sandbox = incusSandbox({
  image: "niceeval/docker-execution-v1@sha256:${digest}",
  project: "${runtimeProject}",
  storagePool: "niceeval-sandbox-dev",
  acceptDevelopmentDomain: true,
  resources: { dockerDataBytes: ${1024 ** 3} },
}).before(shell({ id: "incus-ledger-prefix", command: "true", changeFrequency: 10 }));

export default defineExperiment({
  agent: quickAgent,
  sandbox,
  evals: ["probe"],
  attempts: 1,
  maxConcurrency: 1,
});
`, "utf8");

      const baseEnv: NodeJS.ProcessEnv = {
        ...process.env,
        PATH: `${binDir}:${process.env.PATH ?? ""}`,
        NICEEVAL_HOME: join(runtimeRoot, "user"),
        XDG_STATE_HOME: join(runtimeRoot, "xdg-state"),
        NICEEVAL_INCUS_DESCRIPTOR: descriptor,
        NICEEVAL_E2E_FAKE_INCUS_STATE: state,
        NICEEVAL_E2E_FAKE_INCUS_JOURNAL: journalPath,
      };
      const niceeval = command(["pnpm", "--silent", "exec", "niceeval"]);

      const cold = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], { cwd: projectRoot, env: baseEnv });
      expect(cold.exitCode, "the fixture deliberately fails agent.ensure after provider setup").not.toBe(0);
      const afterCold = await journal(journalPath);
      expect(artifactPublishes(afterCold), `${cold.diagnostic()}\nprovider journal:\n${JSON.stringify(afterCold, null, 2)}`).toHaveLength(1);
      expect(artifactConsumers(afterCold)).toHaveLength(1);

      const warmStart = afterCold.length;
      const warm = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], { cwd: projectRoot, env: baseEnv });
      expect(warm.exitCode, "the fixture deliberately fails agent.ensure after committed artifact lookup").not.toBe(0);
      const afterWarm = await journal(journalPath);
      const warmRecords = afterWarm.slice(warmStart);
      expect(artifactPublishes(warmRecords)).toHaveLength(0);
      expect(artifactConsumers(warmRecords)).toHaveLength(1);

      const fenceClaim = `${state}.block-claimed`;
      await rm(fenceClaim, { force: true });
      const fenceCrash = await killAtProviderBoundary(projectRoot, {
        ...baseEnv,
        NICEEVAL_E2E_FAKE_INCUS_BLOCK_ONCE: `GET /1.0/instances?project=${runtimeProject}`,
      }, journalPath);
      expect(fenceCrash.some((record) => record.event === "blocked" && record.detail.label?.startsWith("GET /1.0/instances"))).toBe(true);
      const afterFence = (await journal(journalPath)).length;
      const fenceRecovery = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], { cwd: projectRoot, env: baseEnv });
      expect(fenceRecovery.exitCode).not.toBe(0);
      expect(artifactConsumers((await journal(journalPath)).slice(afterFence))).toHaveLength(1);

      await rm(fenceClaim, { force: true });
      const allocationCrashRecords = await killAtProviderBoundary(projectRoot, {
        ...baseEnv,
        NICEEVAL_E2E_FAKE_INCUS_BLOCK_ONCE: `POST /1.0/instances?project=${runtimeProject}`,
      }, journalPath);
      const crashedCreate = [...allocationCrashRecords].reverse().find((record) => record.event === "query" &&
        record.detail.method === "POST" && record.detail.path === "/1.0/instances" && record.detail.project === runtimeProject);
      const crashedName = crashedCreate?.detail.body?.name;
      expect(crashedName).toBeTruthy();
      const recoveryStart = (await journal(journalPath)).length;
      const allocationRecovery = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], { cwd: projectRoot, env: baseEnv });
      expect(allocationRecovery.exitCode).not.toBe(0);
      const recoveryRecords = (await journal(journalPath)).slice(recoveryStart);
      expect(recoveryRecords.some((record) => record.event === "query" && record.detail.method === "DELETE" &&
        record.detail.path === `/1.0/instances/${crashedName}` && record.detail.project === runtimeProject)).toBe(true);
      expect(artifactConsumers(recoveryRecords)).toHaveLength(1);

      const providerState = JSON.parse(await readFile(state, "utf8")) as {
        instances: Record<string, Record<string, unknown>>;
        volumes: Record<string, Record<string, unknown>>;
      };
      const orphanArtifact = "nea-orphan-without-intent";
      providerState.instances[artifactProject] ??= {};
      providerState.instances[artifactProject]![orphanArtifact] = {
        name: orphanArtifact,
        status: "Stopped",
        type: "virtual-machine",
        config: {
          "user.niceeval.artifactState": "committed",
          "user.niceeval.allocationId": "orphan-artifact-id",
        },
        expanded_devices: {},
      };
      await writeFile(state, `${JSON.stringify(providerState)}\n`, "utf8");

      const doctor = await niceeval.run(["sandbox", "provider", "doctor", "incus", "--development"], { cwd: projectRoot, env: baseEnv });
      expect(doctor.exitCode, doctor.diagnostic()).toBe(1);
      expect(doctor.stdout).toContain("status: FAIL (fail closed)");
      expect(doctor.stdout).toContain("4 free of 4");
      expect(doctor.stdout).toContain("artifact-inventory: FAIL [sandbox-artifact-unverified]");
      expect(doctor.stdout).toContain(`project=${artifactProject} instance=${orphanArtifact}`);
      expect(doctor.stdout).toContain("artifact-capacity: FAIL");

      delete providerState.instances[artifactProject]![orphanArtifact];
      await writeFile(state, `${JSON.stringify(providerState)}\n`, "utf8");

      await writeFile(join(projectRoot, "experiments/incus-ledger.ts"), `
import { defineExperiment } from "niceeval";
import { incusSandbox, shell } from "niceeval/sandbox";
import { quickAgent } from "../agents/deterministic.ts";
const sandbox = incusSandbox({ image: "niceeval/docker-execution-v1@sha256:${digest}", project: "${runtimeProject}", storagePool: "niceeval-sandbox-dev", acceptDevelopmentDomain: true, resources: { dockerDataBytes: ${1024 ** 3} } })
  .before(shell({ id: "incus-ledger-prefix-v2", command: "true", changeFrequency: 10 }));
export default defineExperiment({ agent: quickAgent, sandbox, evals: ["probe"], attempts: 1, maxConcurrency: 1 });
`, "utf8");
      const evictionStart = (await journal(journalPath)).length;
      const eviction = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], { cwd: projectRoot, env: baseEnv });
      expect(eviction.exitCode).not.toBe(0);
      expect(`${eviction.stdout}\n${eviction.stderr}`).toContain("still-current replacement lineage");
      const evictionRecords = (await journal(journalPath)).slice(evictionStart);
      expect(artifactDeletes(evictionRecords)).toHaveLength(0);
      expect(artifactPublishes(evictionRecords)).toHaveLength(0);
      expect(artifactConsumers(evictionRecords)).toHaveLength(0);

      await writeFile(join(projectRoot, "experiments/incus-ledger.ts"), `
import { defineExperiment } from "niceeval";
import { incusSandbox, shell } from "niceeval/sandbox";
import { quickAgent } from "../agents/deterministic.ts";
const sandbox = incusSandbox({ image: "niceeval/docker-execution-v1@sha256:${digest}", project: "${runtimeProject}", storagePool: "niceeval-sandbox-dev", acceptDevelopmentDomain: true, resources: { dockerDataBytes: ${1024 ** 3} } })
  .before(shell({ id: "incus-ledger-prefix", command: "true", changeFrequency: 10 }));
export default defineExperiment({ agent: quickAgent, sandbox, evals: ["probe"], attempts: 1, maxConcurrency: 1 });
`, "utf8");
      await writeFile(`${state}.fail-next`, `POST /1.0/instances?project=${runtimeProject}\n`, "utf8");
      const failedMutation = await niceeval.run(["exp", "incus-ledger", "probe", "--rerun=all"], {
        cwd: projectRoot,
        env: baseEnv,
      });
      expect(failedMutation.exitCode).not.toBe(0);
      const failedMutationOutput = `${failedMutation.stdout}\n${failedMutation.stderr}`;
      expect(failedMutationOutput).toContain(
        "Incus POST /1.0/instances?project=niceeval-eval-dev failed (exit 1): Error: Failed",
      );
      expect(failedMutationOutput).toContain("creating instance: storage pool capacity exhausted");
      expect(failedMutationOutput).not.toContain("unexpected JSON shape");
    });
  });
});
```

### `e2e/record/test/record-journey.test.ts`

#### `e2e/record/test/record-journey.test.ts#necase_71RKBRSMD0ER677F`

active Run 发布首个 Attempt 后，精确 Attempt 读取保持完整，默认 Results 同时如实显示 1/2 partial 并折叠已通过明细。 It exercises 安装后 niceeval exp 启动两 Attempt Run，在首个 Attempt 发布且第二个仍 pending 时调用 niceeval show @locator 与 niceeval show。 and asserts 精确读取包含 locator 与 completed；默认 Results 包含 1/2 和 1 passed Attempts hidden，不错误要求折叠视图展开 locator。. Deleting this case would allow 删除此 case 会失去 Attempt 在 Run 收口前可读及 partial overview 展示的跨入口 Journey 守护。. The final contract is [docs/feature/run/architecture.md#attempt-publication](docs/feature/run/architecture.md#attempt-publication).

```ts

import { randomUUID } from "node:crypto";
import { readFile, rename, writeFile } from "node:fs/promises";
import { join, resolve } from "node:path";
import { createE2EContext, only, pollUntil } from "@niceeval/testkit";
import { decodeExpPlanDocument } from "niceeval/experiment/host";
import { expect, test } from "vitest";
import { createLoopbackBackend, whileRunning } from "./support.js";

const e2e = createE2EContext({
  repoId: "record",
  project: {
    from: process.cwd(),
    prefix: "niceeval-e2e-run-",
    omitTopLevel: [".e2e-artifacts", ".niceeval", "node_modules", "test"],
    links: [{ from: resolve("node_modules"), to: "node_modules", type: "dir" }],
  },
  commands: { niceeval: [join(process.cwd(), "node_modules", ".bin", "niceeval")] },
});

test.concurrent("运行创建后立即可发现，并冻结完整 expected slots [necase_SVJG4JP8WN5TWCQF]", async () => {
  await e2e.case("run-create-discovery", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) =>
          run.state === "active" && run.coverage.expected === 2 && run.coverage.published === 0
        );
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the created Run to be listed" }), process, "the created Run became visible");
      expect(active).toMatchObject({
        experimentId: "run-journey",
        state: "active",
        coverage: { expected: 2, published: 0, missing: 2 },
      });
      expect(active.runId).toMatch(/^[0-9a-f-]{36}$/u);
      expect(active.invocationId).toEqual(expect.any(String));

      const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
      const shown = receipt.runGetDocument();
      expect(shown.run).toMatchObject({
        runId: active.runId,
        state: "active",
        coverage: { expected: 2, published: 0, missing: 2 },
      });
      expect(shown.run.slots).toHaveLength(2);
      expect(shown.run.slots).toEqual(expect.arrayContaining([
        expect.objectContaining({ evalId: "run-journey", attemptOrdinal: 0, publication: { state: "pending" } }),
        expect.objectContaining({ evalId: "run-journey", attemptOrdinal: 1, publication: { state: "pending" } }),
      ]));
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("Attempt 原子发布后，active Run 与 portable Record 均完整可读 [necase_71RKBRSMD0ER677F]", async () => {
  await e2e.case("attempt-readable-while-active", async ({ paths, commands: { niceeval } }) => {
    const unpublishedCanary = `niceeval-unpublished-attempt-canary-${randomUUID()}`;
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      {
        env: {
          NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint,
        },
        timeoutMs: 90_000,
      },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the active Run to be listed" }), process, "the active Run became visible");
      const beforePublicationReceipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(beforePublicationReceipt.exitCode, beforePublicationReceipt.diagnostic()).toBe(0);
      const beforePublication = beforePublicationReceipt.runGetDocument();
      expect(beforePublication.run).toMatchObject({
        state: "active",
        coverage: { expected: 2, published: 0, missing: 2 },
      });
      expect(beforePublication.run.slots).toEqual(expect.arrayContaining([
        expect.objectContaining({ attemptOrdinal: 0, publication: { state: "pending" } }),
        expect.objectContaining({ attemptOrdinal: 1, publication: { state: "pending" } }),
      ]));

      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const shown = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the first Attempt publication" }), process, "the first Attempt publication became visible");
      expect(shown.run).toMatchObject({ state: "active", coverage: { expected: 2, published: 1, missing: 1 } });
      const published = only(shown.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(shown));
      expect(published).toMatchObject({
        evalId: "run-journey",
        attemptOrdinal: 0,
        publication: {
          state: "published",
          action: "executed",
          attemptLocator: expect.stringMatching(/^@1[0-9A-HJKMNP-TV-Z]{12}$/u),
          originRunId: active.runId,
          originSlotId: published.slotId,
        },
      });
      expect(only(shown.run.slots, (slot) => slot.publication.state === "pending", JSON.stringify(shown))).toMatchObject({
        attemptOrdinal: 1,
        publication: { state: "pending" },
      });
      if (published.publication.state !== "published") throw new Error("Expected a published slot");

      const request = join(paths.projectRoot, "published-attempt.query.json");
      await writeFile(request, `${JSON.stringify({
        protocol: "niceeval.query/v1",
        operation: { kind: "attempt.get", locator: published.publication.attemptLocator },
      })}\n`, "utf8");
      const attemptReceipt = await niceeval.run(["query", "run", "--request", request]);
      expect(attemptReceipt.exitCode, attemptReceipt.diagnostic()).toBe(0);
      expect(attemptReceipt.attempt()).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "attempt.get",
        issues: [],
        attempt: {
          locator: published.publication.attemptLocator,
          core: { outcome: "completed" },
        },
      });

      const humanAttempt = await niceeval.run(["show", published.publication.attemptLocator]);
      expect(humanAttempt.exitCode, humanAttempt.diagnostic()).toBe(0);
      expect(humanAttempt.stdout, humanAttempt.diagnostic()).toContain(published.publication.attemptLocator);
      expect(humanAttempt.stdout, humanAttempt.diagnostic()).toContain("completed");

      const humanOverview = await niceeval.run(["show"]);
      expect(humanOverview.exitCode, humanOverview.diagnostic()).toBe(0);
      expect(humanOverview.stdout, humanOverview.diagnostic()).toContain("1/2");
      expect(humanOverview.stdout, humanOverview.diagnostic()).toContain("1 passed Attempts hidden");

      backend.completeAttempt(1, `run-journey-attempt-published ${unpublishedCanary}`);
      await whileRunning(backend.waitForAssertion(1), process, "the second Attempt recorded its unpublished assertion");

      expect(process.signal("SIGINT")).toBe(true);
      const interruptedReceipt = await process.done;
      expect(interruptedReceipt.exitCode, interruptedReceipt.diagnostic()).toBe(130);
      expect(interruptedReceipt.expReceipt(), interruptedReceipt.diagnostic()).toMatchObject({
        completion: "interrupted",
        createdRunIds: [active.runId],
      });

      const canonicalRecord = join(paths.projectRoot, ".niceeval", "record.sqlite");
      const canonicalBytes = await readFile(canonicalRecord);
      expect(canonicalBytes.includes(Buffer.from(unpublishedCanary, "utf8"))).toBe(false);

      const externalRecord = join(paths.projectRoot, "finished-record.sqlite");
      await rename(canonicalRecord, externalRecord);
      const externalAttemptReceipt = await niceeval.run([
        "query",
        "run",
        "--record",
        externalRecord,
        "--request",
        request,
      ]);
      expect(externalAttemptReceipt.exitCode, externalAttemptReceipt.diagnostic()).toBe(0);
      expect(externalAttemptReceipt.attempt()).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "attempt.get",
        issues: [],
        attempt: {
          locator: published.publication.attemptLocator,
          core: { outcome: "completed" },
        },
      });
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("用户 SIGINT 中断时保留已发布 Attempt 并解释未发布 slot [necase_XAJRPPHVE3PG7TBV]", async () => {
  await e2e.case("sigint-preserves-publication", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the active Run to be listed" }), process, "the active Run became visible");
      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const before = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the first Attempt publication" }), process, "the first Attempt publication became visible");
      const published = only(before.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(before));
      if (published.publication.state !== "published") throw new Error("Expected a published slot");

      expect(process.signal("SIGINT")).toBe(true);
      const interruptedReceipt = await process.done;
      expect(interruptedReceipt.exitCode, interruptedReceipt.diagnostic()).toBe(130);
      expect(interruptedReceipt.expReceipt(), interruptedReceipt.diagnostic()).toMatchObject({
        completion: "interrupted",
        createdRunIds: [active.runId],
      });
      const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
      const interrupted = receipt.runGetDocument();
      expect(interrupted.run).toMatchObject({ state: "interrupted", coverage: { expected: 2, published: 1, missing: 1 } });
      expect(only(interrupted.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(interrupted))).toMatchObject({
        publication: { attemptId: published.publication.attemptId, attemptLocator: published.publication.attemptLocator },
      });
      expect(only(interrupted.run.slots, (slot) => slot.publication.state === "absent", JSON.stringify(interrupted))).toMatchObject({
        attemptOrdinal: 1,
        publication: { state: "absent", reason: "interrupted-before-publication" },
      });
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("存在引用时拒绝删除 origin，删除依赖后可安全重试 [necase_AY5TKPWYF4GQ8EDT]", async () => {
  await e2e.case("reference-safe-delete", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const origin = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the origin Run to be listed" }), process, "the origin Run became visible");
      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const originShown = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", origin.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the origin Attempt publication" }), process, "the origin Attempt publication became visible");
      const published = only(originShown.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(originShown));
      if (published.publication.state !== "published") throw new Error("Expected a published slot");
      expect(process.signal("SIGINT")).toBe(true);
      const interrupted = await process.done;
      expect(interrupted.exitCode, interrupted.diagnostic()).toBe(130);

      const beforeReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(beforeReceipt.exitCode, beforeReceipt.diagnostic()).toBe(0);
      const known = new Set(beforeReceipt.runListDocument().runs.map((run) => run.runId));
      const accepted = await niceeval.run(["accept", published.publication.attemptLocator]);
      expect(accepted.exitCode, accepted.diagnostic()).toBe(0);
      const afterReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(afterReceipt.exitCode, afterReceipt.diagnostic()).toBe(0);
      const dependency = only(afterReceipt.runListDocument().runs, (run) => !known.has(run.runId), afterReceipt.diagnostic());
      expect(dependency).toMatchObject({ state: "completed", coverage: { expected: 1, published: 1, missing: 0 } });
      const dependencyReceipt = await niceeval.run(["run", "show", dependency.runId, "--json"]);
      expect(dependencyReceipt.exitCode, dependencyReceipt.diagnostic()).toBe(0);
      expect(only(dependencyReceipt.runGetDocument().run.slots, (slot) => slot.publication.state === "published", dependencyReceipt.diagnostic())).toMatchObject({
        publication: { state: "published", action: "accepted", attemptId: published.publication.attemptId, originRunId: origin.runId },
      });

      const refused = await niceeval.run(["run", "delete", origin.runId, "--yes", "--json"]);
      expect(refused.exitCode, refused.diagnostic()).not.toBe(0);
      expect(`${refused.stdout}\n${refused.stderr}`).toContain("run-referenced");
      expect(`${refused.stdout}\n${refused.stderr}`).toContain(dependency.runId);
      expect(`${refused.stdout}\n${refused.stderr}`).toContain(published.publication.attemptLocator);
      const retainedReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(retainedReceipt.exitCode, retainedReceipt.diagnostic()).toBe(0);
      expect(retainedReceipt.runListDocument().runs.map((run) => run.runId)).toContain(origin.runId);

      const deleteDependency = await niceeval.run(["run", "delete", dependency.runId, "--yes", "--json"]);
      expect(deleteDependency.exitCode, deleteDependency.diagnostic()).toBe(0);
      const deleteOrigin = await niceeval.run(["run", "delete", origin.runId, "--yes", "--json"]);
      expect(deleteOrigin.exitCode, deleteOrigin.diagnostic()).toBe(0);
      const finalReceipt = await niceeval.run(["run", "list", "--json"]);
      expect(finalReceipt.exitCode, finalReceipt.diagnostic()).toBe(0);
      expect(finalReceipt.runListDocument().runs.map((run) => run.runId)).not.toContain(origin.runId);
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});

test.concurrent("SIGKILL 后自动沿用已发布 Attempt，只执行缺失 slot 并可显式收口旧 Run [necase_H632V0FG1N2KEBJ5]", async () => {
  await e2e.case("sigkill-recovery", async ({ commands: { niceeval } }) => {
    const backend = await createLoopbackBackend();
    const process = niceeval.start(
      ["exp", "run-journey", "--rerun", "all", "--json"],
      { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
    );
    try {
      await whileRunning(backend.waitForAttempt(0), process, "the first Attempt reached its backend");
      const active = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "list", "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        return receipt.runListDocument().runs.find((run) => run.state === "active" && run.coverage.expected === 2);
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the active Run to be listed" }), process, "the active Run became visible");
      backend.completeAttempt(0);
      await whileRunning(backend.waitForAttempt(1), process, "the second Attempt reached its backend");
      const beforeKill = await whileRunning(pollUntil(async () => {
        const receipt = await niceeval.run(["run", "show", active.runId, "--json"]);
        expect(receipt.exitCode, receipt.diagnostic()).toBe(0);
        const document = receipt.runGetDocument();
        return document.run.coverage.published === 1 ? document : undefined;
      }, { timeoutMs: 20_000, intervalMs: 50, label: "the first Attempt publication" }), process, "the first Attempt publication became visible");
      const published = only(beforeKill.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(beforeKill));
      if (published.publication.state !== "published") throw new Error("Expected a published slot");

      expect(process.signal("SIGKILL")).toBe(true);
      const killed = await process.done;
      expect(killed.signal, killed.diagnostic()).toBe("SIGKILL");
      const activeReceipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(activeReceipt.exitCode, activeReceipt.diagnostic()).toBe(0);
      const stillActive = activeReceipt.runGetDocument();
      expect(stillActive.run).toMatchObject({ state: "active", coverage: { expected: 2, published: 1, missing: 1 } });
      expect(only(stillActive.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(stillActive))).toMatchObject({
        publication: { attemptLocator: published.publication.attemptLocator },
      });

      const recoveryPlanReceipt = await niceeval.run(["exp", "run-journey", "--dry", "--json"], {
        env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint },
      });
      expect(recoveryPlanReceipt.exitCode, recoveryPlanReceipt.diagnostic()).toBe(0);
      const recoveryPlan = decodeExpPlanDocument(recoveryPlanReceipt.json());
      expect(recoveryPlan, recoveryPlanReceipt.diagnostic()).toMatchObject({ total: 2, reused: 1 });
      expect(only(recoveryPlan.matrix.flatMap((row) => row.slots), (slot) => slot.state === "reused", JSON.stringify(recoveryPlan))).toMatchObject({
        state: "reused",
      });
      const resumed = niceeval.start(
        ["exp", "run-journey", "--json"],
        { env: { NICEEVAL_RUN_JOURNEY_ENDPOINT: backend.endpoint }, timeoutMs: 90_000 },
      );
      const dispatchedOrdinal = await whileRunning(Promise.race([
        backend.waitForAttempt(0, 2).then(() => 0 as const),
        backend.waitForAttempt(1, 2).then(() => 1 as const),
      ]), resumed, "the missing Attempt to be dispatched");
      expect(dispatchedOrdinal).toBe(1);
      backend.completeAttempt(1);
      const resumedReceipt = await resumed.done;
      expect(resumedReceipt.exitCode, resumedReceipt.diagnostic()).toBe(0);

      const resumedRunId = resumedReceipt.expReceipt().createdRunIds[0]!;
      const resumedRunReceipt = await niceeval.run(["run", "show", resumedRunId, "--json"]);
      expect(resumedRunReceipt.exitCode, resumedRunReceipt.diagnostic()).toBe(0);
      const resumedRun = resumedRunReceipt.runGetDocument();
      expect(resumedRun.run).toMatchObject({ state: "completed", coverage: { expected: 2, published: 2, missing: 0 } });
      expect(only(resumedRun.run.slots, (slot) =>
        slot.publication.state === "published" && slot.publication.action === "carried",
      JSON.stringify(resumedRun))).toMatchObject({
        attemptOrdinal: 0,
        publication: { attemptLocator: published.publication.attemptLocator, originRunId: active.runId },
      });
      expect(only(resumedRun.run.slots, (slot) =>
        slot.publication.state === "published" && slot.publication.action === "executed",
      JSON.stringify(resumedRun))).toMatchObject({ attemptOrdinal: 1 });

      const recovered = await niceeval.run(["run", "recover", active.runId, "--yes", "--json"]);
      expect(recovered.exitCode, recovered.diagnostic()).toBe(0);
      const recoveredReceipt = await niceeval.run(["run", "show", active.runId, "--json"]);
      expect(recoveredReceipt.exitCode, recoveredReceipt.diagnostic()).toBe(0);
      const recoveredRun = recoveredReceipt.runGetDocument();
      expect(recoveredRun.run).toMatchObject({ state: "interrupted", coverage: { expected: 2, published: 1, missing: 1 } });
      expect(only(recoveredRun.run.slots, (slot) => slot.publication.state === "published", JSON.stringify(recoveredRun))).toMatchObject({
        publication: { attemptLocator: published.publication.attemptLocator },
      });
      expect(only(recoveredRun.run.slots, (slot) => slot.publication.state === "absent", JSON.stringify(recoveredRun))).toMatchObject({
        publication: { state: "absent", reason: "interrupted-before-publication" },
      });

      const cleanupReference = await niceeval.run(["run", "delete", resumedRunId, "--yes", "--json"]);
      expect(cleanupReference.exitCode, cleanupReference.diagnostic()).toBe(0);
      const cleanupOrigin = await niceeval.run(["run", "delete", active.runId, "--yes", "--json"]);
      expect(cleanupOrigin.exitCode, cleanupOrigin.diagnostic()).toBe(0);
    } finally {
      await process.dispose();
      await backend.close();
    }
  });
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791082266&installation_model_id=431746&pr_number=215&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F215&signature=66877fd2884b28ca084ca1b57bc8d355c04f2c39e6aaba890691a95aa9b2aaac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
