### PR TITLE
修正 show 的 Experiment 分组并明确题型一致性

### DIFF
--- a/docs/feature/eval/README.md
+++ b/docs/feature/eval/README.md
@@ -148,8 +148,8 @@ Boolean mismatch 不会得到 `failed`；正常封口为 `passed`，execution er
 百分比或隐式每项 `+1`。
 
 题型是定义期事实，进入 `EvalDescriptor.evaluationKind`（`"pass" | "score"`）供 Inspection
-选择主读数，而不是 durable family。`points` 只在 Score Eval 内表示 Assertion 分值。一个 Experiment 可以
-同时选择两种题型，但每条 Attempt 按自己的 evaluationKind 解释。
+选择主读数，而不是 durable family。`points` 只在 Score Eval 内表示 Assertion 分值。单个 Experiment 的实际选择必须同型；
+不同 Experiment 可以各自选择 Pass 或 Score Eval，Inspection 仍按每条 Attempt 自己的 `evaluationKind` 解释历史 Record。
 
 完整 score 语义见 [Assertions · Score Eval](../assertions/library/score-points.md)，完整场景见
 [Score Eval 用例](use-case/rubric-points.md)。

--- a/docs/feature/inspection/cli.md
+++ b/docs/feature/inspection/cli.md
@@ -40,8 +40,8 @@ origin Run 是否 active 不影响已经原子发布的 Attempt 可见性。
 旧 occurrence 仍可由 Run operation 读取，但不重复进入默认 Results 分母。结果保留 experiment、Eval 路径 group、
 Eval、Attempt ordinal、selected Run、target Slot、membership action、origin/reference relation 与 locator。
 
-每个 `experimentId + evalId` cell 同时交付 `pass | points | mixed` evaluation kind。
-它还交付 expected／observed／classified／missing denominator、四态 Verdict tally、pass rate、points score、
+每个 `experimentId + evalId` cell 交付 `pass | points` evaluation kind；历史 Record 中同一逻辑 cell 留有两种题型时，
+协议保留 `mixed` 以忠实读取既有事实。它还交付 expected／observed／classified／missing denominator、四态 Verdict tally、pass rate、points score、
 coverage 与 issues。
 顶层 totals、Experiment totals 与路径 group totals 由同一批 selected cell 折叠。调用方不得从 locator 数、历史 Run、
 最后一条 Attempt 或单独的 score 值重新计算另一套结果。
