### PR TITLE
fix(inspection): 保留部分可用的成本聚合

### DIFF
--- a/docs/engineering/agent-docs/README.md
+++ b/docs/engineering/agent-docs/README.md
@@ -90,7 +90,9 @@ Coding agent 在用户项目里接入 niceeval、编写配置和 Eval 时，如�
 2. **打包与发版时生成。**
    `packages/niceeval` 不声明 `prepare`。它的 `prepack` 运行 runtime、Report client、`build:index` 与 docs staging；普通 `pnpm install` 不生成发布面。某页缺 `description` 或 staging 清单、digest 不一致时，打包直接失败。
 3. **打包时只收 package closure。**
-   从 `packages/niceeval` 运行 `pnpm pack`；`files` 白名单收刚生成的 `INDEX.md` 与 staging 后的 `docs-site/zh/**`、`docs-site/images/**`。发布流程只移动并校验这一份 tarball，不再次 pack。
+   从 `packages/niceeval` 运行 `pnpm --config.node-linker=hoisted pack`；仓库默认的 isolated linker 不支持
+   `bundledDependencies`，不能省略这项 pack-local override。`files` 白名单收刚生成的 `INDEX.md` 与 staging 后的
+   `docs-site/zh/**`、`docs-site/images/**`。发布流程只移动并校验这一份 tarball，不再次 pack。
 
 ## 维护与验收
 
@@ -102,4 +104,6 @@ Coding agent 在用户项目里接入 niceeval、编写配置和 Eval 时，如�
   对发布闭包执行一次真实 `pnpm pack`，再建立开发链接并核对下游实际解析的 realpath；它不修改下游
   `package.json`，但 pnpm 会把开发 link 持久化到下游 workspace override 与 lockfile；这些机器本地路径
   通常不提交。手工 `pnpm link` 不会触发完整重建，容易让下游继续消费旧的预编译产物。
