### PR TITLE
修正纯 Score 实验的 show 结果语义

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -75,6 +75,16 @@ when terminology is unchanged.
 - Required capability: <why the supporting API, protocol, or internal mechanism is necessary>
 - User outcome: <what becomes possible after this PR>
 
+## Closing issues
+
+<!--
+Delete this section when merging the PR must not close an issue. Add one
+`Fixes #<issue>` line per issue only through `pnpm pr:body edit closing-issue`;
+GitHub will close each referenced issue when the PR merges into the default branch.
+-->
+
+Fixes #<issue>
+
 ## Use cases
 
 <!--

--- a/apps/docs-site/tutorials/evaluation-kinds.mdx
+++ b/apps/docs-site/tutorials/evaluation-kinds.mdx
@@ -79,7 +79,7 @@ When `test` returns normally, NiceEval closes the score automatically. No scorin
 | `defineEval` | `passed` | `failed` | `errored` | `errored` |
 | `defineScoreEval` | `scored`, with a rankable score | Does not normally invalidate; score continues to accumulate | Unrankable when an item configured with score or control is unavailable | `errored`, retaining only `partialScore` |
 
-`scored` can be a zero score. Zero means evaluation successfully formed a score; it is not execution failure or insufficient evidence. A scored eval has no Attempt Verdict.
+`scored` can be a zero score. Zero means evaluation successfully formed a score; it is not execution failure or insufficient evidence. Every Attempt still records a terminal Verdict, but the Report uses `scored` or `errored` as the primary result for a Score Eval; it does not convert that Verdict into a pass rate.
 
 ## Judge is also a measurement
 