@@ -68,7 +68,7 @@ observed。只要所选 source 未命中全部 eligible slot，`state` 就是 `p
 折叠。member 与 cell score 的 `basis` 是 `slot`；Experiment、group 与 totals score 的 `basis` 是 `eval`，
 其 `samples`／`total` 计 contributing／eligible per-Eval cell。所有值都保留 `MetricValue` state、issues 与 refs。
 
-`mixed` cell 的 pass members 不进入 points 的 `samples` 或 `total`。`totalScore` 不存在，不能成为第二权威字段。
+历史 `mixed` cell 的 pass members 不进入 points 的 `samples` 或 `total`。`totalScore` 不存在，不能成为第二权威字段。
 
 Insight Results 调用同一个 `overview.get` result meaning，并只负责默认 Experiment 选择、表格、链接、
 折叠、本地化和成本 × 通过率或分数散点图。它不是另一套 Results 数据源。`query` 只编码 machine document，下文的 `show`
@@ -249,7 +249,7 @@ denominator、pass rate、score、coverage、usage、timing、diff 或 Evidence�
   `See more: niceeval show --experiment <id>` 命令。
 
   `--all` 展开全部 Attempt。展开后的明细先以 `Eval <id>` 缩进分组，不在每个 Attempt 行重复 Eval ID；
-  同一 Eval 的多个 Attempt 各占一行。Pass 或 mixed Eval 显示 `Attempt`、`Verdict` 与 `Duration`；
+  同一 Eval 的多个 Attempt 各占一行。Pass 或历史 mixed Eval 显示 `Attempt`、`Verdict` 与 `Duration`；
   Score Eval 显示 `Attempt`、`Outcome`、`Duration` 与 `Score`，正常完成写成 `scored` 而不是 `passed`。
 
   Verdict 为 `passed`、`failed`、`errored` 或 `skipped`。Duration 按大小使用 `ms`、`s`、`min` 或 `h`，
@@ -300,7 +300,7 @@ human renderer 不输出 `Score unsupported` 占位：Totals 及某张表的全�
 反过来，纯 score 制 totals 显示 `Outcomes` 与 `Score`，不显示 `Verdicts` 或 `Pass rate`；纯 score 制
 Experiment 表省略 `Pass rate` 列。正常完成数显示为 `scored`，execution error 仍显示为 `errored`。
 
-mixed 投影并排保留 pass rate 与 score。machine result 始终保留原始 typed Verdict 与 metric，不因人读展示而改写。
+包含历史 mixed cell 的投影并排保留 pass rate 与 score。machine result 始终保留原始 typed Verdict 与 metric，不因人读展示而改写。
 machine result 始终保留 typed `unsupported`。Experiment summary 按路径首段分组，
 Attempt 明细再按完整 Experiment 分表，使 80 列终端可以在同一行保留完整 locator：
 

--- a/e2e/inspection/test/show-cli.test.ts.cases.json
+++ b/e2e/inspection/test/show-cli.test.ts.cases.json
@@ -6,7 +6,6 @@
       "owner": "docs/engineering/testing/e2e/inspection.md#show-terminal-review",
       "regressions": [
         "memory/inspection-overview-fixed-byte-limit.md",
-        "memory/show-experiment-heading-detached-from-table.md",
         "memory/show-overview-includes-stale-execution-identity.md",
         "memory/show-score-outcomes-rendered-as-pass-rate.md"
       ],

--- a/e2e/inspection/test/show-experiment-spacing.test.ts
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts
@@ -1,0 +1,29 @@
+// rerun: pnpm e2e test --repo inspection -- --run test/show-experiment-spacing.test.ts
+
+import { expect, test } from "vitest";
+import { inspectionE2E } from "./support.ts";
+
+test.concurrent("Show 把 Experiment 标题和自己的内容排在同一段 [necase_NRD2EXM6620FRXHN]", async () => {
+  await inspectionE2E.case(
+    "show-experiment-spacing",
+    async ({ commands: { niceeval } }) => {
+      for (const experimentId of ["harness/alternate", "harness/canary"]) {
+        const produced = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
+        expect(produced.exitCode, produced.diagnostic()).toBe(0);
+      }
+
+      const overview = await niceeval.run(["show"]);
+      expect(overview.exitCode, overview.diagnostic()).toBe(0);
+      expect(overview.stdout).toContain([
+        "Attempts · harness",
+        "  Experiment harness/alternate",
+        "  1 scored Attempts hidden",
+        "  See more  niceeval show --experiment harness/alternate",
+        "  ",
+        "  Experiment harness/canary",
+        "  1 scored Attempts hidden",
+        "  See more  niceeval show --experiment harness/canary",
+      ].join("\n"));
+    },
+  );
+});

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/certificate.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "candidateSha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+  "greenReceipt": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-1.json",
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-2.json",
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-4.json",
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-6.json",
+    "singleCase": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/green.json",
+    "cleanup": [
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/e2e/show-spacing-new-case-takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/e2e/show-spacing-new-case-takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/e2e/show-spacing-new-case-takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/e2e/show-spacing-new-case-takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/e2e/show-spacing-new-case-takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/e2e/show-spacing-new-case-takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/e2e/show-spacing-new-case-takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "23c4fc31c029f96936462aa343f07916a712e097dd80a17c9d019c30db4dc252"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/green.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/green.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-lmqgZ3/runs/takeover/target-single/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3285501 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3285503 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3285545 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "cc22133d-59df-437e-8266-18951274fc7c",
+  "receiptSha256": "a87b46dbff920c639e1d03655bad90f96043eeea9e1f386966d9f449103daa39"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/inventory.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/inventory.json
@@ -1,0 +1,55 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "inspection",
+  "argv": [
+    "/nix/store/k3nz3s314bipvqbcbw3faq823hxpwbn1-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-r5TVNL/repos/inspection/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+  "files": [
+    "e2e/inspection/test/inspection-query.test.ts",
+    "e2e/inspection/test/show-cli.test.ts",
+    "e2e/inspection/test/show-experiment-spacing.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/inspection-query.test.ts",
+      "titlePath": [
+        "machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]"
+      ],
+      "caseId": "necase_79TQ9VGG316D8FK0"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-cli.test.ts",
+      "titlePath": [
+        "用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]"
+      ],
+      "caseId": "necase_9FHHSQTVB492P8DS"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-experiment-spacing.test.ts",
+      "titlePath": [
+        "Show 把 Experiment 标题和自己的内容排在同一段 [necase_NRD2EXM6620FRXHN]"
+      ],
+      "caseId": "necase_NRD2EXM6620FRXHN"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/red.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/red.json
@@ -1,0 +1,52 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "021de711dcd8735d93ee0e61815375ba7a82e9f33554c49a2c297d6604b12a27",
+    "sri": "sha512-1C3uGwPdBt9xTTYqcRJXL2UfckpFSWYmJQiZ50p40eMp8GYilhwcBHhUxuXPnqTW5fLx/T2mHFrS8z8WBfFCXQ=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-OqcybT/runs/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 3279215 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "29e4c7a2-37f0-4059-ba2f-2a0bdbe0a43e",
+  "receiptSha256": "178cb8875fe24279c24a78cc6af73f55068782d735bedd7338a22963324ce1bb"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-1.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-1.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-lmqgZ3/runs/takeover/isolated-copy-1/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3279704 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3279705 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3279760 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "6c4b09f1-6692-46d1-adc0-9f2c2e0a0e82",
+  "receiptSha256": "75d2fe83c60c84237399ba73e00df063ad9a7d70ff4345559db48cc58a318998"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-2.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-2.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-lmqgZ3/runs/takeover/isolated-copy-2/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3280114 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3280115 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3280145 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "22e54af8-91b5-431f-8cfb-c32525254e2e",
+  "receiptSha256": "fb4cb7743e2c3f6a4090cdc5f265fa283c69306d3a10a279d54fba9ab98dae6a"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-3.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-3.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-lmqgZ3/runs/takeover/isolated-copy-3/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3280513 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3280514 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3280626 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "7217e5b7-ef18-4603-ab64-97d474f562b2",
+  "receiptSha256": "b42804c61226ae74346819b029ad8fa8c82c489f7068bf7113ec6ad227b0c095"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-4.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-4.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-lmqgZ3/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3280951 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3280952 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3280981 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3281301 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "729dfd72-b492-4509-8dd6-01ec4cef58db",
+  "receiptSha256": "97f78ad7b20b35e033ec7df4892bd324bd87ddc1294205b09c123ab4a386c029"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-5.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-5.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-lmqgZ3/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3280951 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3280952 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3280981 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3281301 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1b9419ee-8588-46df-b307-3b9d424c558e",
+  "receiptSha256": "7ee2201b14c444b3e7c42036571e3e556bf7f53af60eb3f2f3a9e79d4fb5411a"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-6.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/reliability-6.json
@@ -1,0 +1,62 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "testFileSha256": "0a1d165a82f0d15b05dc420c98ec1d9933dc1f766f420a1cfe5bb9d30759fcf1",
+    "sidecarSha256": "e5de9b66858bdd51702086ea7a1da3b5a44a0de2596aa002d505354ede94d675"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-lmqgZ3/runs/takeover/repo-default-parallel/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3281643 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3281644 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3281673 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "2b50514f-f395-4296-b276-95ce284daf9b",
+  "receiptSha256": "d782a65ecbf2ccd414abfdf0b5ea5ceafa62b4e7a6dbb46cf38f423dc6bbb2e5"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/certificate.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/certificate.json
@@ -1,0 +1,30 @@
+{
+  "format": "niceeval.e2e-takeover-certificate/v1",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "candidateSha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+  "greenReceipt": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/green.json",
+  "observations": {
+    "isolatedCopies": [
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-1.json",
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-2.json",
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-3.json"
+    ],
+    "sameCopy": [
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-4.json",
+      "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-5.json"
+    ],
+    "defaultParallel": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-6.json",
+    "singleCase": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/green.json",
+    "cleanup": [
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/refresh-takeover/case-evidence/takeover-isolated-copy-1-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/refresh-takeover/case-evidence/takeover-isolated-copy-2-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/refresh-takeover/case-evidence/takeover-isolated-copy-3-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/refresh-takeover/case-evidence/takeover-same-copy-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/refresh-takeover/case-evidence/takeover-same-copy-2.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/refresh-takeover/case-evidence/takeover-repo-default-parallel-1.json",
+      "/home/ctrdh/Code/NiceEval/NiceEval/artifacts/refresh-takeover/case-evidence/takeover-target-single-1.json"
+    ]
+  },
+  "certificateSha256": "5ef23d379c7bd18dac347badb59a6be3773dafdeb3f964a89c9e7b01d0714262"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/green.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/green.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "green",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-cdECrj/runs/takeover/target-single/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3324001 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3324002 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3324175 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "1c1dce7d-c0da-447b-9982-199e37ced9b4",
+  "receiptSha256": "2008b127abf3a703a977e53cbbef459148d98bff0af9189ef3b3ec36c8ac4138"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/inventory.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/inventory.json
@@ -1,0 +1,55 @@
+{
+  "executor": {
+    "name": "vitest",
+    "version": "4.1.11"
+  },
+  "repo": "inspection",
+  "argv": [
+    "/nix/store/k3nz3s314bipvqbcbw3faq823hxpwbn1-nodejs-slim-24.19.0/bin/node",
+    "/tmp/niceeval-case-inventory-9JyMbv/repos/inspection/node_modules/.pnpm/vitest@4.1.11_@types+node@24.13.3_vite@8.2.2_@types+node@24.13.3_esbuild@0.28.2_jiti@2.7.0_tsx@4.23.12_yaml@2.9.0_/node_modules/vitest/vitest.mjs",
+    "list",
+    "--json"
+  ],
+  "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+  "files": [
+    "e2e/inspection/test/inspection-query.test.ts",
+    "e2e/inspection/test/show-cli.test.ts",
+    "e2e/inspection/test/show-experiment-spacing.test.ts"
+  ],
+  "cases": [
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/inspection-query.test.ts",
+      "titlePath": [
+        "machine consumer 发现固定 catalog，再从 project Run 读取 origin Attempt 的闭合事实 [necase_79TQ9VGG316D8FK0]"
+      ],
+      "caseId": "necase_79TQ9VGG316D8FK0"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-cli.test.ts",
+      "titlePath": [
+        "用户从多个 Experiment 收据完整浏览 Show 总览、Run、Attempt 与确定性证据切面 [necase_9FHHSQTVB492P8DS]"
+      ],
+      "caseId": "necase_9FHHSQTVB492P8DS"
+    },
+    {
+      "executor": "vitest",
+      "repo": "inspection",
+      "path": "e2e/inspection/test/show-experiment-spacing.test.ts",
+      "titlePath": [
+        "Show 把 Experiment 标题和自己的内容排在同一段 [necase_NRD2EXM6620FRXHN]"
+      ],
+      "caseId": "necase_NRD2EXM6620FRXHN"
+    }
+  ],
+  "unassignedCases": [],
+  "bodyExecutions": 0,
+  "forbiddenSetupExecutions": 0,
+  "findings": [],
+  "exit": 0,
+  "signal": null,
+  "digest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/red.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/red.json
@@ -1,0 +1,52 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "red",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+    "sha256": "021de711dcd8735d93ee0e61815375ba7a82e9f33554c49a2c297d6604b12a27",
+    "sri": "sha512-1C3uGwPdBt9xTTYqcRJXL2UfckpFSWYmJQiZ50p40eMp8GYilhwcBHhUxuXPnqTW5fLx/T2mHFrS8z8WBfFCXQ=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "regression",
+    "stage": "test",
+    "exitCode": 1,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-scratch-LdsEjA/runs/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "gone": true,
+        "detail": "owned process group 3315702 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "cb0c8b4d-508a-42a7-aa81-c533ffcdbe40",
+  "receiptSha256": "b695dd251ad8d369204ce3f6e38ad503b6247c79135a56e5c8c061309cd1b26d"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-1.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-1.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-cdECrj/runs/takeover/isolated-copy-1/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3316257 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3316259 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3316308 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "40205c28-283c-4d19-a8b9-5c66cf19f519",
+  "receiptSha256": "b2a7f040be96746b04561b24e45226246ac9791f29b42f5c419b0a9dc93d5be0"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-2.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-2.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-cdECrj/runs/takeover/isolated-copy-2/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3316650 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3316651 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3316684 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "f90b927b-53d2-4590-aed2-5508e1e19e1a",
+  "receiptSha256": "38ef0189336a76fa35beb0bd649764b28c10e8943013a2b87f660ac9ffb9dd17"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-3.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-3.json
@@ -1,0 +1,65 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-cdECrj/runs/takeover/isolated-copy-3/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3317029 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3317030 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3317077 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "292513b1-1d2d-461b-b4c8-68d22d4c73bf",
+  "receiptSha256": "e0944142d4331defbcc06c3ade8e1b8531d33f282cf78d96b1d2c63da011fb86"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-4.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-4.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-cdECrj/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3317430 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3317431 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3317459 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3317785 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "9bb3eca0-97ce-45f7-8c09-66da30e1d087",
+  "receiptSha256": "4bb0e762b0c571194696a133a83f0e8571cb6cdac675683c457a0d7aa3250cdf"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-5.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-5.json
@@ -1,0 +1,71 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs",
+      "test/show-experiment-spacing.test.ts",
+      "--testNamePattern",
+      "^Show 把 Experiment 标题和自己的内容排在同一段 \\[necase_NRD2EXM6620FRXHN\\]$"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-cdECrj/runs/takeover/same-copy/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3317430 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3317431 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3317459 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3317785 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "5053f491-e244-46b9-a803-a2da44c46859",
+  "receiptSha256": "a00530ccc6441ec5b8a3aa2dc5825bc5a86fbd6450672417a48d8a3b1deabb0b"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-6.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/reliability-6.json
@@ -1,0 +1,62 @@
+{
+  "format": "niceeval.e2e-case-receipt/v1",
+  "mode": "formal",
+  "observation": "reliability",
+  "selector": "e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN",
+  "caseId": "necase_NRD2EXM6620FRXHN",
+  "inventoryDigest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95",
+  "candidate": {
+    "gitSha": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "sha256": "eac45fc60b382d64f0cc399a48e6cd1bdce8a55953392821cb5a1abc1fb35818",
+    "sri": "sha512-omvbeXX2ijUrIG5rTaIyiOV4lq/XLH5IkOe3zfdaLRpFV1QVq2NyrBo9eSHgkogcZH6X8R1gCI8ZPbipwDj6bA=="
+  },
+  "source": {
+    "checkout": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+    "testFileSha256": "348cd1438968972955dcfaffa9a920afc13370b8143b0a1c412dc94e636b20d3",
+    "sidecarSha256": "87ad4907f3eb67425341f3149689a225f865204af5e7fa8a6ae4ca15c340ab2c"
+  },
+  "runner": {
+    "executor": "vitest",
+    "version": "4.1.11",
+    "argv": [
+      "node",
+      "scripts/run-native.mjs"
+    ]
+  },
+  "result": {
+    "disposition": "pass",
+    "stage": "test",
+    "exitCode": 0,
+    "signal": null
+  },
+  "cleanup": {
+    "ok": true,
+    "resources": [
+      {
+        "kind": "workdir",
+        "path": "/tmp/niceeval-e2e-takeover-scratch-cdECrj/runs/takeover/repo-default-parallel/inspection",
+        "ok": true
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "preflight",
+        "gone": true,
+        "detail": "owned process group 3318115 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "install",
+        "gone": true,
+        "detail": "owned process group 3318116 has no running members after leader close"
+      },
+      {
+        "kind": "owned-process-group",
+        "stage": "test",
+        "gone": true,
+        "detail": "owned process group 3318147 has no running members after leader close"
+      }
+    ]
+  },
+  "invocationId": "ed539777-c826-413a-b0cc-57aa73dd2429",
+  "receiptSha256": "37a520ddeab311670bb8d1c3f50c830237edb07417129047367d8bab9748d431"
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.cases.evidence.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.cases.evidence.json
@@ -1,0 +1,51 @@
+{
+  "format": "niceeval.e2e-case-evidence-index/v1",
+  "current": {
+    "necase_NRD2EXM6620FRXHN": {
+      "memory/show-experiment-heading-detached-from-table.md": {
+        "red": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/red.json",
+          "digest": "sha256:acf89edf97968f02d523566a0424e74292ca6b012c5828bdcca17fb21c181ac5"
+        },
+        "green": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/green.json",
+          "digest": "sha256:8b347ec98801c0b92ab5a6926433c253e336841e7e85af534c205e71ce11d3d3"
+        },
+        "certificate": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/certificate.json",
+          "digest": "sha256:87b29bf0634b55d98caafd0bc6c16c0577a43143a00c70e26fa9f26f5ceebbf0"
+        },
+        "inventory": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_T14PWWB7GN7FFG9D-netake_2EPSHS9C8K6S2NQB/inventory.json",
+          "digest": "sha256:58e407c3f87d056e0e5a5fe21cfbda9d40b682251eb507b2f7d37564552aac95"
+        }
+      }
+    }
+  },
+  "history": [
+    {
+      "caseId": "necase_NRD2EXM6620FRXHN",
+      "memory": "memory/show-experiment-heading-detached-from-table.md",
+      "evidence": {
+        "red": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/red.json",
+          "digest": "sha256:c7b30fc3d971fc5eadf514f3649a1798ca4d009c1aba8432ba201d6f8ed27c76"
+        },
+        "green": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/green.json",
+          "digest": "sha256:499ac2968cc2a79623e2a7d3be63fe6c4070a2ffa1149c1a2e6669e56697aa49"
+        },
+        "certificate": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/certificate.json",
+          "digest": "sha256:c50f361f9130ce146f0c87feda3428dd7bf8c219b7a4f677979abd50c0bb7304"
+        },
+        "inventory": {
+          "path": "e2e/inspection/test/show-experiment-spacing.test.ts.case-evidence/necase_NRD2EXM6620FRXHN/memory_show-experiment-heading-detached-from-table.md/nered_93EYDKQ33V7N56EY-netake_QD1H6K6YCY2266QZ/inventory.json",
+          "digest": "sha256:bd2ed7462a46b70838767eb5a146ccd85dfc93463366eff786f5e700387ec32b"
+        }
+      },
+      "reason": "Refresh managed evidence after finalizing the exact expected output source.",
+      "retiredAtCommit": "b3d673420ec09bfeeb65a0610f53960af02be7fe"
+    }
+  ]
+}

--- a/e2e/inspection/test/show-experiment-spacing.test.ts.cases.json
+++ b/e2e/inspection/test/show-experiment-spacing.test.ts.cases.json
@@ -1,0 +1,53 @@
+{
+  "format": "niceeval.e2e-case-relations/v1",
+  "testFile": "e2e/inspection/test/show-experiment-spacing.test.ts",
+  "current": {
+    "necase_NRD2EXM6620FRXHN": {
+      "owner": "docs/engineering/testing/e2e/inspection.md#show-terminal-review",
+      "regressions": [
+        "memory/show-experiment-heading-detached-from-table.md"
+      ],
+      "issues": []
+    }
+  },
+  "history": [
+    {
+      "caseId": "necase_NRD2EXM6620FRXHN",
+      "atCommit": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+      "transactionId": "netxn_d257e190c20d4fd292304631a602b4e0",
+      "action": "case-attached",
+      "to": {
+        "owner": "docs/engineering/testing/e2e/inspection.md#show-terminal-review"
+      }
+    },
+    {
+      "caseId": "necase_NRD2EXM6620FRXHN",
+      "atCommit": "f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d",
+      "transactionId": "netxn_2af81bc784644205b2e5d8ba48b71123",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/show-experiment-heading-detached-from-table.md"
+      }
+    },
+    {
+      "caseId": "necase_NRD2EXM6620FRXHN",
+      "atCommit": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+      "transactionId": "netxn_8d2b99e82649480386faba2bdceb5fb3",
+      "action": "regression-retired",
+      "from": {
+        "memory": "memory/show-experiment-heading-detached-from-table.md"
+      },
+      "reason": "Refresh managed evidence after finalizing the exact expected output source."
+    },
+    {
+      "caseId": "necase_NRD2EXM6620FRXHN",
+      "atCommit": "b3d673420ec09bfeeb65a0610f53960af02be7fe",
+      "transactionId": "netxn_9689ec9b2369482f831dc881a1b35dcc",
+      "action": "regression-added",
+      "to": {
+        "memory": "memory/show-experiment-heading-detached-from-table.md"
+      }
+    }
+  ],
+  "tombstones": []
+}

--- a/memory/show-experiment-heading-detached-from-table.md
+++ b/memory/show-experiment-heading-detached-from-table.md
@@ -9,8 +9,9 @@ kind:
   resolution:
     kind: fixed
     proof:
-      - "red: /tmp/niceeval-e2e-artifacts-3e5UZr/report/receipt.json"
-      - "green: /tmp/niceeval-e2e-artifacts-N2KVHv/report/receipt.json"
+      - "red: nered_T14PWWB7GN7FFG9D"
+      - "takeover: netake_2EPSHS9C8K6S2NQB"
+      - niceeval.fixed-evidence/v1:{"selectors":["e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN"]}
 promotions: []
 ---
 ## Problem
@@ -24,3 +25,45 @@ The shared terminal block renderer inserts spacing before every non-divider bloc
 ## Expected resolution
 
 The installed CLI must render a blank line before each subsequent Experiment section, then place `Experiment <id>` immediately adjacent to its following `Eval / Attempt / Score` table header. Other panels and non-divider block spacing must remain unchanged.
+
+## Resolution history
+
+<!-- niceeval.memory-resolution-history/v1 -->
+
+### Reopened at `f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d`
+
+```json
+{
+  "kind": "fixed",
+  "proof": [
+    "red: /tmp/niceeval-e2e-artifacts-3e5UZr/report/receipt.json",
+    "green: /tmp/niceeval-e2e-artifacts-N2KVHv/report/receipt.json"
+  ]
+}
+```
+
+### Reopened at `f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d`
+
+```json
+{
+  "kind": "fixed",
+  "proof": [
+    "red: nered_EBEWBSJXA9DWH1TE",
+    "takeover: netake_NRWAXFBS12YQKJQB",
+    "niceeval.fixed-evidence/v1:{\"selectors\":[\"e2e/inspection/test/show-cli.test.ts#necase_9FHHSQTVB492P8DS\"]}"
+  ]
+}
+```
+
+### Reopened at `b3d673420ec09bfeeb65a0610f53960af02be7fe`
+
+```json
+{
+  "kind": "fixed",
+  "proof": [
+    "red: nered_93EYDKQ33V7N56EY",
+    "takeover: netake_QD1H6K6YCY2266QZ",
+    "niceeval.fixed-evidence/v1:{\"selectors\":[\"e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN\"]}"
+  ]
+}
+```

--- a/packages/niceeval/src/show/render.ts
+++ b/packages/niceeval/src/show/render.ts
@@ -305,6 +305,7 @@ export function renderOverview(
             {
               kind: "divider" as const,
               title: `Experiment ${experiment.experimentId}`,
+              attachNext: true,
             },
             ...attemptBlocks(experimentCells, group.name, all),
             ...compactContinuation(experimentCells, experiment.experimentId, all),

--- a/packages/niceeval/src/terminal/blocks.ts
+++ b/packages/niceeval/src/terminal/blocks.ts
@@ -229,11 +229,10 @@ function renderPanelBlock(block: TerminalPanelBlock, options: TerminalRenderOpti
   block.blocks.forEach((child, index) => {
     const previous = block.blocks[index - 1];
     if (index > 0) {
-      if (child.kind === "divider" && child.attachNext === true) {
-        rows.push({ kind: "line", text: "" });
-      } else if (
-        child.kind !== "divider" &&
-        !(previous?.kind === "divider" && previous.attachNext === true)
+      const attachedToPrevious = previous?.kind === "divider" && previous.attachNext === true;
+      if (
+        !attachedToPrevious &&
+        (child.kind !== "divider" || child.attachNext === true)
       ) {
         rows.push({ kind: "line", text: "" });
       }


### PR DESCRIPTION
<!-- niceeval:pr-body
base: f75021ab2f3b9e42e079bda7b25b4dd3f71fdb8d
templateSha256: 6d2dc9748b9a82ac4f2c36d1324ff50ef87ecd622843d15559307e4170aec67e
head: 3f5a45e866d5426bff2378e06cc6e95636f9c359
-->

## Problem

- User goal: 在总览中快速辨认每个 Experiment 的 Attempt 结果，并确认一个 Experiment 使用一致的评测方式。
- Current limitation: show 在 Experiment 标题与其内容之间插入空行，标题视觉上更靠近上一组；Eval Feature 总览还错误地允许同一 Experiment 混用 pass 与 score。
- Required capability: show 必须让 Experiment 标题紧贴自身内容、在相邻 Experiment 之间分段；Feature 文档必须明确单个 Experiment 只能全 pass 或全 score，混用由 exp 在启动前拒绝。
- User outcome: 用户能按清晰分组阅读多个 Experiment；配置混合题型时会在产生运行数据前收到可操作错误，同时历史 mixed 记录仍可查看。

## Use cases

### Changed

#### Case: 比较多个 Experiment 的质量与成本

##### Starting state

```text
工作区已有同一 harness 下多个 Experiment 的结果。
```

##### Action

```text
运行 niceeval show 查看总览。
```

##### Result

```text
每个 Experiment 标题紧贴自己的 Attempt 摘要，相邻 Experiment 之间保留空行。
```

阅读者无需借助缩进猜测标题属于上一组还是下一组。 [Canonical Use Case](docs/feature/inspection/use-case/比较质量与成本.md).

## CLI

### Changed

#### Case: show 中相邻 Experiment 的分组

##### Before

```text
niceeval show
```

```text
Experiment harness/alternate