-- 验收：`pnpm lint:docs-site` 绿；发版前抽查 `pnpm pack --dry-run`（或 `npm pack --dry-run`）的文件清单包含 `INDEX.md`、`docs-site/zh/**` 与 `docs-site/images/**`。
+- 验收：`pnpm lint:docs-site` 绿；发版前抽查 `pnpm --config.node-linker=hoisted pack --dry-run` 的文件清单包含
+  `INDEX.md`、`docs-site/zh/**` 与 `docs-site/images/**`。`npm pack` 不应用于候选验收：它不会按 pnpm 的
+  `bundledDependencies` 闭包产出可注入候选。

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -56,6 +56,10 @@ Attempt `refs` 始终一起交付。状态穷尽为 `available | partial | unava
 producer/固定事实族 无此能力是 `unsupported`；已选择事实无法解释是 `failed`。points 的 `value` 是 earned，
 `bounds.max` 是 possible；consumer 不从 Assertion 或其它 scalar 重算它。
 
+成本聚合不会混合 observed 与 estimated。它选择 `samples` 最多的单一 source；`samples` 相同时优先
+observed。只要所选 source 未命中全部 eligible slot，`state` 就是 `partial`，但仍保留已知的 `value`、
+`samples`、`total`、`bounds`、`source`、`refs` 与 `issues`；只有两个 source 都没有样本时才是 `unavailable`。
+
 `overview.cells[].members[].score.value` 是一个 selected Attempt 的 earned 真值。
 `overview.cells[].score.value` 是同一 Experiment × Eval 中 eligible Attempt score 的 mean。
 

--- a/e2e/adapter/claude-code/experiments/mcp.ts
+++ b/e2e/adapter/claude-code/experiments/mcp.ts
@@ -6,12 +6,14 @@ import { sandbox } from "../sandbox.ts";
 const MCP_HTTP_PORT = 32131;
 const MCP_HTTP_LOG = "/tmp/niceeval-e2e-mcp-http.log";
 const MCP_HTTP_PID = "/tmp/niceeval-e2e-mcp-http.pid";
+const MCP_FIXTURE_ROOT = "/tmp/niceeval-e2e-mcp-fixture";
+const MCP_FIXTURE_ENTRY = `${MCP_FIXTURE_ROOT}/node_modules/@modelcontextprotocol/server-everything/dist/index.js`;
 const agent = claudeCodeAgent({
   apiKey: process.env.ANTHROPIC_API_KEY,
   baseUrl: process.env.ANTHROPIC_BASE_URL,
   env: claudeCodeProviderEnv,
   mcpServers: [
-    { name: "e2e-stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-everything@2026.7.4"] },
+    { name: "e2e-stdio", command: "node", args: [MCP_FIXTURE_ENTRY] },
     { name: "e2e-http", url: `http://127.0.0.1:${MCP_HTTP_PORT}/mcp` },
   ],
   postSetup: [
@@ -38,10 +40,12 @@ const agent = claudeCodeAgent({
           rm -f ${MCP_HTTP_PID} ${MCP_HTTP_LOG}
         `);
       });
-      // 这个启动同时预热 e2e-stdio 所用的同一份 npx 包缓存。
+      // 先完成整个 fixture 安装，再启动两种 transport。这样 registry 或依赖解析失败
+      // 会归因到 agent.setup，不会消耗 Claude Code 自己的 MCP startup window。
       await sb.runShellOrThrow(`
         set -eu
-        nohup env PORT=${MCP_HTTP_PORT} npx -y @modelcontextprotocol/server-everything@2026.7.4 streamableHttp >${MCP_HTTP_LOG} 2>&1 &
+        npm install --prefix ${MCP_FIXTURE_ROOT} --no-save --no-package-lock @modelcontextprotocol/server-everything@2026.7.4
+        nohup env PORT=${MCP_HTTP_PORT} node ${MCP_FIXTURE_ENTRY} streamableHttp >${MCP_HTTP_LOG} 2>&1 &
         echo "$!" >${MCP_HTTP_PID}
         for attempt in $(seq 1 60); do
           status="$(curl --silent --connect-timeout 1 --max-time 2 --output /dev/null --write-out '%{http_code}' http://127.0.0.1:${MCP_HTTP_PORT}/mcp || true)"

--- a/e2e/adapter/codex-cli/experiments/mcp.ts
+++ b/e2e/adapter/codex-cli/experiments/mcp.ts
@@ -2,12 +2,25 @@ import { defineExperiment } from "niceeval";
 import { codexAgent } from "niceeval/adapter";
 import { sandbox } from "../sandbox.ts";
 
+const MCP_FIXTURE_ROOT = "/tmp/niceeval-e2e-mcp-fixture";
+const MCP_FIXTURE_ENTRY = `${MCP_FIXTURE_ROOT}/node_modules/@modelcontextprotocol/server-everything/dist/index.js`;
+
 const agent = codexAgent({
   apiKey: process.env.OPENAI_API_KEY,
   baseUrl: process.env.OPENAI_BASE_URL,
   mcpServers: [
-    { name: "e2e", command: "npx", args: ["-y", "@modelcontextprotocol/server-everything@2026.7.4"] },
+    { name: "e2e", command: "node", args: [MCP_FIXTURE_ENTRY] },
     { name: "deepwiki", url: "https://mcp.deepwiki.com/mcp" },
+  ],
+  postSetup: [
+    async (sb) => {
+      // Install before Codex starts the MCP process. A cold npx here used Codex's
+      // shorter MCP startup window for registry resolution and obscured install
+      // failures as tool-call mismatches.
+      await sb.runShellOrThrow(
+        `npm install --prefix ${MCP_FIXTURE_ROOT} --no-save --no-package-lock @modelcontextprotocol/server-everything@2026.7.4`,
+      );
+    },
   ],
 });
 

--- a/e2e/inspection/agents/deterministic.ts
+++ b/e2e/inspection/agents/deterministic.ts
@@ -34,6 +34,21 @@ export function deterministicAgent(): Agent {
         if (ctx.signal.aborted) throw new Error("inspection fixture aborted");
         await ctx.sandbox.writeText("inspection-agent-change.txt", "inspection diff evidence\n");
         ctx.session.capture("inspection-fixture");
+        const attemptIndex = ctx.attempt?.index ?? 0;
+        const hasUsage = ctx.experimentId !== "inspection-multi" ||
+          (ctx.evalId === "inspection" ? attemptIndex < 2 : attemptIndex === 0);
+        const hasObservedCost = ctx.experimentId === "main" ||
+          (ctx.experimentId === "inspection-multi" && attemptIndex === 0);
+        const usage = !hasUsage
+          ? {}
+          : {
+              usage: {
+                inputTokens: 10,
+                outputTokens: 5,
+                requests: 1,
+                ...(hasObservedCost ? { costUSD: 0.00003 } : {}),
+              },
+            };
         return {
           status: "completed",
           evidenceCoverage: {
@@ -42,11 +57,7 @@ export function deterministicAgent(): Agent {
               reason: "fixture conversation history is intentionally partial",
             },
           },
-          usage: {
-            inputTokens: 10,
-            outputTokens: 5,
-            requests: 1,
-          },
+          ...usage,
           events: [
             {
               type: "operation.started",

--- a/e2e/inspection/evals/overview/secondary.eval.ts
+++ b/e2e/inspection/evals/overview/secondary.eval.ts
@@ -4,6 +4,7 @@ import { equals } from "niceeval/expect";
 export default defineScoreEval({
   description: "overview-secondary: 固定第二个计分 Eval，验证 Overview 跨题总分",
   async test(t) {
+    await t.send("produce secondary overview evidence");
     t.check("secondary", equals("secondary"))
       .score(2)
       .label("Secondary score contribution");

--- a/e2e/inspection/experiments/inspection-multi.ts
+++ b/e2e/inspection/experiments/inspection-multi.ts
@@ -6,6 +6,6 @@ export default defineExperiment({
   agent: deterministicAgent(),
   sandbox: deterministicSandbox,
   model: "inspection-fixture-v1",
-  evals: ["inspection", "overview-secondary"],
-  attempts: 2,
+  evals: ["inspection", "overview/secondary"],
+  attempts: 3,
 });

--- a/e2e/inspection/test/inspection-query.test.ts
+++ b/e2e/inspection/test/inspection-query.test.ts
@@ -84,12 +84,12 @@ test("machine consumer 发现固定 catalog，再从 project Run 读取 origin A
         multi.expEvalEvents(),
         (event) => event.evalId === "inspection",
         multi.diagnostic(),
-      )).toMatchObject({ verdict: "passed", attempts: 2, passed: 2 });
+      )).toMatchObject({ verdict: "passed", attempts: 3, passed: 3 });
       expect(only(
         multi.expEvalEvents(),
-        (event) => event.evalId === "overview-secondary",
+        (event) => event.evalId === "overview/secondary",
         multi.diagnostic(),
-      )).toMatchObject({ verdict: "passed", attempts: 2, passed: 2 });
+      )).toMatchObject({ verdict: "passed", attempts: 3, passed: 3 });
 
       const discovery = await niceeval.run(["query", "discover"]);
       expect(discovery.exitCode, discovery.diagnostic()).toBe(0);
@@ -176,8 +176,8 @@ test("machine consumer 发现固定 catalog，再从 project Run 读取 origin A
         },
         costUSD: {
           state: "available",
-          value: 0.00002,
-          source: "estimated",
+          value: 0.00003,
+          source: "observed",
           samples: 1,
           total: 1,
           basis: "slot",
@@ -257,16 +257,16 @@ test("machine consumer 发现固定 catalog，再从 project Run 读取 origin A
       const multiInspectionLocators = multiInspectionCell.members
         .map(({ publication }) => publication.attemptLocator)
         .toSorted();
-      expect(multiInspectionLocators).toHaveLength(2);
-      expect(new Set(multiInspectionLocators).size).toBe(2);
+      expect(multiInspectionLocators).toHaveLength(3);
+      expect(new Set(multiInspectionLocators).size).toBe(3);
       expect(multiInspectionCell).toMatchObject({
         evaluationKind: "points",
-        denominator: { expected: 2, observed: 2, classified: 2, missing: 0 },
+        denominator: { expected: 3, observed: 3, classified: 3, missing: 0 },
         score: {
           state: "available",
           value: 37.111111111111114,
-          samples: 2,
-          total: 2,
+          samples: 3,
+          total: 3,
           basis: "slot",
           issues: [],
           refs: multiInspectionLocators.map((memberLocator) => ({
@@ -275,7 +275,22 @@ test("machine consumer 发现固定 catalog，再从 project Run 读取 origin A
           unit: "points",
           bounds: { min: 0, max: 43.111111111111114 },
         },
+        costUSD: {
+          state: "partial",
+          value: 0.00004,
+          source: "estimated",
+          samples: 2,
+          total: 3,
+          basis: "slot",
+          issues: [],
+          refs: expect.any(Array),
+          unit: "USD",
+          bounds: { min: 0, max: 0.00004 },
+        },
       });
+      expect(multiInspectionCell.costUSD.refs).toHaveLength(2);
+      expect(multiInspectionCell.costUSD.refs.every(({ identity }) =>
+        multiInspectionLocators.includes(identity.locator))).toBe(true);
       for (const memberLocator of multiInspectionLocators) {
         expect(only(
           multiInspectionCell.members,
@@ -304,23 +319,34 @@ test("machine consumer 发现固定 catalog，再从 project Run 读取 origin A
       }
       const multiSecondaryCell = only(
         overviewDocument.overview.cells,
-        (cell) => cell.experimentId === "inspection-multi" && cell.evalId === "overview-secondary",
+        (cell) => cell.experimentId === "inspection-multi" && cell.evalId === "overview/secondary",
         overview.diagnostic(),
       );
       const multiSecondaryLocators = multiSecondaryCell.members
         .map(({ publication }) => publication.attemptLocator)
         .toSorted();
-      expect(multiSecondaryLocators).toHaveLength(2);
-      expect(new Set(multiSecondaryLocators).size).toBe(2);
+      expect(multiSecondaryLocators).toHaveLength(3);
+      expect(new Set(multiSecondaryLocators).size).toBe(3);
       expect(multiSecondaryCell).toMatchObject({
         score: {
           state: "available",
           value: 2,
-          samples: 2,
-          total: 2,
+          samples: 3,
+          total: 3,
           basis: "slot",
           bounds: { min: 0, max: 2 },
         },
+      });
+      expect(multiSecondaryCell.costUSD).toMatchObject({
+        state: "partial",
+        value: 0.00003,
+        source: "observed",
+        samples: 1,
+        total: 3,
+        basis: "slot",
+        issues: [],
+        unit: "USD",
+        bounds: { min: 0, max: 0.00003 },
       });
       for (const memberLocator of multiSecondaryLocators) {
         expect(only(
@@ -355,6 +381,33 @@ test("machine consumer 发现固定 catalog，再从 project Run 读取 origin A
         basis: "eval",
         unit: "points",
         bounds: { min: 0, max: 45.111111111111114 },
+      });
+      expect(multiExperiment.costUSD).toMatchObject({
+        state: "partial",
+        value: 0.00006000000000000001,
+        source: "estimated",
+        samples: 3,
+        total: 6,
+        basis: "slot",
+        issues: [],
+        unit: "USD",
+        bounds: { min: 0, max: 0.00006000000000000001 },
+      });
+      expect(only(
+        multiExperiment.groups,
+        (group) => group.groupPath.join("/") === "overview",
+        overview.diagnostic(),
+      ).costUSD).toMatchObject(multiSecondaryCell.costUSD);
+      expect(overviewDocument.overview.totals.costUSD).toMatchObject({
+        state: "partial",
+        value: 0.0001,
+        source: "estimated",
+        samples: 5,
+        total: 8,
+        basis: "slot",
+        issues: [],
+        unit: "USD",
+        bounds: { min: 0, max: 0.0001 },
       });
 
       const requestPath = join(projectRoot, "run-summary.request.json");

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/certificate.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "candidateSha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+  "greenReceipt": "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-1.json",
+      "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-2.json",
+      "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-4.json",
+      "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-6.json",
+    "singleCase": "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-cost-bug/artifacts/e2e/inspection-cost-takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-cost-bug/artifacts/e2e/inspection-cost-takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-cost-bug/artifacts/e2e/inspection-cost-takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-cost-bug/artifacts/e2e/inspection-cost-takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-cost-bug/artifacts/e2e/inspection-cost-takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-cost-bug/artifacts/e2e/inspection-cost-takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-cost-bug/artifacts/e2e/inspection-cost-takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "0b6974cde34e4de96487ba0ca7ad2abcede7304fdfc7fba066f2a3157e6d0595"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/green.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/green.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+    "sri": "sha512-iMeoEjnF/1HS+JI9doM95Q7U70K+lyeTKa5+dCMuwe8cJkIBGusoIZAfeJQuWtshPQ8YjBMwKdQsYamyqgQujA=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/inspection-query.test.ts",
+      "--testNamePattern",
+      "^machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 \\[necase_79TQ9VGG316D8FK0\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-dXO2yL/runs/takeover/target-single/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2409792 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2409794 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2409822 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "c498a8a7-9a61-45d8-8fd0-0c1873f7af25",
+  "receiptSha256": "6d530c217f2927b2cd3d3e3dc847de382ffbc813b0fe492adcfe22484c829421"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/inventory.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/inventory.json
@@ -1,0 +1,45 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "inspection",
+  "argv": [
+    "/nix/store/k3nz3s314bipvqbcbw3faq823hxpwbn1-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-VeObcW/repos/inspection/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+  "files": [
+    "e2e/inspection/test/inspection-query.test.ts",
+    "e2e/inspection/test/show-cli.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/inspection-query.test.ts",
+      "titlePath": [
+        "machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]"
+      ],
+      "caseId": "necase_79TQ9VGG316D8FK0"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-cli.test.ts",
+      "titlePath": [
+        "用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]"
+      ],
+      "caseId": "necase_9FHHSQTVB492P8DS"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/red.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/red.json
@@ -1,0 +1,52 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "50d0a5ec31d6d1c8a370231db5c870245fae706e1a44065f7c6aa54cccdf9e0f",
+    "sri": "sha512-GZhbDpwCyXQzyCzJD81S5QUtnaTpyWJqLfebardEF1oQgBVU8qnizh/HDIcEnvOIqEk+fgHFnMjWJUcXlADSQQ=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/inspection-query.test.ts",
+      "--testNamePattern",
+      "^machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 \\[necase_79TQ9VGG316D8FK0\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-QfB3nD/runs/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 2411758 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1cd85891-fab4-46da-b992-e7cca44fcce0",
+  "receiptSha256": "3504aec40fd18bdd836c8b19d51937f625dab935b48f2ea55bea59e6c2d285ac"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-1.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-1.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+    "sri": "sha512-iMeoEjnF/1HS+JI9doM95Q7U70K+lyeTKa5+dCMuwe8cJkIBGusoIZAfeJQuWtshPQ8YjBMwKdQsYamyqgQujA=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/inspection-query.test.ts",
+      "--testNamePattern",
+      "^machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 \\[necase_79TQ9VGG316D8FK0\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-dXO2yL/runs/takeover/isolated-copy-1/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2395039 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2395040 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2395229 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "186e1d63-60b1-4914-9e5c-37039822192e",
+  "receiptSha256": "4e5a03b89b4857da85105e9b2f00eca64e2e45abfa86bddcb0aec2f28c1bde34"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-2.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-2.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+    "sri": "sha512-iMeoEjnF/1HS+JI9doM95Q7U70K+lyeTKa5+dCMuwe8cJkIBGusoIZAfeJQuWtshPQ8YjBMwKdQsYamyqgQujA=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/inspection-query.test.ts",
+      "--testNamePattern",
+      "^machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 \\[necase_79TQ9VGG316D8FK0\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-dXO2yL/runs/takeover/isolated-copy-2/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2397575 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2397576 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2397603 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "0fdc770c-527a-42f3-8735-3034280a711a",
+  "receiptSha256": "d1079f439dcdfccea8ee5ff784d6e20a07cec780d50c79b2dd87a98602d7f8f0"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-3.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-3.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+    "sri": "sha512-iMeoEjnF/1HS+JI9doM95Q7U70K+lyeTKa5+dCMuwe8cJkIBGusoIZAfeJQuWtshPQ8YjBMwKdQsYamyqgQujA=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/inspection-query.test.ts",
+      "--testNamePattern",
+      "^machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 \\[necase_79TQ9VGG316D8FK0\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-dXO2yL/runs/takeover/isolated-copy-3/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2399077 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2399078 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2399124 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "ad11e577-2324-4274-887c-aa033afbf7dd",
+  "receiptSha256": "0f2607e0d06de2e369f6cdd523316df19cdd332102e08872ff2cf14feabdaa71"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-4.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-4.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+    "sri": "sha512-iMeoEjnF/1HS+JI9doM95Q7U70K+lyeTKa5+dCMuwe8cJkIBGusoIZAfeJQuWtshPQ8YjBMwKdQsYamyqgQujA=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/inspection-query.test.ts",
+      "--testNamePattern",
+      "^machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 \\[necase_79TQ9VGG316D8FK0\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-dXO2yL/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2400831 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2400832 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2400897 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2402371 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "ffa547bc-931e-484b-a022-0d912a793a5f",
+  "receiptSha256": "128d32aeba37c3ae4176245066c2c15a4976d04753453f18a212dcb92417d70e"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-5.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-5.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+    "sri": "sha512-iMeoEjnF/1HS+JI9doM95Q7U70K+lyeTKa5+dCMuwe8cJkIBGusoIZAfeJQuWtshPQ8YjBMwKdQsYamyqgQujA=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/inspection-query.test.ts",
+      "--testNamePattern",
+      "^machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 \\[necase_79TQ9VGG316D8FK0\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-dXO2yL/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2400831 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2400832 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2400897 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2402371 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "58b781c5-c046-4ae4-8389-d952e8021850",
+  "receiptSha256": "491998b30a4fc72331889ac88d24369dd1f5826d949dc0fb556acec69a400486"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-6.json
+++ b/e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/reliability-6.json
@@ -1,0 +1,62 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0",
+  "caseId": "necase_79TQ9VGG316D8FK0",
+  "inventoryDigest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76",
+  "candidate": {
+    "gitSha": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "sha256": "15ef4c4fa4a49dc1011477ca3da323f937f6c9271ecd803ef72ae307a15a6a24",
+    "sri": "sha512-iMeoEjnF/1HS+JI9doM95Q7U70K+lyeTKa5+dCMuwe8cJkIBGusoIZAfeJQuWtshPQ8YjBMwKdQsYamyqgQujA=="
+  },
+  "source": {
+    "checkout": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+    "testFileSha256": "07a619adb8fd071021b5bbdb6827cb735cede41c0e8c1251402e0afbab218d1f",
+    "sidecarSha256": "a0cbc388e60c4c185551f20bad33749ecd696402421d524fdf69b8b35683b383"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-dXO2yL/runs/takeover/repo-default-parallel/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2403757 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2403765 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2403831 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "3d17c1ac-5bfb-4188-96c2-06b203a632b3",
+  "receiptSha256": "46e76fc355e7657bd065f94cb7c5cd3bc16c7dba7d924f8ce8c26183f7d36f98"
+}

--- a/e2e/inspection/test/inspection-query.test.ts.cases.evidence.json
+++ b/e2e/inspection/test/inspection-query.test.ts.cases.evidence.json
@@ -1,0 +1,25 @@
+{
+  "format": "niceeval.e2e-case-evidence-index/v1",
+  "current": {
+    "necase_79TQ9VGG316D8FK0": {
+      "memory/inspection-overview-partial-cost-drops-known-samples.md": {
+        "red": {
+          "path": "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/red.json",
+          "digest": "sha256:b1751f25eea3dfd69f4178113f3404a73dc86caee22b85a5f8d3b0e26acdbb6f"
+        },
+        "green": {
+          "path": "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/green.json",
+          "digest": "sha256:d8ac549b59b03e37299e18194ddc1f83d513272453fa7fbf6a88c4016e21f332"
+        },
+        "certificate": {
+          "path": "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/certificate.json",
+          "digest": "sha256:2ae4dc131d71d4fe765649c36adf4091a893a3c2b6818f6ad6fde1156f5c89c9"
+        },
+        "inventory": {
+          "path": "e2e/inspection/test/inspection-query.test.ts.case-evidence/necase_79TQ9VGG316D8FK0/memory_inspection-overview-partial-cost-drops-known-samples.md/nered_MEV73PEC01ZTZ08D-netake_Y35M8M11HP6J5GW9/inventory.json",
+          "digest": "sha256:514cefdf0f149f27dbaa215b0436aca809223fa1043f36374b834b7766132c76"
+        }
+      }
+    }
+  }
+}

--- a/e2e/inspection/test/inspection-query.test.ts.cases.json
+++ b/e2e/inspection/test/inspection-query.test.ts.cases.json
@@ -6,6 +6,7 @@
       "owner": "docs/engineering/testing/e2e/inspection.md#inspection-query",
       "regressions": [
         "memory/analysis-usage-projection-conflates-conversation-limitations.md",
+        "memory/inspection-overview-partial-cost-drops-known-samples.md",
         "memory/inspection-query-missing-overview-and-trace-detail.md"
       ],
       "issues": []
@@ -21,6 +22,15 @@
         "owner": "docs/engineering/testing/e2e/inspection.md#inspection-query",
         "legacySourceDigest": "sha256:18eee253f959f241ef0965265c031c9019360efdad0f7f263b7e1bff39bac9e4",
         "mappingDigest": "sha256:3f47cf12dfb7eedf325b5ad2020b991db79e015c6e0f9f26766fadfac51a4402"
+      }
+    },
+    {
+      "caseId": "necase_79TQ9VGG316D8FK0",
+      "atCommit": "debfaf550ad16f7ac6f17429309e2c038dc6b5ba",
+      "transactionId": "netxn_fcb5e65addb14a919a93bf122382fbbf",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/inspection-overview-partial-cost-drops-known-samples.md"
       }
     }
   ],

--- a/memory/inspection-overview-partial-cost-drops-known-samples.md
+++ b/memory/inspection-overview-partial-cost-drops-known-samples.md
@@ -1,0 +1,27 @@
+---
+format: niceeval.memory/v1
+id: inspection-overview-partial-cost-drops-known-samples
+title: Inspection Overview drops known costs when coverage is partial
+createdAt: 2026-09-04
+kind:
+  type: problem
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - nered_MEV73PEC01ZTZ08D
+      - netake_Y35M8M11HP6J5GW9
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0"]}
+promotions: []
+---
+## Problem
+
+Inspection `overview.get` returns `unavailable` with a null value when an aggregate contains known observed or estimated cost samples plus one or more Attempts without cost data. Cell, Experiment, path-group, and totals therefore discard paid-cost evidence that remains valid.
+
+## Root cause
+
+`costForSlots` required one cost source to cover every selected subject before choosing it. That condition conflated incomplete coverage with absence: as soon as one eligible Attempt lacked both sources, the function selected no source and erased all known samples.
+
+## Required behavior
+
+Cost aggregation keeps observed and estimated facts separate, chooses the source with the greatest sample coverage, and prefers observed when coverage ties. Missing samples make the metric `partial`, while known `value`, `samples`, `total`, `bounds`, `source`, Attempt `refs`, and `issues` remain observable at member, cell, Experiment, path-group, and totals scopes.

--- a/packages/e2e-runner/src/red-evidence.ts
+++ b/packages/e2e-runner/src/red-evidence.ts
@@ -36,7 +36,13 @@ export interface RedEvidenceSummary {
 }
 
 export class RedEvidenceError extends Data.TaggedError("RedEvidenceError")<{ readonly detail: string }> {}
-const failure = (cause: unknown): RedEvidenceError => new RedEvidenceError({ detail: cause instanceof Error ? cause.message : String(cause) });
+const failure = (cause: unknown): RedEvidenceError => new RedEvidenceError({
+  detail: typeof cause === "object" && cause !== null && "detail" in cause && typeof cause.detail === "string"
+    ? cause.detail
+    : cause instanceof Error
+      ? cause.message
+      : String(cause),
+});
 
 const checkoutHead = (root: string): Effect.Effect<string, RedEvidenceError, OwnedProcess | import("effect").Scope.Scope> =>
   runOwnedProcess(["git", "rev-parse", "HEAD"], { cwd: root, env: process.env, output: "capture", stream: false, timeoutMs: 10_000 }).pipe(
@@ -94,6 +100,9 @@ export const runRedEvidence = (options: RedEvidenceOptions): Effect.Effect<RedEv
   const repoResult = summary.results[0]!;
   const repoReceiptText = yield* fileSystem.readFileString(repoResult.receiptPath).pipe(Effect.mapError(failure));
   const repoReceipt = yield* decodeReceipt(repoReceiptText, repoResult.receiptPath);
+  if (repoReceipt.category !== "regression") {
+    return yield* Effect.fail(new RedEvidenceError({ detail: repoReceipt.detail }));
+  }
   const regression = yield* Effect.try({ try: () => validateExpectedRegression(repoReceipt), catch: failure });
   const receipt = signFormalCaseReceipt({
     format: "niceeval.e2e-case-receipt/v1", mode: "formal", observation: "red", selector: options.selector, caseId: selected.caseId, inventoryDigest: inventory.digest,

--- a/packages/niceeval/src/inspection/overview.ts
+++ b/packages/niceeval/src/inspection/overview.ts
@@ -621,9 +621,9 @@ function costForSlots(slots: readonly SelectedSlot[]): InspectionCostMetricValue
   const subjects = [...unique.values()];
   const observed = subjects.filter(({ analysis }) => analysis.costUSD.observed !== null);
   const estimated = subjects.filter(({ analysis }) => analysis.costUSD.estimated !== null);
-  const source = subjects.length > 0 && observed.length === subjects.length
+  const source = observed.length >= estimated.length && observed.length > 0
     ? "observed" as const
-    : subjects.length > 0 && estimated.length === subjects.length
+    : estimated.length > 0
       ? "estimated" as const
       : null;
   const valued = source === "observed" ? observed : source === "estimated" ? estimated : [];
@@ -633,7 +633,11 @@ function costForSlots(slots: readonly SelectedSlot[]): InspectionCostMetricValue
   return Object.freeze({
     value,
     source,
-    state: source === null ? "unavailable" as const : "available" as const,
+    state: source === null
+      ? "unavailable" as const
+      : valued.length < subjects.length
+        ? "partial" as const
+        : "available" as const,
     samples: valued.length,
     total: subjects.length,
     basis: "slot" as const,


### PR DESCRIPTION
<!-- niceeval:pr-body
base: debfaf550ad16f7ac6f17429309e2c038dc6b5ba
templateSha256: eb6229addd88cc656e34ff37690eeafb0349afae4be1139547c919be122cacb2
head: fc07b5c43cd6c718a9b9dbf786100923bd64e0a2
-->

## Problem

- User goal: 在 overview.get 中比较各 Experiment 的质量与成本，即使少数 Attempt 没有成本事实也能看到其余已知费用。
- Current limitation: 任一 eligible Attempt 缺少 observed 与 estimated 成本时，cell、Experiment、group 与 totals 会把全部已知成本降为 unavailable。
- Required capability: 成本聚合必须保持 observed/estimated 单一口径，选择样本更多的来源，并用 partial 表达缺失而不丢弃已知值。
- User outcome: 用户无需重跑 Attempt，即可从现有 Record 读取可审计的部分成本、样本数、边界和下钻引用。

## Use cases

### Changed

#### Case: 比较质量与成本

##### Starting state

```text
Record 中同一 Experiment 含多个已发布 Attempt；部分 Attempt 有 observed 或 estimated USD cost，另一些没有成本事实。
```

##### Action

```sh
niceeval query run --request overview.json
```

##### Result

```text
overview.get 在各层返回单一 source 的已知合计；样本不完整时 state 为 partial，并保留 value、samples、total、bounds 与 refs。
```

这让既有 Record 的已知成本继续可比较；没有成本的 Attempt 不会被伪装成零，也不会抹掉其它样本。 [Canonical Use Case](docs/feature/inspection/use-case/比较质量与成本.md).

## Observable behavior and data contracts

### Changed

#### Case: overview.get 部分成本聚合

##### Before

```json
niceeval query run --request overview.json
```

```text
"costUSD":{"state":"unavailable","value":null,"source":null,"samples":0,"total":36}
```

##### After

```json
niceeval query run --request overview.json
```

```text
"costUSD":{"state":"partial","value":0.42,"source":"estimated","samples":35,"total":36}
```

##### User impact

已有 35 条可计价 Attempt、1 条缺失成本时，用户现在能看到 35 条的已知合计和明确缺口，无需重跑评测。

## Package scripts

### Changed

#### Case: 无效候选的 red evidence 诊断

##### Before

```sh
pnpm e2e evidence red --candidate invalid.tgz ...
```

```text
E2ECliError:
```

##### After

```sh
pnpm e2e evidence red --candidate invalid.tgz ...
```

```text
E2ECliError: Candidate injection failed: missing bundled dependency ...
```

##### User impact

贡献者能直接看到候选注入失败的原始原因，并且 infra receipt 不会被误判为回归红灯。

## Tests

### `e2e/inspection/test/inspection-query.test.ts`

#### `e2e/inspection/test/inspection-query.test.ts#necase_79TQ9VGG316D8FK0`

overview.get 在成本样本不完整时保留单一来源的已知值，并在各聚合层返回 partial。 It exercises 安装后的 niceeval query run 公开 CLI。 and asserts estimated 样本更多时选择 estimated；样本数相同时选择 observed；cell、Experiment、group 与 totals 保留 value、samples、total、bounds、source 与 refs。. Deleting this case would allow 不读取 SQLite 或私有 Record 文件，不从 member scalar 在测试中重算聚合。. The final contract is [docs/feature/inspection/cli.md#niceeval-query](docs/feature/inspection/cli.md#niceeval-query). It also prevents the regression recorded in [memory/inspection-overview-partial-cost-drops-known-samples.md](memory/inspection-overview-partial-cost-drops-known-samples.md).

```ts
// rerun: pnpm e2e test --repo inspection -- --run test/inspection-query.test.ts

import { only } from "@niceeval/testkit";
import { access, readFile, writeFile } from "node:fs/promises";
import { join } from "node:path";
import { expect, test } from "vitest";
import { inspectionCaseArtifacts, inspectionE2E } from "./support.ts";

const OPERATION_CATALOG = [
  "overview.get",
  "experiment.get",
  "runs.list",
  "run.get",
  "run.summary",
  "run.overview",
  "attempt.get",
  "attempt.assertion.detail",
  "attempt.trace",
  "attempt.trace.detail",
  "attempt.timing",
  "attempt.usage",
  "attempt.diff",
  "attempt.sources",
  "attempt.artifacts",
  "runs.compare",
] as const;

test("machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]", async () => {
  await inspectionE2E.case(
    "inspection-query",
    { artifacts: inspectionCaseArtifacts() },
    async ({ paths: { projectRoot }, commands: { niceeval } }) => {
      const run = await niceeval.run(["exp", "main", "--rerun", "all", "--json"]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      expect(run.expReceipt(), run.diagnostic()).toMatchObject({ completion: "completed" });
      const runId = only(run.expReceipt().createdRunIds, () => true, run.diagnostic());
      const attempt = only(
        run.expEvalEvents(),
        (event) => event.evalId === "inspection",
        run.diagnostic(),
      );
      expect(attempt).toMatchObject({ verdict: "passed" });
      const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;

      const mainExperimentPath = join(projectRoot, "experiments", "main.ts");
      const mainExperiment = await readFile(mainExperimentPath, "utf8");
      await writeFile(
        mainExperimentPath,
        mainExperiment.replace('labels: { memory: "origin" }', 'labels: { memory: "current" }'),
        "utf8",
      );

      const carried = await niceeval.run(["exp", "main", "--json"]);
      expect(carried.exitCode, carried.diagnostic()).toBe(0);
      expect(carried.expReceipt(), carried.diagnostic()).toMatchObject({ completion: "completed" });
      const carriedRunId = only(carried.expReceipt().createdRunIds, () => true, carried.diagnostic());
      const carriedStart = only(
        carried.ndjson<{ readonly event?: string; readonly total?: number; readonly reused?: number }>(),
        (event) => event.event === "start",
        carried.diagnostic(),
      );
      expect(carriedRunId).not.toBe(runId);
      expect(carriedStart).toMatchObject({ event: "start", total: 1, reused: 1 });

      const alternate = await niceeval.run(["exp", "alternate", "--rerun", "all", "--json"]);
      expect(alternate.exitCode, alternate.diagnostic()).toBe(0);
      expect(alternate.expReceipt(), alternate.diagnostic()).toMatchObject({ completion: "completed" });
      const alternateRunId = only(alternate.expReceipt().createdRunIds, () => true, alternate.diagnostic());
      const alternateAttempt = only(
        alternate.expEvalEvents(),
        (event) => event.evalId === "inspection",
        alternate.diagnostic(),
      );
      expect(alternateAttempt).toMatchObject({ verdict: "passed" });
      const alternateLocator = alternateAttempt.locator.startsWith("@")
        ? alternateAttempt.locator
        : `@${alternateAttempt.locator}`;

      const multi = await niceeval.run(["exp", "inspection-multi", "--rerun", "all", "--json"]);
      expect(multi.exitCode, multi.diagnostic()).toBe(0);
      expect(multi.expReceipt(), multi.diagnostic()).toMatchObject({ completion: "completed" });
      const multiRunId = only(multi.expReceipt().createdRunIds, () => true, multi.diagnostic());
      expect(only(
        multi.expEvalEvents(),
        (event) => event.evalId === "inspection",
        multi.diagnostic(),
      )).toMatchObject({ verdict: "passed", attempts: 3, passed: 3 });
      expect(only(
        multi.expEvalEvents(),
        (event) => event.evalId === "overview/secondary",
        multi.diagnostic(),
      )).toMatchObject({ verdict: "passed", attempts: 3, passed: 3 });

      const discovery = await niceeval.run(["query", "discover"]);
      expect(discovery.exitCode, discovery.diagnostic()).toBe(0);
      const discoveryDocument = discovery.queryDiscovery();
      expect(discovery.stdout).toBe(`${JSON.stringify(discoveryDocument)}\n`);
      expect(discoveryDocument.protocol).toBe("niceeval.query/v1");
      expect(discoveryDocument.operations.map(({ id }) => id).toSorted()).toEqual(
        [...OPERATION_CATALOG].sort(),
      );

      const sourceBoundDiscovery = await niceeval.run([
        "query",
        "discover",
        "--record",
        "removed-record-snapshot.sqlite",
      ]);
      expect(sourceBoundDiscovery.exitCode, sourceBoundDiscovery.diagnostic()).toBe(2);
      expect(sourceBoundDiscovery.queryFailure()).toMatchObject({
        protocol: "niceeval.query/v1",
        outcome: "failure",
        operation: null,
        failure: {
          code: "inspection-request-invalid",
          correction: "fix-request",
        },
      });

      const overviewRequestPath = join(projectRoot, "overview.request.json");
      await writeFile(
        overviewRequestPath,
        `${JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "overview.get" },
        })}\n`,
        "utf8",
      );
      const overview = await niceeval.run([
        "query",
        "run",
        "--request",
        overviewRequestPath,
      ]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      const overviewDocument = overview.querySuccess("overview.get");
      expect(overview.stdout).toBe(`${JSON.stringify(overviewDocument)}\n`);
      expect(overviewDocument).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "overview.get",
        source: {
          kind: "project-record",
          sealedCutoffIdentity: expect.any(String),
        },
      });
      const mainCell = only(
        overviewDocument.overview.cells,
        (cell) => cell.experimentId === "main" && cell.evalId === "inspection",
        overview.diagnostic(),
      );
      expect(mainCell).toMatchObject({
        evaluationKind: "points",
        denominator: { expected: 1, observed: 1, classified: 1, missing: 0 },
        verdict: {
          tally: { passed: 1, failed: 0, errored: 0, skipped: 0 },
          passRate: {
            state: "available",
            value: 1,
            samples: 1,
            total: 1,
            basis: "slot",
            issues: [],
            refs: [{ identity: { kind: "attempt", locator } }],
          },
        },
        score: {
          state: "available",
          value: 37.111111111111114,
          samples: 1,
          total: 1,
          basis: "slot",
          issues: [],
          refs: [{ identity: { kind: "attempt", locator } }],
          unit: "points",
          bounds: { min: 0, max: 43.111111111111114 },
        },
        costUSD: {
          state: "available",
          value: 0.00003,
          source: "observed",
          samples: 1,
          total: 1,
          basis: "slot",
          issues: [],
          refs: [{ identity: { kind: "attempt", locator } }],
        },
        coverage: expect.any(Array),
        issues: expect.any(Array),
        members: [{
          runId: carriedRunId,
          labels: { memory: { state: "available", value: "current" } },
          publication: {
            state: "published",
            action: "carried",
            attemptLocator: locator,
            originRunId: runId,
          },
        }],
      });
      const mainExperimentOverview = only(
        overviewDocument.overview.experiments,
        (experiment) => experiment.experimentId === "main",
        overview.diagnostic(),
      );
      expect(mainExperimentOverview.labels).toEqual({
        memory: { state: "available", value: "current" },
      });
      expect(overview.stdout).not.toContain("privateExecutionFlag");
      const alternateCell = only(
        overviewDocument.overview.cells,
        (cell) => cell.experimentId === "alternate" && cell.evalId === "inspection",
        overview.diagnostic(),
      );
      expect(alternateCell).toMatchObject({
        evaluationKind: "points",
        denominator: { expected: 1, observed: 1, classified: 1, missing: 0 },
        verdict: {
          tally: { passed: 1, failed: 0, errored: 0, skipped: 0 },
          passRate: {
            state: "available",
            value: 1,
            samples: 1,
            total: 1,
            basis: "slot",
            issues: [],
            refs: [{ identity: { kind: "attempt", locator: alternateLocator } }],
          },
        },
        score: {
          state: "available",
          value: 37.111111111111114,
          samples: 1,
          total: 1,
          basis: "slot",
          issues: [],
          refs: [{ identity: { kind: "attempt", locator: alternateLocator } }],
          unit: "points",
          bounds: { min: 0, max: 43.111111111111114 },
        },
        coverage: expect.any(Array),
        issues: expect.any(Array),
        members: [{
          runId: alternateRunId,
          publication: {
            state: "published",
            action: "executed",
            attemptLocator: alternateLocator,
            originRunId: alternateRunId,
          },
        }],
      });
      const multiInspectionCell = only(
        overviewDocument.overview.cells,
        (cell) => cell.experimentId === "inspection-multi" && cell.evalId === "inspection",
        overview.diagnostic(),
      );
      const multiInspectionLocators = multiInspectionCell.members
        .map(({ publication }) => publication.attemptLocator)
        .toSorted();
      expect(multiInspectionLocators).toHaveLength(3);
      expect(new Set(multiInspectionLocators).size).toBe(3);
      expect(multiInspectionCell).toMatchObject({
        evaluationKind: "points",
        denominator: { expected: 3, observed: 3, classified: 3, missing: 0 },
        score: {
          state: "available",
          value: 37.111111111111114,
          samples: 3,
          total: 3,
          basis: "slot",
          issues: [],
          refs: multiInspectionLocators.map((memberLocator) => ({
            identity: { kind: "attempt", locator: memberLocator },
          })),
          unit: "points",
          bounds: { min: 0, max: 43.111111111111114 },
        },
        costUSD: {
          state: "partial",
          value: 0.00004,
          source: "estimated",
          samples: 2,
          total: 3,
          basis: "slot",
          issues: [],
          refs: expect.any(Array),
          unit: "USD",
          bounds: { min: 0, max: 0.00004 },
        },
      });
      expect(multiInspectionCell.costUSD.refs).toHaveLength(2);
      expect(multiInspectionCell.costUSD.refs.every(({ identity }) =>
        multiInspectionLocators.includes(identity.locator))).toBe(true);
      for (const memberLocator of multiInspectionLocators) {
        expect(only(
          multiInspectionCell.members,
          (member) => member.publication.attemptLocator === memberLocator,
          overview.diagnostic(),
        )).toMatchObject({
          runId: multiRunId,
          publication: {
            state: "published",
            action: "executed",
            attemptLocator: memberLocator,
            originRunId: multiRunId,
            score: {
              state: "available",
              value: 37.111111111111114,
              samples: 1,
              total: 1,
              basis: "slot",
              issues: [],
              refs: [{ identity: { kind: "attempt", locator: memberLocator } }],
              unit: "points",
              bounds: { min: 0, max: 43.111111111111114 },
            },
          },
        });
      }
      const multiSecondaryCell = only(
        overviewDocument.overview.cells,
        (cell) => cell.experimentId === "inspection-multi" && cell.evalId === "overview/secondary",
        overview.diagnostic(),
      );
      const multiSecondaryLocators = multiSecondaryCell.members
        .map(({ publication }) => publication.attemptLocator)
        .toSorted();
      expect(multiSecondaryLocators).toHaveLength(3);
      expect(new Set(multiSecondaryLocators).size).toBe(3);
      expect(multiSecondaryCell).toMatchObject({
        score: {
          state: "available",
          value: 2,
          samples: 3,
          total: 3,
          basis: "slot",
          bounds: { min: 0, max: 2 },
        },
      });
      expect(multiSecondaryCell.costUSD).toMatchObject({
        state: "partial",
        value: 0.00003,
        source: "observed",
        samples: 1,
        total: 3,
        basis: "slot",
        issues: [],
        unit: "USD",
        bounds: { min: 0, max: 0.00003 },
      });
      for (const memberLocator of multiSecondaryLocators) {
        expect(only(
          multiSecondaryCell.members,
          (member) => member.publication.attemptLocator === memberLocator,
          overview.diagnostic(),
        )).toMatchObject({
          publication: {
            state: "published",
            attemptLocator: memberLocator,
            score: {
              state: "available",
              value: 2,
              samples: 1,
              total: 1,
              basis: "slot",
              bounds: { min: 0, max: 2 },
            },
          },
        });
      }
      const multiExperiment = only(
        overviewDocument.overview.experiments,
        (experiment) => experiment.experimentId === "inspection-multi",
        overview.diagnostic(),
      );
      expect(multiExperiment.score).toMatchObject({
        state: "available",
        value: 39.111111111111114,
        samples: 2,
        total: 2,
        basis: "eval",
        unit: "points",
        bounds: { min: 0, max: 45.111111111111114 },
      });
      expect(multiExperiment.costUSD).toMatchObject({
        state: "partial",
        value: 0.00006000000000000001,
        source: "estimated",
        samples: 3,
        total: 6,
        basis: "slot",
        issues: [],
        unit: "USD",
        bounds: { min: 0, max: 0.00006000000000000001 },
      });
      expect(only(
        multiExperiment.groups,
        (group) => group.groupPath.join("/") === "overview",
        overview.diagnostic(),
      ).costUSD).toMatchObject(multiSecondaryCell.costUSD);
      expect(overviewDocument.overview.totals.costUSD).toMatchObject({
        state: "partial",
        value: 0.0001,
        source: "estimated",
        samples: 5,
        total: 8,
        basis: "slot",
        issues: [],
        unit: "USD",
        bounds: { min: 0, max: 0.0001 },
      });

      const requestPath = join(projectRoot, "run-summary.request.json");
      await writeFile(
        requestPath,
        `${JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "run.get", runId },
        })}\n`,
        "utf8",
      );
      const explained = await niceeval.run([
        "query",
        "explain",
        "--request",
        requestPath,
      ]);
      expect(explained.exitCode, explained.diagnostic()).toBe(0);
      const explanation = explained.queryExplanation("run.get");
      expect(explained.stdout).toBe(`${JSON.stringify(explanation)}\n`);
      expect(explanation).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "run.get",
        source: {
          kind: "project-record",
          sealedCutoffIdentity: expect.any(String),
        },
        sealedCutoff: expect.anything(),
        selection: expect.anything(),
        factKinds: expect.any(Array),
      });

      const queried = await niceeval.run([
        "query",
        "run",
        "--request",
        requestPath,
      ]);
      expect(queried.exitCode, queried.diagnostic()).toBe(0);
      const document = queried.querySuccess("run.get");
      expect(queried.stdout).toBe(`${JSON.stringify(document)}\n`);
      expect(document).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "run.get",
        source: {
          kind: "project-record",
          sealedCutoffIdentity: explanation.source.sealedCutoffIdentity,
        },
        sealedCutoff: expect.anything(),
        selection: expect.anything(),
        issues: expect.any(Array),
        evidence: expect.anything(),
        run: expect.anything(),
      });
      const publicSummary = JSON.stringify(document.run);
      expect(publicSummary).toContain(runId);
      expect(publicSummary).toContain("executed");
      expect(queried.stdout).not.toContain(projectRoot);
      expect(queried.stdout).not.toContain(".niceeval/");

      await writeFile(
        requestPath,
        `${JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "attempt.usage", locator },
        })}\n`,
        "utf8",
      );
      const overviewQueried = await niceeval.run([
        "query",
        "run",
        "--request",
        requestPath,
      ]);
      expect(overviewQueried.exitCode, overviewQueried.diagnostic()).toBe(0);
      const runOverviewDocument = overviewQueried.querySuccess("attempt.usage");
      expect(runOverviewDocument).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "attempt.usage",
        source: {
          kind: "project-record",
          sealedCutoffIdentity: explanation.source.sealedCutoffIdentity,
        },
        issues: [],
        usage: expect.anything(),
      });
      expect(runOverviewDocument.usage.totals).toMatchObject({
        inputTokens: { state: "available", value: 10 },
        outputTokens: { state: "available", value: 5 },
      });
      expect(runOverviewDocument.usage.limitations).toEqual([]);
      expect(overviewQueried.stdout).not.toContain(projectRoot);
      expect(overviewQueried.stdout).not.toContain(".niceeval/");

      await writeFile(
        requestPath,
        `${JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "run.get", runId: carriedRunId },
        })}\n`,
        "utf8",
      );
      const carriedSummary = await niceeval.run([
        "query",
        "run",
        "--request",
        requestPath,
      ]);
      expect(carriedSummary.exitCode, carriedSummary.diagnostic()).toBe(0);
      const carriedSummaryDocument = carriedSummary.querySuccess("run.get");
      expect(carriedSummaryDocument).toMatchObject({
        protocol: "niceeval.query/v1",
        operation: "run.get",
        issues: [],
      });
      expect(JSON.stringify(carriedSummaryDocument.run)).toContain(carriedRunId);
      expect(JSON.stringify(carriedSummaryDocument.run)).toContain('"action":"carried"');

      const operationRequestPath = join(projectRoot, "fixed-operation.request.json");
      let matcherToolOccurrenceId: string | undefined;
      const operations = [
        { kind: "runs.list" },
        { kind: "experiment.get", experimentId: "main" },
        { kind: "run.get", runId },
        { kind: "attempt.get", locator },
        { kind: "attempt.trace", locator },
        { kind: "attempt.timing", locator },
        { kind: "attempt.usage", locator },
        { kind: "attempt.diff", locator },
        { kind: "attempt.sources", locator },
        { kind: "attempt.artifacts", locator },
        { kind: "runs.compare", mode: "paired", leftRunIds: [runId], rightRunIds: [runId] },
      ] as const;
      for (const operation of operations) {
        await writeFile(operationRequestPath, `${JSON.stringify({
          protocol: "niceeval.query/v1",
          operation,
        })}\n`, "utf8");
        const result = await niceeval.run([
          "query",
          "run",
          "--request",
          operationRequestPath,
        ]);
        expect(result.exitCode, result.diagnostic()).toBe(0);
        const operationDocument = result.querySuccess(operation.kind);
        expect(result.stdout).toBe(`${JSON.stringify(operationDocument)}\n`);
        expect(operationDocument).toMatchObject({
          protocol: "niceeval.query/v1",
          operation: operation.kind,
        });

        if (operation.kind === "attempt.get") {
          const attemptDocument = operationDocument;
          const matcherEntry = only(
            attemptDocument.attempt.assertions.entries,
            (entry) => entry.display.label === "Inspection tool occurrence",
            result.diagnostic(),
          );
          expect(matcherEntry.entryId).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
          await writeFile(operationRequestPath, `${JSON.stringify({
            protocol: "niceeval.query/v1",
            operation: {
              kind: "attempt.assertion.detail",
              locator,
              entryId: matcherEntry.entryId,
            },
          })}\n`, "utf8");
          const assertionDetail = await niceeval.run([
            "query",
            "run",
            "--request",
            operationRequestPath,
          ]);
          expect(assertionDetail.exitCode, assertionDetail.diagnostic()).toBe(0);
          const assertionDocument = assertionDetail.querySuccess("attempt.assertion.detail");
          expect(assertionDetail.stdout).toBe(`${JSON.stringify(assertionDocument)}\n`);
          expect(assertionDocument).toMatchObject({
            protocol: "niceeval.query/v1",
            operation: "attempt.assertion.detail",
            assertion: {
              entryId: matcherEntry.entryId,
              display: { label: "Inspection tool occurrence" },
              sourceSites: expect.any(Array),
              check: {
                label: "Inspection tool occurrence",
                state: "matched",
                expected: expect.anything(),
                observed: expect.anything(),
                reason: null,
                anchor: null,
                children: expect.any(Array),
              },
              matcher: {
                state: "available",
                sourceState: "complete",
                comparator: expect.anything(),
                sourceLedger: expect.anything(),
                debugger: {
                  state: "current",
                  subject: "tool",
                  query: {
                    kind: "collection-filter",
                    summary: expect.anything(),
                  },
                  receipt: expect.anything(),
                  source: {
                    final: {
                      state: "complete",
                      rows: expect.any(Array),
                      limitations: [],
                    },
                    atEvaluation: {
                      state: "complete",
                      rows: expect.any(Array),
                      limitations: [],
                    },
                  },
                  identityRelation: { state: "exact" },
                  overlayRetention: "complete",
                  steps: [],
                },
                sandboxCommandJoin: { state: "unavailable", reason: "not-recorded" },
              },
            },
          });
          const matcherTarget = only(
            assertionDocument.assertion.matcher.targets,
            (target) => target.anchor.kind === "tool-occurrence" &&
              typeof target.anchor.toolOccurrenceId === "string",
            assertionDetail.diagnostic(),
          );
          expect(matcherTarget).toMatchObject({
            state: "matched",
            anchor: {
              kind: "tool-occurrence",
              toolOccurrenceId: expect.any(String),
            },
          });
          matcherToolOccurrenceId = matcherTarget.anchor.toolOccurrenceId;
          const atEvaluationRow = only(
            assertionDocument.assertion.matcher.debugger?.source.atEvaluation.rows ?? [],
            (row) => row.locator?.kind === "tool-occurrence" &&
              row.locator.toolOccurrenceId === matcherToolOccurrenceId,
            assertionDetail.diagnostic(),
          );
          expect(atEvaluationRow).toMatchObject({
            kind: "tool",
            rowId: `tool:${matcherToolOccurrenceId}`,
            number: "1",
            phase: "at-evaluation",
            summary: "inspection_fixture",
            detail: { kind: "fields", fields: expect.any(Array) },
            locator: {
              kind: "tool-occurrence",
              toolOccurrenceId: matcherToolOccurrenceId,
            },
            evaluation: { result: "matched" },
            conversationTarget: {
              state: "exact",
              turnId: expect.any(String),
              eventId: expect.any(String),
              anchor: expect.any(String),
            },
          });
          const finalRow = only(
            assertionDocument.assertion.matcher.debugger?.source.final.rows ?? [],
            (row) => row.rowId === atEvaluationRow.rowId,
            assertionDetail.diagnostic(),
          );
          expect(finalRow).toEqual(atEvaluationRow);
        }

        if (operation.kind === "attempt.trace") {
          const traceDocument = operationDocument;
          const toolCall = only(
            traceDocument.trace.conversation.items,
            (item) => item.kind === "tool-call" && item.tool === "inspection_fixture",
            result.diagnostic(),
          );
          const toolResult = only(
            traceDocument.trace.conversation.items,
            (item) => item.kind === "tool-result" && item.outcome === "completed",
            result.diagnostic(),
          );
          expect(toolCall).toMatchObject({
            itemId: expect.any(String),
            kind: "tool-call",
            toolOccurrenceId: expect.any(String),
            input: expect.stringContaining("inspection-tool-input"),
          });
          expect(toolResult).toMatchObject({
            itemId: expect.any(String),
            kind: "tool-result",
            toolOccurrenceId: toolCall.toolOccurrenceId,
            output: expect.stringContaining("inspection-tool-result"),
          });
          expect(JSON.stringify(traceDocument.trace)).not.toMatch(/"kind":"tool-(?:start|finish)"/u);

          const toolOccurrenceId = toolCall.toolOccurrenceId;
          if (toolOccurrenceId === undefined) throw new Error("expected exact tool occurrence identity");
          expect(toolOccurrenceId).toBe(matcherToolOccurrenceId);
          expect(toolOccurrenceId).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
          expect(toolCall.itemId).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
          expect(toolResult.itemId).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
          await writeFile(operationRequestPath, `${JSON.stringify({
            protocol: "niceeval.query/v1",
            operation: {
              kind: "attempt.trace.detail",
              locator,
              selector: { kind: "tool-occurrence", toolOccurrenceId },
            },
          })}\n`, "utf8");
          const detail = await niceeval.run([
            "query",
            "run",
            "--request",
            operationRequestPath,
          ]);
          expect(detail.exitCode, detail.diagnostic()).toBe(0);
          const detailDocument = detail.querySuccess("attempt.trace.detail");
          expect(detail.stdout).toBe(`${JSON.stringify(detailDocument)}\n`);
          expect(detailDocument).toMatchObject({
            protocol: "niceeval.query/v1",
            operation: "attempt.trace.detail",
            detail: {
              kind: "tool-occurrence",
              toolOccurrenceId,
              call: {
                itemId: toolCall.itemId,
                kind: "tool-call",
                tool: "inspection_fixture",
                input: expect.stringContaining("inspection-tool-input"),
              },
              result: {
                itemId: toolResult.itemId,
                kind: "tool-result",
                outcome: "completed",
                output: expect.stringContaining("inspection-tool-result"),
              },
            },
          });
        }

        if (operation.kind === "attempt.sources") {
          const sourcesDocument = operationDocument;
          expect(sourcesDocument.sources.state, JSON.stringify(sourcesDocument.sources)).toBe("available");
          expect(sourcesDocument).toMatchObject({
            sources: {
              state: "available",
              assertions: { state: "available" },
            },
          });
          const sourceSite = (sourcesDocument.sources.assertions.sourceSites ?? []).find(
            (site) => site.role === "declaration" && site.source.state === "mapped",
          );
          expect(sourceSite, result.diagnostic()).toBeDefined();
          if (sourceSite === undefined) throw new Error("expected a mapped declaration source site");
          const sourceItem = only(
            sourcesDocument.sources.items,
            (item) => item.sourceItemId === sourceSite.source.sourceItemId,
            result.diagnostic(),
          );
          expect(sourceSite).toMatchObject({
            entryId: expect.any(String),
            sourceOrder: expect.any(Number),
            source: {
              state: "mapped",
              sourceItemId: sourceItem.sourceItemId,
              sha256: sourceItem.sha256,
            },
          });
          expect(sourceItem).toMatchObject({
            path: "evals/inspection.eval.ts",
            content: {
              state: "available",
              text: expect.stringContaining("defineScoreEval"),
            },
          });
        }
      }

      await writeFile(operationRequestPath, `${JSON.stringify({
        protocol: "niceeval.query/v1",
        operation: { kind: "run.get", runId: "missing-run" },
      })}\n`, "utf8");
      const missing = await niceeval.run([
        "query",
        "run",
        "--request",
        operationRequestPath,
      ]);
      expect(missing.exitCode, missing.diagnostic()).toBe(2);
      const missingDocument = missing.queryFailure();
      expect(missing.stdout).toBe(`${JSON.stringify(missingDocument)}\n`);
      expect(missingDocument).toMatchObject({
        protocol: "niceeval.query/v1",
        outcome: "failure",
        operation: "run.get",
        failure: {
          code: "inspection-selection-missing",
          correction: "choose-existing-selection",
        },
      });
      expect(missing.stderr).toBe("niceeval query failed: inspection-selection-missing\n");

      await writeFile(operationRequestPath, '{"protocol":"niceeval.query/v0"}\n', "utf8");
      const invalid = await niceeval.run([
        "query",
        "run",
        "--request",
        operationRequestPath,
      ]);
      expect(invalid.exitCode, invalid.diagnostic()).toBe(2);
      const invalidDocument = invalid.queryFailure();
      expect(invalid.stdout).toBe(`${JSON.stringify(invalidDocument)}\n`);
      expect(invalidDocument).toMatchObject({
        protocol: "niceeval.query/v1",
        outcome: "failure",
        operation: null,
        failure: {
          code: "inspection-request-invalid",
          correction: "fix-request",
        },
      });
      expect(invalid.stderr).toBe("niceeval query failed: inspection-request-invalid\n");

      for (const retiredCommand of ["insight"] as const) {
        const retired = await niceeval.run([retiredCommand]);
        expect(retired.exitCode, retired.diagnostic()).toBe(1);
        expect(retired.stdout).toBe("");
        expect(retired.stderr).toBe(
          `Unknown command "${retiredCommand}".\nRun \`niceeval --help\` for usage.\n`,
        );
      }

      const retiredStaticPath = join(projectRoot, "retired-static-view");
      const staticView = await niceeval.run(["view", "--out", retiredStaticPath]);
      expect(staticView.exitCode, staticView.diagnostic()).toBe(1);
      expect(staticView.stdout).toBe("");
      expect(staticView.stderr).toContain("Unknown option '--out'");
      expect(staticView.stderr).toContain("Run `niceeval --help` for usage.\n");
      await expect(access(retiredStaticPath)).rejects.toMatchObject({ code: "ENOENT" });
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791082741&installation_model_id=431746&pr_number=216&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F216&signature=45406da4705844947e8594cd9d85da6da064a3cd25d66b030e1d160b72030e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->