--- a/apps/docs-site/zh/tutorials/evaluation-kinds.mdx
+++ b/apps/docs-site/zh/tutorials/evaluation-kinds.mdx
@@ -77,7 +77,7 @@ export default defineScoreEval({
 | `defineEval` | `passed` | `failed` | `errored` | `errored` |
 | `defineScoreEval` | `scored`，可排名的 score | 正常不失效；score 照常累计 | 已配置 score 或 control 的项不可用时不可排名 | `errored`，只保留 `partialScore` |
 
-计分制的 `scored` 可以是 0 分。零分说明评估成功形成了分数，不等于执行失败或证据不足。计分制没有 Attempt Verdict。
+计分制的 `scored` 可以是 0 分。零分说明评估成功形成了分数，不等于执行失败或证据不足。每条 Attempt 仍记录终态 Verdict，但报告以 `scored` 或 `errored` 作为 Score Eval 的主结果，不把该 Verdict 换算成通过率。
 
 ## Judge 也是 measurement
 

--- a/docs/engineering/testing/e2e/inspection.md
+++ b/docs/engineering/testing/e2e/inspection.md
@@ -23,6 +23,8 @@ Contract: [Inspection CLI · `niceeval show`](../../../feature/inspection/cli.md
 
 overview 必须保留 operation 已选的 totals、Experiment summary 与完整 locator。层级固定为 Experiment 路径首段显示分组 → 完整 Experiment → Eval → Attempt；同组多个 Experiment 之间留空行，Experiment 标题与自己的 Eval 表头紧邻。默认 Attempt 表不以 membership action 或 relation 挤占 identity。健康 metric 隐藏 `available`，其它 state 继续可见。
 
+纯 Score Experiment 的 totals 与 summary 只呈现 score outcome 和 Score，不生成 Pass rate；Attempt 行把正常完成显示为 `scored`，把 execution error 保持为 `errored`。mixed Results 仍并排呈现两类读数。
+
 Attempt 概览要给出可执行的 source、execution、timing、usage 和 diff 后续命令。Journey 分别运行 `--source`、`--execution [--expand <stable-id>]`、`--timing`、`--usage` 与 `--diff`。
 
 它核对 source/Assertion facts，以及 execution 有界 outline 与其 `itemId` / `toolOccurrenceId` / `commandId` 详情。

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -243,11 +243,13 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
   Experiment ID 含 `/` 时，首段形成显示分组，组内 Experiment 与同前缀 Eval 使用相对标签。
   每个 Experiment 小节仍显示一次完整 ID，每个可下钻 Attempt 显示完整稳定 locator。
 
-  默认 Attempt 明细隐藏 `passed` 与 `failed` 项；每个 Experiment 最多展开 5 个 `errored` 项，超出的部分也折叠。
-  `skipped`、pending 与 absent 项始终可见。每个 Experiment 显示各 Verdict 的隐藏数量及可复制的
+  默认 Attempt 明细隐藏 `passed`、`failed` 与 `scored` 项；每个 Experiment 最多展开 5 个 `errored` 项，超出的部分也折叠。
+  `skipped`、pending 与 absent 项始终可见。每个 Experiment 显示各结果的隐藏数量及可复制的
   `See more: niceeval show --experiment <id>` 命令。
+
   `--all` 展开全部 Attempt。展开后的明细先以 `Eval <id>` 缩进分组，不在每个 Attempt 行重复 Eval ID；
-  同一 Eval 的多个 Attempt 各占一行，显示 `Attempt`、`Verdict`、`Duration` 与适用时的 `Score`。
+  同一 Eval 的多个 Attempt 各占一行。Pass 或 mixed Eval 显示 `Attempt`、`Verdict` 与 `Duration`；
+  Score Eval 显示 `Attempt`、`Outcome`、`Duration` 与 `Score`，正常完成写成 `scored` 而不是 `passed`。
 
   Verdict 为 `passed`、`failed`、`errored` 或 `skipped`。Duration 按大小使用 `ms`、`s`、`min` 或 `h`，
   最多保留两位小数。
@@ -293,7 +295,11 @@ human renderer 将 pass rate 显示为百分比。`available` 是健康 metric �
 
 Score 在纯 pass 制投影中是不适用的指标，
 human renderer 不输出 `Score unsupported` 占位：Totals 及某张表的全部成员均为 pass 制时，分别省略 Score 行或整列。
-只要该投影范围内存在 score 制成员，Score 行或列仍须显示，并为其它不可用、部分或失败的 score 保留具名状态。
+
+反过来，纯 score 制 totals 显示 `Outcomes` 与 `Score`，不显示 `Verdicts` 或 `Pass rate`；纯 score 制
+Experiment 表省略 `Pass rate` 列。正常完成数显示为 `scored`，execution error 仍显示为 `errored`。
+
+mixed 投影并排保留 pass rate 与 score。machine result 始终保留原始 typed Verdict 与 metric，不因人读展示而改写。
 machine result 始终保留 typed `unsupported`。Experiment summary 按路径首段分组，
 Attempt 明细再按完整 Experiment 分表，使 80 列终端可以在同一行保留完整 locator：
 

--- a/e2e/inspection/evals/score-error.eval.ts
+++ b/e2e/inspection/evals/score-error.eval.ts
@@ -1,0 +1,9 @@
+import { defineScoreEval } from "niceeval";
+
+export default defineScoreEval({
+  description: "score-error: 签入确定性 Score execution error",
+  test(t) {
+    t.score(1).label("partial score before deterministic error");
+    throw new Error("deterministic score error");
+  },
+});

--- a/e2e/inspection/experiments/score-only.ts
+++ b/e2e/inspection/experiments/score-only.ts
@@ -1,0 +1,10 @@
+import { defineExperiment } from "niceeval";
+import { deterministicAgent, deterministicSandbox } from "../agents/deterministic.ts";
+
+export default defineExperiment({
+  description: "score-only: 验证纯 Score 结果不被展示为通过率",
+  agent: deterministicAgent(),
+  sandbox: deterministicSandbox,
+  model: "inspection-fixture-v1",
+  evals: ["score", "overview/secondary", "score-error"],
+});

--- a/e2e/inspection/test/show-cli.test.ts
+++ b/e2e/inspection/test/show-cli.test.ts
@@ -59,6 +59,7 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       const mainExperimentId = "harness/canary";
       const alternateExperimentId = "harness/alternate";
       const scaleExperimentId = "harness/scale";
+      const scoreOnlyExperimentId = "score-only";
       const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
       expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
       expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
@@ -120,6 +121,40 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(passOnlyExperiment.stdout).not.toContain("Score");
       expect(passOnlyExperiment.stdout).not.toContain("unsupported");
 
+      const scoreOnlyProduced = await niceeval.run([
+        "exp",
+        scoreOnlyExperimentId,
+        "--rerun",
+        "all",
+        "--json",
+      ]);
+      expect(scoreOnlyProduced.exitCode, scoreOnlyProduced.diagnostic()).not.toBe(0);
+      expect(scoreOnlyProduced.expReceipt(), scoreOnlyProduced.diagnostic()).toMatchObject({
+        completion: "completed",
+      });
+      expect(scoreOnlyProduced.expEvalEvents(), scoreOnlyProduced.diagnostic()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ evalId: "score", verdict: "passed" }),
+          expect.objectContaining({ evalId: "overview/secondary", verdict: "passed" }),
+          expect.objectContaining({ evalId: "score-error", verdict: "errored" }),
+        ]),
+      );
+
+      const scoreOnlyExperiment = await niceeval.run([
+        "show",
+        "--experiment",
+        scoreOnlyExperimentId,
+      ]);
+      expect(scoreOnlyExperiment.exitCode, scoreOnlyExperiment.diagnostic()).toBe(0);
+      expectHumanText(scoreOnlyExperiment.stdout);
+      expect(scoreOnlyExperiment.stdout).toMatch(/Observed\s+3\/3/u);
+      expect(scoreOnlyExperiment.stdout).toMatch(/Outcomes\s+2 scored; 1 errored; 0 skipped/u);
+      expect(scoreOnlyExperiment.stdout).toContain("Score");
+      expect(scoreOnlyExperiment.stdout).toMatch(/Attempt\s+Outcome\s+Duration\s+Score/u);
+      expect(scoreOnlyExperiment.stdout).not.toContain("Verdicts");
+      expect(scoreOnlyExperiment.stdout).not.toContain("Pass rate");
+      expect(scoreOnlyExperiment.stdout).not.toContain("passed Attempts hidden");
+
       const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
       writeFileSync(
         overviewRequestPath,
@@ -154,6 +189,8 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
       expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
       expect(overview.stdout).toContain(`Experiment ${scaleExperimentId}`);
+      expect(overview.stdout).toContain(`Experiment ${scoreOnlyExperimentId}`);
+      expect(overview.stdout).toMatch(/Experiment\s+Observed\s+Agent\s+Model\s+Score[\s\S]+score-only\s+3\/3/u);
       expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
       expect(overview.stdout).toContain("passed Attempts hidden");
       expect(overview.stdout).toContain(
@@ -168,9 +205,9 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(expandedOverview.exitCode, expandedOverview.diagnostic()).toBe(0);
       expectInOrder(expandedOverview.stdout, [`Experiment ${mainExperimentId}`, "Eval inspection", locator]);
       expectInOrder(expandedOverview.stdout, [`Experiment ${alternateExperimentId}`, "Eval inspection", alternateLocator]);
-      expect(expandedOverview.stdout).toMatch(/Attempt\s+Verdict\s+Duration\s+Score/u);
-      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
-      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
+      expect(expandedOverview.stdout).toMatch(/Attempt\s+Outcome\s+Duration\s+Score/u);
+      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
+      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
 
       const run = await niceeval.run(["show", "--run", mainRunId]);
       expect(run.exitCode, run.diagnostic()).toBe(0);
@@ -409,10 +446,10 @@ test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 
       expect(historicalOverview.stdout).toContain(locator);
       expect(historicalOverview.stdout).toContain(alternateLocator);
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*${locator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*${locator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).toMatch(
-        new RegExp(`^\\s*${alternateLocator}\\s+passed\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
+        new RegExp(`^\\s*${alternateLocator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
       );
       expect(historicalOverview.stdout).not.toContain("Observed   0/0");
     },

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/certificate.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "candidateSha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+  "greenReceipt": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-1.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-2.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-4.json",
+      "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-6.json",
+    "singleCase": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/green.json",
+    "cleanup": [
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-show/.e2e-artifacts/issue-218/takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-show/.e2e-artifacts/issue-218/takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-show/.e2e-artifacts/issue-218/takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-show/.e2e-artifacts/issue-218/takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-show/.e2e-artifacts/issue-218/takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-show/.e2e-artifacts/issue-218/takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/.herdr/worktrees/NiceEval/fix-show/.e2e-artifacts/issue-218/takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "4c06154574f9c20778c6187242ebc88e94db99bd8e39fb73b53baf02c3b47fd1"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/green.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/green.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+    "sri": "sha512-4Lza4LwRXHIA5IfatsXlz9WrG7UyOAHrA7Lcs95Xgu1KnwYZkqXE3F2nf+hkZGzXGcjHNJ3Q3HGECYbKPTgRPQ=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-7sZPGA/runs/takeover/target-single/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2918998 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2918999 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2919073 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "d0b6b1be-ae77-4326-8e4f-ae1437ba03e2",
+  "receiptSha256": "7330094ba99450dd671c389e6060bd8f48eeee96ff1a7805a6bff6fcc5ac832b"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/inventory.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/inventory.json
@@ -1,0 +1,45 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "inspection",
+  "argv": [
+    "/nix/store/k3nz3s314bipvqbcbw3faq823hxpwbn1-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-aHV0eO/repos/inspection/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+  "files": [
+    "e2e/inspection/test/inspection-query.test.ts",
+    "e2e/inspection/test/show-cli.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/inspection-query.test.ts",
+      "titlePath": [
+        "machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]"
+      ],
+      "caseId": "necase_79TQ9VGG316D8FK0"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-cli.test.ts",
+      "titlePath": [
+        "用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]"
+      ],
+      "caseId": "necase_9FHHSQTVB492P8DS"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/red.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/red.json
@@ -1,0 +1,52 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "8e0bf335df12132a228b11095d18a766d5c3560123baced382548a2f12030e0f",
+    "sri": "sha512-ZBBHKZOJluWPKjbDBm3D0rWKGL6HclyjZPOT/IMdKXkiphBta0BosNieSCRFiY8GENfrD1/8EHWwodRKJFd68A=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-x8To8a/runs/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 2896189 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "e3378bc4-bf09-4a81-9955-cad3e8eb80b5",
+  "receiptSha256": "215f84207bef467bb4688b8c741c49a0ff1b0dc035d1cf85bf050d24aceb56f2"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-1.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-1.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+    "sri": "sha512-4Lza4LwRXHIA5IfatsXlz9WrG7UyOAHrA7Lcs95Xgu1KnwYZkqXE3F2nf+hkZGzXGcjHNJ3Q3HGECYbKPTgRPQ=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-7sZPGA/runs/takeover/isolated-copy-1/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2899376 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2899377 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2899452 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "25593c09-5c97-43d7-a246-7d1b243ce459",
+  "receiptSha256": "d5f44e37d7a57af710a405385459dde63b593c052bf9afe846c27a32490c1d42"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-2.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-2.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+    "sri": "sha512-4Lza4LwRXHIA5IfatsXlz9WrG7UyOAHrA7Lcs95Xgu1KnwYZkqXE3F2nf+hkZGzXGcjHNJ3Q3HGECYbKPTgRPQ=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-7sZPGA/runs/takeover/isolated-copy-2/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2902117 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2902118 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2902187 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "a2f10b85-6315-433e-af37-6f35987ddf17",
+  "receiptSha256": "7473dc72c21fa52f90ce3a831b338f0ae48c5b71b0729122b517462213f80755"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-3.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-3.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+    "sri": "sha512-4Lza4LwRXHIA5IfatsXlz9WrG7UyOAHrA7Lcs95Xgu1KnwYZkqXE3F2nf+hkZGzXGcjHNJ3Q3HGECYbKPTgRPQ=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-7sZPGA/runs/takeover/isolated-copy-3/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2905749 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2905750 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2905814 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "48c5099d-8b5d-4fd3-8437-289ffae1e67e",
+  "receiptSha256": "c7c475dd86cf8f043229d7984e3a84cb829f477dc1953eee6ee9863d2656122d"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-4.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-4.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+    "sri": "sha512-4Lza4LwRXHIA5IfatsXlz9WrG7UyOAHrA7Lcs95Xgu1KnwYZkqXE3F2nf+hkZGzXGcjHNJ3Q3HGECYbKPTgRPQ=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-7sZPGA/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2909641 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2909642 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2909670 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2912212 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "d9e9fe9b-5260-458c-bc75-45540c145e9a",
+  "receiptSha256": "71328e806d3d9aa1b2b85dd48b27d5e16206408eb347b4af101818821fc3a14c"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-5.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-5.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+    "sri": "sha512-4Lza4LwRXHIA5IfatsXlz9WrG7UyOAHrA7Lcs95Xgu1KnwYZkqXE3F2nf+hkZGzXGcjHNJ3Q3HGECYbKPTgRPQ=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-cli.test.ts",
+      "--testNamePattern",
+      "^用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 \\[necase_9FHHSQTVB492P8DS\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-7sZPGA/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2909641 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2909642 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2909670 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2912212 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "d4c2dfb5-54c9-4fea-9496-25befe92c423",
+  "receiptSha256": "1c6222557b7643f5791ca199bcce6ad21744c3eafe62ac838d3c017973062f10"
+}

--- a/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-6.json
+++ b/e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/reliability-6.json
@@ -1,0 +1,62 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS",
+  "caseId": "necase_9FHHSQTVB492P8DS",
+  "inventoryDigest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463",
+  "candidate": {
+    "gitSha": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "sha256": "e5d4c9849afbcbbea06ac914f718e6f622ebbec5a8eda0fd3ac3d3b1ff311900",
+    "sri": "sha512-4Lza4LwRXHIA5IfatsXlz9WrG7UyOAHrA7Lcs95Xgu1KnwYZkqXE3F2nf+hkZGzXGcjHNJ3Q3HGECYbKPTgRPQ=="
+  },
+  "source": {
+    "checkout": "087cc17f99a4443a4405fa89174dbf39dd741795",
+    "testFileSha256": "680f3bd797f02b8d57d7898b668320ee3ed3a69ab73789f8ccca27598a9838da",
+    "sidecarSha256": "26e9eb8ab619f3546a5b13a913b0850db5169792af1306547eee5116f02f5218"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-7sZPGA/runs/takeover/repo-default-parallel/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 2914963 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 2914964 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 2914991 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1b47cd74-eb02-44fa-86dd-7705feb5d286",
+  "receiptSha256": "ddcfcace8963b92ac891308d8f0e7b7c783faaf34933e1423b95aa3b889110d7"
+}

--- a/e2e/inspection/test/show-cli.test.ts.cases.evidence.json
+++ b/e2e/inspection/test/show-cli.test.ts.cases.evidence.json
@@ -37,6 +37,24 @@
           "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_inspection-overview-fixed-byte-limit.md/nered_108H8RGQ1RGRRNKW-netake_MSCB4EXBKKC1A1CH/inventory.json",
           "digest": "sha256:e92bef83901f0aefd783c1878c3afd4278b68e79b8234404d0bfd9ff662b3d9d"
         }
+      },
+      "memory/show-score-outcomes-rendered-as-pass-rate.md": {
+        "red": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/red.json",
+          "digest": "sha256:ef7138cb2c28ae160b0aa7f70adbab37c3d41506e5fbf477b0c9cc657fd006c4"
+        },
+        "green": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/green.json",
+          "digest": "sha256:66f33be6411bb97f33af87d126d89e4a43c86ae87fafbbcefc7cf75d912eafef"
+        },
+        "certificate": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/certificate.json",
+          "digest": "sha256:0cd7ddd2950d4844f26835059a3ac82b3f75765f558c9b40abe7cf7d95f07d3a"
+        },
+        "inventory": {
+          "path": "e2e/inspection/test/show-cli.test.ts.case-evidence/necase_9FHHSQTVB492P8DS/memory_show-score-outcomes-rendered-as-pass-rate.md/nered_99F7WPXW2JB629D5-netake_40G7KZMW4Z54KAB6/inventory.json",
+          "digest": "sha256:c3e47bd9c4df51324e16fb39ba64b96bc8985725bb5b1192794a519a36742463"
+        }
       }
     }
   },