1 scored Attempts hidden
Experiment harness/canary

1 scored Attempts hidden
```

##### After

```text
niceeval show
```

```text
Experiment harness/alternate
1 scored Attempts hidden

Experiment harness/canary
1 scored Attempts hidden
```

##### User impact

Experiment 标题和自己的内容形成一段，不再视觉归属到上一组。

## Tests

### `e2e/cli/test/evaluation-kind-admission.test.ts`

#### `e2e/cli/test/evaluation-kind-admission.test.ts#necase_9MQ99DC3XKAN6NNW`

exp 在执行前拒绝同一 Experiment 混合 pass 与 score Eval。 It exercises 通过公开 niceeval exp 运行包含两种 evaluation kind 的 Experiment。 and asserts 命令失败、列出两类 Eval 与拆分建议，且不会创建 .niceeval。. Deleting this case would allow 使用安装后候选的公开 CLI；仅在 fixture 边界动态写入用户配置。. The final contract is [docs/feature/experiments/use-case/选择评测/拆开混型评测.md](docs/feature/experiments/use-case/选择评测/拆开混型评测.md).

```ts
// rerun: pnpm e2e test --repo cli -- --run test/evaluation-kind-admission.test.ts

import { mkdir, stat, writeFile } from "node:fs/promises";
import { join } from "node:path";
import { expect, test } from "vitest";
import { cliE2E } from "./context.ts";

test("运行与 check 在执行前拒绝混合 Pass Eval 与 Score Eval 的 Experiment 和 Eval Group [necase_9MQ99DC3XKAN6NNW]", async () => {
  await cliE2E.case("mixed-experiment-kinds", async ({ paths, commands: { niceeval } }) => {
    await writeFile(join(paths.projectRoot, "experiments", "mixed-evaluation-kinds.ts"), `