--- a/e2e/inspection/test/show-cli.test.ts.cases.json
+++ b/e2e/inspection/test/show-cli.test.ts.cases.json
@@ -7,7 +7,8 @@
       "regressions": [
         "memory/inspection-overview-fixed-byte-limit.md",
         "memory/show-experiment-heading-detached-from-table.md",
-        "memory/show-overview-includes-stale-execution-identity.md"
+        "memory/show-overview-includes-stale-execution-identity.md",
+        "memory/show-score-outcomes-rendered-as-pass-rate.md"
       ],
       "issues": []
     }
@@ -50,6 +51,15 @@
       "action": "regression-added",
       "to": {
         "memory": "memory/inspection-overview-fixed-byte-limit.md"
+      }
+    },
+    {
+      "caseId": "necase_9FHHSQTVB492P8DS",
+      "atCommit": "087cc17f99a4443a4405fa89174dbf39dd741795",
+      "transactionId": "netxn_9e39286de10848bd95463a21cd43ed9c",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/show-score-outcomes-rendered-as-pass-rate.md"
       }
     }
   ],

--- a/memory/show-score-outcomes-rendered-as-pass-rate.md
+++ b/memory/show-score-outcomes-rendered-as-pass-rate.md
@@ -1,0 +1,28 @@
+---
+format: niceeval.memory/v1
+id: show-score-outcomes-rendered-as-pass-rate
+title: Show renders Score outcomes as a synthetic pass rate
+createdAt: 2026-09-04
+kind:
+  type: problem
+  state: resolved
+  resolution:
+    kind: fixed
+    proof:
+      - e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS
+      - nered_99F7WPXW2JB629D5
+      - netake_40G7KZMW4Z54KAB6
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS"]}
+promotions: []
+---
+## Problem
+
+For an Experiment containing only `defineScoreEval` evaluations, `niceeval show` renders successful Score Attempts as `passed`, includes `Verdicts`, and computes a pass rate. If two Score Attempts complete and one errors, the human output reports `66.67%` even though no pass threshold exists.
+
+## Root cause
+
+The human renderer formats every Inspection aggregate through one Verdict-first layout. It already receives the aggregate `evaluationKind`, but uses that discriminator only to decide whether to append Score. Totals, Experiment columns, Attempt headings, Attempt values, and compact hidden-result summaries continue to use pass-oriented labels unconditionally.
+
+## Repair boundary
+
+Keep machine Inspection Verdict and metric facts unchanged. In the human `show` projection, pure Score aggregates display `Outcomes` and `Score`, omit Verdicts and Pass rate, render successful Attempts as `scored`, preserve `errored`, and omit the Pass rate column from pure Score Experiment tables. Mixed aggregates continue to expose both kinds of metric.