import { defineExperiment } from "niceeval";
import { deterministicAgent } from "../agents/deterministic.ts";

export default defineExperiment({
  agent: deterministicAgent("mixed-evaluation-kinds"),
  evals: ["greet", "deliberate-score"],
});
`);

    const receipt = await niceeval.run(["exp", "mixed-evaluation-kinds", "--json"]);

    expect(receipt.exitCode, receipt.diagnostic()).not.toBe(0);
    expect(receipt.stdout).toBe("");
    expect(receipt.stderr).toContain('Experiment "mixed-evaluation-kinds"');
    expect(receipt.stderr).toContain("pass (1): greet/hello");
    expect(receipt.stderr).toContain("score (1): deliberate-score/scored");
    expect(receipt.stderr).toContain("Split the Experiment");
    await expect(stat(join(paths.projectRoot, ".niceeval"))).rejects.toMatchObject({ code: "ENOENT" });
  });

  await cliE2E.case("mixed-group-kinds", async ({ paths, commands: { niceeval } }) => {
    const groupDir = join(paths.projectRoot, "evals", "mixed-evaluation-kinds");
    await mkdir(groupDir, { recursive: true });
    await writeFile(join(groupDir, "eval-group.ts"), `
import { defineEvalGroup } from "niceeval";
import passEval from "../greet/hello.eval.ts";
import scoreEval from "../deliberate-score/scored.eval.ts";

export default defineEvalGroup({
  evals: [passEval, scoreEval],
  onUnavailable: "stop-group",
});
`);

    const receipt = await niceeval.run(["check", "normal"]);

    expect(receipt.exitCode, receipt.diagnostic()).not.toBe(0);
    expect(receipt.stdout).toBe("");
    expect(receipt.stderr).toContain('Eval Group "mixed-evaluation-kinds"');
    expect(receipt.stderr).toContain("pass (1): greet/hello");
    expect(receipt.stderr).toContain("score (1): deliberate-score/scored");
    expect(receipt.stderr).toContain("Split the Eval Group");
  });
});
```

### `e2e/inspection/test/show-experiment-spacing.test.ts`

#### `e2e/inspection/test/show-experiment-spacing.test.ts#necase_NRD2EXM6620FRXHN`

多个 Experiment 的标题与各自 Attempt 摘要保持正确视觉分组。 It exercises 安装候选后依次运行两个 Experiment，再调用公开 niceeval show。 and asserts 精确断言标题后无空行、相邻 Experiment 之间有一个空行。. Deleting this case would allow 使用真实打包 CLI 和两个真实 Experiment，不复制终端 block 排版实现。. The final contract is [docs/feature/inspection/cli.md#niceeval-show](docs/feature/inspection/cli.md#niceeval-show). It also prevents the regression recorded in [memory/show-experiment-heading-detached-from-table.md](memory/show-experiment-heading-detached-from-table.md).

```ts
// rerun: pnpm e2e test --repo inspection -- --run test/show-experiment-spacing.test.ts

import { expect, test } from "vitest";
import { inspectionE2E } from "./support.ts";

test.concurrent("Show 把 Experiment 标题和自己的内容排在同一段 [necase_NRD2EXM6620FRXHN]", async () => {
  await inspectionE2E.case(
    "show-experiment-spacing",
    async ({ commands: { niceeval } }) => {
      for (const experimentId of ["harness/alternate", "harness/canary"]) {
        const produced = await niceeval.run(["exp", experimentId, "--rerun", "all", "--json"]);
        expect(produced.exitCode, produced.diagnostic()).toBe(0);
      }

      const overview = await niceeval.run(["show"]);
      expect(overview.exitCode, overview.diagnostic()).toBe(0);
      expect(overview.stdout).toContain([
        "Attempts · harness",
        "  Experiment harness/alternate",
        "  1 scored Attempts hidden",
        "  See more  niceeval show --experiment harness/alternate",
        "  ",
        "  Experiment harness/canary",
        "  1 scored Attempts hidden",
        "  See more  niceeval show --experiment harness/canary",
      ].join("\n"));
    },
  );
});
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NiceEval/codesmith/NiceEval/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791125559&installation_model_id=431746&pr_number=221&repository=NiceEval%2FNiceEval&return_to=https%3A%2F%2Fgithub.com%2FNiceEval%2FNiceEval%2Fpull%2F221&signature=32ea78cb40d6ee9dde713f6dda3a51fe898df9696bb0320e64c7cc9f63a0bef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