--- a/packages/niceeval/src/show/render.ts
+++ b/packages/niceeval/src/show/render.ts
@@ -67,13 +67,17 @@ const aggregateEntries = (
   kind: "keyValue",
   entries: [
     { key: "Observed", value: `${value.observed}/${value.expected}` },
-    {
-      key: "Verdicts",
-      value: value.failed === 0 && value.errored === 0 && value.skipped === 0
-        ? `${value.passed} passed`
-        : `${value.passed} passed; ${value.failed} failed; ${value.errored} errored; ${value.skipped} skipped`,
-    },
-    { key: "Pass rate", value: passRate(value.passRate) },
+    ...(value.evaluationKind === "points"
+      ? [{
+        key: "Outcomes",
+        value: `${value.passed} scored; ${value.errored} errored; ${value.skipped} skipped`,
+      }]
+      : [{
+        key: "Verdicts",
+        value: value.failed === 0 && value.errored === 0 && value.skipped === 0
+          ? `${value.passed} passed`
+          : `${value.passed} passed; ${value.failed} failed; ${value.errored} errored; ${value.skipped} skipped`,
+      }, { key: "Pass rate", value: passRate(value.passRate) }]),
     ...(value.evaluationKind === "pass"
       ? []
       : [{ key: "Score", value: metric(value.score) }]),
@@ -116,6 +120,7 @@ const attemptBlocks = (
   let shownErrors = 0;
   return cells.flatMap((cell) => {
     const showScore = cell.aggregate.evaluationKind !== "pass";
+    const showScoreOutcome = cell.aggregate.evaluationKind === "points";
     const members = all
       ? cell.members
       : cell.members.filter((member) => {
@@ -139,7 +144,7 @@ const attemptBlocks = (
       kind: "table" as const,
       columns: [
         { header: "Attempt", maxWidth: 14 },
-        { header: "Verdict" },
+        { header: showScoreOutcome ? "Outcome" : "Verdict" },
         { header: "Duration" },
         ...(showScore ? [{ header: "Score" }] : []),
       ],
@@ -158,7 +163,11 @@ const attemptBlocks = (
               ? `absent (${member.publication.reason})`
               : "pending",
           member.publication.state === "published"
-            ? member.publication.verdict ?? "not-recorded"
+            ? showScoreOutcome
+              ? member.publication.verdict === "passed"
+                ? "scored"
+                : member.publication.verdict ?? "not-recorded"
+              : member.publication.verdict ?? "not-recorded"
             : member.publication.state,
           member.publication.state === "published"
             ? duration(member.publication.durationMs)
@@ -175,21 +184,22 @@ const attemptBlocks = (
 };
 
 const hiddenAttemptSummary = (cells: OverviewView["cells"]): string | null => {
-  const counts = { passed: 0, failed: 0, errored: 0 };
+  const counts = { passed: 0, failed: 0, scored: 0, errored: 0 };
   for (const cell of cells) {
     for (const member of cell.members) {
       if (member.publication.state !== "published") continue;
       const verdict = member.publication.verdict;
-      if (
-        verdict === "passed" ||
-        verdict === "failed" ||
-        verdict === "errored"
-      ) counts[verdict] += 1;
+      if (verdict === "passed") {
+        counts[cell.aggregate.evaluationKind === "points" ? "scored" : "passed"] += 1;
+      } else if (verdict === "failed" || verdict === "errored") {
+        counts[verdict] += 1;
+      }
     }
   }
   const hidden = [
     ...(counts.passed > 0 ? [`${counts.passed} passed`] : []),
     ...(counts.failed > 0 ? [`${counts.failed} failed`] : []),
+    ...(counts.scored > 0 ? [`${counts.scored} scored`] : []),
     ...(counts.errored > 5 ? [`${counts.errored - 5} errored`] : []),
   ];
   return hidden.length === 0 ? null : `${hidden.join("; ")} Attempts hidden`;
@@ -247,6 +257,9 @@ export function renderOverview(
       kind: "panel",
       title: "Experiments",
       blocks: groups.flatMap((group) => {
+        const showPassRate = group.experiments.some(({ aggregate }) =>
+          aggregate.evaluationKind !== "points"
+        );
         const showScore = group.experiments.some(({ aggregate }) =>
           aggregate.evaluationKind !== "pass"
         );
@@ -261,7 +274,7 @@ export function renderOverview(
               { header: "Observed" },
               { header: "Agent" },
               { header: "Model" },
-              { header: "Pass rate" },
+              ...(showPassRate ? [{ header: "Pass rate" }] : []),
               ...(showScore ? [{ header: "Score" }] : []),
             ],
             rows: group.experiments.map((experiment) => [
@@ -269,7 +282,7 @@ export function renderOverview(
               `${experiment.aggregate.observed}/${experiment.aggregate.expected}`,
               executionValue(experiment.agent),
               executionValue(experiment.model),
-              passRate(experiment.aggregate.passRate),
+              ...(showPassRate ? [passRate(experiment.aggregate.passRate)] : []),
               ...(showScore ? [metric(experiment.aggregate.score)] : []),
             ]),
           },

--- a/packages/repo-tools/src/cli.ts
+++ b/packages/repo-tools/src/cli.ts
@@ -532,6 +532,15 @@ const prEditProblem = Command.make("problem", {
   userOutcome,
 }, json)).pipe(Command.withDescription("Set the four required Problem fields."));
 
+const prClosingIssueOption = Options.integer("issue").pipe(Options.withDescription("GitHub issue number."));
+const prEditClosingIssueAdd = Command.make("add", {
+  pr: prNumberOption.pipe(Options.optional), source: sourceOption.pipe(Options.optional), issue: prClosingIssueOption, json: jsonOption,
+}, ({ pr, source, issue, json }) => runPr({ command: "edit", operation: "closing-issue-add", pr: Option.getOrUndefined(pr), source: Option.getOrUndefined(source), issue }, json)).pipe(Command.withDescription("Add a GitHub closing keyword for one issue."));
+const prEditClosingIssueRemove = Command.make("remove", {
+  pr: prNumberOption.pipe(Options.optional), source: sourceOption.pipe(Options.optional), issue: prClosingIssueOption, json: jsonOption,
+}, ({ pr, source, issue, json }) => runPr({ command: "edit", operation: "closing-issue-remove", pr: Option.getOrUndefined(pr), source: Option.getOrUndefined(source), issue }, json)).pipe(Command.withDescription("Remove one GitHub closing issue reference."));
+const prEditClosingIssue = Command.make("closing-issue").pipe(Command.withDescription("Maintain issue references that close when the PR merges."), Command.withSubcommands([prEditClosingIssueAdd, prEditClosingIssueRemove]));
+
 const prCaseSectionOption = Options.choice("section", PR_BODY_CASE_SECTIONS).pipe(Options.withDescription("PR template section owned by this case."));
 const prCaseDirectionOption = Options.choice("direction", PR_BODY_CASE_DIRECTIONS);
 const prCaseNameOption = Options.string("name").pipe(Options.withDescription("Stable Case heading."));
@@ -678,7 +687,7 @@ const prEditTest = Command.make("test").pipe(
 
 const prEdit = Command.make("edit").pipe(
   Command.withDescription("Edit a managed PR draft without writing Markdown directly."),
-  Command.withSubcommands([prEditReset, prEditProblem, prEditUseCase, prEditCase, prEditTest]),
+  Command.withSubcommands([prEditReset, prEditProblem, prEditClosingIssue, prEditUseCase, prEditCase, prEditTest]),
 );
 
 const prRender = Command.make("render", {

--- a/packages/repo-tools/src/pr/editor.ts
+++ b/packages/repo-tools/src/pr/editor.ts
@@ -74,6 +74,10 @@ export function updateEditorState(state: PrBodyEditorState, input: EditPrBodyInp
           userOutcome: input.userOutcome,
         },
       };
+    case "closing-issue-add":
+      return { ...state, closingIssues: [...new Set([...(state.closingIssues ?? []), input.issue])].sort((a, b) => a - b) };
+    case "closing-issue-remove":
+      return { ...state, closingIssues: (state.closingIssues ?? []).filter((issue) => issue !== input.issue) };
     case "case-set": {
       const item: PrBodyCase = {
         section: input.section,
@@ -215,6 +219,11 @@ function renderProblem(state: PrBodyEditorState): string | undefined {
   ].join("\n");
 }
 
+function renderClosingIssues(state: PrBodyEditorState): string | undefined {
+  if (!state.closingIssues?.length) return undefined;
+  return ["## Closing issues", "", ...state.closingIssues.map((issue) => `Fixes #${issue}`)].join("\n");
+}
+
 function renderCases(state: PrBodyEditorState): readonly string[] {
   const sections: string[] = [];
   for (const section of PR_BODY_CASE_SECTIONS) {
@@ -258,7 +267,7 @@ function renderTests(tests: readonly TestDirective[]): string | undefined {
 }
 
 export function renderEditorState(state: PrBodyEditorState): string {
-  const blocks = [renderProblem(state), renderUseCases(state), ...renderCases(state), renderTests(state.tests)]
+  const blocks = [renderProblem(state), renderClosingIssues(state), renderUseCases(state), ...renderCases(state), renderTests(state.tests)]
     .filter((block): block is string => block !== undefined);
   return `${blocks.join("\n\n")}\n`;
 }

--- a/packages/repo-tools/src/pr/model.ts
+++ b/packages/repo-tools/src/pr/model.ts
@@ -36,6 +36,18 @@ export interface EditProblemInput extends EditLocationInput, PrBodyProblem {
   readonly operation: "problem";
 }
 
+export interface EditClosingIssueAddInput extends EditLocationInput {
+  readonly command: "edit";
+  readonly operation: "closing-issue-add";
+  readonly issue: number;
+}
+
+export interface EditClosingIssueRemoveInput extends EditLocationInput {
+  readonly command: "edit";
+  readonly operation: "closing-issue-remove";
+  readonly issue: number;
+}
+
 export interface EditCaseSetInput extends EditLocationInput, PrBodyCase {
   readonly command: "edit";
   readonly operation: "case-set";
@@ -92,6 +104,8 @@ export interface EditTestRemoveInput extends EditLocationInput {
 export type EditPrBodyInput =
   | EditResetInput
   | EditProblemInput
+  | EditClosingIssueAddInput
+  | EditClosingIssueRemoveInput
   | EditCaseSetInput
   | EditCaseRemoveInput
   | EditUseCaseSetInput
@@ -222,6 +236,7 @@ export interface PrBodyCase {
 export interface PrBodyEditorState {
   readonly version: 2;
   readonly problem?: PrBodyProblem | undefined;
+  readonly closingIssues?: readonly number[] | undefined;
   readonly cases: readonly PrBodyCase[];
   readonly useCases: readonly PrBodyUseCase[];
   readonly tests: readonly TestDirective[];

--- a/packages/repo-tools/src/pr/schema.ts
+++ b/packages/repo-tools/src/pr/schema.ts
@@ -115,6 +115,18 @@ const EditProblemInputSchema = Schema.Struct({
   ...EditorLocationFields,
   ...ProblemFields,
 });
+const EditClosingIssueAddInputSchema = Schema.Struct({
+  command: Schema.Literal("edit"),
+  operation: Schema.Literal("closing-issue-add"),
+  ...EditorLocationFields,
+  issue: PositiveInteger,
+});
+const EditClosingIssueRemoveInputSchema = Schema.Struct({
+  command: Schema.Literal("edit"),
+  operation: Schema.Literal("closing-issue-remove"),
+  ...EditorLocationFields,
+  issue: PositiveInteger,
+});
 const EditCaseSetInputSchema = Schema.Struct({
   command: Schema.Literal("edit"),
   operation: Schema.Literal("case-set"),
@@ -167,6 +179,8 @@ export const PrBodyInputSchema = Schema.Union([
   DiscardInputSchema,
   EditResetInputSchema,
   EditProblemInputSchema,
+  EditClosingIssueAddInputSchema,
+  EditClosingIssueRemoveInputSchema,
   EditCaseSetInputSchema,
   EditCaseRemoveInputSchema,
   EditUseCaseSetInputSchema,
@@ -182,6 +196,7 @@ export const PrBodyInputSchema = Schema.Union([
 const PrBodyEditorStateSchema = Schema.Struct({
   version: Schema.Literal(2),
   problem: Schema.optional(Schema.Struct(ProblemFields)),
+  closingIssues: Schema.optional(Schema.Array(PositiveInteger)),
   cases: Schema.Array(Schema.Struct(CaseFields)),
   useCases: Schema.Array(Schema.Struct(UseCaseFields)),
   tests: Schema.Array(TestDirectiveSchema),


### PR DESCRIPTION
<!-- niceeval:pr-body
base: 087cc17f99a4443a4405fa89174dbf39dd741795
templateSha256: 6d2dc9748b9a82ac4f2c36d1324ff50ef87ecd622843d15559307e4170aec67e
head: f404b261e9477ee5864e5e0115bb3e212d5af9ea
-->

## Problem

- User goal: 查看纯 Score 实验时准确理解已计分、报错与总分
- Current limitation: show 把已计分 Attempt 当成 passed，并为纯 Score 实验显示无意义的 Pass rate
- Required capability: 展示层必须按 evaluation kind 投影 Outcomes、Attempt Outcome 与实验列
- User outcome: 纯 Score 报告只显示 scored/errored/skipped 和 Score，不再暗示通过率

## Closing issues

Fixes #218

## CLI

### Added

#### Case: 受管 PR 正文关闭 Issue

##### Before

```sh
pnpm pr:body edit closing-issue add --issue 218
```

```text
Unknown subcommand: closing-issue
```

##### After

```sh
pnpm pr:body edit closing-issue add --issue 218
```

```text
Fixes #218
```

##### User impact

PR 作者可通过受管工具声明合并时自动关闭对应 Issue，无需绕过模板手改正文。

### Changed

#### Case: 纯 Score 实验汇总

##### Before

```sh
pnpm exec niceeval show --experiment score-only
```

```text
Verdicts  2 passed; 0 failed; 1 errored; 0 skipped
Pass rate  66.67%
Score      18
```

##### After

```sh
pnpm exec niceeval show --experiment score-only
```

```text
Outcomes  2 scored; 1 errored; 0 skipped
Score     18
```

##### User impact

用户不会再把 Score 完成情况误读成 pass/fail 质量门。

## Tests

### `e2e/inspection/test/show-cli.test.ts`

#### `e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS`

纯 Score 实验汇总使用 scored/errored Outcomes 并省略 Verdicts 与 Pass rate It exercises 安装候选包后运行 score-only 实验，再通过 niceeval show 查看 Experiment 与 Overview and asserts 汇总、Attempt 表与纯 Score 实验列均按 Score 语义呈现，且错误 Attempt 保持 errored. Deleting this case would allow 删除这些断言会放走把 scored 重新显示为 passed 或重新生成合成通过率的回归. The final contract is [docs/feature/inspection/cli.md#niceeval-show](docs/feature/inspection/cli.md#niceeval-show). It also prevents the regression recorded in [memory/show-score-outcomes-rendered-as-pass-rate.md](memory/show-score-outcomes-rendered-as-pass-rate.md).

```ts
// rerun: pnpm e2e test --repo inspection -- --run test/show-cli.test.ts

import { only } from "@niceeval/testkit";
import { readFileSync, writeFileSync } from "node:fs";
import { join } from "node:path";
import { expect, test } from "vitest";
import { inspectionCaseArtifacts, inspectionE2E } from "./support.ts";

function expectHumanText(stdout: string): void {
  expect(stdout.trim()).not.toBe("");
  expect(() => JSON.parse(stdout)).toThrow();
}

function expectInOrder(stdout: string, values: readonly string[]): void {
  let cursor = 0;
  for (const value of values) {
    const position = stdout.indexOf(value, cursor);
    expect(
      position,
      `expected ${JSON.stringify(value)} after byte ${cursor} in:\n${stdout}`,
    ).toBeGreaterThanOrEqual(cursor);
    cursor = position + value.length;
  }
}

interface FailedShowResult {
  readonly exitCode: number;
  readonly stdout: string;
  readonly stderr: string;
  diagnostic(): string;
}

function expectShowFailure(
  result: FailedShowResult,
  stderrValues: readonly string[],
): void {
  expect(result.exitCode, result.diagnostic()).not.toBe(0);
  expect(result.stdout, result.diagnostic()).toBe("");
  expect(result.stderr.trim(), result.diagnostic()).not.toBe("");
  for (const value of stderrValues) {
    expect(result.stderr, result.diagnostic()).toContain(value);
  }
}

function stableIdentity(stdout: string, label: string): string {
  const escaped = label.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
  const identity = stdout.match(new RegExp(`^\\s*${escaped}\\s+(\\S+)\\s*$`, "mu"))?.[1];
  expect(identity, `expected ${label} in stable identity index:\n${stdout}`).toBeDefined();
  if (identity === undefined) throw new Error(`expected ${label} stable identity`);
  expect(identity).not.toMatch(/^(?:t\d+\.c\d+|cmd\d+)$/u);
  return identity;
}

test("用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]", async () => {
  await inspectionE2E.case(
    "show-terminal-review",
    { artifacts: inspectionCaseArtifacts() },
    async ({ commands: { niceeval }, paths }) => {
      const mainExperimentId = "harness/canary";
      const alternateExperimentId = "harness/alternate";
      const scaleExperimentId = "harness/scale";
      const scoreOnlyExperimentId = "score-only";
      const mainProduced = await niceeval.run(["exp", mainExperimentId, "--rerun", "all", "--json"]);
      expect(mainProduced.exitCode, mainProduced.diagnostic()).toBe(0);
      expect(mainProduced.expReceipt(), mainProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const mainRunId = only(mainProduced.expReceipt().createdRunIds, () => true, mainProduced.diagnostic());
      const attempt = only(
        mainProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        mainProduced.diagnostic(),
      );
      expect(attempt).toMatchObject({ verdict: "passed" });
      const locator = attempt.locator.startsWith("@") ? attempt.locator : `@${attempt.locator}`;

      const alternateProduced = await niceeval.run(["exp", alternateExperimentId, "--rerun", "all", "--json"]);
      expect(alternateProduced.exitCode, alternateProduced.diagnostic()).toBe(0);
      expect(alternateProduced.expReceipt(), alternateProduced.diagnostic()).toMatchObject({ completion: "completed" });
      const alternateRunId = only(
        alternateProduced.expReceipt().createdRunIds,
        () => true,
        alternateProduced.diagnostic(),
      );
      const alternateAttempt = only(
        alternateProduced.expEvalEvents(),
        (event) => event.evalId === "inspection",
        alternateProduced.diagnostic(),
      );
      expect(alternateAttempt).toMatchObject({ verdict: "passed" });
      const alternateLocator = alternateAttempt.locator.startsWith("@")
        ? alternateAttempt.locator
        : `@${alternateAttempt.locator}`;

      const scaleProduced = await niceeval.run([
        "exp",
        scaleExperimentId,
        "--rerun",
        "all",
        "--json",
      ]);
      expect(scaleProduced.exitCode, scaleProduced.diagnostic()).toBe(0);
      expect(scaleProduced.expReceipt(), scaleProduced.diagnostic()).toMatchObject({
        completion: "completed",
      });
      expect(scaleProduced.expEvalEvents(), scaleProduced.diagnostic()).toEqual([
        expect.objectContaining({
          evalId: "overview-scale",
          attempts: 10,
          passed: 10,
          verdict: "passed",
        }),
      ]);

      const passOnlyExperiment = await niceeval.run(["show", "--experiment", scaleExperimentId]);
      expect(passOnlyExperiment.exitCode, passOnlyExperiment.diagnostic()).toBe(0);
      expectHumanText(passOnlyExperiment.stdout);
      expect(passOnlyExperiment.stdout).toContain("Pass rate");
      expect(passOnlyExperiment.stdout).toContain("Eval overview-scale");
      expect(passOnlyExperiment.stdout).toMatch(/Attempt\s+Verdict\s+Duration/u);
      expect(passOnlyExperiment.stdout.match(/^\s*@\S+\s+passed\s+\d+(?:\.\d+)? (?:ms|s|min|h)\s*$/gmu)).toHaveLength(10);
      expect(passOnlyExperiment.stdout).not.toContain("Attempts hidden");
      expect(passOnlyExperiment.stdout).not.toContain("Score");
      expect(passOnlyExperiment.stdout).not.toContain("unsupported");

      const scoreOnlyProduced = await niceeval.run([
        "exp",
        scoreOnlyExperimentId,
        "--rerun",
        "all",
        "--json",
      ]);
      expect(scoreOnlyProduced.exitCode, scoreOnlyProduced.diagnostic()).not.toBe(0);
      expect(scoreOnlyProduced.expReceipt(), scoreOnlyProduced.diagnostic()).toMatchObject({
        completion: "completed",
      });
      expect(scoreOnlyProduced.expEvalEvents(), scoreOnlyProduced.diagnostic()).toEqual(
        expect.arrayContaining([
          expect.objectContaining({ evalId: "score", verdict: "passed" }),
          expect.objectContaining({ evalId: "overview/secondary", verdict: "passed" }),
          expect.objectContaining({ evalId: "score-error", verdict: "errored" }),
        ]),
      );

      const scoreOnlyExperiment = await niceeval.run([
        "show",
        "--experiment",
        scoreOnlyExperimentId,
      ]);
      expect(scoreOnlyExperiment.exitCode, scoreOnlyExperiment.diagnostic()).toBe(0);
      expectHumanText(scoreOnlyExperiment.stdout);
      expect(scoreOnlyExperiment.stdout).toMatch(/Observed\s+3\/3/u);
      expect(scoreOnlyExperiment.stdout).toMatch(/Outcomes\s+2 scored; 1 errored; 0 skipped/u);
      expect(scoreOnlyExperiment.stdout).toContain("Score");
      expect(scoreOnlyExperiment.stdout).toMatch(/Attempt\s+Outcome\s+Duration\s+Score/u);
      expect(scoreOnlyExperiment.stdout).not.toContain("Verdicts");
      expect(scoreOnlyExperiment.stdout).not.toContain("Pass rate");
      expect(scoreOnlyExperiment.stdout).not.toContain("passed Attempts hidden");

      const overviewRequestPath = join(paths.projectRoot, "overview-request.json");
      writeFileSync(
        overviewRequestPath,
        JSON.stringify({
          protocol: "niceeval.query/v1",
          operation: { kind: "overview.get" },
        }),
        "utf8",
      );
      const machineOverview = await niceeval.run([
        "query",
        "run",
        "--request",
        overviewRequestPath,
      ]);
      expect(machineOverview.exitCode, machineOverview.diagnostic()).toBe(0);
      expect(Buffer.byteLength(machineOverview.stdout, "utf8")).toBeGreaterThan(512 * 1024);

      const overview = await niceeval.run(["show"]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      expectHumanText(overview.stdout);
      expectInOrder(overview.stdout, ["Totals", "Experiments"]);
      expectInOrder(overview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(overview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${scaleExperimentId}`);
      expect(overview.stdout).toContain(`Experiment ${scoreOnlyExperimentId}`);
      expect(overview.stdout).toMatch(/Experiment\s+Observed\s+Agent\s+Model\s+Score[\s\S]+score-only\s+3\/3/u);
      expect(overview.stdout).toMatch(/scale\s+10\/10\s+/u);
      expect(overview.stdout).toContain("passed Attempts hidden");
      expect(overview.stdout).toContain(
        `See more  niceeval show --experiment ${mainExperimentId}`,
      );
      expect(overview.stdout).not.toMatch(/\bAction\b|\bRelation\b|\(available\)/u);
      expect(overview.stdout).not.toContain(locator);
      expect(overview.stdout).not.toContain(alternateLocator);
      expect(overview.stdout).toContain("100%");

      const expandedOverview = await niceeval.run(["show", "--all"]);
      expect(expandedOverview.exitCode, expandedOverview.diagnostic()).toBe(0);
      expectInOrder(expandedOverview.stdout, [`Experiment ${mainExperimentId}`, "Eval inspection", locator]);
      expectInOrder(expandedOverview.stdout, [`Experiment ${alternateExperimentId}`, "Eval inspection", alternateLocator]);
      expect(expandedOverview.stdout).toMatch(/Attempt\s+Outcome\s+Duration\s+Score/u);
      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${locator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));
      expect(expandedOverview.stdout).toMatch(new RegExp(`^\\s*${alternateLocator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"));

      const run = await niceeval.run(["show", "--run", mainRunId]);
      expect(run.exitCode, run.diagnostic()).toBe(0);
      expectHumanText(run.stdout);
      expect(run.stdout).toContain(mainRunId);
      expectInOrder(run.stdout, [mainExperimentId, "inspection", locator]);

      const runs = await niceeval.run([
        "show",
        "--run",
        alternateRunId,
        "--run",
        mainRunId,
      ]);
      expect(runs.exitCode, runs.diagnostic()).toBe(0);
      expectHumanText(runs.stdout);
      expect(runs.stdout).toContain(`Run ${mainRunId}`);
      expect(runs.stdout).toContain(`Run ${alternateRunId}`);
      expect(runs.stdout).toContain(locator);
      expect(runs.stdout).toContain(alternateLocator);
      expect(runs.stdout.match(/^Run /gmu)).toHaveLength(2);

      const atomicRunsFailure = await niceeval.run([
        "show",
        "--run",
        mainRunId,
        "--run",
        "missing-run",
      ]);
      expectShowFailure(atomicRunsFailure, ["missing-run"]);

      const mainExperiment = await niceeval.run(["show", "--experiment", mainExperimentId]);
      expect(mainExperiment.exitCode, mainExperiment.diagnostic()).toBe(0);
      expectHumanText(mainExperiment.stdout);
      expect(mainExperiment.stdout).toContain(mainExperimentId);
      expect(mainExperiment.stdout).toContain(locator);
      expect(mainExperiment.stdout).not.toContain(alternateLocator);

      const experiments = await niceeval.run([
        "show",
        "--experiment",
        alternateExperimentId,
        "--experiment",
        mainExperimentId,
      ]);
      expect(experiments.exitCode, experiments.diagnostic()).toBe(0);
      expectHumanText(experiments.stdout);
      expect(experiments.stdout).toContain(mainExperimentId);
      expect(experiments.stdout).toContain(alternateExperimentId);
      expect(experiments.stdout).toContain(locator);
      expect(experiments.stdout).toContain(alternateLocator);

      const missingExperiment = await niceeval.run([
        "show",
        "--experiment",
        mainExperimentId,
        "--experiment",
        "does-not-exist",
      ]);
      expectShowFailure(missingExperiment, ["does-not-exist"]);

      const attemptOverview = await niceeval.run(["show", locator]);
      expect(attemptOverview.exitCode, attemptOverview.diagnostic()).toBe(0);
      expectHumanText(attemptOverview.stdout);
      expect(attemptOverview.stdout).toContain(locator);
      expectInOrder(attemptOverview.stdout, [mainExperimentId, "inspection", "Outcome", "Score", "Evidence"]);
      expect(attemptOverview.stdout).toContain("passed");
      expect(attemptOverview.stdout).toContain("Inspection tool occurrence");
      expect(attemptOverview.stdout).toContain("Compact score contribution");
      expect(attemptOverview.stdout).toContain("Mismatched Boolean contributes zero");
      expect(attemptOverview.stdout).toContain("Measurement contributes three points");
      expect(attemptOverview.stdout).toContain("Collection evidence remains bounded");
      expect(attemptOverview.stdout).toMatch(/assertions\s+(?:available|partial)\s+·\s+5 entries/u);
      expect(attemptOverview.stdout).toMatch(/coverage\s+.+/u);
      expect(attemptOverview.stdout).toMatch(/limitations\s+.+/u);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --source`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --execution`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --timing`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --usage`);
      expect(attemptOverview.stdout).toContain(`niceeval show ${locator} --diff`);

      const source = await niceeval.run(["show", locator, "--source"]);
      expect(source.exitCode, source.diagnostic()).toBe(0);
      expectHumanText(source.stdout);
      expect(source.stdout).toContain("Captured source");
      expect(source.stdout).toContain("inspection.eval.ts");
      expect(source.stdout).toContain("Inspection tool occurrence");
      const sourceIdentity = source.stdout.match(/inspection\.eval\.ts · (\S+) · \d+ bytes/u)?.[1];
      expect(sourceIdentity, source.diagnostic()).toBeDefined();
      if (sourceIdentity === undefined) throw new Error("expected captured source identity");
      expect(source.stdout.split(sourceIdentity).length - 1).toBeGreaterThan(1);
      expect(source.stdout).toMatch(
        new RegExp(`Assertion source facts[\\s\\S]+mapped · ${sourceIdentity} · [0-9a-f]{64}`, "u"),
      );

      const execution = await niceeval.run(["show", locator, "--execution"]);
      expect(execution.exitCode, execution.diagnostic()).toBe(0);
      expectHumanText(execution.stdout);
      expect(execution.stdout).toContain(locator);
      expect(execution.stdout).toContain("Conversation · partial");
      expect(execution.stdout).toContain("Commands ·");
      expect(execution.stdout).toContain("Stable identities");
      expect(execution.stdout).toContain("inspection_fixture");
      expect(execution.stdout).toContain("inspection-tool-input");
      expect(execution.stdout).toContain("inspection-tool-result");
      const itemIdentity = stableIdentity(execution.stdout, "item");
      const toolIdentity = stableIdentity(execution.stdout, "tool occurrence");
      const commandIdentity = stableIdentity(execution.stdout, "command");
      expect(execution.stdout.split(itemIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(toolIdentity).length - 1).toBeGreaterThan(1);
      expect(execution.stdout.split(commandIdentity).length - 1).toBeGreaterThan(1);

      const itemDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        itemIdentity,
      ]);
      expect(itemDetail.exitCode, itemDetail.diagnostic()).toBe(0);
      expectHumanText(itemDetail.stdout);
      expect(itemDetail.stdout).toContain(locator);
      expect(itemDetail.stdout).toContain(itemIdentity);
      expect(itemDetail.stdout).toContain("item");

      const toolDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        toolIdentity,
      ]);
      expect(toolDetail.exitCode, toolDetail.diagnostic()).toBe(0);
      expectHumanText(toolDetail.stdout);
      expect(toolDetail.stdout).toContain(locator);
      expect(toolDetail.stdout).toContain(toolIdentity);
      expect(toolDetail.stdout).toContain("inspection_fixture");
      expect(toolDetail.stdout).toContain("inspection-tool-input");
      expect(toolDetail.stdout).toContain("inspection-tool-result");

      const commandDetail = await niceeval.run([
        "show",
        locator,
        "--execution",
        "--expand",
        commandIdentity,
      ]);
      expect(commandDetail.exitCode, commandDetail.diagnostic()).toBe(0);
      expectHumanText(commandDetail.stdout);
      expect(commandDetail.stdout).toContain(locator);
      expect(commandDetail.stdout).toContain(commandIdentity);
      expect(commandDetail.stdout).toMatch(/invocation|command/iu);
      expect(commandDetail.stdout).toMatch(/outcome|exit/iu);

      const timing = await niceeval.run(["show", locator, "--timing"]);
      expect(timing.exitCode, timing.diagnostic()).toBe(0);
      expectHumanText(timing.stdout);
      expect(timing.stdout).toContain(locator);
      expect(timing.stdout).toMatch(/timing/iu);
      expect(timing.stdout).toContain("eval.run");

      const usage = await niceeval.run(["show", locator, "--usage"]);
      expect(usage.exitCode, usage.diagnostic()).toBe(0);
      expectHumanText(usage.stdout);
      expect(usage.stdout).toContain(locator);
      expect(usage.stdout).toMatch(/usage/iu);
      expect(usage.stdout).toMatch(/input(?: tokens)?\s+10/iu);
      expect(usage.stdout).toMatch(/output(?: tokens)?\s+5/iu);
      expect(usage.stdout).toMatch(/requests?\s+1/iu);

      const diff = await niceeval.run(["show", locator, "--diff"]);
      expect(diff.exitCode, diff.diagnostic()).toBe(0);
      expectHumanText(diff.stdout);
      expect(diff.stdout).toContain(locator);
      expect(diff.stdout).toMatch(/diff/iu);
      expect(diff.stdout).toContain("complete");
      expect(diff.stdout).toContain("inspection-agent-change.txt");
      expect(diff.stdout).toContain("created");

      const usageErrors: readonly {
        readonly argv: readonly string[];
        readonly stderr: readonly string[];
      }[] = [
        { argv: ["show", locator, "--source", "--execution"], stderr: ["--source", "--execution"] },
        { argv: ["show", locator, "--expand", itemIdentity], stderr: ["--expand", "--execution"] },
        { argv: ["show", locator, "--run", mainRunId], stderr: ["--run"] },
        { argv: ["show", locator, "--experiment", mainExperimentId], stderr: ["--experiment"] },
        { argv: ["show", locator, "--all"], stderr: ["--all"] },
        { argv: ["show", "--run", mainRunId, "--all"], stderr: ["--all", "--run"] },
        { argv: ["show", "--experiment", mainExperimentId, "--all"], stderr: ["--all", "--experiment"] },
        { argv: ["show", locator, "--timing", "--usage"], stderr: ["--timing", "--usage"] },
        { argv: ["show", locator, "--source", "--diff"], stderr: ["--source", "--diff"] },
        { argv: ["show", locator, "--execution", "--expand", "item_missing"], stderr: ["item_missing"] },
        { argv: ["show", locator, "--execution", "--expand", "t1.c1"], stderr: ["stable", "itemId"] },
        { argv: ["show", locator, "--execution", "--expand", "cmd1"], stderr: ["stable", "commandId"] },
        { argv: ["show", locator, "--json"], stderr: ["--json"] },
        { argv: ["show", locator, "--report", "standard"], stderr: ["--report"] },
        { argv: ["show", "@does-not-exist"], stderr: ["does-not-exist"] },
      ];
      for (const usageError of usageErrors) {
        expectShowFailure(
          await niceeval.run([...usageError.argv]),
          usageError.stderr,
        );
      }

      const evalPath = join(paths.projectRoot, "evals", "inspection.eval.ts");
      const evalSource = readFileSync(evalPath, "utf8");
      expect(evalSource).toContain("inspection-fixture");
      writeFileSync(
        evalPath,
        evalSource.replace("inspection-fixture", "inspection-fixture-after-review"),
        "utf8",
      );

      const changedPlan = await niceeval.run(["exp", mainExperimentId, "--dry"]);
      expect(changedPlan.exitCode, changedPlan.diagnostic()).toBe(0);
      expect(changedPlan.stdout).toContain("identity-mismatch");
      expect(changedPlan.stdout).toContain(`niceeval accept ${locator}`);

      const historicalOverview = await niceeval.run(["show", "--all"]);
      expect(historicalOverview.exitCode, historicalOverview.diagnostic()).toBe(0);
      expectHumanText(historicalOverview.stdout);
      expectInOrder(historicalOverview.stdout, ["Totals", "Experiments"]);
      expectInOrder(historicalOverview.stdout, [
        "harness",
        "Experiment",
        "Observed",
        "Pass rate",
        "Score",
        "alternate",
        "canary",
      ]);
      expect(historicalOverview.stdout).toContain(`Experiment ${mainExperimentId}`);
      expect(historicalOverview.stdout).toContain(`Experiment ${alternateExperimentId}`);
      expect(historicalOverview.stdout).toContain(locator);
      expect(historicalOverview.stdout).toContain(alternateLocator);
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*${locator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).toMatch(
        new RegExp(`^\\s*${alternateLocator}\\s+scored\\s+\\d+(?:\\.\\d+)? (?:ms|s|min|h)\\s+37\\.11\\s*$`, "mu"),
      );
      expect(historicalOverview.stdout).not.toContain("Observed   0/0");
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791107240&installation_model_id=431746&pr_number=220&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F220&signature=4cf0d18bc71f0996b2547a3f68041b6bcdf2b5c56c4828f5c5d30f33c37ac069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->